### PR TITLE
Update `to_numpy` function so that multiple data types are allowed.

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1770,5 +1770,5 @@ struct NDArray[dtype: DType = DType.float32](Stringable, CollectionElement, Size
     fn unsafe_ptr(self) -> DTypePointer[dtype, 0]:
         return self.data
 
-    fn to_numpy(self) -> PythonObject:
+    fn to_numpy(self) raises -> PythonObject:
         return to_numpy(self)

--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -85,7 +85,7 @@ fn _traverse_iterative[
         )
 
 
-fn to_numpy(array: NDArray) -> PythonObject:
+fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
     try:
         var np = Python.import_module("numpy")
 
@@ -99,15 +99,26 @@ fn to_numpy(array: NDArray) -> PythonObject:
 
         # Implement a dictionary for this later
         var numpyarray: PythonObject
-        if array.datatype == DType.float16:
-            numpyarray = np.empty(np_arr_dim, dtype=np.float16)
-            var pointer = int(
-                numpyarray.__array_interface__["data"][0].to_float16()
-            )
-            var pointer_d = DTypePointer[array.dtype](address=pointer)
-            memcpy(pointer_d, array.data, array.num_elements())
-        else:
-            raise Error("Only f16 numpy at this time")
+
+        var np_dtype = np.float64
+        if dtype == DType.float16:
+            np_dtype = np.float16
+        elif dtype == DType.float32:
+            np_dtype = np.float32
+        elif dtype == DType.int64:
+            np_dtype = np.int64
+        elif dtype == DType.int32:
+            np_dtype = np.int32
+        elif dtype == DType.int16:
+            np_dtype = np.int16
+        elif dtype == DType.int8:
+            np_dtype = np.int8
+
+        numpyarray = np.empty(np_arr_dim, dtype=np_dtype)
+        var pointer = numpyarray.__array_interface__["data"][0]
+        var pointer_d = DTypePointer[array.dtype](address=pointer)
+        memcpy(pointer_d, array.data, array.num_elements())
+
         # elif array.datatype == DType.float32:
         #     numpyarray = np.empty(np_arr_dim, dtype=np.float32)
         #     var pointer = int(numpyarray.__array_interface__["data"][0].to_float32())


### PR DESCRIPTION
Update `to_numpy` function so that multiple data types are allowed.

Example:
```
import numojo as nm
from python import Python

fn main() raises:
    var array = nm.NDArray[nm.i32](1000,1000,random=True)
    print(array.to_numpy())
```

float64:
```
[[0.085  0.8916 0.1897 ... 0.5549 0.2582 0.0078]
 [0.8286 0.6087 0.1889 ... 0.8907 0.6361 0.82  ]
 [0.6088 0.0533 0.7494 ... 0.0336 0.7792 0.7019]
 ...
 [0.7376 0.4745 0.6004 ... 0.1094 0.8473 0.231 ]
 [0.3293 0.7703 0.4481 ... 0.1036 0.252  0.1913]
 [0.8816 0.6159 0.8896 ... 0.5805 0.7877 0.0112]]
```

int32:
```
[[ 1015961569 -1622847108  2029044002 ...  -454831891  1704168191
   1437546358]
 [ -520992968 -1055649167  -126675237 ...   -67502823 -1586034558
   -316907984]
 [-1275429598 -1923702087   133396804 ... -1838852486   688436754
  -1148766235]
 ...
 [  826482507  1735843351   885640559 ...   635159423  1318392211
   1438666918]
 [ 1004778054  1109507528  1954911815 ...   175739532 -1995920687
   -585378106]
 [  489140068 -1218268742 -2041196043 ...  -457175955  1927216093
  -1085590885]]
```