### PR TITLE
Type stuff and testing

### DIFF
--- a/new_tests/README.md
+++ b/new_tests/README.md
@@ -1,0 +1,12 @@
+# Testing guide
+
+Inorder to ensure that all of our code works and that a new code doesn't break old code we need to instate a testing policy (which we can hopefully implement a CI/CD process for running).
+
+Due to the similiarity with NumPy, a Numpy equivelent comparison will be our method for confirming validity.
+
+The functions contained in utils_for_test.mojo `check` and `check_is_close` will be used to compare NuMojo results with NumPy equivelents.
+
+Each test must be in it's own def function and begin with the word test example `test_arange`. This allows the `mojo test` command to find it. A single function can cover multiple similiar tests but they should have unique strings to identify which check failed.
+
+
+

--- a/new_tests/test_array_creation.mojo
+++ b/new_tests/test_array_creation.mojo
@@ -1,0 +1,68 @@
+import numojo as nm
+from time import now
+from python import Python, PythonObject
+from utils_for_test import check, check_is_close
+    
+def test_arange():
+    var np = Python.import_module("numpy")
+    check(nm.arange[nm.i64](0,100),np.arange(0,100,dtype=np.int64),"Arange is broken")
+    check(nm.arange[nm.f64](0,100),np.arange(0,100,dtype=np.float64),"Arange is broken")
+
+def test_linspace():
+    var np = Python.import_module("numpy")
+    check(nm.linspace[nm.f64](0,100),np.linspace(0,100,dtype=np.float64),"Linspace is broken")
+
+def test_logspace():
+    var np = Python.import_module("numpy")
+    check_is_close(nm.logspace[nm.f64](0,100,5),np.logspace(0,100,5,dtype=np.float64),"Logspace is broken")
+
+def test_geomspace():
+    var np = Python.import_module("numpy")
+    check_is_close(nm.geomspace[nm.f64](1,100,5),np.geomspace(1,100,5,dtype=np.float64),"Logspace is broken")
+
+def test_zeros():
+    var np = Python.import_module("numpy")
+    check(nm.zeros[nm.f64](10,10,10,10),np.zeros((10,10,10,10),dtype=np.float64),"Zeros is broken")
+
+def test_ones():
+    var np = Python.import_module("numpy")
+    check(nm.ones[nm.f64](10,10,10,10),np.ones((10,10,10,10),dtype=np.float64),"Ones is broken")
+
+def test_full():
+    var np = Python.import_module("numpy")
+    check(nm.full[nm.f64](10,10,10,10,fill_value=10),np.full((10,10,10,10),10,dtype=np.float64),"Full is broken")
+
+def test_identity():
+    var np = Python.import_module("numpy")
+    check(nm.identity[nm.i64](100),np.identity(100,dtype=np.int64),"Identity is broken")
+
+def test_eye():
+    var np = Python.import_module("numpy")
+    check(nm.eye[nm.i64](100,100),np.eye(100,100,dtype=np.int64),"Eye is broken")
+def main():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,100)
+    arr.reshape(10,10)
+    var np_arr = np.arange(0,100).reshape(10,10)
+    # Arange like flat arrays
+    # check(nm.arange[nm.i64](0,100),np.arange(0,100,dtype=np.int64),"Arange is broken")
+    # check(nm.linspace[nm.i64](0,100),np.linspace(0,100,dtype=np.float64),"Linspace is broken")
+    # check_is_close(nm.logspace[nm.i64](0,100,5),np.logspace(0,100,5,dtype=np.float64),"Logspace is broken")
+    # check_is_close(nm.geomspace[nm.i64](1,100,5),np.geomspace(1,100,5,dtype=np.float64),"Logspace is broken")
+    # print((arr@arr).to_numpy()-np.matmul(np_arr,np_arr))
+    print(nm.matmul_naive[nm.f64](arr,arr).to_numpy())#-np.matmul(np_arr,np_arr))
+    print(np.matmul(np_arr,np_arr))
+    # # Basic ND arrays
+    # print(nm.sin[nm.f64](nm.arange[nm.f64](0,15)))
+    # print( np.sin(np.arange(0,15, dtype=np.float64)))
+    # check(nm.zeros[nm.f64](10,10,10,10),np.zeros((10,10,10,10),dtype=np.float64),"Zeros is broken")
+    # check(nm.ones[nm.f64](10,10,10,10),np.ones((10,10,10,10),dtype=np.float64),"Ones is broken")
+    # check(nm.full[nm.f64](10,10,10,10,fill_value=10),np.full((10,10,10,10),10,dtype=np.float64),"Full is broken")
+    
+    # # 2d Linalg related arrays
+    
+    # check(nm.identity[nm.i64](100),np.identity(100,dtype=np.int64),"Identity is broken")
+    # check(nm.eye[nm.i64](100,100),np.eye(100,100,dtype=np.int64),"Eye is broken")
+    
+
+    

