### PR TITLE
Add bubble sort and quick sort

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1705,8 +1705,8 @@ struct NDArray[dtype: DType = DType.float32](Stringable, Sized):
     # fn round(self):
     #     pass
 
-    # fn sort(self):
-    #     pass
+    fn sort(self) raises -> Self:
+        return numojo.core.sort.quick_sort(self)
 
     fn sum(self: Self, axis: Int) raises -> Self:
         """

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -12,6 +12,8 @@ from ..core.ndarray import NDArray, NDArrayShape
 """
 TODO: 
 1) Add more sorting algorithms.
+2) Add argument "inplace" for some functions.
+3) Add axis.
 """
 
 # ===------------------------------------------------------------------------===#
@@ -33,7 +35,7 @@ fn bubble_sort[
         dtype: The input element type.
 
     Args:
-        ndarray: A NDArray.
+        ndarray: An NDArray.
 
     Returns:
         The sorted NDArray.
@@ -47,5 +49,80 @@ fn bubble_sort[
                 var temp = result.data.load[width=1](j)
                 result.data.store[width=1](j, result.data.load[width=1](j+1))
                 result.data.store[width=1](j+1, temp)
+
+    return result
+
+
+# ===------------------------------------------------------------------------===#
+# Quick sort
+# ===------------------------------------------------------------------------===#
+
+fn _partition(
+    inout ndarray: NDArray, 
+    left: Int, 
+    right: Int, 
+    pivot_index: Int
+    ) raises -> Int:
+    
+    var pivot_value = ndarray[pivot_index]
+    ndarray[pivot_index], ndarray[right] = ndarray[right], ndarray[pivot_index]
+    var store_index = left
+
+    for i in range(left, right):
+        if ndarray[i] < pivot_value:
+            ndarray[store_index], ndarray[i] = ndarray[i], ndarray[store_index]
+            store_index = store_index + 1
+    ndarray[right], ndarray[store_index] = ndarray[store_index], ndarray[right]
+    
+    return store_index
+
+fn quick_sort_inplace[dtype: DType](
+    inout ndarray: NDArray[dtype],
+    left: Int,
+    right: Int,
+    ) raises:
+    """
+    Quick sort (in-place) the NDArray.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        ndarray: An NDArray.
+        left: Left index of the partition.
+        right: Right index of the partition.
+    """
+
+    if right > left:
+        var pivot_index = left + (right - left) // 2
+        var pivot_new_index = _partition(ndarray, left, right, pivot_index)
+        quick_sort_inplace(ndarray, left, pivot_new_index-1)
+        quick_sort_inplace(ndarray, pivot_new_index+1, right)
+
+fn quick_sort[dtype: DType](
+    ndarray: NDArray[dtype],
+    ) raises -> NDArray[dtype]:
+    """
+    Quick sort the NDArray.
+    Adopt in-place partition.
+    Average complexity: O(nlogn).
+    Worst-case complexity: O(n^2).
+    Worst-case space complexity: O(n).
+    Unstable.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        ndarray: An NDArray.
+
+    Returns:
+        The sorted NDArray.
+    """
+
+    var result: NDArray[dtype] = ndarray
+    var length = ndarray.size()
+
+    quick_sort_inplace(result, 0, length-1)
 
     return result

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -1,0 +1,51 @@
+"""
+# ===----------------------------------------------------------------------=== #
+# Sort Module - Implements sort functions
+# Last updated: 2024-06-20
+# ===----------------------------------------------------------------------=== #
+"""
+
+import math
+from algorithm import vectorize
+from ..core.ndarray import NDArray, NDArrayShape
+
+"""
+TODO: 
+1) Add more sorting algorithms.
+"""
+
+# ===------------------------------------------------------------------------===#
+# Bubble sort
+# ===------------------------------------------------------------------------===#
+
+fn bubble_sort[
+    dtype: DType
+    ](
+        ndarray: NDArray[dtype]
+        ) raises -> NDArray[dtype]:
+    """
+    Bubble sort the NDArray.
+    Average complexity: O(n^2) comparisons, O(n^2) swaps.
+    Worst-case complexity: O(n^2) comparisons, O(n^2) swaps.
+    Worst-case space complexity: O(n).
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        ndarray: A NDArray.
+
+    Returns:
+        The sorted NDArray.
+    """
+    var result: NDArray[dtype] = ndarray
+    var length = ndarray.size()
+
+    for i in range(length):
+        for j in range(length-i-1):
+            if result.data.load[width=1](j) > result.data.load[width=1](j+1):
+                var temp = result.data.load[width=1](j)
+                result.data.store[width=1](j, result.data.load[width=1](j+1))
+                result.data.store[width=1](j+1, temp)
+
+    return result


### PR DESCRIPTION
Add bubble sort and quick sort in `numojo.core.sort` module. Implement the `sort` method using the quick sort algorithm. 

The location of the module is similar to the Numpy (`numpy._core.npysort`).

There is also a `binary_sort` function in the `numojo.math.statistics.cumulative_reduce`. I personally prefer a standalone `sort` module because the sorting functions are quite essential. Let's keep it an open discussion.

Test with an array of 10000 Float64 numbers, 1000 times.

```
Original array

[[      -1.2397359036589188     1.6120094337313993      1.3828016699156287      ...     -0.96682603166308989    -1.2589781838685108     -1.2540323302923684       ]]
Shape: [1, 10000]  DType: float64

==================================================
Binary sort
0.109690972 s

[[      -3.9278628912283353     -3.340264055200961      -3.2176295771029255     ...     3.9035814954840511      3.9165463112981165      4.1622896659028186        ]]
Shape: [1, 10000]  DType: float64

==================================================
Bubble sort
0.101396972 s

[[      -3.9278628912283353     -3.340264055200961      -3.2176295771029255     ...     3.9035814954840511      3.9165463112981165      4.1622896659028186        ]]
Shape: [1, 10000]  DType: float64

==================================================
Quick sort
0.00059504199999999995 s

[[      -3.9278628912283353     -3.340264055200961      -3.2176295771029255     ...     3.9035814954840511      3.9165463112981165      4.1622896659028186        ]]
Shape: [1, 10000]  DType: float64

==================================================
ndarray.sort method adopting quick sort
0.000594846 s

[[      -3.9278628912283353     -3.340264055200961      -3.2176295771029255     ...     3.9035814954840511      3.9165463112981165      4.1622896659028186        ]]
Shape: [1, 10000]  DType: float64
```