### PR TITLE
Iter

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -516,9 +516,6 @@ struct _NDArrayIter[
         lifetime: The lifetime of the underlying NDArray data.
         dtype: The data type of the item.
         forward: The iteration direction. `False` is backwards.
-
-    Notes:
-        Need to add lifetimes after the new release.
     """
 
     var index: Int

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -17,6 +17,7 @@
 10) Add List[Int] and Variadic[Int] Shape args for __init__ to make it more flexible
 """
 
+from builtin.type_aliases import AnyLifetime
 from random import rand
 from builtin.math import pow
 from builtin.bool import all as allb
@@ -503,12 +504,16 @@ struct NDArrayStride[dtype: DType = DType.int32](Stringable):
 
 @value
 struct _NDArrayIter[
+    is_mutable: Bool, //,
+    lifetime: AnyLifetime[is_mutable].type,
     dtype: DType,
     forward: Bool = True,
 ]:
     """Iterator for NDArray.
 
     Parameters:
+        is_mutable: Wether the iterator is mutable.
+        lifetime: The lifetime of the underlying NDArray data.
         dtype: The data type of the item.
         forward: The iteration direction. `False` is backwards.
 
@@ -1259,7 +1264,6 @@ struct NDArray[dtype: DType = DType.float32](
                 + self.ndshape.__str__()
                 + "  DType: "
                 + self.dtype.__str__()
-                + "\n"
             )
         except e:
             print("Cannot convert array to string", e)
@@ -1268,7 +1272,7 @@ struct NDArray[dtype: DType = DType.float32](
     fn __len__(self) -> Int:
         return self.ndshape._size
 
-    fn __iter__(self) -> _NDArrayIter[dtype]:
+    fn __iter__(self) -> _NDArrayIter[__lifetime_of(self), dtype]:
         """Iterate over elements of the NDArray, returning copied value.
 
         Returns:
@@ -1278,12 +1282,12 @@ struct NDArray[dtype: DType = DType.float32](
             Need to add lifetimes after the new release.
         """
 
-        return _NDArrayIter[dtype](
+        return _NDArrayIter[__lifetime_of(self), dtype](
             unsafe_pointer=self.data,
             length=len(self),
         )
 
-    fn __reversed__(self) -> _NDArrayIter[dtype, forward=False]:
+    fn __reversed__(self) -> _NDArrayIter[__lifetime_of(self), dtype, forward=False]:
         """Iterate backwards over elements of the NDArray, returning
         copied value.
 
@@ -1291,7 +1295,7 @@ struct NDArray[dtype: DType = DType.float32](
             A reversed iterator of NDArray elements.
         """
 
-        return _NDArrayIter[dtype, forward=False](
+        return _NDArrayIter[__lifetime_of(self), dtype, forward=False](
             unsafe_pointer=self.data,
             length=len(self),
         )

--- a/tests/iter.mojo
+++ b/tests/iter.mojo
@@ -1,0 +1,16 @@
+# Test file for `__iter__` method of `NDArray`
+
+import numojo as nm
+
+fn main() raises:
+    test[nm.i8](10)
+    test[nm.f64](20)
+
+fn test[dtype: DType](length: Int) raises:
+    var A = nm.NDArray[dtype](length, random=True)
+    print(A)
+    print("Iterate over the array:")
+    for i in A:
+        print(i, end="\t")
+    print()
+    print(str("=") * 30)


### PR DESCRIPTION
PR #43 introduced iterator of NDArray. Due to ASAP destruction of the variables, the array is destroyed after the last use, meaning that the user to manually call it after the iterator to extend its lifetime. Otherwise, there is a dangling pointer.

```mojo
var A = nm.NDArray(10, random=True)
for i in A: 
    print(i, end="\t")  # dangling pointer! Unexpected printing results.
var _ = A^  # Force A's lifetime to be extended to here.
```

This is now fixed by using built-in `AnyLifetime` type to explicitly indicate the lifetime of the pointer.

Test code:

```mojo
import numojo as nm

fn main() raises:
    test[nm.i8](10)
    test[nm.f64](20)

fn test[dtype: DType](length: Int) raises:
    var A = nm.NDArray[dtype](length, random=True)
    print(A)
    print("Iterate over the array:")
    for i in A:
        print(i, end="\t")
    print()
    print(str("=") * 30)
```

Test results:

```console
[       14      97      -59     ...     -40     66      -2      ]
Shape: [10]  DType: int8
Iterate over the array:
14      97      -59     -4      112     -94     -48     -40     66      -2
==============================

[       0.56038992815200594     0.80956665342737133     0.51171255280046901     ...     0.77284646408542756     0.19185895447404114     0.78036676197514943     ]
Shape: [20]  DType: float64
Iterate over the array:
0.56038992815200594     0.80956665342737133     0.51171255280046901     0.99508454830702531     0.96661136330079034     0.42605082744229772     0.65299872691067640.96153310957578975      0.85798733908715086     0.29402614920162445     0.41464457882825878     0.51489290517673014     0.78978453202871557     0.544272801735292580.093629911904999585    0.43225952539313756     0.84492743866956055     0.77284646408542756     0.19185895447404114     0.78036676197514943
==============================
```