### PR TITLE
NDArray Initialization from UnsafePointer

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -782,7 +782,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.order = order
         if fill is not None:
             fill_pointer[dtype](self.data, self.ndshape.ndsize, fill.value())
-
+    
     fn __init__(
         inout self,
         data: List[SIMD[dtype, 1]],
@@ -811,115 +811,52 @@ struct NDArray[dtype: DType = DType.float64](
         self.order = order
         for i in range(self.ndshape.ndsize):
             self.data[i] = data[i]
-
-    @always_inline("nodebug")
-    fn __init__(
-        inout self,
-        *shape: Int,
-        min: Scalar[dtype],
-        max: Scalar[dtype],
-        order: String = "C",
-    ) raises:
-        """
-        NDArray initialization for variadic shape with random values between min and max.
-
-        Args:
-            shape: Variadic shape.
-            min: Minimum value for the NDArray.
-            max: Maximum value for the NDArray.
-            order: Memory order C or F.
-
-        Example:
-            ```mojo
-            import numojo as nm
-            fn main() raises:
-                var A = nm.NDArray[DType.float16](2, 2, min=0.0, max=10.0)
-                print(A)
-            ```
-            A is an array with shape 2 x 2 and randomly values between 0 and 10.
-            The output goes as follows.
-
-            ```console
-            [[	6.046875	6.98046875	]
-             [	6.6484375	1.736328125	]]
-            2-D array  Shape: [2, 2]  DType: float16
-            ```
-        """
-        self.ndim = shape.__len__()
-        self.ndshape = NDArrayShape(shape)
-        self.stride = NDArrayStride(shape, offset=0, order=order)
-        self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.datatype = dtype
-        self.order = order
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
-        if dtype.is_floating_point():
-            for i in range(self.ndshape.ndsize):
-                self.data.store(
-                    i,
-                    random_float64(
-                        min.cast[DType.float64](), max.cast[DType.float64]()
-                    ).cast[dtype](),
-                )
-                # UnsafePointer[Scalar[DType.float32]]().
-        elif dtype.is_integral():
-            for i in range(self.ndshape.ndsize):
-                self.data.store(
-                    i, random_si64(int(min), int(max)).cast[dtype]()
-                )
-
+    
     @always_inline("nodebug")
     fn __init__(
         inout self,
         shape: List[Int],
-        min: Scalar[dtype],
-        max: Scalar[dtype],
-        order: String = "C",
+        data: UnsafePointer[Scalar[dtype]],
+        order: String = "C"
     ) raises:
         """
-        NDArray initialization for list shape with random values between min and max.
+        NDArray initialization for list shape from an UnsafePointer.
 
         Args:
             shape: List of shape.
-            min: Minimum value for the NDArray.
-            max: Maximum value for the NDArray.
+            data: UnsafePointer with the data.
             order: Memory order C or F.
-
-        Example:
-            ```mojo
-            import numojo as nm
-            fn main() raises:
-                var A = nm.NDArray[DType.float16](List[Int](2, 2), min=0.0, max=10.0)
-                print(A)
-            ```
-            A is an array with shape 2 x 2 and randomly values between 0 and 10.
-            The output goes as follows.
-
-            ```console
-            [[	6.046875	6.98046875	]
-             [	6.6484375	1.736328125	]]
-            2-D array  Shape: [2, 2]  DType: float16
-            ```
         """
-        self.ndim = shape.__len__()
+        self.ndim = len(shape)
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
         self.datatype = dtype
         self.order = order
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
-        if dtype.is_floating_point():
-            for i in range(self.ndshape.ndsize):
-                self.data.store(
-                    i,
-                    random_float64(
-                        min.cast[DType.float64](), max.cast[DType.float64]()
-                    ).cast[dtype](),
-                )
-        elif dtype.is_integral():
-            for i in range(self.ndshape.ndsize):
-                self.data.store(
-                    i, random_si64(int(min), int(max)).cast[dtype]()
-                )
+        self.data = data
+
+    @always_inline("nodebug")
+    fn __init__(
+        inout self,
+        shape: VariadicList[Int], 
+        data: UnsafePointer[Scalar[dtype]],
+        order: String = "C"
+    ) raises:
+        """
+        NDArray initialization for a variadic shape from an UnsafePointer.
+
+        Args:
+            shape: Variadic List of shape.
+            data: UnsafePointer with the data.
+            order: Memory order C or F.
+        """
+        self.ndim = len(shape)
+        self.ndshape = NDArrayShape(shape)
+        self.stride = NDArrayStride(shape, offset=0, order=order)
+        self.coefficient = NDArrayStride(shape, offset=0, order=order)
+        self.datatype = dtype
+        self.order = order
+        self.data = data
 
     fn __init__(
         inout self,


### PR DESCRIPTION
New initialization method from an `UnsafePointer`. Additionally, removed the initialization for random arrays from the `ndarray.mojo` file.