### PR TITLE
Add stats function sumall, prodall, meanall. Improve performance of matmul function

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -19,6 +19,8 @@
 
 from random import rand
 from builtin.math import pow
+from builtin.bool import all as allb
+from builtin.bool import any as anyb
 from algorithm import parallelize, vectorize
 
 import . _array_funcs as _af
@@ -33,6 +35,7 @@ from ..math.statistics.cumulative_reduce import (
 from ..math.check import any, all
 from ..math.arithmetic import abs
 from .ndarray_utils import _get_index, _traverse_iterative, to_numpy
+from .utility_funcs import is_inttype
 
 
 @register_passable("trivial")
@@ -474,16 +477,16 @@ struct NDArrayStride[dtype: DType = DType.int32](Stringable):
 
     @always_inline("nodebug")
     fn load[width: Int = 1](self, index: Int) raises -> SIMD[dtype, width]:
-        if index >= self._len:
-            raise Error("Index out of bound")
+        # if index >= self._len:
+        #     raise Error("Index out of bound")
         return self._stride.load[width=width](index)
 
     @always_inline("nodebug")
     fn store[
         width: Int = 1
     ](inout self, index: Int, val: SIMD[dtype, width]) raises:
-        if index >= self._len:
-            raise Error("Index out of bound")
+        # if index >= self._len:
+        #     raise Error("Index out of bound")
         self._stride.store[width=width](index, val)
 
     @always_inline("nodebug")
@@ -797,9 +800,9 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         self.order = existing.order
         self.data = existing.data
 
-    # @always_inline("nodebug")
-    # fn __del__(owned self):
-    #     self.data.free()
+    @always_inline("nodebug")
+    fn __del__(owned self):
+        self.data.free()
 
     # ===-------------------------------------------------------------------===#
     # Operator dunders
@@ -951,11 +954,16 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
 
         var ndims: Int = 0
         var spec: List[Int] = List[Int]()
+        var count: Int = 0
         for i in range(slices.__len__()):
             self._adjust_slice_(slices[i], self.ndshape[i])
             spec.append(slices[i].unsafe_indices())
             if slices[i].unsafe_indices() != 1:
                 ndims += 1
+            else:
+                count += 1
+        if count == slices.__len__():
+            ndims = 1
 
         var nshape: List[Int] = List[Int]()
         var ncoefficients: List[Int] = List[Int]()
@@ -963,8 +971,10 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         var nnum_elements: Int = 1
 
         var j: Int = 0
+        count = 0
         for _ in range(ndims):
             while spec[j] == 1:
+                count+=1
                 j += 1
             if j >= self.ndim:
                 break
@@ -972,6 +982,11 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
             nnum_elements *= slices[j].unsafe_indices()
             ncoefficients.append(self.stride[j] * slices[j].step)
             j += 1
+
+        if count == slices.__len__():
+            nshape.append(1)
+            nnum_elements = 1
+            ncoefficients.append(1)
 
         var noffset: Int = 0
         if self.order == "C":
@@ -1007,6 +1022,7 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         var index = List[Int]()
         for _ in range(ndims):
             index.append(0)
+
         _traverse_iterative[dtype](
             self, narr, nshape, ncoefficients, nstrides, noffset, index, 0
         )
@@ -1411,25 +1427,67 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
     # # not urgent: argpartition, byteswap, choose, conj, dump, getfield
     # # partition, put, repeat, searchsorted, setfield, squeeze, swapaxes, take,
     # # tobyets, tofile, view
+    # TODO: Implement axis parameter for all
 
-    fn all(self):
+    fn all(self) raises -> Bool:
+        # make this a compile time check
+        if not (self.dtype == DType.bool or is_inttype(dtype)):
+            raise Error("Array elements must be Boolean or Integer.")
         # We might need to figure out how we want to handle truthyness before can do this
+        alias nelts: Int = simdwidthof[dtype]()
+        var result: Bool = True
+        @parameter
+        fn vectorized_all[simd_width: Int](idx: Int) -> None:
+            result = result and allb(self.data.load[width=simd_width](idx) ) 
+        vectorize[vectorized_all, nelts](self.ndshape._size)
+        return result 
+
+    fn any(self) raises -> Bool:
+        # make this a compile time check
+        if not (self.dtype == DType.bool or is_inttype(dtype)):
+            raise Error("Array elements must be Boolean or Integer.")
+        alias nelts: Int = simdwidthof[dtype]()
+        var result: Bool = False 
+        @parameter
+        fn vectorized_any[simd_width: Int](idx: Int) -> None:
+            result = result or anyb(self.data.load[width=simd_width](idx) ) 
+        vectorize[vectorized_any, nelts](self.ndshape._size)
+        return result
+
+    fn argmax(self) -> Int:
+        var result: Int = 0
+        var max_val: SIMD[dtype, 1] = self.load[width=1](0)
+        for i in range(1, self.ndshape._size):
+            var temp: SIMD[dtype, 1] = self.load[width=1](i) 
+            if  temp > max_val:
+                max_val = temp 
+                result = i
+        return result
+
+    fn argmin(self) -> Int:
+        var result: Int = 0
+        var min_val: SIMD[dtype, 1] = self.load[width=1](0)
+        for i in range(1, self.ndshape._size):
+            var temp: SIMD[dtype, 1] = self.load[width=1](i) 
+            if  temp < min_val:
+                min_val = temp 
+                result = i
+        return result
+
+    fn argsort(self):
         pass
 
-    # fn any(self):
-    #     pass
+    fn astype[type: DType](inout self) raises -> NDArray[type]:
+        # I wonder if we can do this operation inplace instead of allocating memory.
+        alias nelts = simdwidthof[dtype]()
+        var narr: NDArray[type] = NDArray[type](self.ndshape, random=False, order=self.order)
+        narr.datatype = type
+        @parameter
+        fn vectorized_astype[width: Int](idx: Int) -> None:
+            narr.store[width](idx, self.load[width](idx).cast[type]())
 
-    # fn argmax(self):
-    #     pass
-
-    # fn argmin(self):
-    #     pass
-
-    # fn argsort(self):
-    #     pass
-
-    # fn astype(self):
-    #     pass
+        vectorize[vectorized_astype, nelts](self.ndshape._size)    
+        return narr
 
     # fn clip(self):
     #     pass
@@ -1471,10 +1529,15 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         vectorize[vectorized_fill, simd_width](self.ndshape._size)
         return self
 
-    fn flatten(inout self) raises -> Self:
-        var res: NDArray[dtype] = NDArray[dtype](self.ndshape._size)
-        alias simd_width: Int = simdwidthof[dtype]()
+    fn flatten(inout self, inplace: Bool = False) raises -> Self:
+        # inplace has some problems right now
+        # if inplace:
+        #     self.ndshape = NDArrayShape(self.ndshape._size, size=self.ndshape._size)
+        #     self.stride = NDArrayStride(shape = self.ndshape, offset=0)
+        #     return self
 
+        var res: NDArray[dtype] = NDArray[dtype](self.ndshape._size, random=False)
+        alias simd_width: Int = simdwidthof[dtype]()
         @parameter
         fn vectorized_flatten[simd_width: Int](index: Int) -> None:
             res.data.store[width=simd_width](
@@ -1490,7 +1553,8 @@ struct NDArray[dtype: DType = DType.float32](Stringable):
         else:
             return self.data.load[width=1](_get_index(indices, self.stride))
 
-    fn max(self, axis: Int = 0) raises -> Self:
+    #TODO:  not finished yet
+    fn max(self, axis: Int = 0) raises -> Self: 
         var ndim: Int = self.ndim
         var shape: List[Int] = List[Int]()
         for i in range(ndim):

--- a/numojo/core/utility_funcs.mojo
+++ b/numojo/core/utility_funcs.mojo
@@ -17,6 +17,16 @@ fn is_inttype[dtype: DType]() -> Bool:
     return False
 
 
+fn is_inttype(dtype: DType) -> Bool:
+    if (
+        dtype == DType.int8
+        or dtype == DType.int16
+        or dtype == DType.int32
+        or dtype == DType.int64
+    ):
+        return True
+    return False
+
 fn is_floattype[dtype: DType]() -> Bool:
     if (
         dtype == DType.float16

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -100,6 +100,19 @@ fn prod(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
 
     return result
 
+fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
+    """
+    Product of all items in the array.
+    Args:
+        array: NDArray.
+    Returns:
+        Scalar.
+    """
+
+    var result = Scalar[array.dtype](1)
+    for i in range(array.ndshape._size):
+            result[0] *= array.data[i]
+    return result
 
 fn mean(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
     """

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -8,7 +8,7 @@
 from ...core.ndarray import NDArray
 
 
-fn sum(array: NDArray, axis: Int=0) raises -> NDArray[array.dtype]:
+fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     """
     Sum of array elements over a given axis.
     Args:
@@ -60,7 +60,7 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
             result[0] += array.data[i]
     return result
 
-fn prod(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
+fn prod(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     """
     Product of array elements over a given axis.
     Args:
@@ -114,7 +114,7 @@ fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
             result[0] *= array.data[i]
     return result
 
-fn mean(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
+fn mean(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     """
     Mean of array elements over a given axis.
     Args:

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -8,7 +8,7 @@
 from ...core.ndarray import NDArray
 
 
-fn sum(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
+fn sum(array: NDArray, axis: Int=-1) raises -> NDArray[array.dtype]:
     """
     Sum of array elements over a given axis.
     Args:
@@ -48,6 +48,19 @@ fn sum(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
 
     return result
 
+fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
+    """
+    Sum of all items in the array.
+    Args:
+        array: NDArray.
+    Returns:
+        Scalar.
+    """
+
+    var result = Scalar[array.dtype](0)
+    for i in range(array.ndshape._size):
+            result[0] += array.data[i]
+    return result
 
 fn prod(array: NDArray, axis: Int) raises -> NDArray[array.dtype]:
     """

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -8,7 +8,7 @@
 from ...core.ndarray import NDArray
 
 
-fn sum(array: NDArray, axis: Int=-1) raises -> NDArray[array.dtype]:
+fn sum(array: NDArray, axis: Int=0) raises -> NDArray[array.dtype]:
     """
     Sum of array elements over a given axis.
     Args:
@@ -38,8 +38,6 @@ fn sum(array: NDArray, axis: Int=-1) raises -> NDArray[array.dtype]:
     var result: NDArray[array.dtype] = NDArray[array.dtype](
         NDArrayShape(result_shape)
     )
-
-    # result += 0
 
     for i in range(axis_size):
         slices[axis] = Slice(i, i + 1)

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -125,3 +125,15 @@ fn mean(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
 
     """
     return sum(array, axis) / Scalar[array.dtype](array.ndshape[axis])
+
+fn meanall(array: NDArray) raises -> Float64:
+    """
+    Mean of all items in the array.
+    Args:
+        array: NDArray.
+    Returns:
+        Float64.
+
+    """
+
+    return sumall(array).cast[DType.float64]() / Int32(array.ndshape._size).cast[DType.float64]()


### PR DESCRIPTION
## Add functions in stats

Add stats function `sumall`, `prodall`, `meanall` which return a scalar of all items in an array.

Set the default axis of `sum`, `prod`, `mean` to `0`.

## Add function `matmul_parallelized_simd`

Compared to `matmul_parallelized`, this function increase the size of the SIMD vector from the default width to 16. The purpose is to increase the performance via SIMD. The function reduces the execution time by ~50% compared to `matmul_parallelized` and `matmul_tiled_unrolled_parallelized` for large matrices.

Example: two 1000x1000 matrices, 100 times:

```
==================================================
Matmul paralelled CxC
0.13595043000000001 s

[[      -23.483741841786355     -15.701597076540736     26.473091851878582      ...    -31.718022704728931      1.6964271388761831      28.632800765314453      ]
 [      -43.233593257424936     17.049138931287565      32.618187250485185      ...    18.783659991176876       27.92076483390781       3.9659833391638917      ]
 [      47.14442157400314       -60.806358543680417     36.401417494961457      ...    -8.6906117952914155      -12.97988096709012      4.8113582294888371      ]
...
 [      55.72750917086443       -31.878635011324135     5.0798819981552237      ...    0.69397495367225526      13.068364470346129      -23.380195913699559     ]
 [      22.835549164834685      -24.886999375511106     -13.959557015048651     ...    43.575505939403563       56.757641404795976      -2.6661609432295559     ]
 [      -42.676020059673355     11.693076330239709      6.6692060208009742      ...    -16.198446613171239      -0.96172564005890637    -38.374990575773573     ]]
Shape: [1000, 1000]  DType: float64

==================================================
Matmul paralelled tiled unrolling CxC
0.14608930000000001 s

[[      -23.483741841786355     -15.701597076540736     26.473091851878582      ...    -31.718022704728931      1.6964271388761831      28.632800765314453      ]
 [      -43.233593257424936     17.049138931287565      32.618187250485185      ...    18.783659991176876       27.92076483390781       3.9659833391638917      ]
 [      47.14442157400314       -60.806358543680417     36.401417494961457      ...    -8.6906117952914155      -12.97988096709012      4.8113582294888371      ]
...
 [      55.72750917086443       -31.878635011324135     5.0798819981552237      ...    0.69397495367225526      13.068364470346129      -23.380195913699559     ]
 [      22.835549164834685      -24.886999375511106     -13.959557015048651     ...    43.575505939403563       56.757641404795976      -2.6661609432295559     ]
 [      -42.676020059673355     11.693076330239709      6.6692060208009742      ...    -16.198446613171239      -0.96172564005890637    -38.374990575773573     ]]
Shape: [1000, 1000]  DType: float64

==================================================
Matmul paralelled with larger SIMD vector CxC
0.069114350000000005 s

[[      -23.483741841786355     -15.701597076540736     26.473091851878582      ...    -31.718022704728931      1.6964271388761831      28.632800765314453      ]
 [      -43.233593257424936     17.049138931287565      32.618187250485185      ...    18.783659991176876       27.92076483390781       3.9659833391638917      ]
 [      47.14442157400314       -60.806358543680417     36.401417494961457      ...    -8.6906117952914155      -12.97988096709012      4.8113582294888371      ]
...
 [      55.72750917086443       -31.878635011324135     5.0798819981552237      ...    0.69397495367225526      13.068364470346129      -23.380195913699559     ]
 [      22.835549164834685      -24.886999375511106     -13.959557015048651     ...    43.575505939403563       56.757641404795976      -2.6661609432295559     ]
 [      -42.676020059673355     11.693076330239709      6.6692060208009742      ...    -16.198446613171239      -0.96172564005890637    -38.374990575773573     ]]
Shape: [1000, 1000]  DType: float64
```