--- a/new_tests/test_math.mojo
+++ b/new_tests/test_math.mojo
@@ -1,0 +1,41 @@
+import numojo as nm
+from time import now
+from python import Python, PythonObject
+from utils_for_test import check, check_is_close
+
+
+def test_add_array():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,15)
+
+    check(nm.add[nm.f64](arr,5.0),np.arange(0,15)+5,"Add array + scalar")
+    check(nm.add[nm.f64](arr,arr),np.arange(0,15)+np.arange(0,15),"Add array + array")
+
+def test_add_array_par():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,500)
+
+    check(nm.add[nm.f64,backend=nm.math.math_funcs.VectorizedParallelizedNWorkers[6]](arr,5.0),np.arange(0,500)+5,"Add array + scalar")
+    check(nm.add[nm.f64,nm.math.math_funcs.VectorizedParallelizedNWorkers[6]](arr,arr),np.arange(0,500)+np.arange(0,500),"Add array + array")
+
+def test_sin():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,15)
+
+    check_is_close(nm.sin[nm.f64](arr),np.sin(np.arange(0,15)),"Add array + scalar")
+
+def test_sin_par():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,15)
+
+    check_is_close(nm.sin[nm.f64, backend=nm .math.math_funcs.VectorizedParallelizedNWorkers[6]](arr),np.sin(np.arange(0,15)),"Add array + scalar")
+
+def test_matmul():
+    var np = Python.import_module("numpy")
+    var arr = nm.arange[nm.f64](0,100)
+    arr.reshape(10,10)
+    var np_arr = np.arange(0,100).reshape(10,10)
+    check_is_close(arr@arr,np.matmul(np_arr,np_arr),"Dunder matmul is broken")
+    # The only matmul that currently works is par (__matmul__)
+    # check_is_close(nm.matmul_tiled_unrolled_parallelized(arr,arr),np.matmul(np_arr,np_arr),"TUP matmul is broken")
+

--- a/new_tests/utils_for_test.mojo
+++ b/new_tests/utils_for_test.mojo
@@ -1,0 +1,12 @@
+from python import Python, PythonObject
+from testing.testing import assert_true
+import numojo as nm
+
+
+fn check(array:nm.NDArray,np_sol:PythonObject,st:String)raises:
+    var np = Python.import_module("numpy")
+    assert_true(np.all(np.equal(array.to_numpy(),np_sol)),st)
+
+fn check_is_close(array:nm.NDArray,np_sol:PythonObject,st:String)raises:
+    var np = Python.import_module("numpy")
+    assert_true(np.all(np.isclose(array.to_numpy(),np_sol)),st)

