### PR TITLE
Fix all the stuff that the new get and set methods broke

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -33,6 +33,7 @@ from ..math.statistics.cumulative_reduce import (
     maxT,
     minT,
 )
+import .sort as sort
 from ..math.check import any, all
 from ..math.arithmetic import abs
 from .ndarray_utils import (
@@ -1332,7 +1333,8 @@ struct NDArray[dtype: DType = DType.float32](
         
         Example:
         ```mojo
-        var A = numojo.core.NDArray[numojo.i16](6, random=True)
+        import numojo
+        var A = numojo.NDArray[numojo.i16](6, random=True)
         var idx = A.argsort()
         print(A)
         print(idx)
@@ -1973,6 +1975,14 @@ struct NDArray[dtype: DType = DType.float32](
     # # tobyets, tofile, view
     # TODO: Implement axis parameter for all
 
+    fn __bool__(self)raises->Bool:
+        if self.dtype == DType.bool:
+            if self.all():
+                return True
+            else:
+                return False
+        raise Error("core:ndarray:NDArray:__bool__: Bool is currently only implemented for DType.bool")
+
     fn all(self) raises -> Bool:
         # make this a compile time check
         if not (self.dtype == DType.bool or is_inttype(dtype)):
@@ -2032,7 +2042,7 @@ struct NDArray[dtype: DType = DType.float32](
             The indices of the sorted NDArray.
         """
 
-        return numojo.core.sort.argsort(self)
+        return sort.argsort(self)
 
     fn astype[type: DType](inout self) raises -> NDArray[type]:
         # I wonder if we can do this operation inplace instead of allocating memory.
@@ -2247,7 +2257,7 @@ struct NDArray[dtype: DType = DType.float32](
     #     pass
 
     fn sort(self) raises -> Self:
-        return numojo.core.sort.quick_sort(self)
+        return sort.quick_sort(self)
 
     fn sum(self: Self, axis: Int) raises -> Self:
         """

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -186,15 +186,15 @@ fn binary_sort[
     """
     var result: NDArray[out_dtype] = NDArray[out_dtype](array.shape())
     for i in range(array.ndshape._size):
-        result[i] = array[i].cast[out_dtype]()
+        result.store(i, array.get_scalar(i).cast[out_dtype]())
 
     var n = array.num_elements()
     for end in range(n, 1, -1):
         for i in range(1, end):
             if result[i - 1] > result[i]:
-                var temp: Scalar[out_dtype] = result[i - 1]
+                var temp: Scalar[out_dtype] = result.get_scalar(i - 1)
                 result[i - 1] = result[i]
-                result[i] = temp
+                result.store(i, temp)
     return result
 
 

--- a/numojo/math/arithmetic.mojo
+++ b/numojo/math/arithmetic.mojo
@@ -96,16 +96,14 @@ fn diff[
         NDArrayShape(array.num_elements())
     )
     for i in range(array.num_elements()):
-        array1[i] = array[i].cast[out_dtype]()
+        array1.store(i,array.get_scalar(i).cast[out_dtype]())
 
     for num in range(n):
         var result: NDArray[out_dtype] = NDArray[out_dtype](
             NDArrayShape(array.num_elements() - (num + 1))
         )
         for i in range(array1.num_elements() - 1):
-            result[i] = (array1.load[1](i + 1) - array1.load[1](i)).cast[
-                out_dtype
-            ]()
+            result.store(i, (array1.load[1](i + 1) - array1.load[1](i)).cast[out_dtype]())
         array1 = result
     return array1
 

--- a/numojo/math/calculus/differentiation.mojo
+++ b/numojo/math/calculus/differentiation.mojo
@@ -5,6 +5,7 @@
 
 import math
 import .. math_funcs as _mf
+import ...core as core
 from ...core.ndarray import NDArray, NDArrayShape
 from ...core.utility_funcs import is_inttype, is_floattype
 
@@ -45,28 +46,28 @@ fn gradient[
     #     space = numojo.arange[in_dtype, out_dtype](1, x.num_elements(), step=int)
 
     var result: NDArray[out_dtype] = NDArray[out_dtype](x.shape(), random=False)
-    var space: NDArray[out_dtype] = numojo.arange[in_dtype, out_dtype](
+    var space: NDArray[out_dtype] = core.arange[in_dtype, out_dtype](
         1, x.num_elements() + 1, step=spacing.cast[in_dtype]()
     )
-    var hu: Scalar[out_dtype] = space[1]
-    var hd: Scalar[out_dtype] = space[0]
-    result[0] = (x[1].cast[out_dtype]() - x[0].cast[out_dtype]()) / (hu - hd)
+    var hu: Scalar[out_dtype] = space.get_scalar(1)
+    var hd: Scalar[out_dtype] = space.get_scalar(0)
+    result.store(0, (x.get_scalar(1).cast[out_dtype]() - x.get_scalar(0).cast[out_dtype]()) / (hu - hd))
 
-    hu = space[x.num_elements() - 1]
-    hd = space[x.num_elements() - 2]
-    result[x.num_elements() - 1] = (
-        x[x.num_elements() - 1].cast[out_dtype]()
-        - x[x.num_elements() - 2].cast[out_dtype]()
-    ) / (hu - hd)
+    hu = space.get_scalar(x.num_elements() - 1)
+    hd = space.get_scalar(x.num_elements() - 2)
+    result.store(x.num_elements() - 1, (
+        x.get_scalar(x.num_elements() - 1).cast[out_dtype]()
+        - x.get_scalar(x.num_elements() - 2).cast[out_dtype]()
+    ) / (hu - hd))
 
     for i in range(1, x.num_elements() - 1):
-        var hu: Scalar[out_dtype] = space[i + 1] - space[i]
-        var hd: Scalar[out_dtype] = space[i] - space[i - 1]
+        var hu: Scalar[out_dtype] = space.get_scalar(i + 1) - space.get_scalar(i)
+        var hd: Scalar[out_dtype] = space.get_scalar(i) - space.get_scalar(i - 1)
         var fi: Scalar[out_dtype] = (
-            hd**2 * x[i + 1].cast[out_dtype]()
-            + (hu**2 - hd**2) * x[i].cast[out_dtype]()
-            - hu**2 * x[i - 1].cast[out_dtype]()
+            hd**2 * x.get_scalar(i + 1).cast[out_dtype]()
+            + (hu**2 - hd**2) * x.get_scalar(i).cast[out_dtype]()
+            - hu**2 * x.get_scalar(i - 1).cast[out_dtype]()
         ) / (hu * hd * (hu + hd))
-        result[i] = fi
+        result.store(i, fi)
 
     return result

--- a/numojo/math/calculus/integral.mojo
+++ b/numojo/math/calculus/integral.mojo
@@ -45,7 +45,7 @@ fn trapz[
 
     var integral: SIMD[out_dtype] = 0.0
     for i in range(x.num_elements() - 1):
-        var temp = (x[i + 1] - x[i]).cast[out_dtype]() * (y[i] + y[i + 1]).cast[
+        var temp = (x.get_scalar(i + 1) - x.get_scalar(i)).cast[out_dtype]() * (y.get_scalar(i) + y.get_scalar(i + 1)).cast[
             out_dtype
         ]() / 2.0
         integral += temp

--- a/numojo/math/check.mojo
+++ b/numojo/math/check.mojo
@@ -49,7 +49,7 @@ fn isinf[
 
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
     for i in range(result_array.size()):
-        result_array[i] = math.isinf(array[i])
+        result_array.store(i, math.isinf(array.get_scalar(i)))
     return result_array
 
 
@@ -72,7 +72,7 @@ fn isfinite[
     # return backend().math_func_is[dtype, math.isfinite](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
     for i in range(result_array.size()):
-        result_array[i] = math.isfinite(array[i])
+        result_array.store(i, math.isfinite(array.get_scalar(i)))
     return result_array
 
 
@@ -95,7 +95,7 @@ fn isnan[
     # return backend().math_func_is[dtype, math.isnan](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape())
     for i in range(result_array.size()):
-        result_array[i] = math.isnan(array[i])
+        result_array.store(i, math.isnan(array.get_scalar(i)))
     return result_array
 
 
@@ -119,7 +119,7 @@ fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
     for i in range(array.size()):
-        result |= array[i]
+        result |= array.get_scalar(i)
     return result
 
 
@@ -143,5 +143,5 @@ fn all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
     for i in range(array.size()):
-        result &= array[i]
+        result &= array.get_scalar(i)
     return result

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -1,337 +1,337 @@
-"""
-Interpolate Module - Implements interpolation functions
-"""
-# ===----------------------------------------------------------------------=== #
+# """
 # Interpolate Module - Implements interpolation functions
-# Last updated: 2024-06-14
-# ===----------------------------------------------------------------------=== #
+# """
+# # ===----------------------------------------------------------------------=== #
+# # Interpolate Module - Implements interpolation functions
+# # Last updated: 2024-06-14
+# # ===----------------------------------------------------------------------=== #
 
 
-from ..core.ndarray import NDArray, NDArrayShape
+# from ..core.ndarray import NDArray, NDArrayShape
 
-"""
-# TODO:
-1) Cross check all the functions with numpy
-2) Add support for axis argument
-"""
-
-
-fn interp1d[
-    dtype: DType = DType.float64
-](
-    xi: NDArray[dtype],
-    x: NDArray[dtype],
-    y: NDArray[dtype],
-    method: String = "linear",
-    fill_value: String = "interpolate",
-) raises -> NDArray[dtype]:
-    """
-    Interpolate the values of y at the points xi.
-
-    Parameters:
-        dtype: The element type.
-
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-        method: The interpolation method.
-        fill_value: The fill value.
-
-    Returns:
-        The interpolated values of y at the points xi as An Array of `dtype`.
-    """
-    # linear
-    if method == "linear" and fill_value == "extrapolate":
-        return _interp1d_linear_extrapolate(xi, x, y)
-    elif method == "linear" and fill_value == "interpolate":
-        return _interp1d_linear_interpolate(xi, x, y)
-
-    # quadratic
-    elif method == "quadratic" and fill_value == "extrapolate":
-        return _interp1d_quadratic_extrapolate(xi, x, y)
-    elif method == "quadratic" and fill_value == "interpolate":
-        return _interp1d_quadratic_interpolate(xi, x, y)
-
-    # cubic
-    elif method == "cubic" and fill_value == "extrapolate":
-        return _interp1d_cubic_extrapolate(xi, x, y)
-    elif method == "cubic" and fill_value == "interpolate":
-        return _interp1d_cubic_interpolate(xi, x, y)
-
-    else:
-        print("Invalid interpolation method: " + method)
-        return NDArray[dtype]()
+# """
+# # TODO:
+# 1) Cross check all the functions with numpy
+# 2) Add support for axis argument
+# """
 
 
-fn _interp1d_linear_interpolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Linear interpolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The linearly interpolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            result[i] = y[0]
-        elif xi[i] >= x[x.num_elements() - 1]:
-            result[i] = y[y.num_elements() - 1]
-        else:
-            var j = 0
-            while xi[i] > x[j]:
-                j += 1
-            var x0 = x[j - 1]
-            var x1 = x[j]
-            var y0 = y[j - 1]
-            var y1 = y[j]
-            var t = (xi[i] - x0) / (x1 - x0)
-            result[i] = y0 + t * (y1 - y0)
-    return result
+# fn interp1d[
+#     dtype: DType = DType.float64
+# ](
+#     xi: NDArray[dtype],
+#     x: NDArray[dtype],
+#     y: NDArray[dtype],
+#     method: String = "linear",
+#     fill_value: String = "interpolate",
+# ) raises -> NDArray[dtype]:
+#     """
+#     Interpolate the values of y at the points xi.
+
+#     Parameters:
+#         dtype: The element type.
+
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#         method: The interpolation method.
+#         fill_value: The fill value.
+
+#     Returns:
+#         The interpolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     # linear
+#     if method == "linear" and fill_value == "extrapolate":
+#         return _interp1d_linear_extrapolate(xi, x, y)
+#     elif method == "linear" and fill_value == "interpolate":
+#         return _interp1d_linear_interpolate(xi, x, y)
+
+#     # quadratic
+#     elif method == "quadratic" and fill_value == "extrapolate":
+#         return _interp1d_quadratic_extrapolate(xi, x, y)
+#     elif method == "quadratic" and fill_value == "interpolate":
+#         return _interp1d_quadratic_interpolate(xi, x, y)
+
+#     # cubic
+#     elif method == "cubic" and fill_value == "extrapolate":
+#         return _interp1d_cubic_extrapolate(xi, x, y)
+#     elif method == "cubic" and fill_value == "interpolate":
+#         return _interp1d_cubic_interpolate(xi, x, y)
+
+#     else:
+#         print("Invalid interpolation method: " + method)
+#         return NDArray[dtype]()
 
 
-fn _interp1d_linear_extrapolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Linear extrapolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The linearly extrapolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            var slope = (y[1] - y[0]) / (x[1] - x[0])
-            result[i] = y[0] + slope * (xi[i] - x[0])
-        elif xi[i] >= x[x.num_elements() - 1]:
-            var slope = (y[y.num_elements() - 1] - y[y.num_elements() - 2]) / (
-                x[x.num_elements() - 1] - x[x.num_elements() - 2]
-            )
-            result[i] = y[y.num_elements() - 1] + slope * (
-                xi[i] - x[x.num_elements() - 1]
-            )
-        else:
-            var j = 0
-            while xi[i] > x[j]:
-                j += 1
-            var x0 = x[j - 1]
-            var x1 = x[j]
-            var y0 = y[j - 1]
-            var y1 = y[j]
-            var t = (xi[i] - x0) / (x1 - x0)
-            result[i] = y0 + t * (y1 - y0)
-    return result
+# fn _interp1d_linear_interpolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Linear interpolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The linearly interpolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if xi[i] <= x[0]:
+#             result[i] = y[0]
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             result[i] = y[y.num_elements() - 1]
+#         else:
+#             var j = 0
+#             while xi[i] > x[j]:
+#                 j += 1
+#             var x0 = x[j - 1]
+#             var x1 = x[j]
+#             var y0 = y[j - 1]
+#             var y1 = y[j]
+#             var t = (xi[i] - x0) / (x1 - x0)
+#             result[i] = y0 + t * (y1 - y0)
+#     return result
 
 
-fn _interp1d_quadratic_interpolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Quadratic interpolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The quadratically interpolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            result[i] = y[0]
-        elif xi[i] >= x[x.num_elements() - 1]:
-            result[i] = y[y.num_elements() - 1]
-        else:
-            var j = 1
-            while xi[i] > x[j]:
-                j += 1
-            var x0 = x[j - 2]
-            var x1 = x[j - 1]
-            var x2 = x[j]
-            var y0 = y[j - 2]
-            var y1 = y[j - 1]
-            var y2 = y[j]
-            var t = (xi[i] - x1) / (x2 - x1)
-            var a = y0
-            var b = y1
-            var c = y2
-            result[i] = a * t * t + b * t + c
-    return result
+# fn _interp1d_linear_extrapolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Linear extrapolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The linearly extrapolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if xi[i] <= x[0]:
+#             var slope = (y[1] - y[0]) / (x[1] - x[0])
+#             result[i] = y[0] + slope * (xi[i] - x[0])
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             var slope = (y[y.num_elements() - 1] - y[y.num_elements() - 2]) / (
+#                 x[x.num_elements() - 1] - x[x.num_elements() - 2]
+#             )
+#             result[i] = y[y.num_elements() - 1] + slope * (
+#                 xi[i] - x[x.num_elements() - 1]
+#             )
+#         else:
+#             var j = 0
+#             while xi[i] > x[j]:
+#                 j += 1
+#             var x0 = x[j - 1]
+#             var x1 = x[j]
+#             var y0 = y[j - 1]
+#             var y1 = y[j]
+#             var t = (xi[i] - x0) / (x1 - x0)
+#             result[i] = y0 + t * (y1 - y0)
+#     return result
 
 
-fn _interp1d_quadratic_extrapolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Quadratic extrapolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The quadratically extrapolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            var slope = (y[1] - y[0]) / (x[1] - x[0])
-            var intercept = y[0] - slope * x[0]
-            result[i] = intercept + slope * xi[i]
-        elif xi[i] >= x[x.num_elements() - 1]:
-            var slope = (y[y.num_elements() - 1] - y[y.num_elements() - 2]) / (
-                x[x.num_elements() - 1] - x[x.num_elements() - 2]
-            )
-            var intercept = y[y.num_elements() - 1] - slope * x[
-                x.num_elements() - 1
-            ]
-            result[i] = intercept + slope * xi[i]
-        else:
-            var j = 1
-            while xi[i] > x[j]:
-                j += 1
-            var x0 = x[j - 2]
-            var x1 = x[j - 1]
-            var x2 = x[j]
-            var y0 = y[j - 2]
-            var y1 = y[j - 1]
-            var y2 = y[j]
-            var t = (xi[i] - x1) / (x2 - x1)
-            var a = y0
-            var b = y1
-            var c = y2
-            result[i] = a * t * t + b * t + c
-    return result
+# fn _interp1d_quadratic_interpolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Quadratic interpolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The quadratically interpolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if xi[i] <= x[0]:
+#             result[i] = y[0]
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             result[i] = y[y.num_elements() - 1]
+#         else:
+#             var j = 1
+#             while xi[i] > x[j]:
+#                 j += 1
+#             var x0 = x[j - 2]
+#             var x1 = x[j - 1]
+#             var x2 = x[j]
+#             var y0 = y[j - 2]
+#             var y1 = y[j - 1]
+#             var y2 = y[j]
+#             var t = (xi[i] - x1) / (x2 - x1)
+#             var a = y0
+#             var b = y1
+#             var c = y2
+#             result[i] = a * t * t + b * t + c
+#     return result
 
 
-fn _interp1d_cubic_interpolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Cubic interpolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The cubically interpolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            result[i] = y[0]
-        elif xi[i] >= x[x.num_elements() - 1]:
-            result[i] = y[y.num_elements() - 1]
-        else:
-            var j = 0
-            while xi[i] > x[j]:
-                j += 1
-            # Ensure we have enough points for cubic interpolation
-            # var j = math.max(j, 2)
-            # var j = math.min(j, x.num_elements() - 2)
-
-            var x0 = x[j - 2]
-            var x1 = x[j - 1]
-            var x2 = x[j]
-            var x3 = x[j + 1]
-
-            var y0 = y[j - 2]
-            var y1 = y[j - 1]
-            var y2 = y[j]
-            var y3 = y[j + 1]
-
-            var t = (xi[i] - x1) / (x2 - x1)
-
-            # Cubic interpolation formula
-            var a0 = y3 - y2 - y0 + y1
-            var a1 = y0 - y1 - a0
-            var a2 = y2 - y0
-            var a3 = y1
-
-            result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
-    return result
+# fn _interp1d_quadratic_extrapolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Quadratic extrapolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The quadratically extrapolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if xi[i] <= x[0]:
+#             var slope = (y[1] - y[0]) / (x[1] - x[0])
+#             var intercept = y[0] - slope * x[0]
+#             result[i] = intercept + slope * xi[i]
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             var slope = (y[y.num_elements() - 1] - y[y.num_elements() - 2]) / (
+#                 x[x.num_elements() - 1] - x[x.num_elements() - 2]
+#             )
+#             var intercept = y[y.num_elements() - 1] - slope * x[
+#                 x.num_elements() - 1
+#             ]
+#             result[i] = intercept + slope * xi[i]
+#         else:
+#             var j = 1
+#             while xi[i] > x[j]:
+#                 j += 1
+#             var x0 = x[j - 2]
+#             var x1 = x[j - 1]
+#             var x2 = x[j]
+#             var y0 = y[j - 2]
+#             var y1 = y[j - 1]
+#             var y2 = y[j]
+#             var t = (xi[i] - x1) / (x2 - x1)
+#             var a = y0
+#             var b = y1
+#             var c = y2
+#             result[i] = a * t * t + b * t + c
+#     return result
 
 
-fn _interp1d_cubic_extrapolate[
-    dtype: DType
-](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
-    dtype
-]:
-    """
-    Cubic extrapolation of the (x, y) values at the points xi.
-    Parameters:
-        dtype: The element type.
-    Args:
-        xi: An Array.
-        x: An Array.
-        y: An Array.
-    Returns:
-        The cubically extrapolated values of y at the points xi as An Array of `dtype`.
-    """
-    var result = NDArray[dtype](xi.shape())
-    for i in range(xi.num_elements()):
-        if xi[i] <= x[0]:
-            var t = (xi[i] - x[0]) / (x[1] - x[0])
-            var a0 = y[2] - y[1] - y[0] + y[1]
-            var a1 = y[0] - y[1] - a0
-            var a2 = y[1] - y[0]
-            var a3 = y[0]
-            result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
-        elif xi[i] >= x[x.num_elements() - 1]:
-            var t = (xi[i] - x[x.num_elements() - 2]) / (
-                x[x.num_elements() - 1] - x[x.num_elements() - 2]
-            )
-            var a0 = y[y.num_elements() - 1] - y[y.num_elements() - 2] - y[
-                y.num_elements() - 3
-            ] + y[y.num_elements() - 2]
-            var a1 = y[y.num_elements() - 3] - y[y.num_elements() - 2] - a0
-            var a2 = y[y.num_elements() - 2] - y[y.num_elements() - 3]
-            var a3 = y[y.num_elements() - 2]
-            result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
-        else:
-            var j = 1
-            while xi[i] > x[j]:
-                j += 1
-            var x0 = x[j - 2]
-            var x1 = x[j - 1]
-            var x2 = x[j]
-            var x3 = x[j + 1]
-            var y0 = y[j - 2]
-            var y1 = y[j - 1]
-            var y2 = y[j]
-            var y3 = y[j + 1]
-            var t = (xi[i] - x1) / (x2 - x1)
-            var a0 = y3 - y2 - y0 + y1
-            var a1 = y0 - y1 - a0
-            var a2 = y2 - y0
-            var a3 = y1
-            result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
-    return result
+# fn _interp1d_cubic_interpolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Cubic interpolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The cubically interpolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if xi[i] <= x[0]:
+#             result[i] = y[0]
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             result[i] = y[y.num_elements() - 1]
+#         else:
+#             var j = 0
+#             while xi[i] > x[j]:
+#                 j += 1
+#             # Ensure we have enough points for cubic interpolation
+#             # var j = math.max(j, 2)
+#             # var j = math.min(j, x.num_elements() - 2)
+
+#             var x0 = x[j - 2]
+#             var x1 = x[j - 1]
+#             var x2 = x[j]
+#             var x3 = x[j + 1]
+
+#             var y0 = y[j - 2]
+#             var y1 = y[j - 1]
+#             var y2 = y[j]
+#             var y3 = y[j + 1]
+
+#             var t = (xi[i] - x1) / (x2 - x1)
+
+#             # Cubic interpolation formula
+#             var a0 = (y3 - y2) - (y0 + y1)
+#             var a1 = y0 - y1 - a0
+#             var a2 = y2 - y0
+#             var a3 = y1
+
+#             result.store(i, (a0 * t) * (t * t) + (a1 * t) * (t + a2) * (t + a3))
+#     return result
+
+
+# fn _interp1d_cubic_extrapolate[
+#     dtype: DType
+# ](xi: NDArray[dtype], x: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[
+#     dtype
+# ]:
+#     """
+#     Cubic extrapolation of the (x, y) values at the points xi.
+#     Parameters:
+#         dtype: The element type.
+#     Args:
+#         xi: An Array.
+#         x: An Array.
+#         y: An Array.
+#     Returns:
+#         The cubically extrapolated values of y at the points xi as An Array of `dtype`.
+#     """
+#     var result = NDArray[dtype](xi.shape())
+#     for i in range(xi.num_elements()):
+#         if (xi[i] <= x[0]):
+#             var t = (xi[i] - x[0]) / (x[1] - x[0])
+#             var a0: NDArray[dtype] = (y[2] - y[1]) + (y[1]-y[0])
+#             var a1 = y[0] - y[1] - a0
+#             var a2 = y[1] - y[0]
+#             var a3 = y[0]
+#             result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
+#         elif xi[i] >= x[x.num_elements() - 1]:
+#             var t = (xi[i] - x[x.num_elements() - 2]) / (
+#                 x[x.num_elements() - 1] - x[x.num_elements() - 2]
+#             )
+#             var a0 = y[y.num_elements() - 1] - y[y.num_elements() - 2] - y[
+#                 y.num_elements() - 3
+#             ] + y[y.num_elements() - 2]
+#             var a1 = y[y.num_elements() - 3] - y[y.num_elements() - 2] - a0
+#             var a2 = y[y.num_elements() - 2] - y[y.num_elements() - 3]
+#             var a3 = y[y.num_elements() - 2]
+#             result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
+#         else:
+#             var j = 1
+#             while xi[i] > x[j]:
+#                 j += 1
+#             var x0 = x[j - 2]
+#             var x1 = x[j - 1]
+#             var x2 = x[j]
+#             var x3 = x[j + 1]
+#             var y0 = y[j - 2]
+#             var y1 = y[j - 1]
+#             var y2 = y[j]
+#             var y3 = y[j + 1]
+#             var t = (xi[i] - x1) / (x2 - x1)
+#             var a0 = y3 - y2 - y0 + y1
+#             var a1 = y0 - y1 - a0
+#             var a2 = y2 - y0
+#             var a3 = y1
+#             result[i] = a0 * t * t * t + a1 * t * t + a2 * t + a3
+#     return result

--- a/numojo/math/linalg/linalg.mojo
+++ b/numojo/math/linalg/linalg.mojo
@@ -39,15 +39,13 @@ fn cross[
 
     if array1.ndshape._len == array2.ndshape._len == 3:
         var array3: NDArray[out_dtype] = NDArray[out_dtype](NDArrayShape(3))
-        array3[0] = (array1[1] * array2[2] - array1[2] * array2[1]).cast[
+        array3.store(0,(array1.get_scalar(1) * array2.get_scalar(2) - array1.get_scalar(2) * array2.get_scalar(1)).cast[out_dtype]())
+        array3.store(1,(array1.get_scalar(2) * array2.get_scalar(0) - array1.get_scalar(0) * array2.get_scalar(2)).cast[
             out_dtype
-        ]()
-        array3[1] = (array1[2] * array2[0] - array1[0] * array2[2]).cast[
+        ]())
+        array3.store(2,(array1.get_scalar(0) * array2.get_scalar(1) - array1.get_scalar(1) * array2.get_scalar(0)).cast[
             out_dtype
-        ]()
-        array3[2] = (array1[0] * array2[1] - array1[1] * array2[0]).cast[
-            out_dtype
-        ]()
+        ]())
         return array3
     else:
         raise Error(

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -233,11 +233,10 @@ fn maxT[
 
     vectorize[vectorized_max, opt_nelts](array.num_elements())
 
-    var result: Scalar[in_dtype] = Scalar[out_dtype](max_value[0])
+    var result: Scalar[in_dtype] = Scalar[out_dtype](max_value.get_scalar(0))
     for i in range(max_value.__len__()):
-        if max_value[i] > result:
-            result = max_value[i]
-
+        if max_value.get_scalar(i) > result:
+            result = max_value.get_scalar(i)
     return result.cast[out_dtype]()
 
 
@@ -274,10 +273,10 @@ fn minT[
 
     vectorize[vectorized_min, opt_nelts](array.num_elements())
 
-    var result: Scalar[in_dtype] = Scalar[out_dtype](min_value[0])
+    var result: Scalar[in_dtype] = Scalar[out_dtype](min_value.get_scalar(0))
     for i in range(min_value.__len__()):
-        if min_value[i] < result:
-            result = min_value[i]
+        if min_value.get_scalar(i) < result:
+            result = min_value.get_scalar(i)
 
     return result.cast[out_dtype]()
 
@@ -316,7 +315,7 @@ fn cumpvariance[
     var result = Scalar[out_dtype]()
 
     for i in range(array.num_elements()):
-        result += (array[i].cast[out_dtype]() - mean_value) ** 2
+        result += (array.get_scalar(i).cast[out_dtype]() - mean_value) ** 2
 
     return result / (array.num_elements())
 
@@ -355,7 +354,7 @@ fn cumvariance[
 
     var result = Scalar[out_dtype]()
     for i in range(array.num_elements()):
-        result += (array[i].cast[out_dtype]() - mean_value) ** 2
+        result += (array.get_scalar(i).cast[out_dtype]() - mean_value) ** 2
 
     return result / (array.num_elements() - 1)
 
@@ -584,10 +583,10 @@ fn argmax[dtype: DType](array: NDArray[dtype]) raises -> Int:
         raise Error("array is empty")
 
     var idx: Int = 0
-    var max_val: Scalar[dtype] = array[0]
+    var max_val: Scalar[dtype] = array.get_scalar(0)
     for i in range(1, array.num_elements()):
-        if array[i] > max_val:
-            max_val = array[i]
+        if array.get_scalar(i) > max_val:
+            max_val = array.get_scalar(i)
             idx = i
     return idx
 
@@ -607,10 +606,10 @@ fn argmin[dtype: DType](array: NDArray[dtype]) raises -> Int:
         raise Error("array is empty")
 
     var idx: Int = 0
-    var min_val: Scalar[dtype] = array[0]
+    var min_val: Scalar[dtype] = array.get_scalar(0)
 
     for i in range(1, array.num_elements()):
-        if array[i] < min_val:
-            min_val = array[i]
+        if array.get_scalar(i) < min_val:
+            min_val = array.get_scalar(i)
             idx = i
     return idx


### PR DESCRIPTION
I fixed all of the stuff in the package that is broken by the get and set item calls for NDArray. Except for interpolation, because that thing has like 200 get item calls and when I tried to make it work with ndarray singles it had the unable to infer parameter issue.