### PR TITLE
Remove References to tensor and fix some doctrings

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -53,8 +53,8 @@
 
 NuMojo intends to capture a wide swath of numerics capability present in the Python packages NumPy, SciPy and Scikit.
 
-NuMojo intends to try and get the most out of the capabilities of Mojo including vectorization, parallelization, and GPU acceleration(once available). Currently, NuMojo extends (most of) the standard library math functions to work on tensor inputs.
-NuMojo intends to try and get the most out of the capabilities of Mojo including vectorization, parallelization, and GPU acceleration(once available). Currently, NuMojo extends (most of) the standard library math functions to work on tensor inputs.
+NuMojo intends to try and get the most out of the capabilities of Mojo including vectorization, parallelization, and GPU acceleration(once available). Currently, NuMojo extends (most of) the standard library math functions to work on array inputs.
+NuMojo intends to try and get the most out of the capabilities of Mojo including vectorization, parallelization, and GPU acceleration(once available). Currently, NuMojo extends (most of) the standard library math functions to work on array inputs.
 
 NuMojo intends to be a building block for other Mojo packages that need fast math under the hood without the added weight of a ML back and forward propagation system
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -6,16 +6,16 @@ With that in mind NuMojo as a project is in an early stage of development. If yo
 
 ## TASKS
 