--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -25,43 +25,45 @@ from .utility_funcs import is_inttype, is_floattype
 # Arranged Value NDArray generation
 # ===------------------------------------------------------------------------===#
 fn arange[
-    in_dtype: DType, out_dtype: DType = DType.float64
+    dtype:DType = DType.float64
 ](
-    start: Scalar[in_dtype],
-    stop: Scalar[in_dtype],
-    step: Scalar[in_dtype] = Scalar[in_dtype](1),
-) raises -> NDArray[out_dtype]:
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
+    step: Scalar[dtype] = Scalar[dtype](1),
+) raises -> NDArray[dtype]:
     """
     Function that computes a series of values starting from "start" to "stop" with given "step" size.
 
     Raises:
-        Error if both in_dtype and out_dtype are integers or if in_dtype is a float and out_dtype is an integer.
+        Error if both dtype and dtype are integers or if dtype is a float and dtype is an integer.
 
     Parameters:
-        in_dtype: Input datatype of the input values.
-        out_dtype: Output datatype of the output NDArray.
+        dtype: Input datatype of the input values.
+        dtype: Output datatype of the output NDArray.
 
     Args:
-        start: Scalar[in_dtype] - Start value.
-        stop: Scalar[in_dtype]  - End value.
-        step: Scalar[in_dtype]  - Step size between each element (default 1).
+        start: Scalar[dtype] - Start value.
+        stop: Scalar[dtype]  - End value.
+        step: Scalar[dtype]  - Step size between each element (default 1).
 
     Returns:
-        A NDArray of datatype `out_dtype` with elements ranging from `start` to `stop` incremented with `step`.
+        A NDArray of datatype `dtype` with elements ranging from `start` to `stop` incremented with `step`.
     """
-    if (is_floattype[in_dtype]() and is_inttype[out_dtype]()) or (
-        is_inttype[in_dtype]() and is_inttype[out_dtype]()
-    ):
-        raise Error(
-            "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
-        )
+    # if (is_floattype[dtype]() and is_inttype[dtype]()) or (
+    #     is_inttype[dtype]() and is_inttype[dtype]()
+    # ):
+    #     raise Error(
+    #         "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
+    #     )
+    
+
 
     var num: Int = ((stop - start) / step).__int__()
