### PR TITLE
[fix] Solve the issue in parallelization for `solve`

### DIFF
--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -588,6 +588,7 @@ fn tri[
 # Construct array from string representation or txt files
 # ===------------------------------------------------------------------------===#
 
+
 fn fromstring[
     dtype: DType = DType.float64
 ](text: String, order: String = "C",) raises -> NDArray[dtype]:
@@ -682,6 +683,7 @@ fn fromstring[
 # Construct array from various objects.
 # It can be reloaded to allow different types of input.
 # ===------------------------------------------------------------------------===#
+
 
 fn array[
     dtype: DType = DType.float64

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -119,11 +119,13 @@ def test_eye():
         "Eye is broken",
     )
 
+
 def test_fromstring():
     var A = nm.fromstring("[[[1,2],[3,4]],[[5,6],[7,8]]]")
     var B = nm.array[DType.int32]("[0.1, -2.3, 41.5, 19.29145, -199]")
     print(A)
     print(B)
+
 
 # def test_diagflat():
 #     var np = Python.import_module("numpy")


### PR DESCRIPTION
Solve the issue in parallelization for `solve`. This allows us to enable `parallelize` again for the solver.