### PR TITLE
[lib] Implement the `argsort` functionality

### DIFF
--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -155,3 +155,99 @@ fn binary_sort[
                 result[i - 1] = result[i]
                 result[i] = temp
     return result
+
+
+# ===------------------------------------------------------------------------===#
+# Argsort using quick sort algorithm
+# ===------------------------------------------------------------------------===#
+
+
+fn _argsort_partition(
+    inout ndarray: NDArray,
+    inout idx_array: NDArray,
+    left: Int,
+    right: Int,
+    pivot_index: Int,
+) raises -> Int:
+    var pivot_value = ndarray[pivot_index]
+    ndarray[pivot_index], ndarray[right] = ndarray[right], ndarray[pivot_index]
+    idx_array[pivot_index], idx_array[right] = (
+        idx_array[right],
+        idx_array[pivot_index],
+    )
+    var store_index = left
+
+    for i in range(left, right):
+        if ndarray[i] < pivot_value:
+            ndarray[store_index], ndarray[i] = ndarray[i], ndarray[store_index]
+            idx_array[store_index], idx_array[i] = (
+                idx_array[i],
+                idx_array[store_index],
+            )
+            store_index = store_index + 1
+
+    ndarray[right], ndarray[store_index] = ndarray[store_index], ndarray[right]
+    idx_array[right], idx_array[store_index] = (
+        idx_array[store_index],
+        idx_array[right],
+    )
+
+    return store_index
+
+
+fn argsort_inplace[
+    dtype: DType
+](
+    inout ndarray: NDArray[dtype],
+    inout idx_array: NDArray[DType.int32],
+    left: Int,
+    right: Int,
+) raises:
+    """
+    Conduct Argsort (in-place) based on the NDArray using quick sort.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        ndarray: An NDArray.
+        idx_array: An NDArray of the indices.
+        left: Left index of the partition.
+        right: Right index of the partition.
+    """
+
+    if right > left:
+        var pivot_index = left + (right - left) // 2
+        var pivot_new_index = _argsort_partition(
+            ndarray, idx_array, left, right, pivot_index
+        )
+        argsort_inplace(ndarray, idx_array, left, pivot_new_index - 1)
+        argsort_inplace(ndarray, idx_array, pivot_new_index + 1, right)
+
+
+fn argsort[
+    dtype: DType
+](ndarray: NDArray[dtype],) raises -> NDArray[DType.int32]:
+    """
+    Argsort of the NDArray using quick sort algorithm.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        ndarray: An NDArray.
+
+    Returns:
+        The indices of the sorted NDArray.
+    """
+
+    var array: NDArray[dtype] = ndarray
+    var length = array.size()
+
+    var idx_array = NDArray[DType.int32](length)
+    for i in range(length):
+        idx_array[i] = i
+
+    argsort_inplace(array, idx_array, 0, length - 1)
+
+    return idx_array

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -199,7 +199,7 @@ fn argsort_inplace[
     dtype: DType
 ](
     inout ndarray: NDArray[dtype],
-    inout idx_array: NDArray[DType.int32],
+    inout idx_array: NDArray[DType.index],
     left: Int,
     right: Int,
 ) raises:
@@ -227,7 +227,7 @@ fn argsort_inplace[
 
 fn argsort[
     dtype: DType
-](ndarray: NDArray[dtype],) raises -> NDArray[DType.int32]:
+](ndarray: NDArray[dtype],) raises -> NDArray[DType.index]:
     """
     Argsort of the NDArray using quick sort algorithm.
 
@@ -244,7 +244,7 @@ fn argsort[
     var array: NDArray[dtype] = ndarray
     var length = array.size()
 
-    var idx_array = NDArray[DType.int32](length)
+    var idx_array = NDArray[DType.index](length)
     for i in range(length):
         idx_array[i] = i
 

--- a/tests/argsort.mojo
+++ b/tests/argsort.mojo
@@ -1,0 +1,19 @@
+# Test file for
+# numojo.core.sort.argsort()
+
+import numojo as nm
+from numojo.core.ndarray import NDArray
+import time
+
+fn main() raises:
+    test[nm.f64](6)
+    test[nm.i32](12)
+    test[nm.f64](1000)
+
+fn test[dtype: DType](length: Int) raises:
+    # Initialize an ND arrays of type
+    var t0 = time.now()
+    var A = NDArray[dtype](length, random=True)
+    print(A)
+    print(nm.core.sort.argsort(A))
+    print((time.now() - t0)/1e9, "s")


### PR DESCRIPTION
Implement the `argsort` function. Add a test file.

Test results:

```console
[       0.085032448717433665    0.89161127730485756     0.18968977189964392     0.39800838814628897     0.74351245153226475     0.56038992815200594     ]
Shape: [6]  DType: float64

[       0       2       3       5       4       1       ]
Shape: [6]  DType: index

0.000174 s
==============================

[       11198796        2124991490      170454577       ...     1417941715      43647677        -248010538      ]
Shape: [12]  DType: int32

[       7       11      4       ...     5       9       1       ]
Shape: [12]  DType: index

7.8999999999999996e-05 s
==============================

[       0.54427280173529258     0.093629911904999585    0.43225952539313756     ...     0.34496925357704927     0.47419842610100349     0.15551212399418565]
Shape: [1000]  DType: float64

[       122     968     613     ...     831     565     651     ]
Shape: [1000]  DType: index

0.00018799999999999999 s
==============================
```