### PR TITLE
prod function always generates zeros

### DIFF
--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -70,8 +70,11 @@ fn _traverse_iterative[
         var nidx = _get_index(index, strides)
         var temp = orig.data.load[width=1](
             idx
-        )  # TODO: replace with load_unsafe later for reduced checks overhead
-        narr.__setitem__(nidx, temp)
+        )
+        if nidx >= narr.ndshape._size:
+            raise Error("Invalid index: index out of bound")
+        else:
+            narr.data.store[width=1](nidx, temp)
         return
 
     for i in range(ndim[depth]):

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -78,9 +78,11 @@ fn prod(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
     var result: NDArray[array.dtype] = NDArray[array.dtype](
         NDArrayShape(result_shape)
     )
-    # result += 1
 
-    for i in range(axis_size):
+    slices[axis] = Slice(0, 1)
+    result = array[slices]
+
+    for i in range(1, axis_size):
         slices[axis] = Slice(i, i + 1)
         var arr_slice = array[slices]
         result = result * arr_slice


### PR DESCRIPTION
The current prod function is not correct because it init an ndarray of zeros. Then the products will always be zeros. This pull request fix this.

Boundary check to enable _traverse_iterative to use store function without crash.