### PR TITLE
[lib] `__getitem__` uniformed behavior + 0d-array + get item with indices

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1116,6 +1116,47 @@ struct NDArray[dtype: DType = DType.float32](
         var narr: Self = self[slice_list]
         return narr
 
+
+    fn __getitem__(self, indices: NDArray[DType.index]) raises -> Self:
+        """Get items of array from indices.
+
+        To-do:
+        Currently it supports 1d array.
+        In future, expand it to high dimensional arrays.
+        
+        Example:
+        ```mojo
+        var A = numojo.core.NDArray[numojo.i16](6, random=True)
+        var idx = numojo.core.sort.argsort(A)
+        print(A)
+        print(idx)
+        print(A[idx])
+        ```
+        ```console
+        [       -32768  -24148  16752   -2709   2148    -18418  ]
+        Shape: [6]  DType: int16
+        [       0       1       5       3       4       2       ]
+        Shape: [6]  DType: index
+        [       -32768  -24148  -18418  -2709   2148    16752   ]
+        Shape: [6]  DType: int16
+        ```
+
+        Args:
+            indices: NDArray with Dtype.index.
+
+        Returns:
+            NDArray with items from the indices.
+        """
+
+        var length = indices.size()
+        var result = NDArray[dtype](length)
+
+        for i in range(length):
+            result[i] = self[int(indices[i])]
+
+        return result
+
+
     fn __int__(self) -> Int:
         return self.ndshape._size
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1127,7 +1127,7 @@ struct NDArray[dtype: DType = DType.float32](
         Example:
         ```mojo
         var A = numojo.core.NDArray[numojo.i16](6, random=True)
-        var idx = numojo.core.sort.argsort(A)
+        var idx = A.argsort()
         print(A)
         print(idx)
         print(A[idx])
@@ -1657,8 +1657,17 @@ struct NDArray[dtype: DType = DType.float32](
                 result = i
         return result
 
-    fn argsort(self):
-        pass
+    fn argsort (self) raises -> NDArray[DType.index]:
+        """
+        Sort the NDArray and return the sorted indices.
+
+        See `numojo.core.sort.argsort()`.
+
+        Returns:
+            The indices of the sorted NDArray.
+        """
+
+        return numojo.core.sort.argsort(self)
 
     fn astype[type: DType](inout self) raises -> NDArray[type]:
         # I wonder if we can do this operation inplace instead of allocating memory.

--- a/tests/argsort.mojo
+++ b/tests/argsort.mojo
@@ -14,6 +14,8 @@ fn test[dtype: DType](length: Int) raises:
     # Initialize an ND arrays of type
     var t0 = time.now()
     var A = NDArray[dtype](length, random=True)
-    print(A)
-    print(nm.core.sort.argsort(A))
+    var idx = nm.core.sort.argsort(A)
+    print("Array:", A)
+    print("Sorted indices:", idx)
+    print("Sorted array", A[idx])
     print((time.now() - t0)/1e9, "s")

--- a/tests/argsort.mojo
+++ b/tests/argsort.mojo
@@ -14,7 +14,7 @@ fn test[dtype: DType](length: Int) raises:
     # Initialize an ND arrays of type
     var t0 = time.now()
     var A = NDArray[dtype](length, random=True)
-    var idx = nm.core.sort.argsort(A)
+    var idx = A.argsort()
     print("Array:", A)
     print("Sorted indices:", idx)
     print("Sorted array", A[idx])

--- a/tests/getitem.mojo
+++ b/tests/getitem.mojo
@@ -6,26 +6,72 @@ from numojo.core.ndarray import NDArray
 import time
 
 fn main() raises:
-    test[nm.i8](4, 4)
+    test_matrix[nm.i8](4, 4)
+    print(str("=")*30)
+    test_vector[nm.i8](4)
+    print(str("=")*30)
+    test_3darray[nm.i8](4,4,4)
+    print(str("=")*30)
 
-fn test[dtype: DType](*shape: Int) raises:
+fn test_matrix[dtype: DType](*shape: Int) raises:
     var A = NDArray[dtype](shape, random=True)
-    print(A)
+    print("A is a matrix")
+    print(A, end="\n\n")
 
     print("A[0]")
-    print(A[0])
+    print(A[0], end="\n\n")
     
     print("A[0, 1]")
-    print(A[0, 1])
+    print(A[0, 1], end="\n\n")
     
     print("A[Slice(1,3)]")
-    print(A[Slice(1,3)])
+    print(A[Slice(1,3)], end="\n\n")
     
     print("A[1, Slice(2,4)]")
-    print(A[1, Slice(2,4)])
+    print(A[1, Slice(2,4)], end="\n\n")
     
     print("A[Slice(1,3), Slice(1,3)]")
-    print(A[Slice(1,3), Slice(1,3)])
+    print(A[Slice(1,3), Slice(1,3)], end="\n\n")
     
-    print("A at (0,1) as scalar")
-    print(A.at(0, 1))
+    print("A.at(0,1) as Scalar")
+    print(A.at(0, 1), end="\n\n")
+
+fn test_vector[dtype: DType](*shape: Int) raises:
+    var A = NDArray[dtype](shape, random=True)
+    print("A is a vector")
+    print(A, end="\n\n")
+
+    print("A[0]")
+    print(A[0], end="\n\n")
+    
+    print("A[Slice(1,3)]")
+    print(A[Slice(1,3)], end="\n\n")
+    
+    print("A.at(0) as Scalar")
+    print(A.at(0), end="\n\n")
+
+fn test_3darray[dtype: DType](*shape: Int) raises:
+    var A = NDArray[dtype](shape, random=True)
+    print("A is a 3darray")
+    print(A, end="\n\n")
+
+    print("A[0]")
+    print(A[0], end="\n\n")
+    
+    print("A[0, 1]")
+    print(A[0, 1], end="\n\n")
+
+    print("A[0, 1, 2]")
+    print(A[0, 1, 2], end="\n\n")
+    
+    print("A[Slice(1,3)]")
+    print(A[Slice(1,3)], end="\n\n")
+    
+    print("A[1, Slice(2,4)]")
+    print(A[1, Slice(2,4)], end="\n\n")
+    
+    print("A[Slice(1,3), Slice(1,3), 2]")
+    print(A[Slice(1,3), Slice(1,3), 2], end="\n\n")
+    
+    print("A.at(0,1,2) as Scalar")
+    print(A.at(0, 1, 2), end="\n\n")


### PR DESCRIPTION
## Uniform the `getitem` method and allows 0d array

Related to Discussion #70 

- Use the `Variant[Slice, Int]` as the uniformed way to `__getitem__`. The `__getitem__` always returns an array.
- The previous `__getitem(self, idx: Int)` is renamed as `get_scalar`. It gets a scalar from the buffer.
- The previous `__getitem(self, *idices: Int)` is renamed as `at`, which always returns a scalar at the given coordinates.

Here are example when `A` is a vector, a matrix, and a 3d array. The behavior met our expectation: The number of dimension reduced equals to the number of integers as input.

```console
A is a matrix
[[      -128    -95     65      -11     ]
 [      8       -72     -116    45      ]
 [      45      111     -30     4       ]
 [      84      -120    -115    7       ]]
2-D array  Shape: [4, 4]  DType: int8

A[0]
[       -128    -95     65      -11     ]
1-D array  Shape: [4]  DType: int8

A[0, 1]
-95
0-D array  Shape: [0]  DType: int8

A[Slice(1,3)]
[[      8       -72     -116    45      ]
 [      45      111     -30     4       ]]
2-D array  Shape: [2, 4]  DType: int8

A[1, Slice(2,4)]
[       -116    45      ]
1-D array  Shape: [2]  DType: int8

A[Slice(1,3), Slice(1,3)]
[[      -72     -116    ]
 [      111     -30     ]]
2-D array  Shape: [2, 2]  DType: int8

A.at(0,1) as Scalar
-95

==============================
A is a vector
[       43      -127    -30     -111    ]
1-D array  Shape: [4]  DType: int8

A[0]
43
0-D array  Shape: [0]  DType: int8

A[Slice(1,3)]
[       -127    -30     ]
1-D array  Shape: [2]  DType: int8

A.at(0) as Scalar
43

==============================
A is a 3darray
[[[     -22     47      22      110     ]
  [     88      6       -105    39      ]
  [     -22     51      105     67      ]
  [     -61     -116    60      -44     ]]
 [[     33      65      125     -35     ]
  [     -65     123     57      64      ]
  [     38      -110    33      98      ]
  [     -59     -17     68      -6      ]]
 [[     -68     -58     -37     -86     ]
  [     -4      101     104     -113    ]
  [     103     1       4       -47     ]
  [     124     -2      -60     -105    ]]
 [[     114     -110    0       -30     ]
  [     -58     105     7       -10     ]
  [     112     -116    66      69      ]
  [     83      -96     -124    48      ]]]
3-D array  Shape: [4, 4, 4]  DType: int8

A[0]
[[      -22     47      22      110     ]
 [      88      6       -105    39      ]
 [      -22     51      105     67      ]
 [      -61     -116    60      -44     ]]
2-D array  Shape: [4, 4]  DType: int8

A[0, 1]
[       88      6       -105    39      ]
1-D array  Shape: [4]  DType: int8

A[0, 1, 2]
-105
0-D array  Shape: [0]  DType: int8

A[Slice(1,3)]
[[[     33      65      125     -35     ]
  [     -65     123     57      64      ]
  [     38      -110    33      98      ]
  [     -59     -17     68      -6      ]]
 [[     -68     -58     -37     -86     ]
  [     -4      101     104     -113    ]
  [     103     1       4       -47     ]
  [     124     -2      -60     -105    ]]]
3-D array  Shape: [2, 4, 4]  DType: int8

A[1, Slice(2,4)]
[[      38      -110    33      98      ]
 [      -59     -17     68      -6      ]]
2-D array  Shape: [2, 4]  DType: int8

A[Slice(1,3), Slice(1,3), 2]
[[      57      33      ]
 [      104     4       ]]
2-D array  Shape: [2, 2]  DType: int8

A.at(0,1,2) as Scalar
-105
```

## Get items of array from indices

To-do:
Currently it supports 1-d array.
In future, expand it to high dimensional arrays.

Example:
```mojo
var A = numojo.core.NDArray[numojo.i16](6, random=True)
var idx = A.argsort()
print(A)
print(idx)
print(A[idx])
```
```console
[       -32768  -24148  16752   -2709   2148    -18418  ]
Shape: [6]  DType: int16

[       0       1       5       3       4       2       ]
Shape: [6]  DType: index

[       -32768  -24148  -18418  -2709   2148    16752   ]
Shape: [6]  DType: int16
```