### PR TITLE
[doc] Add a bunch of docstrings and examples mainly for `math` module

### DIFF
--- a/numojo/core/datatypes.mojo
+++ b/numojo/core/datatypes.mojo
@@ -8,16 +8,27 @@
 # Rust-like data type alias
 
 alias i8 = DType.int8
+"""Data type alias for DType.int8"""
 alias i16 = DType.int16
+"""Data type alias for DType.int16"""
 alias i32 = DType.int32
+"""Data type alias for DType.int32"""
 alias i64 = DType.int64
+"""Data type alias for DType.int64"""
 alias u8 = DType.uint8
+"""Data type alias for DType.uint8"""
 alias u16 = DType.uint16
+"""Data type alias for DType.uint16"""
 alias u32 = DType.uint32
+"""Data type alias for DType.uint32"""
 alias u64 = DType.uint64
+"""Data type alias for DType.uint64"""
 alias f16 = DType.float16
+"""Data type alias for DType.float16"""
 alias f32 = DType.float32
+"""Data type alias for DType.float32"""
 alias f64 = DType.float64
+"""Data type alias for DType.float64"""
 
 
 fn cvtdtype[

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1289,7 +1289,7 @@ struct NDArray[dtype: DType = DType.float32](
         Returns:
             An ndarray with a smaller or equal dimension of the original one.
         """
-        
+
         var n_slices: Int = slices.__len__()
         if n_slices > self.ndim:
             raise Error("Error: No of slices greater than rank of array")

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1121,10 +1121,175 @@ struct NDArray[dtype: DType = DType.float32](
 
 
     fn __getitem__(self, owned *slices: Variant[Slice, Int]) raises -> Self:
+        """Get items by a series of either slices or integers.
+
+        A decrease of dimensions may or may not happen when `__getitem__` is 
+        called on an ndarray. An ndarray of X-D array can become Y-D array after 
+        `__getitem__` where `Y <= X`.
+        
+        Whether the dimension decerases or not depends on: 
+        1. What types of arguments are passed into `__getitem__`.
+        2. The number of arguments that are passed in `__getitem__`.
+
+        PRINCIPAL: The number of dimensions to be decreased is determined by
+        the number of `Int` passed in `__getitem__`.
+
+        For example, `A` is a 10x10x10 ndarray (3-D). Then,
+
+        - `A[1, 2, 3]` leads to a 0-D array (scalar), since there are 3 integers.
+        - `A[1, 2]` leads to a 1-D array (vector), since there are 2 integers, 
+        so the dimension decreases by 2.
+        - `A[1]` leads to a 2-D array (matrix), since there is 1 integer, so the 
+        dimension decreases by 1.
+
+        The number of dimensions will not decrease when Slice is passed in 
+        `__getitem__` or no argument is passed in for a certain dimension 
+        (it is an implicit slide and a slide of all items will be used).
+
+        Take the same example `A` with 10x10x10 in shape. Then,
+
+        - `A[1:4, 2:5, 3:6]`, leads to a 3-D array (no decrease in dimension), 
+        since there are 3 slices.
+        - `A[2:8]`, leads to a 3-D array (no decrease in dimension), since there 
+        are 1 explicit slice and 2 implicit slices.
+
+        When there is a mixture of int and slices passed into `__getitem__`, 
+        the number of integers will be the number of dimensions to be decreased. 
+        Example,
+
+        - `A[1:4, 2, 2]`, leads to a 1-D array (vector), since there are 2 
+        integers, so the dimension decreases by 2.
+
+        Note that, even though a slice contains one row, it does not reduce the 
+        dimensions. Example,
+
+        - `A[1:2, 2:3, 3:4]`, leads to a 3-D array (no decrease in dimension),
+        since there are 3 slices.
+        
+        Note that, when the number of integers equals to the number of 
+        dimensions, the final outcome is an 0-D array instead of a number.
+        The user has to upack the 0-D array with the method`A.at(0)` to get the
+        corresponding number.
+        This behavior is different from numpy where the latter returns a number.
+
+        More examples for 1-D, 2-D, and 3-D arrays.
+
+        ```console
+        A is a matrix
+        [[      -128    -95     65      -11     ]
+        [      8       -72     -116    45      ]
+        [      45      111     -30     4       ]
+        [      84      -120    -115    7       ]]
+        2-D array  Shape: [4, 4]  DType: int8
+
+        A[0]
+        [       -128    -95     65      -11     ]
+        1-D array  Shape: [4]  DType: int8
+
+        A[0, 1]
+        -95
+        0-D array  Shape: [0]  DType: int8
+
+        A[Slice(1,3)]
+        [[      8       -72     -116    45      ]
+        [      45      111     -30     4       ]]
+        2-D array  Shape: [2, 4]  DType: int8
+
+        A[1, Slice(2,4)]
+        [       -116    45      ]
+        1-D array  Shape: [2]  DType: int8
+
+        A[Slice(1,3), Slice(1,3)]
+        [[      -72     -116    ]
+        [      111     -30     ]]
+        2-D array  Shape: [2, 2]  DType: int8
+
+        A.at(0,1) as Scalar
+        -95
+
+        ==============================
+        A is a vector
+        [       43      -127    -30     -111    ]
+        1-D array  Shape: [4]  DType: int8
+
+        A[0]
+        43
+        0-D array  Shape: [0]  DType: int8
+
+        A[Slice(1,3)]
+        [       -127    -30     ]
+        1-D array  Shape: [2]  DType: int8
+
+        A.at(0) as Scalar
+        43
+
+        ==============================
+        A is a 3darray
+        [[[     -22     47      22      110     ]
+        [     88      6       -105    39      ]
+        [     -22     51      105     67      ]
+        [     -61     -116    60      -44     ]]
+        [[     33      65      125     -35     ]
+        [     -65     123     57      64      ]
+        [     38      -110    33      98      ]
+        [     -59     -17     68      -6      ]]
+        [[     -68     -58     -37     -86     ]
+        [     -4      101     104     -113    ]
+        [     103     1       4       -47     ]
+        [     124     -2      -60     -105    ]]
+        [[     114     -110    0       -30     ]
+        [     -58     105     7       -10     ]
+        [     112     -116    66      69      ]
+        [     83      -96     -124    48      ]]]
+        3-D array  Shape: [4, 4, 4]  DType: int8
+
+        A[0]
+        [[      -22     47      22      110     ]
+        [      88      6       -105    39      ]
+        [      -22     51      105     67      ]
+        [      -61     -116    60      -44     ]]
+        2-D array  Shape: [4, 4]  DType: int8
+
+        A[0, 1]
+        [       88      6       -105    39      ]
+        1-D array  Shape: [4]  DType: int8
+
+        A[0, 1, 2]
+        -105
+        0-D array  Shape: [0]  DType: int8
+
+        A[Slice(1,3)]
+        [[[     33      65      125     -35     ]
+        [     -65     123     57      64      ]
+        [     38      -110    33      98      ]
+        [     -59     -17     68      -6      ]]
+        [[     -68     -58     -37     -86     ]
+        [     -4      101     104     -113    ]
+        [     103     1       4       -47     ]
+        [     124     -2      -60     -105    ]]]
+        3-D array  Shape: [2, 4, 4]  DType: int8
+
+        A[1, Slice(2,4)]
+        [[      38      -110    33      98      ]
+        [      -59     -17     68      -6      ]]
+        2-D array  Shape: [2, 4]  DType: int8
+
+        A[Slice(1,3), Slice(1,3), 2]
+        [[      57      33      ]
+        [      104     4       ]]
+        2-D array  Shape: [2, 2]  DType: int8
+
+        A.at(0,1,2) as Scalar
+        -105
+        ```
+
+        Args:
+            slices: A series of either Slice or Int.
+
+        Returns:
+            An ndarray with a smaller or equal dimension of the original one.
         """
-        Example:
-            `arr[1:3, 2:4]` returns the corresponding sliced array (2 x 2).
-        """
+        
         var n_slices: Int = slices.__len__()
         if n_slices > self.ndim:
             raise Error("Error: No of slices greater than rank of array")

--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -89,11 +89,11 @@ fn bool_to_numeric[
     # Can't use simd becuase of bit packing error
     var res: NDArray[dtype] = NDArray[dtype](array.shape())
     for i in range(array.size()):
-        var t = array[i]
+        var t = array.at(i)
         if t:
-            res[i] = 1
+            res.__setitem__(i, 1)
         else:
-            res[i] = 0
+            res.__setitem__(i, 0)
     return res
 
 

--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -98,6 +98,35 @@ fn bool_to_numeric[
 
 
 fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
+    """Transform the Numojo NDArray to a Numpy NDArray.
+
+    Example:
+    ```console
+    > var A = NDArray(3, 3, random=True)
+    > print(A)
+    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
+     [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
+     [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
+    2-D array  Shape: [3, 3]  DType: float32
+    > var B = A.to_numpy()
+    > print(B)
+    [[0.1315 0.4587 0.219 ]
+     [0.6789 0.9347 0.5194]
+     [0.0346 0.5297 0.0077]]
+    > print(B.dtype)
+    float32
+    ```
+
+    Parameters:
+        dtype: The dtype of the original array.
+    
+    Args:
+        array: The original Numojo NDArray.
+
+    Returns:
+        A Numpy NDArray with the same data type.
+    """
+    
     try:
         var np = Python.import_module("numpy")
 

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -29,17 +29,23 @@ TODO:
 fn cumsum[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) -> SIMD[out_dtype, 1]:
-    """
-    Cumulative Sum of a array.
+    """Sum of all items of an array.
+
+    To-do:
+    1. The function currently returns a single number. In future, the function
+    returns an array of the same shape as the input one.
+    2. In future, allow users to specify the axis along which the statistics are 
+    calculated.
 
     Parameters:
         in_dtype: The input element type.
         out_dtype: The output element type.
 
     Args:
-        array: A NDArray.
+        array: An NDArray.
+
     Returns:
-        The cumulative sum of the array as a SIMD Value of `dtype`.
+        The sum of all items in the array as a SIMD Value of `dtype`.
     """
     var result = Scalar[out_dtype]()
     alias opt_nelts: Int = simdwidthof[in_dtype]()
@@ -56,16 +62,23 @@ fn cumsum[
 fn cumprod[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) -> SIMD[out_dtype, 1]:
-    """
-    Cumulative Product of a array.
+    """Product of all items in an array.
+
+    To-do:
+    1. The function currently returns a single number. In future, the function
+    returns an array of the same shape as the input one.
+    2. In future, allow users to specify the axis along which the statistics are 
+    calculated.
 
     Parameters:
         in_dtype: The input element type.
         out_dtype: The output element type.
+
     Args:
-        array: A NDArray.
+        array: An NDArray.
+
     Returns:
-        The cumulative product of the array as a SIMD Value of `dtype`.
+        The product of all items in the array as a SIMD Value of `dtype`.
     """
 
     var result: SIMD[out_dtype, 1] = SIMD[out_dtype, 1](1.0)
@@ -89,14 +102,21 @@ fn cumprod[
 fn cummean[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) raises -> SIMD[out_dtype, 1]:
-    """
-    Cumulative Arithmatic Mean of a array.
+    """Arithmatic mean of all items of an array.
+
+    To-do:
+    1. The function currently returns a single number. In future, the function
+    returns an array of the same shape as the input one.
+    2. In future, allow users to specify the axis along which the statistics are 
+    calculated.
 
     Parameters:
         in_dtype: The input element type.
         out_dtype: The output element type.
+    
     Args:
-        array: A NDArray.
+        array: An NDArray.
+
     Returns:
         The mean of all of the member values of array as a SIMD Value of `dtype`.
     """
@@ -112,15 +132,19 @@ fn cummean[
 fn mode[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) raises -> SIMD[out_dtype, 1]:
-    """
-    Cumulative Mode of a array.
+    """Mode of all items of an array.
+
+    To-do:
+    In future, allow users to specify the axis along which the statistics are 
+    calculated.
 
     Parameters:
         in_dtype: The input element type.
         out_dtype: The output element type.
 
     Args:
-        array: A NDArray.
+        array: An NDArray.
+
     Returns:
         The mode of all of the member values of array as a SIMD Value of `dtype`.
     """
@@ -128,7 +152,7 @@ fn mode[
         array
     )
     var max_count = 0
-    var mode_value = sorted_array[0]
+    var mode_value = sorted_array.at(0)
     var current_count = 1
 
     for i in range(1, array.num_elements()):
@@ -137,11 +161,11 @@ fn mode[
         else:
             if current_count > max_count:
                 max_count = current_count
-                mode_value = sorted_array[i - 1]
+                mode_value = sorted_array.at(i - 1)
             current_count = 1
 
     if current_count > max_count:
-        mode_value = sorted_array[array.num_elements() - 1]
+        mode_value = sorted_array.at(array.num_elements() - 1)
 
     return mode_value
 
@@ -150,24 +174,28 @@ fn mode[
 fn median[
     in_dtype: DType, out_dtype: DType = DType.float64
 ](array: NDArray[in_dtype]) raises -> SIMD[out_dtype, 1]:
-    """
-    Median value of a array.
+    """Median value of all items of an array.
+
+    To-do:
+    In future, allow users to specify the axis along which the statistics are 
+    calculated.
 
     Parameters:
         in_dtype: The input element type.
         out_dtype: The output element type.
 
     Args:
-        array: A NDArray.
+        array: An NDArray.
+
     Returns:
         The median of all of the member values of array as a SIMD Value of `dtype`.
     """
     var sorted_array = binary_sort[in_dtype, out_dtype](array)
     var n = array.num_elements()
     if n % 2 == 1:
-        return sorted_array[n // 2]
+        return sorted_array.at(n // 2)
     else:
-        return (sorted_array[n // 2 - 1] + sorted_array[n // 2]) / 2
+        return (sorted_array.at(n // 2 - 1) + sorted_array.at(n // 2)) / 2
 
 
 # for max and min, I can later change to the latest reduce.max, reduce.min()

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -12,14 +12,14 @@ from .. import mul
 
 
 fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
-    """
-    Sum of array elements over a given axis.
+    """Sum of array elements over a given axis.
+
     Args:
         array: NDArray.
         axis: The axis along which the sum is performed.
+    
     Returns:
         An NDArray.
-
     """
 
     var ndim: Int = array.ndim
@@ -49,10 +49,22 @@ fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
 
 
 fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
-    """
-    Sum of all items in the array.
+    """Sum of all items in the array.
+
+    Example:
+    ```console
+    > print(A)
+    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
+    [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
+    [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
+    2-D array  Shape: [3, 3]  DType: float32
+    > print(nm.math.stats.sumall(A))
+    3.5140917301177979
+    ```
+
     Args:
         array: NDArray.
+    
     Returns:
         Scalar.
     """
@@ -64,14 +76,14 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
 
 
 fn prod(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
-    """
-    Product of array elements over a given axis.
+    """Product of array elements over a given axis.
+
     Args:
         array: NDArray.
         axis: The axis along which the product is performed.
+    
     Returns:
         An NDArray.
-
     """
     var ndim: Int = array.ndim
     var shape: List[Int] = List[Int]()
@@ -105,10 +117,23 @@ fn prod(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
 
 
 fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
-    """
-    Product of all items in the array.
+    """Product of all items in the array.
+    
+    Example:
+    ```console
+    > print(A)
+    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
+    [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
+    [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
+    2-D array  Shape: [3, 3]  DType: float32
+
+    > print(nm.math.stats.prodall(A))
+    6.1377261317829834e-07
+    ```
+
     Args:
         array: NDArray.
+    
     Returns:
         Scalar.
     """
@@ -133,13 +158,25 @@ fn mean(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
 
 
 fn meanall(array: NDArray) raises -> Float64:
-    """
-    Mean of all items in the array.
+    """Mean of all items in the array.
+
+    Example:
+    ```console
+    > print(A)
+    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
+    [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
+    [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
+    2-D array  Shape: [3, 3]  DType: float32
+
+    > print(nm.math.stats.meanall(A))
+    0.39045463667975533
+    ```
+    
     Args:
         array: NDArray.
+    
     Returns:
         Float64.
-
     """
 
     return (

--- a/tests/stats.mojo
+++ b/tests/stats.mojo
@@ -1,0 +1,20 @@
+# Test file for
+# numojo.math.statistics.stats.mojo
+
+import numojo as nm
+from numojo.core.ndarray import NDArray
+import time
+
+fn main() raises:
+    var A = NDArray(3, 3, random=True)
+    print(A)
+    print(nm.math.stats.sumall(A))
+
+    print(A)
+    print(nm.math.stats.prodall(A))
+
+    print(A)
+    print(nm.math.stats.meanall(A))
+
+    print(A)
+    print(nm.math.stats.max(A))


### PR DESCRIPTION
Add a bunch of docstrings and examples mainly for `math` module and two functions (`to_numpy` and `__getitem__` in the `core` module).