### PR TITLE
Added doc strings, all, any, added some functionality to ndarray usinexisting stuff

### DIFF
--- a/numojo/core/_array_funcs.mojo
+++ b/numojo/core/_array_funcs.mojo
@@ -1,4 +1,4 @@
-from ..traits.NDArrayTraits import NDArrayBackend
+# from ..traits.NDArrayTraits import NDArrayBackend
 from algorithm.functional import parallelize, vectorize, num_physical_cores
 
 """

--- a/numojo/math/_math_funcs.mojo
+++ b/numojo/math/_math_funcs.mojo
@@ -1630,7 +1630,7 @@ struct VectorizedVerbose(Backend):
             array: A NDArray
 
         Returns:
-            A a new NDArray that is NDArray with the function func applied.
+            A new NDArray that is NDArray with the function func applied.
         """
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape())
         alias opt_nelts = simdwidthof[dtype]()

--- a/numojo/math/arithmetic.mojo
+++ b/numojo/math/arithmetic.mojo
@@ -644,7 +644,7 @@ fn tround[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](array: NDArray[dtype]) -> NDArray[dtype]:
     """
-    Elementwise  NDArray.
+    Elementwise round NDArray to whole number.
 
     Parameters:
         dtype: The element type.

--- a/numojo/math/check.mojo
+++ b/numojo/math/check.mojo
@@ -82,3 +82,43 @@ fn isnan[
         NDArray[DType.bool] - A array of the same shape as `array` with True for NaN elements and False for others.
     """
     return backend()._math_func_is[dtype, math.isnan](array)