-* Implement tensor version all SIMDable standard library math functions (mostly done waiting on std lib [issue 2492](https://github.com/modularml/mojo/issues/2492))
+* Implement array version all SIMDable standard library math functions (mostly done waiting on std lib [issue 2492](https://github.com/modularml/mojo/issues/2492))
 * Build statistics functions
 * Build optimizers (newton raphson, bisection,etc)
 * Build function approximators
 
 ## N-dimensional Arrays
 
-Now that Modular has decided to no longer support Tensor and to open source and deprecate it NuMojo intends to take Tensor and Make it our own Once they do.
+Now that Modular has decided to no longer support array and to open source and deprecate it NuMojo intends to take array and Make it our own Once they do.
 
-Which means that we will be trying to add many of the features from numpy.array that tensor currently lacks, while not sacrificing performance.
+Which means that we will be trying to add many of the features from numpy.array that array currently lacks, while not sacrificing performance.
 
 ## Notional organization of functions and features
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -9,6 +9,6 @@ from .math import *
 from .math.statistics import stats
 
 # from  .comparison import *
-# from .tensor_func_bit_ops import * #Doesn't work yet due to type issues
+# from .array_func_bit_ops import * #Doesn't work yet due to type issues
 # from .constants import Constants
 # var pi: Float64 = 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555954930381966446229489

--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -82,7 +82,10 @@ fn _traverse_iterative[
             orig, narr, ndim, coefficients, strides, offset, index, newdepth
         )
 
-fn bool_to_numeric[dtype:DType](array: NDArray[DType.bool])raises->NDArray[dtype]:
+
+fn bool_to_numeric[
+    dtype: DType
+](array: NDArray[DType.bool]) raises -> NDArray[dtype]:
     # Can't use simd becuase of bit packing error
     var res: NDArray[dtype] = NDArray[dtype](array.shape())
     for i in range(array.size()):
@@ -92,6 +95,7 @@ fn bool_to_numeric[dtype:DType](array: NDArray[DType.bool])raises->NDArray[dtype
         else:
             res[i] = 0
     return res
+
 
 fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
     try:

--- a/numojo/math/arithmetic.mojo
+++ b/numojo/math/arithmetic.mojo
@@ -28,10 +28,10 @@ fn add[
     backend: _mf.Backend = _mf.Vectorized,
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Perform addition on two tensors.
+    Perform addition on two arrays.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -44,7 +44,7 @@ fn add[
     Returns:
         The elementwise sum of `array1` and`array2`.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__add__](
+    return backend().math_func_2_array_in_one_array_out[dtype, SIMD.__add__](
         array1, array2
     )
 
@@ -53,10 +53,10 @@ fn sub[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Perform subtraction on two tensors.
+    Perform subtraction on two arrays.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -69,7 +69,7 @@ fn sub[
     Returns:
         The elementwise difference of `array1` and`array2`.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__sub__](
+    return backend().math_func_2_array_in_one_array_out[dtype, SIMD.__sub__](
         array1, array2
     )
 
@@ -122,7 +122,7 @@ fn copysign[
     Copy the sign of the first NDArray and apply it to the second NDArray.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -135,9 +135,9 @@ fn copysign[
     Returns:
         The second NDArray multipied by the sign of the first NDArray.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[
-        dtype, math.copysign
-    ](array1, array2)
+    return backend().math_func_2_array_in_one_array_out[dtype, math.copysign](
+        array1, array2
+    )
 
 
 fn mod[
@@ -147,7 +147,7 @@ fn mod[
     Elementwise modulo of array1 and array2.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -160,7 +160,7 @@ fn mod[
     Returns:
         A NDArray equal to array1%array2.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__mod__](
+    return backend().math_func_2_array_in_one_array_out[dtype, SIMD.__mod__](
         array1, array2
     )
 
@@ -172,7 +172,7 @@ fn mul[
     Elementwise product of array1 and array2.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -185,7 +185,7 @@ fn mul[
     Returns:
         A NDArray equal to array1*array2.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, SIMD.__mul__](
+    return backend().math_func_2_array_in_one_array_out[dtype, SIMD.__mul__](
         array1, array2
     )
 
@@ -197,7 +197,7 @@ fn div[
     Elementwise quotent of array1 and array2.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -210,7 +210,7 @@ fn div[
     Returns:
         A NDArray equal to array1/array2.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[
+    return backend().math_func_2_array_in_one_array_out[
         dtype, SIMD.__truediv__
     ](array1, array2)
 
@@ -224,7 +224,7 @@ fn fma[
     Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
     Constraints:
-        Both tensors must have the same shape.
+        Both arrays must have the same shape.
 
     Parameters:
         dtype: The element type.
@@ -250,7 +250,7 @@ fn fma[
     Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
     Constraints:
-        Both tensors must have the same shape
+        Both arrays must have the same shape
 
     Parameters:
         dtype: The element type.
@@ -274,7 +274,7 @@ fn remainder[
     Elementwise remainders of NDArray.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -287,9 +287,9 @@ fn remainder[
     Returns:
         A NDArray equal to array1//array2.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[
-        dtype, math.remainder
-    ](array1, array2)
+    return backend().math_func_2_array_in_one_array_out[dtype, math.remainder](
+        array1, array2
+    )
 
 
 # fn reciprocal[
@@ -299,7 +299,7 @@ fn remainder[
 #     Elementwise reciprocals of array1 and array2.
 
 #     Constraints:
-#         Both tensors must have the same shapes.
+#         Both arrays must have the same shapes.
 
 #     Parameters:
 #         dtype: The element type.
@@ -311,7 +311,7 @@ fn remainder[
 #     Returns:
 #         A NDArray equal to 1/NDArray.
 #     """
-#     return backend().math_func_1_tensor_in_one_tensor_out[
+#     return backend().math_func_1_array_in_one_array_out[
 #         dtype, math.reciprocal
 #     ](NDArray)
 
@@ -326,7 +326,7 @@ fn cbrt[
     Elementwise cuberoot of NDArray.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
@@ -338,9 +338,7 @@ fn cbrt[
     Returns:
         A NDArray equal to NDArray**(1/3).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.cbrt](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.cbrt](array)
 
 
 # fn pow[dtype: DType,
@@ -349,7 +347,7 @@ fn cbrt[
 #     Elementwise NDArray to the power of intval.
 
 #     Constraints:
-#         Both tensors must have the same shapes.
+#         Both arrays must have the same shapes.
 
 #     Parameters:
 #         dtype: The element type.
@@ -381,7 +379,7 @@ fn rsqrt[
     Returns:
         A NDArray equal to 1/NDArray**(1/2).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.rsqrt](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.rsqrt](
         array
     )
 
@@ -402,9 +400,7 @@ fn sqrt[
     Returns:
         A NDArray equal to NDArray**(1/2).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.sqrt](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.sqrt](array)
 
 
 fn exp2[
@@ -424,9 +420,7 @@ fn exp2[
         A NDArray with the shape of `NDArray` with values equal to the
         2 to the power of the value in the original NDArray at each position.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.exp2](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.exp2](array)
 
 
 fn exp[
@@ -446,9 +440,7 @@ fn exp[
         A NDArray with the shape of `NDArray` with values equal to the
         e to the power of the value in the original NDArray at each position.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.exp](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.exp](array)
 
 
 fn expm1[
@@ -468,7 +460,7 @@ fn expm1[
         A NDArray with the shape of `NDArray` with values equal to the negative one plus
         e to the power of the value in the original NDArray at each position.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.expm1](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.expm1](
         array
     )
 
@@ -492,7 +484,7 @@ fn scalb[
         A NDArray with the shape of `NDArray` with values equal to the negative one plus
         e to the power of the value in the original NDArray at each position.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, math.scalb](
+    return backend().math_func_2_array_in_one_array_out[dtype, math.scalb](
         array1, array2
     )
 
@@ -518,9 +510,7 @@ fn log[
     Returns:
         A NDArray equal to ln(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.log](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.log](array)
 
 
 alias ln = log
@@ -542,9 +532,7 @@ fn log2[
     Returns:
         A NDArray equal to log_2(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.log2](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.log2](array)
 
 
 fn log10[
@@ -563,7 +551,7 @@ fn log10[
     Returns:
         A NDArray equal to log_10(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.log10](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.log10](
         array
     )
 
@@ -584,7 +572,7 @@ fn log1p[
     Returns:
         A NDArray equal to ln(NDArray+1).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.log1p](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.log1p](
         array
     )
 
@@ -610,7 +598,7 @@ fn tabs[
     Returns:
         A NDArray equal to abs(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, SIMD.__abs__](
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__abs__](
         array
     )
 
@@ -631,9 +619,9 @@ fn tfloor[
     Returns:
         A NDArray equal to floor(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[
-        dtype, SIMD.__floor__
-    ](array)
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__floor__](
+        array
+    )
 
 
 fn tceil[
@@ -652,9 +640,9 @@ fn tceil[
     Returns:
         A NDArray equal to ceil(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[
-        dtype, SIMD.__ceil__
-    ](array)
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__ceil__](
+        array
+    )
 
 
 fn ttrunc[
@@ -673,9 +661,9 @@ fn ttrunc[
     Returns:
         A NDArray equal to trunc(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[
-        dtype, SIMD.__trunc__
-    ](array)
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__trunc__](
+        array
+    )
 
 
 fn tround[
@@ -694,9 +682,9 @@ fn tround[
     Returns:
         A NDArray equal to trunc(NDArray).
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[
-        dtype, SIMD.__round__
-    ](array)
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__round__](
+        array
+    )
 
 
 fn roundeven[
@@ -706,20 +694,20 @@ fn roundeven[
     Performs elementwise banker's rounding on the elements of a NDArray.
 
     Parameters:
-        dtype: The dtype of the input and output Tensor.
+        dtype: The dtype of the input and output array.
         backend: Sets utility function origin, defualts to `Vectorized`.
 
     Args:
-        array: Tensor to perform rounding on.
+        array: Array to perform rounding on.
 
     Returns:
     The elementwise banker's rounding of NDArray.
 
     This rounding goes to the nearest integer with ties toward the nearest even integer.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[
-        dtype, SIMD.roundeven
-    ](array)
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.roundeven](
+        array
+    )
 
 
 # fn round_half_down[
@@ -729,16 +717,16 @@ fn roundeven[
 #     Rounds ties towards the smaller integer.
 
 #     Parameters:
-#         dtype: The dtype of the input and output Tensor.
+#         dtype: The dtype of the input and output array.
 #         backend: Sets utility function origin, defualts to `Vectorized`.
 
 #     Args:
-#         NDArray: Tensor to perform rounding on.
+#         NDArray: array to perform rounding on.
 
 #     Returns:
 #     The elementwise rounding of x evaluating ties towards the smaller integer.
 #     """
-#     return backend().math_func_1_tensor_in_one_tensor_out[
+#     return backend().math_func_1_array_in_one_array_out[
 #         dtype, SIMD.__round_half_down
 #     ](NDArray)
 
@@ -750,16 +738,16 @@ fn roundeven[
 #     Rounds ties towards the larger integer.
 
 #     Parameters:
-#         dtype: The dtype of the input and output Tensor.
+#         dtype: The dtype of the input and output array.
 #         backend: Sets utility function origin, defualts to `Vectorized`.
 
 #     Args:
-#         NDArray: Tensor to perform rounding on.
+#         NDArray: array to perform rounding on.
 
 #     Returns:
 #     The elementwise rounding of x evaluating ties towards the larger integer.
 #     """
-#     return backend().math_func_1_tensor_in_one_tensor_out[
+#     return backend().math_func_1_array_in_one_array_out[
 #         dtype, math.round_half_up
 #     ](NDArray)
 
@@ -771,7 +759,7 @@ fn nextafter[
     Computes the nextafter of the inputs.
 
     Parameters:
-        dtype: The dtype of the input and output Tensor. Constraints: must be a floating-point type.
+        dtype: The dtype of the input and output array. Constraints: must be a floating-point type.
         backend: Sets utility function origin, defualts to `Vectorized`.
 
 
@@ -782,6 +770,6 @@ fn nextafter[
     Returns:
     The nextafter of the inputs.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[
-        dtype, math.nextafter
-    ](array1, array2)
+    return backend().math_func_2_array_in_one_array_out[dtype, math.nextafter](
+        array1, array2
+    )

--- a/numojo/math/check.mojo
+++ b/numojo/math/check.mojo
@@ -46,7 +46,7 @@ fn isinf[
         NDArray[DType.bool] - A array of the same shape as `array` with True for infinite elements and False for others.
     """
     # return backend().math_func_is[dtype, math.isinf](array)
-    
+
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
     for i in range(result_array.size()):
         result_array[i] = math.isinf(array[i])
@@ -99,7 +99,7 @@ fn isnan[
     return result_array
 
 
-fn any(array: NDArray[DType.bool])raises -> Scalar[DType.bool]:
+fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     """
     If any True.
 
@@ -123,7 +123,7 @@ fn any(array: NDArray[DType.bool])raises -> Scalar[DType.bool]:
     return result
 
 
-fn all(array: NDArray[DType.bool])raises -> Scalar[DType.bool]:
+fn all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     """
     If all True.
 

--- a/numojo/math/comparison.mojo
+++ b/numojo/math/comparison.mojo
@@ -34,10 +34,9 @@ fn greater[
 
     An element of the result NDArray will be True if the corresponding element in x is greater than the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__gt__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__gt__](
         array1, array2
     )
-    
 
 
 fn greater_equal[
@@ -59,9 +58,10 @@ fn greater_equal[
 
     An element of the result NDArray will be True if the corresponding element in x is greater than or equal to the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__ge__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__ge__](
         array1, array2
     )
+
 
 fn less[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
@@ -82,10 +82,10 @@ fn less[
 
     An element of the result NDArray will be True if the corresponding element in x is or equal to the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__lt__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__lt__](
         array1, array2
     )
-    
+
 
 fn less_equal[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
@@ -106,10 +106,9 @@ fn less_equal[
 
     An element of the result NDArray will be True if the corresponding element in x is less than or equal to the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__le__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__le__](
         array1, array2
     )
-    
 
 
 fn equal[
@@ -131,7 +130,7 @@ fn equal[
 
     An element of the result NDArray will be True if the corresponding element in x is equal to the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__eq__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__eq__](
         array1, array2
     )
     # if array1.shape() != array2.shape():
@@ -142,6 +141,7 @@ fn equal[
     # for i in range(result_array.size()):
     #     result_array[i] = array1[i]==array2[i]
     # return result_array
+
 
 fn not_equal[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
@@ -162,7 +162,7 @@ fn not_equal[
 
     An element of the result NDArray will be True if the corresponding element in x is not equal to the corresponding element in y, and False otherwise.
     """
-    return backend().math_func_compare_2_tensors[dtype, SIMD.__ne__](
+    return backend().math_func_compare_2_arrays[dtype, SIMD.__ne__](
         array1, array2
     )
     # if array1.shape() != array2.shape():

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -27,14 +27,17 @@ fn interp1d[
 ) raises -> NDArray[dtype]:
     """
     Interpolate the values of y at the points xi.
+
     Parameters:
         dtype: The element type.
+
     Args:
         xi: An Array.
         x: An Array.
         y: An Array.
         method: The interpolation method.
         fill_value: The fill value.
+
     Returns:
         The interpolated values of y at the points xi as An Array of `dtype`.
     """

--- a/numojo/math/linalg/linalg.mojo
+++ b/numojo/math/linalg/linalg.mojo
@@ -20,7 +20,7 @@ fn cross[
     out_dtype
 ]:
     """
-    Compute the cross product of two tensors.
+    Compute the cross product of two arrays.
 
     Parameters
         in_dtype: Input data type.
@@ -34,7 +34,7 @@ fn cross[
         `array1` and `array2` must be of shape (3,).
 
     Returns:
-        The cross product of two tensors.
+        The cross product of two arrays.
     """
 
     if array1.ndshape._len == array2.ndshape._len == 3:
@@ -51,7 +51,7 @@ fn cross[
         return array3
     else:
         raise Error(
-            "Cross product is not supported for tensors of shape "
+            "Cross product is not supported for arrays of shape "
             + array1.shape().__str__()
             + " and "
             + array2.shape().__str__()

--- a/numojo/math/math_funcs.mojo
+++ b/numojo/math/math_funcs.mojo
@@ -38,18 +38,18 @@ struct Vectorized(Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -89,18 +89,18 @@ struct Vectorized(Backend):
         simd: SIMD[dtype, 1],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            simd: A SIMD[dtype,1] value to be added
+            array1: A NDArray.
+            array2: A NDArray.
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -125,21 +125,21 @@ struct Vectorized(Backend):
         vectorize[closure, opt_nelts](array1.num_elements())
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -158,7 +158,7 @@ struct Vectorized(Backend):
 
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -167,18 +167,18 @@ struct Vectorized(Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -203,7 +203,7 @@ struct Vectorized(Backend):
         vectorize[closure, opt_nelts](result_array.num_elements())
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -229,7 +229,8 @@ struct Vectorized(Backend):
             # )
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
+                i,
+                func[dtype, simdwidth](simd_data1, simd_data2),
             )
 
         vectorize[closure, opt_nelts](array1.num_elements())
@@ -276,9 +277,13 @@ struct Vectorized(Backend):
         vectorize[closure, opt_nelts](array.num_elements())
         return result_array
 
+
 # This provides a way to bypass bitpacking issues with Bool
-fn bool_simd_store[width:Int](ptr:DTypePointer[DType.bool],start:Int, val:SIMD[DType.bool,width]):
-    (ptr+start).simd_strided_store[width=width,T=Int](val,1)
+fn bool_simd_store[
+    width: Int
+](ptr: DTypePointer[DType.bool], start: Int, val: SIMD[DType.bool, width]):
+    (ptr + start).simd_strided_store[width=width, T=Int](val, 1)
+
 
 struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
     """
@@ -302,18 +307,18 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -355,7 +360,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
@@ -363,7 +368,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -389,21 +394,21 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         )
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -424,7 +429,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -433,18 +438,18 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -470,7 +475,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
         )
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -496,8 +501,10 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
             # )
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
+                i,
+                func[dtype, simdwidth](simd_data1, simd_data2),
             )
+
         vectorize[closure, opt_nelts, unroll_factor=unroll_factor](
             array1.num_elements()
         )
@@ -569,18 +576,18 @@ struct Parallelized(Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -642,7 +649,7 @@ struct Parallelized(Backend):
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape.
 
         Parameters:
             dtype: The element type.
@@ -650,7 +657,7 @@ struct Parallelized(Backend):
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -693,21 +700,21 @@ struct Parallelized(Backend):
         # vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -740,7 +747,7 @@ struct Parallelized(Backend):
         # vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -749,18 +756,18 @@ struct Parallelized(Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -803,7 +810,7 @@ struct Parallelized(Backend):
         # vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -837,9 +844,11 @@ struct Parallelized(Backend):
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
                 bool_simd_store[simdwidth](
-                result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
-            )
+                    result_array.unsafe_ptr(),
+                    i,
+                    func[dtype, simdwidth](simd_data1, simd_data2),
+                )
+
             vectorize[closure, opt_nelts](comps_per_core)
 
         parallelize[par_closure]()
@@ -930,18 +939,18 @@ struct VectorizedParallelized(Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1008,7 +1017,7 @@ struct VectorizedParallelized(Backend):
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape.
 
         Parameters:
             dtype: The element type.
@@ -1016,7 +1025,7 @@ struct VectorizedParallelized(Backend):
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1063,21 +1072,21 @@ struct VectorizedParallelized(Backend):
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1114,7 +1123,7 @@ struct VectorizedParallelized(Backend):
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1123,18 +1132,18 @@ struct VectorizedParallelized(Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1182,7 +1191,7 @@ struct VectorizedParallelized(Backend):
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1218,9 +1227,11 @@ struct VectorizedParallelized(Backend):
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
                 bool_simd_store[simdwidth](
-                result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
-            )
+                    result_array.unsafe_ptr(),
+                    i,
+                    func[dtype, simdwidth](simd_data1, simd_data2),
+                )
+
             vectorize[closure, opt_nelts](comps_per_core)
 
         parallelize[par_closure]()
@@ -1235,8 +1246,10 @@ struct VectorizedParallelized(Backend):
             # )
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
+                i,
+                func[dtype, simdwidth](simd_data1, simd_data2),
             )
+
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
@@ -1323,18 +1336,18 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape.
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1406,7 +1419,7 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape.
 
         Parameters:
             dtype: The element type.
@@ -1414,7 +1427,7 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1461,21 +1474,21 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1512,7 +1525,7 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1521,18 +1534,18 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1580,7 +1593,7 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1616,9 +1629,11 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
                 bool_simd_store[simdwidth](
-                result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
-            )
+                    result_array.unsafe_ptr(),
+                    i,
+                    func[dtype, simdwidth](simd_data1, simd_data2),
+                )
+
             vectorize[closure, opt_nelts](comps_per_core)
 
         parallelize[par_closure](num_cores, num_cores)
@@ -1633,8 +1648,10 @@ struct VectorizedParallelizedNWorkers[num_cores: Int = num_physical_cores()](
             # )
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
-                i, func[dtype, simdwidth](simd_data1, simd_data2)
+                i,
+                func[dtype, simdwidth](simd_data1, simd_data2),
             )
+
         vectorize[remainder_closure, opt_nelts](comps_remainder)
         return result_array
 
@@ -1718,18 +1735,18 @@ struct Naive(Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1766,7 +1783,7 @@ struct Naive(Backend):
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
@@ -1774,7 +1791,7 @@ struct Naive(Backend):
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1795,21 +1812,21 @@ struct Naive(Backend):
             )
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1821,7 +1838,7 @@ struct Naive(Backend):
             result_array.store[width=1](i, simd_data)
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1830,18 +1847,18 @@ struct Naive(Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1861,7 +1878,7 @@ struct Naive(Backend):
             )
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -1885,7 +1902,8 @@ struct Naive(Backend):
             # )
             bool_simd_store[1](
                 result_array.unsafe_ptr(),
-                i, func[dtype, 1](simd_data1, simd_data2)
+                i,
+                func[dtype, 1](simd_data1, simd_data2),
             )
         return result_array
 
@@ -1938,18 +1956,18 @@ struct VectorizedVerbose(Backend):
         array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
-            array3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -1999,7 +2017,7 @@ struct VectorizedVerbose(Backend):
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
@@ -2007,7 +2025,7 @@ struct VectorizedVerbose(Backend):
         Args:
             array1: A NDArray.
             array2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -2041,21 +2059,21 @@ struct VectorizedVerbose(Backend):
                 )
         return result_array
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A new NDArray that is NDArray with the function func applied.
@@ -2079,7 +2097,7 @@ struct VectorizedVerbose(Backend):
                 result_array.store[width=1](i, simd_data)
         return result_array
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -2088,18 +2106,18 @@ struct VectorizedVerbose(Backend):
         self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array1: A NDArray
-            array2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -2132,7 +2150,7 @@ struct VectorizedVerbose(Backend):
                 )
         return result_array
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -2158,7 +2176,8 @@ struct VectorizedVerbose(Backend):
             # )
             bool_simd_store[opt_nelts](
                 result_array.unsafe_ptr(),
-                i, func[dtype, opt_nelts](simd_data1, simd_data2)
+                i,
+                func[dtype, opt_nelts](simd_data1, simd_data2),
             )
         if array1.num_elements() % opt_nelts != 0:
             for i in range(
@@ -2171,9 +2190,10 @@ struct VectorizedVerbose(Backend):
                 #     i, func[dtype, 1](simd_data1, simd_data2)
                 # )
                 bool_simd_store[1](
-                result_array.unsafe_ptr(),
-                i, func[dtype, 1](simd_data1, simd_data2)
-            )
+                    result_array.unsafe_ptr(),
+                    i,
+                    func[dtype, 1](simd_data1, simd_data2),
+                )
         return result_array
 
     fn math_func_is[

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -124,24 +124,24 @@ fn mode[
     Returns:
         The mode of all of the member values of array as a SIMD Value of `dtype`.
     """
-    var sorted_tensor: NDArray[out_dtype] = binary_sort[in_dtype, out_dtype](
+    var sorted_array: NDArray[out_dtype] = binary_sort[in_dtype, out_dtype](
         array
     )
     var max_count = 0
-    var mode_value = sorted_tensor[0]
+    var mode_value = sorted_array[0]
     var current_count = 1
 
     for i in range(1, array.num_elements()):
-        if sorted_tensor[i] == sorted_tensor[i - 1]:
+        if sorted_array[i] == sorted_array[i - 1]:
             current_count += 1
         else:
             if current_count > max_count:
                 max_count = current_count
-                mode_value = sorted_tensor[i - 1]
+                mode_value = sorted_array[i - 1]
             current_count = 1
 
     if current_count > max_count:
-        mode_value = sorted_tensor[array.num_elements() - 1]
+        mode_value = sorted_array[array.num_elements() - 1]
 
     return mode_value
 
@@ -162,12 +162,12 @@ fn median[
     Returns:
         The median of all of the member values of array as a SIMD Value of `dtype`.
     """
-    var sorted_tensor = binary_sort[in_dtype, out_dtype](array)
+    var sorted_array = binary_sort[in_dtype, out_dtype](array)
     var n = array.num_elements()
     if n % 2 == 1:
-        return sorted_tensor[n // 2]
+        return sorted_array[n // 2]
     else:
-        return (sorted_tensor[n // 2 - 1] + sorted_tensor[n // 2]) / 2
+        return (sorted_array[n // 2 - 1] + sorted_array[n // 2]) / 2
 
 
 # for max and min, I can later change to the latest reduce.max, reduce.min()
@@ -469,7 +469,7 @@ fn minimum[
     out_dtype
 ]:
     """
-    Element wise minimum of two tensors.
+    Element wise minimum of two arrays.
 
     Parameters:
         in_dtype: The input element type.
@@ -479,7 +479,7 @@ fn minimum[
         array1: An array.
         array2: An array.
     Returns:
-        The element wise minimum of the two tensors as a array of `dtype`.
+        The element wise minimum of the two arrays as a array of `dtype`.
     """
     var result: NDArray[out_dtype] = NDArray[out_dtype](array1.shape())
 
@@ -507,7 +507,7 @@ fn maximum[
     out_dtype
 ]:
     """
-    Element wise maximum of two tensors.
+    Element wise maximum of two arrays.
 
     Parameters:
         in_dtype: The input element type.
@@ -517,7 +517,7 @@ fn maximum[
         array1: A array.
         array2: A array.
     Returns:
-        The element wise maximum of the two tensors as a array of `dtype`.
+        The element wise maximum of the two arrays as a array of `dtype`.
     """
 
     var result: NDArray[out_dtype] = NDArray[out_dtype](array1.shape())

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -10,6 +10,7 @@ Statistics functions for NDArray
 from ...core.ndarray import NDArray
 from .. import mul
 
+
 fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
     """
     Sum of array elements over a given axis.
@@ -141,40 +142,15 @@ fn meanall(array: NDArray) raises -> Float64:
 
     """
 
-    return sumall(array).cast[DType.float64]() / Int32(array.ndshape._size).cast[DType.float64]()
+    return (
+        sumall(array).cast[DType.float64]()
+        / Int32(array.ndshape._size).cast[DType.float64]()
+    )
 
-fn max[dtype:DType](array:NDArray[dtype], axis: Int = 0) raises -> NDArray[dtype]: 
-        var ndim: Int = array.ndim
-        var shape: List[Int] = List[Int]()
-        for i in range(ndim):
-            shape.append(array.ndshape[i])
-        if axis > ndim - 1:
-            raise Error("axis cannot be greater than the rank of the array")
-        var result_shape: List[Int] = List[Int]()
-        var axis_size: Int = shape[axis]
-        var slices: List[Slice] = List[Slice]()
-        for i in range(ndim):
-            if i != axis:
-                result_shape.append(shape[i])
-                slices.append(Slice(0, shape[i]))
-            else:
-                slices.append(Slice(0, 0))
-        print(result_shape.__str__())
-        var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(result_shape))
-        slices[axis] = Slice(0, 1)
-        result = array[slices]
-        for i in range(1,axis_size):
-            slices[axis] = Slice(i, i + 1)
-            var arr_slice = array[slices]
-            var mask1 = greater(arr_slice,result)
-            var mask2 = less(arr_slice,result)
-            # Wherever result is less than the new slice it is set to zero
-            # Wherever arr_slice is greater than the old result it is added to fill those zeros
-            result = add(result * bool_to_numeric[dtype](mask2),arr_slice * bool_to_numeric[dtype](mask1))
 
-        return result
-
-fn min[dtype:DType](array:NDArray[dtype], axis: Int = 0)raises-> NDArray[dtype]:
+fn max[
+    dtype: DType
+](array: NDArray[dtype], axis: Int = 0) raises -> NDArray[dtype]:
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
@@ -190,17 +166,57 @@ fn min[dtype:DType](array:NDArray[dtype], axis: Int = 0)raises-> NDArray[dtype]:
             slices.append(Slice(0, shape[i]))
         else:
             slices.append(Slice(0, 0))
-    
+    print(result_shape.__str__())
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(result_shape))
     slices[axis] = Slice(0, 1)
     result = array[slices]
-    for i in range(1,axis_size):
+    for i in range(1, axis_size):
         slices[axis] = Slice(i, i + 1)
         var arr_slice = array[slices]
-        var mask1 = less(arr_slice,result)
-        var mask2 = greater(arr_slice,result)
+        var mask1 = greater(arr_slice, result)
+        var mask2 = less(arr_slice, result)
+        # Wherever result is less than the new slice it is set to zero
+        # Wherever arr_slice is greater than the old result it is added to fill those zeros
+        result = add(
+            result * bool_to_numeric[dtype](mask2),
+            arr_slice * bool_to_numeric[dtype](mask1),
+        )
+
+    return result
+
+
+fn min[
+    dtype: DType
+](array: NDArray[dtype], axis: Int = 0) raises -> NDArray[dtype]:
+    var ndim: Int = array.ndim
+    var shape: List[Int] = List[Int]()
+    for i in range(ndim):
+        shape.append(array.ndshape[i])
+    if axis > ndim - 1:
+        raise Error("axis cannot be greater than the rank of the array")
+    var result_shape: List[Int] = List[Int]()
+    var axis_size: Int = shape[axis]
+    var slices: List[Slice] = List[Slice]()
+    for i in range(ndim):
+        if i != axis:
+            result_shape.append(shape[i])
+            slices.append(Slice(0, shape[i]))
+        else:
+            slices.append(Slice(0, 0))
+
+    var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(result_shape))
+    slices[axis] = Slice(0, 1)
+    result = array[slices]
+    for i in range(1, axis_size):
+        slices[axis] = Slice(i, i + 1)
+        var arr_slice = array[slices]
+        var mask1 = less(arr_slice, result)
+        var mask2 = greater(arr_slice, result)
         # Wherever result is greater than the new slice it is set to zero
         # Wherever arr_slice is less than the old result it is added to fill those zeros
-        result = add(result * bool_to_numeric[dtype](mask2),arr_slice * bool_to_numeric[dtype](mask1))
+        result = add(
+            result * bool_to_numeric[dtype](mask2),
+            arr_slice * bool_to_numeric[dtype](mask1),
+        )
 
     return result

--- a/numojo/math/trig.mojo
+++ b/numojo/math/trig.mojo
@@ -35,9 +35,7 @@ fn acos[
     Returns:
         The elementwise acos of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.acos](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.acos](array)
 
 
 fn asin[
@@ -56,9 +54,7 @@ fn asin[
     Returns:
         The elementwise asin of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.asin](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.asin](array)
 
 
 fn atan[
@@ -77,34 +73,32 @@ fn atan[
     Returns:
         The elementwise atan of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.atan](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.atan](array)
 
 
 fn atan2[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor1: NDArray[dtype], tensor2: NDArray[dtype]) raises -> NDArray[dtype]:
+](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply atan2 also known as inverse tangent.
     [atan2 wikipedia](https://en.wikipedia.org/wiki/Atan2).
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
         backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
-        tensor1: An Array.
-        tensor2: An Array.
+        array1: An Array.
+        array2: An Array.
 
     Returns:
-        The elementwise atan2 of `tensor1` and`tensor2` in radians.
+        The elementwise atan2 of `array1` and`array2` in radians.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, math.atan2](
-        tensor1, tensor2
+    return backend().math_func_2_array_in_one_array_out[dtype, math.atan2](
+        array1, array2
     )
 
 
@@ -129,9 +123,7 @@ fn cos[
     Returns:
         The elementwise cos of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.cos](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.cos](array)
 
 
 fn sin[
@@ -150,9 +142,7 @@ fn sin[
     Returns:
         The elementwise sin of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.sin](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.sin](array)
 
 
 fn tan[
@@ -171,64 +161,62 @@ fn tan[
     Returns:
         The elementwise tan of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.tan](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.tan](array)
 
 
 fn hypot[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor1: NDArray[dtype], tensor2: NDArray[dtype]) raises -> NDArray[dtype]:
+](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply hypot also known as hypotenuse which finds the longest section of a right triangle
     given the other two sides.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
         backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
-        tensor1: An Array.
-        tensor2: An Array.
+        array1: An Array.
+        array2: An Array.
 
     Returns:
-        The elementwise hypotenuse of `tensor1` and`tensor2`.
+        The elementwise hypotenuse of `array1` and`array2`.
     """
-    return backend().math_func_2_tensor_in_one_tensor_out[dtype, math.hypot](
-        tensor1, tensor2
+    return backend().math_func_2_array_in_one_array_out[dtype, math.hypot](
+        array1, array2
     )
 
 
 fn hypot_fma[
     dtype: DType, backend: _mf.Backend = _mf.Vectorized
-](tensor1: NDArray[dtype], tensor2: NDArray[dtype]) raises -> NDArray[dtype]:
+](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply hypot also known as hypotenuse which finds the longest section of a right triangle
     given the other two sides.
 
     Constraints:
-        Both tensors must have the same shapes.
+        Both arrays must have the same shapes.
 
     Parameters:
         dtype: The element type.
         backend: Sets utility function origin, defualts to `Vectorized.
 
     Args:
-        tensor1: An Array.
-        tensor2: An Array.
+        array1: An Array.
+        array2: An Array.
 
     Returns:
-        The elementwise hypotenuse of `tensor1` and`tensor2`.
+        The elementwise hypotenuse of `array1` and`array2`.
     """
 
-    var tensor2_squared = fma[dtype, backend=backend](
-        tensor2, tensor2, SIMD[dtype, 1](0)
+    var array2_squared = fma[dtype, backend=backend](
+        array2, array2, SIMD[dtype, 1](0)
     )
     return sqrt[dtype, backend=backend](
-        fma[dtype, backend=backend](tensor1, tensor1, tensor2_squared)
+        fma[dtype, backend=backend](array1, array1, array2_squared)
     )
 
 
@@ -253,7 +241,7 @@ fn acosh[
     Returns:
         The elementwise acosh of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.acosh](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.acosh](
         array
     )
 
@@ -274,7 +262,7 @@ fn asinh[
     Returns:
         The elementwise asinh of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.asinh](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.asinh](
         array
     )
 
@@ -295,7 +283,7 @@ fn atanh[
     Returns:
         The elementwise atanh of `array` in radians.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.atanh](
+    return backend().math_func_1_array_in_one_array_out[dtype, math.atanh](
         array
     )
 
@@ -321,9 +309,7 @@ fn cosh[
     Returns:
         The elementwise cosh of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.cosh](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.cosh](array)
 
 
 fn sinh[
@@ -342,9 +328,7 @@ fn sinh[
     Returns:
         The elementwise sinh of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.sinh](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.sinh](array)
 
 
 fn tanh[
@@ -363,6 +347,4 @@ fn tanh[
     Returns:
         The elementwise tanh of `array`.
     """
-    return backend().math_func_1_tensor_in_one_tensor_out[dtype, math.tanh](
-        array
-    )
+    return backend().math_func_1_array_in_one_array_out[dtype, math.tanh](array)

--- a/numojo/traits/backend.mojo
+++ b/numojo/traits/backend.mojo
@@ -21,23 +21,23 @@ trait Backend:
         dtype: DType,
     ](
         self: Self,
-        tensor1: NDArray[dtype],
-        tensor2: NDArray[dtype],
-        tensor3: NDArray[dtype],
+        array1: NDArray[dtype],
+        array2: NDArray[dtype],
+        array3: NDArray[dtype],
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray
+        Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            tensor1: A NDArray
-            tensor2: A NDArray
-            tensor3: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
+            array3: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -51,71 +51,71 @@ trait Backend:
         dtype: DType,
     ](
         self: Self,
-        tensor1: NDArray[dtype],
-        tensor2: NDArray[dtype],
+        array1: NDArray[dtype],
+        array2: NDArray[dtype],
         simd: SIMD[dtype, 1],
     ) raises -> NDArray[dtype]:
         """
         Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
 
         Args:
-            tensor1: A NDArray.
-            tensor2: A NDArray.
-            simd: A SIMD[dtype,1] value to be added
+            array1: A NDArray.
+            array2: A NDArray.
+            simd: A SIMD[dtype,1] value to be added.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
         pass
 
-    fn math_func_1_tensor_in_one_tensor_out[
+    fn math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of one variable and one return to a NDArray
+        Apply a SIMD function of one variable and one return to a NDArray.
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            array: A NDArray
+            array: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
         ...
 
-    fn math_func_2_tensor_in_one_tensor_out[
+    fn math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
-        self: Self, tensor1: NDArray[dtype], tensor2: NDArray[dtype]
+        self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[dtype]:
         """
-        Apply a SIMD function of two variable and one return to a NDArray
+        Apply a SIMD function of two variable and one return to a NDArray.
 
         Constraints:
-            Both tensors must have the same shape
+            Both arrays must have the same shape
 
         Parameters:
             dtype: The element type.
-            func: the SIMD function to to apply.
+            func: The SIMD function to to apply.
 
         Args:
-            tensor1: A NDArray
-            tensor2: A NDArray
+            array1: A NDArray.
+            array2: A NDArray.
 
         Returns:
             A a new NDArray that is NDArray with the function func applied.
@@ -123,13 +123,13 @@ trait Backend:
 
         ...
 
-    fn math_func_compare_2_tensors[
+    fn math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int] (
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](
-        self: Self, tensor1: NDArray[dtype], tensor2: NDArray[dtype]
+        self: Self, array1: NDArray[dtype], array2: NDArray[dtype]
     ) raises -> NDArray[DType.bool]:
         ...
 
@@ -141,12 +141,10 @@ trait Backend:
     ](self: Self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         ...
 
-    fn math_func_simd_int[
-        dtype: DType,
-        func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
-    ](self: Self, tensor1: NDArray[dtype], intval: Int) raises -> NDArray[
-        dtype
-    ]:
-        ...
+    # fn math_func_simd_int[
+    #     dtype: DType,
+    #     func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+    #         type, simd_w
+    #     ],
+    # ](self: Self, array1: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
+    #     ...


### PR DESCRIPTION
All references to tensor type have been removed.  All of the math docstrings are correctly formatted if not perfectly written.

Core needs a lot of work for documentation still.