### PR TITLE
[lib] Improve `iter` and `item` functions

### DIFF
--- a/numojo/core/ndarray_utils.mojo
+++ b/numojo/core/ndarray_utils.mojo
@@ -179,7 +179,7 @@ fn bool_to_numeric[
     # Can't use simd becuase of bit packing error
     var res: NDArray[dtype] = NDArray[dtype](array.shape())
     for i in range(array.size()):
-        var t: Bool = array.at(i)
+        var t: Bool = array.item(i)
         if t:
             res.data[i] = 1
         else:

--- a/numojo/math/statistics/cumulative_reduce.mojo
+++ b/numojo/math/statistics/cumulative_reduce.mojo
@@ -152,7 +152,7 @@ fn mode[
         array
     )
     var max_count = 0
-    var mode_value = sorted_array.at(0)
+    var mode_value = sorted_array.item(0)
     var current_count = 1
 
     for i in range(1, array.num_elements()):
@@ -161,11 +161,11 @@ fn mode[
         else:
             if current_count > max_count:
                 max_count = current_count
-                mode_value = sorted_array.at(i - 1)
+                mode_value = sorted_array.item(i - 1)
             current_count = 1
 
     if current_count > max_count:
-        mode_value = sorted_array.at(array.num_elements() - 1)
+        mode_value = sorted_array.item(array.num_elements() - 1)
 
     return mode_value
 
@@ -193,9 +193,9 @@ fn median[
     var sorted_array = binary_sort[in_dtype, out_dtype](array)
     var n = array.num_elements()
     if n % 2 == 1:
-        return sorted_array.at(n // 2)
+        return sorted_array.item(n // 2)
     else:
-        return (sorted_array.at(n // 2 - 1) + sorted_array.at(n // 2)) / 2
+        return (sorted_array.item(n // 2 - 1) + sorted_array.item(n // 2)) / 2
 
 
 # for max and min, I can later change to the latest reduce.max, reduce.min()

--- a/tests/getitem.mojo
+++ b/tests/getitem.mojo
@@ -33,8 +33,8 @@ fn test_matrix[dtype: DType](*shape: Int) raises:
     print("A[Slice(1,3), Slice(1,3)]")
     print(A[Slice(1,3), Slice(1,3)], end="\n\n")
     
-    print("A.at(0,1) as Scalar")
-    print(A.at(0, 1), end="\n\n")
+    print("A.item(0,1) as Scalar")
+    print(A.item(0, 1), end="\n\n")
 
 fn test_vector[dtype: DType](*shape: Int) raises:
     var A = NDArray[dtype](shape, random=True)
@@ -47,8 +47,8 @@ fn test_vector[dtype: DType](*shape: Int) raises:
     print("A[Slice(1,3)]")
     print(A[Slice(1,3)], end="\n\n")
     
-    print("A.at(0) as Scalar")
-    print(A.at(0), end="\n\n")
+    print("A.item(0) as Scalar")
+    print(A.item(0), end="\n\n")
 
 fn test_3darray[dtype: DType](*shape: Int) raises:
     var A = NDArray[dtype](shape, random=True)
@@ -73,5 +73,5 @@ fn test_3darray[dtype: DType](*shape: Int) raises:
     print("A[Slice(1,3), Slice(1,3), 2]")
     print(A[Slice(1,3), Slice(1,3), 2], end="\n\n")
     
-    print("A.at(0,1,2) as Scalar")
-    print(A.at(0, 1, 2), end="\n\n")
+    print("A.item(0,1,2) as Scalar")
+    print(A.item(0, 1, 2), end="\n\n")

--- a/tests/iter.mojo
+++ b/tests/iter.mojo
@@ -3,8 +3,7 @@
 import numojo as nm
 
 fn main() raises:
-    # test[nm.i8](4)
-    test[nm.i8](4, 4)
+    test[nm.i8](3, 3)
 
 fn test[dtype: DType](*size: Int) raises:
     var A = nm.NDArray[dtype](size, random=True, order="F")
@@ -12,11 +11,9 @@ fn test[dtype: DType](*size: Int) raises:
     print("Iterate over the array:")
     
     for i in A:
-        print(i)  # Return 0-d array
+        print(i)  # Return rows
     print(str("=") * 30)
 
-    for i in A:
-        print(i.item(0))  # Return scalar
+    for i in range(A.size()):
+        print(A.item(i))  # Return 0-d arrays
     print(str("=") * 30)
-
-    print(A.item(4))

--- a/tests/iter.mojo
+++ b/tests/iter.mojo
@@ -3,11 +3,11 @@
 import numojo as nm
 
 fn main() raises:
-    test[nm.i8](4)
+    # test[nm.i8](4)
     test[nm.i8](4, 4)
 
 fn test[dtype: DType](*size: Int) raises:
-    var A = nm.NDArray[dtype](size, random=True)
+    var A = nm.NDArray[dtype](size, random=True, order="F")
     print(A)
     print("Iterate over the array:")
     
@@ -16,5 +16,7 @@ fn test[dtype: DType](*size: Int) raises:
     print(str("=") * 30)
 
     for i in A:
-        print(i.at(0))  # Return scalar
+        print(i.item(0))  # Return scalar
     print(str("=") * 30)
+
+    print(A.item(4))

--- a/tests/iter.mojo
+++ b/tests/iter.mojo
@@ -3,14 +3,18 @@
 import numojo as nm
 
 fn main() raises:
-    test[nm.i8](10)
-    test[nm.f64](20)
+    test[nm.i8](4)
+    test[nm.i8](4, 4)
 
-fn test[dtype: DType](length: Int) raises:
-    var A = nm.NDArray[dtype](length, random=True)
+fn test[dtype: DType](*size: Int) raises:
+    var A = nm.NDArray[dtype](size, random=True)
     print(A)
     print("Iterate over the array:")
+    
     for i in A:
-        print(i, end="\t")
-    print()
+        print(i)  # Return 0-d array
+    print(str("=") * 30)
+
+    for i in A:
+        print(i.at(0))  # Return scalar
     print(str("=") * 30)


### PR DESCRIPTION
## Improve `iter` function

The iterate will return the first dimensions instead of scalars.

```console
> var A = nm.NDArray[dtype](3, 3, random=True, order="F")
> print(A)
[[      14      -4      -48     ]
[      97      112     -40     ]
[      -59     -94     66      ]]
2-D array  Shape: [3, 3]  DType: int8

> for i in A:
>     print(i)  # Return rows
[       14      -4      -48     ]
1-D array  Shape: [3]  DType: int8
[       97      112     -40     ]
1-D array  Shape: [3]  DType: int8
[       -59     -94     66      ]
1-D array  Shape: [3]  DType: int8
```

## Improve the `item` function

Align the behavior of `item` with numpy.

Return the scalar at the coordinates.

If one index is given, get the i-th item of the array.
It first scans over the first row, even if it is a column-major array.

If more than one index is given, the length of the indices must match
the number of dimensions of the array.

```console
> for i in range(A.size()):
>    print(A.item(i))  # Return 0-d arrays
c stride Stride: [3, 1]
14
c stride Stride: [3, 1]
-4
c stride Stride: [3, 1]
-48
c stride Stride: [3, 1]
97
c stride Stride: [3, 1]
112
c stride Stride: [3, 1]
-40
c stride Stride: [3, 1]
-59
c stride Stride: [3, 1]
-94
c stride Stride: [3, 1]
66
```

## Remove `at` function

The `at` function is replaced with `item` function.

`at` function has other behaviors in numpy.