+
+fn any(array: NDArray[DType.bool]) -> Scalar[DType.bool]:
+    """
+    If any True.
+
+    Args:
+        array: A NDArray.
+    Returns:
+        A boolean scalar
+    """
+    var result = Scalar[DType.bool](False)
+    alias opt_nelts: Int = simdwidthof[DType.bool]()
+
+    @parameter
+    fn vectorize_sum[simd_width: Int](idx: Int) -> None:
+        var simd_data = array.load[width=simd_width](idx)
+        result &= (simd_data.reduce_or())
+
+    vectorize[vectorize_sum, opt_nelts](array.num_elements())
+    return result
+
+fn all(array: NDArray[DType.bool]) -> Scalar[DType.bool]:
+    """
+    If all True.
+
+    Args:
+        array: A NDArray.
+    Returns:
+        A boolean scalar
+    """
+    var result = Scalar[DType.bool](True)
+    alias opt_nelts: Int = simdwidthof[DType.bool]()
+
+    @parameter
+    fn vectorize_sum[simd_width: Int](idx: Int) -> None:
+        var simd_data = array.load[width=simd_width](idx)
+        result |= (simd_data.reduce_and())
+
+    vectorize[vectorize_sum, opt_nelts](array.num_elements())
+    return result

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -57,7 +57,7 @@ fn binary_sort[
 # ===------------------------------------------------------------------------===#
 
 
-fn sum[
+fn cumsum[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) -> SIMD[out_dtype, 1]:
     """
@@ -84,7 +84,7 @@ fn sum[
     return result
 
 
-fn prod[
+fn cumprod[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) -> SIMD[out_dtype, 1]:
     """
@@ -117,7 +117,7 @@ fn prod[
 # ===------------------------------------------------------------------------===#
 
 
-fn mean[
+fn cummean[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) raises -> SIMD[out_dtype, 1]:
     """
@@ -137,7 +137,7 @@ fn mean[
             "Input and output cannot be `Int` datatype as it may lead to"
             " precision errors"
         )
-    return sum[in_dtype, out_dtype](array) / (array.num_elements())
+    return cumsum[in_dtype, out_dtype](array) / (array.num_elements())
 
 
 fn mode[
@@ -285,7 +285,7 @@ fn minT[
     return result.cast[out_dtype]()
 
 
-fn pvariance[
+fn cumpvariance[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](
     array: NDArray[in_dtype], mu: Optional[Scalar[in_dtype]] = None
@@ -312,7 +312,7 @@ fn pvariance[
 
     var mean_value: Scalar[out_dtype]
     if not mu:
-        mean_value = mean[in_dtype, out_dtype](array)
+        mean_value = cummean[in_dtype, out_dtype](array)
     else:
         mean_value = mu.value()[].cast[out_dtype]()
 
@@ -324,7 +324,7 @@ fn pvariance[
     return result / (array.num_elements())
 
 
-fn variance[
+fn cumvariance[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](
     array: NDArray[in_dtype], mu: Optional[Scalar[in_dtype]] = None
@@ -352,7 +352,7 @@ fn variance[
     var mean_value: Scalar[out_dtype]
 
     if not mu:
-        mean_value = mean[in_dtype, out_dtype](array)
+        mean_value = cummean[in_dtype, out_dtype](array)
     else:
         mean_value = mu.value()[].cast[out_dtype]()
 
@@ -363,7 +363,7 @@ fn variance[
     return result / (array.num_elements() - 1)
 
 
-fn pstdev[
+fn cumpstdev[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](
     array: NDArray[in_dtype], mu: Optional[Scalar[in_dtype]] = None
@@ -388,7 +388,7 @@ fn pstdev[
             "Input and output cannot be `Int` datatype as it may lead to"
             " precision errors"
         )
-    return math.sqrt(pvariance[in_dtype, out_dtype](array, mu))
+    return math.sqrt(cumpvariance[in_dtype, out_dtype](array, mu))
 
 
 fn stdev[
@@ -415,7 +415,7 @@ fn stdev[
             "Input and output cannot be `Int` datatype as it may lead to"
             " precision errors"
         )
-    return math.sqrt(variance[in_dtype, out_dtype](array, mu))
+    return math.sqrt(cumvariance[in_dtype, out_dtype](array, mu))
 
 
 # this roughly seems to be just an alias for min in numpy

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -1,6 +1,22 @@
+"""
+# ===----------------------------------------------------------------------=== #
+# implements array stats function and supporting functions
+# Last updated: 2024-06-18
+# ===----------------------------------------------------------------------=== #
+"""
 from numojo import NDArray
 
 fn sum(array:NDArray, axis:Int)raises->NDArray[array.dtype]:
+    """
+    Sum of array elements over a given axis.
+    Args:
+        array: NDArray.
+        axis: The axis along which the sum is performed.
+    Returns:
+        An NDArray.
+
+    """
+    
     var ndim: Int = array.info.ndim
     var shape: List[Int] = array.info.shape
     if axis > ndim-1:
@@ -25,6 +41,48 @@ fn sum(array:NDArray, axis:Int)raises->NDArray[array.dtype]:
     
     return result
 
+fn prod(array:NDArray, axis:Int)raises->NDArray[array.dtype]:
+    """
+    Product of array elements over a given axis.
+    Args:
+        array: NDArray.
+        axis: The axis along which the product is performed.
+    Returns:
+        An NDArray.
+
+    """
+    var ndim: Int = array.info.ndim
+    var shape: List[Int] = array.info.shape
+    if axis > ndim-1:
+        raise Error("axis cannot be greater than the rank of the array")
+    var result_shape: List[Int] = List[Int]()
+    var axis_size :Int = shape[axis]
+    var slices : List[Slice] = List[Slice]()
+    for i in range(ndim):
+        if i!=axis:
+            result_shape.append(shape[i])
+            slices.append(Slice(0,shape[i]))
+        else:
+            slices.append(Slice(0,0))
+    var result: numojo.NDArray[array.dtype] =  NDArray[array.dtype](result_shape)
+    
+    result+=1
+    
+    for i in range(axis_size):
+        slices[axis] = Slice(i,i+1)
+        var arr_slice = array[slices]
+        result = result * arr_slice
+    
+    return result
 
 fn mean(array:NDArray, axis:Int)raises->NDArray[array.dtype]:
+    """
+    Mean of array elements over a given axis.
+    Args:
+        array: NDArray.
+        axis: The axis along which the mean is performed.
+    Returns:
+        An NDArray.
+
+    """
     return sum(array, axis)/Scalar[array.dtype](array.shape().shape[axis])


### PR DESCRIPTION
Changed:
* All cumulative operations are now prefixed with cum example cumsum, to distinguish between cumulative and on axis.
* Moved most of the dunder math to _array_func implementations (the exception being pow).
Added:
* all and any functions to check currently require bool DType (we need to discuss applying truthiness to array members at some point)
* The following methods were implemented for NDArray cumprod, cumsum, prod, sum, and mean(both with and without axis).

