### PR TITLE
[lib] Remove matmul_parallelized_simd as it is the same with the matmul_parallelized

### DIFF
--- a/numojo/math/__init__.mojo
+++ b/numojo/math/__init__.mojo
@@ -2,9 +2,9 @@ from .arithmetic import *
 from .check import *
 from .trig import *
 from .comparison import *
-import .linalg
-import .statistics
-import .calculus
+from .linalg import *
+from .statistics import *
+from .calculus import *
 from ._math_funcs import (
     Vectorized,
     VectorizedParallelized,

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -80,7 +80,9 @@ fn matmul_parallelized[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Compared to matmul_parallelized, this function increase the size of 
+    Reference: https://docs.modular.com/mojo/notebooks/Matmul
+
+    Compared to `matmul_parallelized`, this function increase the size of 
     the SIMD vector from the default width to 16. The purpose is to 
     increase the performance via SIMD.
     The function reduces the execution time by ~50 percent compared to

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -79,35 +79,6 @@ fn matmul_tiled_unrolled_parallelized[
 fn matmul_parallelized[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
-    alias nelts = max(simdwidthof[dtype](), 16)
-    var C: NDArray[dtype] = NDArray[dtype](
-        A.ndshape.load_int(0), B.ndshape.load_int(1)
-    )
-    var t0 = A.ndshape.load_int(0)
-    var t1 = A.ndshape.load_int(1)
-    var t2 = B.ndshape.load_int(1)
-
-    @parameter
-    fn calculate_A_rows(m: Int):
-        for k in range(t1):
-
-            @parameter
-            fn dot[nelts: Int](n: Int):
-                C.store(
-                    m * t2 + n,
-                    val=C.load[nelts](m * t2 + n)
-                    + A.load(m * t1 + k) * B.load[nelts](k * t2 + n),
-                )
-
-            vectorize[dot, nelts](t2)
-
-    parallelize[calculate_A_rows](t0, t0)
-    return C
-
-
-fn matmul_parallelized_simd[
-    dtype: DType
-](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Compared to matmul_parallelized, this function increase the size of 
     the SIMD vector from the default width to 16. The purpose is to 


### PR DESCRIPTION
Remove matmul_parallelized_simd as it is the same with the matmul_parallelized after introducing a nelt of 16. Updated the docstring.

Import all functions for the statistics and matmul modules.