### PR TITLE
24.4 Update

### DIFF
--- a/bench.mojo
+++ b/bench.mojo
@@ -1,8 +1,9 @@
 from numojo import *
+import numojo
 import benchmark
 from benchmark.compiler import keep
-from numojo._math_funcs import Vectorized, Naive, Parallelized
-alias backend = Vectorized
+from numojo._math_funcs import Vectorized, Naive, Parallelized, VectorizedParallelized
+alias backend = VectorizedParallelized
 fn main():
     var tens1:Tensor[DType.float32] = Tensor[DType.float32](100,100)
     var tens2:Tensor[DType.float32] = Tensor[DType.float32](100,100)
@@ -15,7 +16,7 @@ fn main():
     fn test_fma()capturing:
         try:
             res = fma[DType.float32,backend=backend](tens1, tens2, tens3)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('fma: Failed shape error')
     var report_fma = benchmark.run[test_fma]()
@@ -24,7 +25,7 @@ fn main():
     fn test_mod()capturing:
         try:
             res = mod[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('mod: Failed shape error')
     var report_mod = benchmark.run[test_mod]()
@@ -33,7 +34,7 @@ fn main():
     fn test_mul()capturing:
         try:
             res = mul[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('mul: Failed shape error')
     var report_mul = benchmark.run[test_mul]()
@@ -42,7 +43,7 @@ fn main():
     fn test_sub()capturing:
         try:
             res = sub[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('sub: Failed shape error')
     var report_sub = benchmark.run[test_sub]()
@@ -51,7 +52,7 @@ fn main():
     fn test_add()capturing:
         try:
             res = add[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('add: Failed shape error')
     var report_add = benchmark.run[test_add]()
@@ -60,7 +61,7 @@ fn main():
     fn test_div()capturing:
         try:
             res = div[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('div: Failed shape error')
     var report_div = benchmark.run[test_div]()
@@ -69,7 +70,7 @@ fn main():
     fn test_copysign()capturing:
         try:
             res = copysign[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('copysign: Failed shape error')
     var report_copysign = benchmark.run[test_copysign]()
@@ -78,7 +79,7 @@ fn main():
     fn test_atan2()capturing:
         try:
             res = atan2[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('atan2: Failed shape error')
     var report_atan2 = benchmark.run[test_atan2]()
@@ -87,7 +88,7 @@ fn main():
     fn test_hypot()capturing:
         try:
             res = hypot[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('hypot: Failed shape error')
     var report_hypot = benchmark.run[test_hypot]()
@@ -96,7 +97,7 @@ fn main():
     fn test_hypot_fma()capturing:
         try:
             res = hypot_fma[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('hypot: Failed shape error')
     var report_hypot_fma = benchmark.run[test_hypot_fma]()
@@ -105,7 +106,7 @@ fn main():
     fn test_nextafter()capturing:
         try:
             res = nextafter[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('nextafter: Failed shape error')
     var report_nextafter = benchmark.run[test_nextafter]()
@@ -114,7 +115,7 @@ fn main():
     fn test_scalb()capturing:
         try:
             res = scalb[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('scalb: Failed shape error')
     var report_scalb = benchmark.run[test_scalb]()
@@ -123,7 +124,7 @@ fn main():
     fn test_remainder()capturing:
         try:
             res = remainder[DType.float32,backend=backend](tens1, tens2)
-            keep(res.data())
+            keep(res.unsafe_ptr())
         except:
             print('remainder: Failed shape error')
     var report_remainder = benchmark.run[test_remainder]()
@@ -133,260 +134,260 @@ fn main():
     for i in range(10_000):
         tens[i]= SIMD[DType.float32,1](3.141592/4)
     fn test_abs()capturing:
-        res = abs[DType.float32,backend=backend](tens)
-        keep(res.data())
+        res = tabs[DType.float32,backend=backend](tens)
+        keep(res.unsafe_ptr())
     var report_abs = benchmark.run[test_abs]()
     print('abs f32 100x100')
     report_abs.print()
     fn test_floor()capturing:
-        res = floor[DType.float32,backend=backend](tens)
-        keep(res.data())
+        res = tfloor[DType.float32,backend=backend](tens)
+        keep(res.unsafe_ptr())
     var report_floor = benchmark.run[test_floor]()
     print('floor f32 100x100')
     report_floor.print()
     fn test_ceil()capturing:
-        res = ceil[DType.float32,backend=backend](tens)
-        keep(res.data())
+        res = tceil[DType.float32,backend=backend](tens)
+        keep(res.unsafe_ptr())
     var report_ceil = benchmark.run[test_ceil]()
     print('ceil f32 100x100')
     report_ceil.print()
     fn test_trunc()capturing:
-        res = trunc[DType.float32,backend=backend](tens)
-        keep(res.data())
+        res = ttrunc[DType.float32,backend=backend](tens)
+        keep(res.unsafe_ptr())
     var report_trunc = benchmark.run[test_trunc]()
     print('trunc f32 100x100')
     report_trunc.print()
     fn test_round()capturing:
-        res = round[DType.float32,backend=backend](tens)
-        keep(res.data())
+        res = tround[DType.float32,backend=backend](tens)
+        keep(res.unsafe_ptr())
     var report_round = benchmark.run[test_round]()
     print('round f32 100x100')
     report_round.print()
     fn test_roundeven()capturing:
         res = roundeven[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_roundeven = benchmark.run[test_roundeven]()
     print('roundeven f32 100x100')
     report_roundeven.print()
-    fn test_round_half_down()capturing:
-        res = round_half_down[DType.float32,backend=backend](tens)
-        keep(res.data())
-    var report_round_half_down = benchmark.run[test_round_half_down]()
-    print('round_half_down f32 100x100')
-    report_round_half_down.print()
-    fn test_round_half_up()capturing:
-        res = round_half_up[DType.float32,backend=backend](tens)
-        keep(res.data())
-    var report_round_half_up = benchmark.run[test_round_half_up]()
-    print('round_half_up f32 100x100')
-    report_round_half_up.print()
+    # fn test_round_half_down()capturing:
+    #     res = round_half_down[DType.float32,backend=backend](tens)
+    #     keep(res.unsafe_ptr())
+    # var report_round_half_down = benchmark.run[test_round_half_down]()
+    # print('round_half_down f32 100x100')
+    # report_round_half_down.print()
+    # fn test_round_half_up()capturing:
+    #     res = round_half_up[DType.float32,backend=backend](tens)
+    #     keep(res.unsafe_ptr())
+    # var report_round_half_up = benchmark.run[test_round_half_up]()
+    # print('round_half_up f32 100x100')
+    # report_round_half_up.print()
     fn test_rsqrt()capturing:
         res = rsqrt[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_rsqrt = benchmark.run[test_rsqrt]()
     print('rsqrt f32 100x100')
     report_rsqrt.print()
     fn test_sqrt()capturing:
         res = sqrt[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_sqrt = benchmark.run[test_sqrt]()
     print('sqrt f32 100x100')
     report_sqrt.print()
     fn test_exp2()capturing:
         res = exp2[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_exp2 = benchmark.run[test_exp2]()
     print('exp2 f32 100x100')
     report_exp2.print()
     fn test_exp()capturing:
         res = exp[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_exp = benchmark.run[test_exp]()
     print('exp f32 100x100')
     report_exp.print()
     fn test_log()capturing:
         res = log[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_log = benchmark.run[test_log]()
     print('log f32 100x100')
     report_log.print()
     fn test_log2()capturing:
         res = log2[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_log2 = benchmark.run[test_log2]()
     print('log2 f32 100x100')
     report_log2.print()
     # fn test_erf()capturing:
     #     res = erf[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_erf = benchmark.run[test_erf]()
     # print('erf f32 100x100')
     # report_erf.print()
     fn test_tanh()capturing:
         res = tanh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_tanh = benchmark.run[test_tanh]()
     print('tanh f32 100x100')
     report_tanh.print()
-    fn test_reciprocal()capturing:
-        res = reciprocal[DType.float32,backend=backend](tens)
-        keep(res.data())
-    var report_reciprocal = benchmark.run[test_reciprocal]()
-    print('reciprocal f32 100x100')
-    report_reciprocal.print()
+    # fn test_reciprocal()capturing:
+    #     res = reciprocal[DType.float32,backend=backend](tens)
+    #     keep(res.unsafe_ptr())
+    # var report_reciprocal = benchmark.run[test_reciprocal]()
+    # print('reciprocal f32 100x100')
+    # report_reciprocal.print()
     # fn test_identity()capturing:
     #     res = identity[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_identity = benchmark.run[test_identity]()
     # print('identity f32 100x100')
     # report_identity.print()
     fn test_acos()capturing:
         res = acos[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_acos = benchmark.run[test_acos]()
     print('acos f32 100x100')
     report_acos.print()
     fn test_asin()capturing:
         res = asin[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_asin = benchmark.run[test_asin]()
     print('asin f32 100x100')
     report_asin.print()
     fn test_atan()capturing:
         res = atan[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_atan = benchmark.run[test_atan]()
     print('atan f32 100x100')
     report_atan.print()
     fn test_cos()capturing:
         res = cos[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_cos = benchmark.run[test_cos]()
     print('cos f32 100x100')
     report_cos.print()
     fn test_sin()capturing:
         res = sin[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_sin = benchmark.run[test_sin]()
     print('sin f32 100x100')
     report_sin.print()
     fn test_tan()capturing:
         res = tan[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_tan = benchmark.run[test_tan]()
     print('tan f32 100x100')
     report_tan.print()
     fn test_acosh()capturing:
         res = acosh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_acosh = benchmark.run[test_acosh]()
     print('acosh f32 100x100')
     report_acosh.print()
     fn test_asinh()capturing:
         res = asinh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_asinh = benchmark.run[test_asinh]()
     print('asinh f32 100x100')
     report_asinh.print()
     fn test_atanh()capturing:
         res = atanh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_atanh = benchmark.run[test_atanh]()
     print('atanh f32 100x100')
     report_atanh.print()
     fn test_cosh()capturing:
         res = cosh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_cosh = benchmark.run[test_cosh]()
     print('cosh f32 100x100')
     report_cosh.print()
     fn test_sinh()capturing:
         res = sinh[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_sinh = benchmark.run[test_sinh]()
     print('sinh f32 100x100')
     report_sinh.print()
     fn test_expm1()capturing:
         res = expm1[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_expm1 = benchmark.run[test_expm1]()
     print('expm1 f32 100x100')
     report_expm1.print()
     fn test_log10()capturing:
         res = log10[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_log10 = benchmark.run[test_log10]()
     print('log10 f32 100x100')
     report_log10.print()
     fn test_log1p()capturing:
         res = log1p[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_log1p = benchmark.run[test_log1p]()
     print('log1p f32 100x100')
     report_log1p.print()
     fn test_cbrt()capturing:
         res = cbrt[DType.float32,backend=backend](tens)
-        keep(res.data())
+        keep(res.unsafe_ptr())
     var report_cbrt = benchmark.run[test_cbrt]()
     print('cbrt f32 100x100')
     report_cbrt.print()
     # fn test_erfc()capturing:
     #     res = erfc[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_erfc = benchmark.run[test_erfc]()
     # print('erfc f32 100x100')
     # report_erfc.print()
     # fn test_lgamma()capturing:
     #     res = lgamma[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_lgamma = benchmark.run[test_lgamma]()
     # print('lgamma f32 100x100')
     # report_lgamma.print()
     # fn test_tgamma()capturing:
     #     res = tgamma[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_tgamma = benchmark.run[test_tgamma]()
     # print('tgamma f32 100x100')
     # report_tgamma.print()
     # fn test_nearbyint()capturing:
     #     res = nearbyint[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_nearbyint = benchmark.run[test_nearbyint]()
     # print('nearbyint f32 100x100')
     # report_nearbyint.print()
     # fn test_rint()capturing:
     #     res = rint[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_rint = benchmark.run[test_rint]()
     # print('rint f32 100x100')
     # report_rint.print()
     # fn test_j0()capturing:
     #     res = j0[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_j0 = benchmark.run[test_j0]()
     # print('j0 f32 100x100')
     # report_j0.print()
     # fn test_j1()capturing:
     #     res = j1[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_j1 = benchmark.run[test_j1]()
     # print('j1 f32 100x100')
     # report_j1.print()
     # fn test_y0()capturing:
     #     res = y0[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_y0 = benchmark.run[test_y0]()
     # print('y0 f32 100x100')
     # report_y0.print()
     # fn test_y1()capturing:
     #     res = y1[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_y1 = benchmark.run[test_y1]()
     # print('y1 f32 100x100')
     # report_y1.print()
     # fn test_ulp()capturing:
     #     res = ulp[DType.float32,backend=backend](tens)
-    #     keep(res.data())
+    #     keep(res.unsafe_ptr())
     # var report_ulp = benchmark.run[test_ulp]()
     # print('ulp f32 100x100')
     # report_ulp.print()

--- a/numojo/arithmetic.mojo
+++ b/numojo/arithmetic.mojo
@@ -529,7 +529,7 @@ fn log1p[
 # ===------------------------------------------------------------------------===#
 
 
-fn abs[
+fn tabs[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
@@ -550,7 +550,7 @@ fn abs[
     )
 
 
-fn floor[
+fn tfloor[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
@@ -571,7 +571,7 @@ fn floor[
     )
 
 
-fn ceil[
+fn tceil[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
@@ -592,7 +592,7 @@ fn ceil[
     )
 
 
-fn trunc[
+fn ttrunc[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """
@@ -613,7 +613,7 @@ fn trunc[
     )
 
 
-fn round[
+fn tround[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](tensor: Tensor[dtype]) -> Tensor[dtype]:
     """

--- a/numojo/arithmetic.mojo
+++ b/numojo/arithmetic.mojo
@@ -31,7 +31,7 @@ fn add[
     Returns:
         The elementwise sum of `tensor1` and`tensor2`.
     """
-    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.add](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__add__](
         tensor1, tensor2
     )
 
@@ -56,7 +56,7 @@ fn sub[
     Returns:
         The elementwise difference of `tensor1` and`tensor2`.
     """
-    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.sub](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__sub__](
         tensor1, tensor2
     )
 
@@ -111,7 +111,7 @@ fn mod[
     Returns:
         A tensor equal to tensor1%tensor2.
     """
-    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.mod](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__mod__](
         tensor1, tensor2
     )
 
@@ -136,7 +136,7 @@ fn mul[
     Returns:
         A tensor equal to tensor1*tensor2.
     """
-    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.mul](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__mul__](
         tensor1, tensor2
     )
 
@@ -161,7 +161,7 @@ fn div[
     Returns:
         A tensor equal to tensor1/tensor2.
     """
-    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, math.div](
+    return backend()._math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__truediv__](
         tensor1, tensor2
     )
 
@@ -243,28 +243,28 @@ fn remainder[
     ](tensor1, tensor2)
 
 
-fn reciprocal[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[dtype]:
-    """
-    Elementwise reciprocals of tensor1 and tensor2.
+# fn reciprocal[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[dtype]:
+#     """
+#     Elementwise reciprocals of tensor1 and tensor2.
 
-    Constraints:
-        Both tensors must have the same shapes.
+#     Constraints:
+#         Both tensors must have the same shapes.
 
-    Parameters:
-        dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+#     Parameters:
+#         dtype: The element type.
+#         backend: Sets utility function origin, defualts to `Vectorized`.
 
-    Args:
-        tensor: A tensor.
+#     Args:
+#         tensor: A tensor.
 
-    Returns:
-        A tensor equal to 1/tensor.
-    """
-    return backend()._math_func_1_tensor_in_one_tensor_out[
-        dtype, math.reciprocal
-    ](tensor)
+#     Returns:
+#         A tensor equal to 1/tensor.
+#     """
+#     return backend()._math_func_1_tensor_in_one_tensor_out[
+#         dtype, math.reciprocal
+#     ](tensor)
 
 
 # ===------------------------------------------------------------------------===#
@@ -545,7 +545,7 @@ fn abs[
     Returns:
         A tensor equal to abs(tensor).
     """
-    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.abs](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__abs__](
         tensor
     )
 
@@ -566,7 +566,7 @@ fn floor[
     Returns:
         A tensor equal to floor(tensor).
     """
-    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.floor](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__floor__](
         tensor
     )
 
@@ -587,7 +587,7 @@ fn ceil[
     Returns:
         A tensor equal to ceil(tensor).
     """
-    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.ceil](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__ceil__](
         tensor
     )
 
@@ -608,7 +608,7 @@ fn trunc[
     Returns:
         A tensor equal to trunc(tensor).
     """
-    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.trunc](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__trunc__](
         tensor
     )
 
@@ -629,7 +629,7 @@ fn round[
     Returns:
         A tensor equal to trunc(tensor).
     """
-    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, math.round](
+    return backend()._math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__round__](
         tensor
     )
 
@@ -653,50 +653,50 @@ fn roundeven[
     This rounding goes to the nearest integer with ties toward the nearest even integer.
     """
     return backend()._math_func_1_tensor_in_one_tensor_out[
-        dtype, math.roundeven
+        dtype, SIMD.roundeven
     ](tensor)
 
 
-fn round_half_down[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[dtype]:
-    """
-    Rounds ties towards the smaller integer.
+# fn round_half_down[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[dtype]:
+#     """
+#     Rounds ties towards the smaller integer.
 
-    Parameters:
-        dtype: The dtype of the input and output Tensor.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+#     Parameters:
+#         dtype: The dtype of the input and output Tensor.
+#         backend: Sets utility function origin, defualts to `Vectorized`.
 
-    Args:
-        tensor: Tensor to perform rounding on.
+#     Args:
+#         tensor: Tensor to perform rounding on.
 
-    Returns:
-    The elementwise rounding of x evaluating ties towards the smaller integer.
-    """
-    return backend()._math_func_1_tensor_in_one_tensor_out[
-        dtype, math.round_half_down
-    ](tensor)
+#     Returns:
+#     The elementwise rounding of x evaluating ties towards the smaller integer.
+#     """
+#     return backend()._math_func_1_tensor_in_one_tensor_out[
+#         dtype, SIMD.__round_half_down
+#     ](tensor)
 
 
-fn round_half_up[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[dtype]:
-    """
-    Rounds ties towards the larger integer.
+# fn round_half_up[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[dtype]:
+#     """
+#     Rounds ties towards the larger integer.
 
-    Parameters:
-        dtype: The dtype of the input and output Tensor.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+#     Parameters:
+#         dtype: The dtype of the input and output Tensor.
+#         backend: Sets utility function origin, defualts to `Vectorized`.
 
-    Args:
-        tensor: Tensor to perform rounding on.
+#     Args:
+#         tensor: Tensor to perform rounding on.
 
-    Returns:
-    The elementwise rounding of x evaluating ties towards the larger integer.
-    """
-    return backend()._math_func_1_tensor_in_one_tensor_out[
-        dtype, math.round_half_up
-    ](tensor)
+#     Returns:
+#     The elementwise rounding of x evaluating ties towards the larger integer.
+#     """
+#     return backend()._math_func_1_tensor_in_one_tensor_out[
+#         dtype, math.round_half_up
+#     ](tensor)
 
 
 fn nextafter[

--- a/numojo/check.mojo
+++ b/numojo/check.mojo
@@ -3,22 +3,22 @@ import . _math_funcs as _mf
 from tensor import Tensor
 
 
-fn is_power_of_2[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return backend()._math_func_is[dtype, math.is_power_of_2](tensor)
+# fn is_power_of_2[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#     return backend()._math_func_is[dtype, math.is_power_of_2](tensor)
 
 
-fn is_even[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return backend()._math_func_is[dtype, math.is_even](tensor)
+# fn is_even[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#     return backend()._math_func_is[dtype, math.is_even](tensor)
 
 
-fn is_odd[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
-    return backend()._math_func_is[dtype, math.is_odd](tensor)
+# fn is_odd[
+#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+# ](tensor: Tensor[dtype]) -> Tensor[DType.bool]:
+#     return backend()._math_func_is[dtype, math.is_odd](tensor)
 
 
 fn isinf[

--- a/numojo/comparison.mojo
+++ b/numojo/comparison.mojo
@@ -29,7 +29,7 @@ fn greater[
 
     An element of the result Tensor will be True if the corresponding element in x is greater than the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.greater](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__gt__](
         tensor1, tensor2
     )
 
@@ -53,7 +53,7 @@ fn greater_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is greater than or equal to the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.greater_equal](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__ge__](
         tensor1, tensor2
     )
 
@@ -77,7 +77,7 @@ fn less[
 
     An element of the result Tensor will be True if the corresponding element in x is or equal to the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.less](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__lt__](
         tensor1, tensor2
     )
 
@@ -101,7 +101,7 @@ fn less_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is less than or equal to the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.less_equal](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__le__](
         tensor1, tensor2
     )
 
@@ -125,7 +125,7 @@ fn equal[
 
     An element of the result Tensor will be True if the corresponding element in x is equal to the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.equal](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__eq__](
         tensor1, tensor2
     )
 
@@ -149,6 +149,6 @@ fn not_equal[
 
     An element of the result Tensor will be True if the corresponding element in x is not equal to the corresponding element in y, and False otherwise.
     """
-    return backend()._math_func_compare_2_tensors[dtype, math.not_equal](
+    return backend()._math_func_compare_2_tensors[dtype, SIMD.__ne__](
         tensor1, tensor2
     )


### PR DESCRIPTION
Update to Mojo 24.4.

all instances of `.data()` are now `.unsafe_ptr`

abs, trunc, floor, ceil, and round are now tabs, ttrunc, tfloor, tceil because mojo is not seeing the overload even when called explicitly from Numojo.

Depricated:
* reciprocal
* is_even
* is_odd
* is_power_of_2

Weirdness:
* Benchmarking doesn't seem to work the same way anymore on the memory side, so there are segfaults when the bench.mojo file is run. I'm not sure why, I think it may have something to do with unsafe pointer conversion. Code otherwise works when not benchmarked.