-    var result: NDArray[out_dtype] = NDArray[out_dtype](
+    var result: NDArray[dtype] = NDArray[dtype](
         NDArrayShape(num, size=num)
     )
     for idx in range(num):
-        result.data[idx] = start.cast[out_dtype]() + step.cast[out_dtype]() * idx
+        result.data[idx] = start.cast[dtype]() + step.cast[dtype]() * idx
 
     return result
 
@@ -73,23 +75,23 @@ fn arange[
 
 # I think defaulting parallelization to False is better
 fn linspace[
-    in_dtype: DType, out_dtype: DType = DType.float64
+    dtype: DType
 ](
-    start: Scalar[in_dtype],
-    stop: Scalar[in_dtype],
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
     num: Int = 50,
     endpoint: Bool = True,
     parallel: Bool = False,
-) raises -> NDArray[out_dtype]:
+) raises -> NDArray[dtype]:
     """
     Function that computes a series of linearly spaced values starting from "start" to "stop" with given size. Wrapper function for _linspace_serial, _linspace_parallel.
 
     Raises:
-        Error if both in_dtype and out_dtype are integers or if in_dtype is a float and out_dtype is an integer.
+        Error if both dtype and dtype are integers or if dtype is a float and dtype is an integer.
 
     Parameters:
-        in_dtype: Datatype of the input values.
-        out_dtype: Datatype of the output NDArray.
+        dtype: Datatype of the input values.
+        dtype: Datatype of the output NDArray.
 
     Args:
         start: Start value.
@@ -99,23 +101,23 @@ fn linspace[
         parallel: Specifies whether the linspace should be calculated using parallelization, deafults to False.
 
     Returns:
-        A NDArray of datatype `out_dtype` with elements ranging from `start` to `stop` with num elements.
+        A NDArray of datatype `dtype` with elements ranging from `start` to `stop` with num elements.
 
     """
-    if (is_inttype[in_dtype]() and is_inttype[out_dtype]()) or (
-        is_floattype[in_dtype]() and is_inttype[out_dtype]()
-    ):
-        raise Error(
-            "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
-        )
-
+    # if (is_inttype[dtype]() and is_inttype[dtype]()) or (
+    #     is_floattype[dtype]() and is_inttype[dtype]()
+    # ):
+    #     raise Error(
+    #         "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
+    #     )
+    constrained[not dtype.is_integral()]()
     if parallel:
-        return _linspace_parallel[out_dtype](
-            start.cast[out_dtype](), stop.cast[out_dtype](), num, endpoint
+        return _linspace_parallel[dtype](
+            start.cast[dtype](), stop.cast[dtype](), num, endpoint
         )
     else:
-        return _linspace_serial[out_dtype](
-            start.cast[out_dtype](), stop.cast[out_dtype](), num, endpoint
+        return _linspace_serial[dtype](
+            start.cast[dtype](), stop.cast[dtype](), num, endpoint
         )
 
 
@@ -205,24 +207,24 @@ fn _linspace_parallel[
 # Logarithmic Spacing NDArray Generation
 # ===------------------------------------------------------------------------===#
 fn logspace[
-    in_dtype: DType, out_dtype: DType = DType.float64
+    dtype: DType
 ](
-    start: Scalar[in_dtype],
-    stop: Scalar[in_dtype],
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
     num: Int,
     endpoint: Bool = True,
-    base: Scalar[in_dtype] = 10.0,
+    base: Scalar[dtype] = 10.0,
     parallel: Bool = False,
-) raises -> NDArray[out_dtype]:
+) raises -> NDArray[dtype]:
     """
     Generate a logrithmic spaced NDArray of `num` elements between `start` and `stop`. Wrapper function for _logspace_serial, _logspace_parallel functions.
 
     Raises:
-        Error if both in_dtype and out_dtype are integers or if in_dtype is a float and out_dtype is an integer.
+        Error if both dtype and dtype are integers or if dtype is a float and dtype is an integer.
 
     Parameters:
-        in_dtype: Datatype of the input values.
-        out_dtype: Datatype of the output NDArray.
+        dtype: Datatype of the input values.
+        dtype: Datatype of the output NDArray.
 
     Args:
         start: The starting value of the NDArray.
@@ -235,26 +237,27 @@ fn logspace[
     Returns:
     - A NDArray of `dtype` with `num` logarithmic spaced elements between `start` and `stop`.
     """
-    if (is_inttype[in_dtype]() and is_inttype[out_dtype]()) or (
-        is_floattype[in_dtype]() and is_inttype[out_dtype]()
-    ):
-        raise Error(
-            "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
-        )
+    constrained[not dtype.is_integral()]()
+    # if (is_inttype[dtype]() and is_inttype[dtype]()) or (
+    #     is_floattype[dtype]() and is_inttype[dtype]()
+    # ):
+    #     raise Error(
+    #         "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
+    #     )
     if parallel:
-        return _logspace_parallel[out_dtype](
-            start.cast[out_dtype](),
-            stop.cast[out_dtype](),
+        return _logspace_parallel[dtype](
+            start.cast[dtype](),
+            stop.cast[dtype](),
             num,
-            base.cast[out_dtype](),
+            base.cast[dtype](),
             endpoint,
         )
     else:
-        return _logspace_serial[out_dtype](
-            start.cast[out_dtype](),
-            stop.cast[out_dtype](),
+        return _logspace_serial[dtype](
+            start.cast[dtype](),
+            stop.cast[dtype](),
             num,
-            base.cast[out_dtype](),
+            base.cast[dtype](),
             endpoint,
         )
 
@@ -347,22 +350,22 @@ fn _logspace_parallel[
 
 # ! Outputs wrong values for Integer type, works fine for float type.
 fn geomspace[
-    in_dtype: DType, out_dtype: DType = DType.float64
+    dtype: DType
 ](
-    start: Scalar[in_dtype],
-    stop: Scalar[in_dtype],
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
     num: Int,
     endpoint: Bool = True,
-) raises -> NDArray[out_dtype]:
+) raises -> NDArray[dtype]:
     """
     Generate a NDArray of `num` elements between `start` and `stop` in a geometric series.
 
     Raises:
-        Error if both in_dtype and out_dtype are integers or if in_dtype is a float and out_dtype is an integer.
+        Error if both dtype and dtype are integers or if dtype is a float and dtype is an integer.
 
     Parameters:
-        in_dtype: Datatype of the input values.
-        out_dtype: Datatype of the output NDArray.
+        dtype: Datatype of the input values.
+        dtype: Datatype of the output NDArray.
 
     Args:
         start: The starting value of the NDArray.
@@ -373,30 +376,30 @@ fn geomspace[
     Returns:
         A NDArray of `dtype` with `num` geometrically spaced elements between `start` and `stop`.
     """
+    constrained[not dtype.is_integral()]()
+    # if (is_inttype[dtype]() and is_inttype[dtype]()) or (
+    #     is_floattype[dtype]() and is_inttype[dtype]()
+    # ):
+    #     raise Error(
+    #         "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
+    #     )
 
-    if (is_inttype[in_dtype]() and is_inttype[out_dtype]()) or (
-        is_floattype[in_dtype]() and is_inttype[out_dtype]()
-    ):
-        raise Error(
-            "Both input and output datatypes cannot be integers. If the input is a float, the output must also be a float."
-        )
-
-    var a: Scalar[out_dtype] = start.cast[out_dtype]()
+    var a: Scalar[dtype] = start.cast[dtype]()
 
     if endpoint:
-        var result: NDArray[out_dtype] = NDArray[out_dtype](NDArrayShape(num))
-        var r: Scalar[out_dtype] = (
-            stop.cast[out_dtype]() / start.cast[out_dtype]()
-        ) ** (1 / (num - 1)).cast[out_dtype]()
+        var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(num))
+        var r: Scalar[dtype] = (
+            stop.cast[dtype]() / start.cast[dtype]()
+        ) ** (1 / (num - 1)).cast[dtype]()
         for i in range(num):
             result.data[i] = a * r**i
         return result
 
     else:
-        var result: NDArray[out_dtype] = NDArray[out_dtype](NDArrayShape(num))
-        var r: Scalar[out_dtype] = (
-            stop.cast[out_dtype]() / start.cast[out_dtype]()
-        ) ** (1 / (num)).cast[out_dtype]()
+        var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(num))
+        var r: Scalar[dtype] = (
+            stop.cast[dtype]() / start.cast[dtype]()
+        ) ** (1 / (num)).cast[dtype]()
         for i in range(num):
             result.data[i] = a * r**i
         return result

--- a/numojo/math/calculus/differentiation.mojo
+++ b/numojo/math/calculus/differentiation.mojo
@@ -16,14 +16,13 @@ from ...core.utility_funcs import is_inttype, is_floattype
 
 
 fn gradient[
-    in_dtype: DType, out_dtype: DType = DType.float32
-](x: NDArray[in_dtype], spacing: Scalar[in_dtype]) raises -> NDArray[out_dtype]:
+    dtype: DType
+](x: NDArray[dtype], spacing: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Compute the integral of y over x using the trapezoidal rule.
 
     Parameters:
-        in_dtype: Input data type.
-        out_dtype: Output data type, defaults to float32.
+        dtype: Input data type.
 
     Args:
         x: An array.
@@ -35,38 +34,38 @@ fn gradient[
     Returns:
         The integral of y over x using the trapezoidal rule.
     """
-    # var result: NDArray[out_dtype] = NDArray[out_dtype](x.shape(), random=False)
-    # var space: NDArray[out_dtype] =  NDArray[out_dtype](x.shape(), random=False)
-    # if spacing.isa[NDArray[in_dtype]]():
+    # var result: NDArray[dtype] = NDArray[dtype](x.shape(), random=False)
+    # var space: NDArray[dtype] =  NDArray[dtype](x.shape(), random=False)
+    # if spacing.isa[NDArray[dtype]]():
     #     for i in range(x.num_elements()):
-    #         space[i] = spacing._get_ptr[NDArray[in_dtype]]()[][i].cast[out_dtype]()
+    #         space[i] = spacing._get_ptr[NDArray[dtype]]()[][i].cast[dtype]()
 
-    # elif spacing.isa[Scalar[in_dtype]]():
-    #     var int: Scalar[in_dtype] = spacing._get_ptr[Scalar[in_dtype]]()[]
-    #     space = numojo.arange[in_dtype, out_dtype](1, x.num_elements(), step=int)
+    # elif spacing.isa[Scalar[dtype]]():
+    #     var int: Scalar[dtype] = spacing._get_ptr[Scalar[dtype]]()[]
+    #     space = numojo.arange[dtype, dtype](1, x.num_elements(), step=int)
 
-    var result: NDArray[out_dtype] = NDArray[out_dtype](x.shape(), random=False)
-    var space: NDArray[out_dtype] = core.arange[in_dtype, out_dtype](
-        1, x.num_elements() + 1, step=spacing.cast[in_dtype]()
+    var result: NDArray[dtype] = NDArray[dtype](x.shape(), random=False)
+    var space: NDArray[dtype] = core.arange[dtype](
+        1, x.num_elements() + 1, step=spacing.cast[dtype]()
     )
-    var hu: Scalar[out_dtype] = space.get_scalar(1)
-    var hd: Scalar[out_dtype] = space.get_scalar(0)
-    result.store(0, (x.get_scalar(1).cast[out_dtype]() - x.get_scalar(0).cast[out_dtype]()) / (hu - hd))
+    var hu: Scalar[dtype] = space.get_scalar(1)
+    var hd: Scalar[dtype] = space.get_scalar(0)
+    result.store(0, (x.get_scalar(1).cast[dtype]() - x.get_scalar(0).cast[dtype]()) / (hu - hd))
 
     hu = space.get_scalar(x.num_elements() - 1)
     hd = space.get_scalar(x.num_elements() - 2)
     result.store(x.num_elements() - 1, (
-        x.get_scalar(x.num_elements() - 1).cast[out_dtype]()
-        - x.get_scalar(x.num_elements() - 2).cast[out_dtype]()
+        x.get_scalar(x.num_elements() - 1).cast[dtype]()
+        - x.get_scalar(x.num_elements() - 2).cast[dtype]()
     ) / (hu - hd))
 
     for i in range(1, x.num_elements() - 1):
-        var hu: Scalar[out_dtype] = space.get_scalar(i + 1) - space.get_scalar(i)
-        var hd: Scalar[out_dtype] = space.get_scalar(i) - space.get_scalar(i - 1)
-        var fi: Scalar[out_dtype] = (
-            hd**2 * x.get_scalar(i + 1).cast[out_dtype]()
-            + (hu**2 - hd**2) * x.get_scalar(i).cast[out_dtype]()
-            - hu**2 * x.get_scalar(i - 1).cast[out_dtype]()
+        var hu: Scalar[dtype] = space.get_scalar(i + 1) - space.get_scalar(i)
+        var hd: Scalar[dtype] = space.get_scalar(i) - space.get_scalar(i - 1)
+        var fi: Scalar[dtype] = (
+            hd**2 * x.get_scalar(i + 1).cast[dtype]()
+            + (hu**2 - hd**2) * x.get_scalar(i).cast[dtype]()
+            - hu**2 * x.get_scalar(i - 1).cast[dtype]()
         ) / (hu * hd * (hu + hd))
         result.store(i, fi)
 


### PR DESCRIPTION
This update replaces in_dtype and out_dtype in functions where they were used with dtype. This was done because having two dtype options was confusing and the desired result was preventing Integer types from being used when those types are unsuitable. Additionally, I added constraints to the functions that cannot return ints (usually because the ability to represent values is exceeded) such that a compile-time error will occur if integral types are used in those functions.

This pull request also adds some basic tests and provides a basic framework to test correctness by comparing our results with numpy.

As a side note, this led me to discover that only the parallel version of matmul is correct.