### PR TITLE
[lib] Remove extra line when print array

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1259,7 +1259,6 @@ struct NDArray[dtype: DType = DType.float32](
                 + self.ndshape.__str__()
                 + "  DType: "
                 + self.dtype.__str__()
-                + "\n"
             )
         except e:
             print("Cannot convert array to string", e)


### PR DESCRIPTION
Currently, the `__str__` method of `NDArray` adds an extra `\n` at the end of the string. This causes an extra line to be printed when `print(array)` is used. This PR fixes this.