### PR TITLE
[new] Add `prelude` module for better importing

### DIFF
--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -2,15 +2,15 @@
 prelude
 =======
 
-Numojo comes a wide range of functions, types, and constants. 
-If you have to manually import every thing, 
-it would makes the header of the file too long. 
+NuMojo comes a wide range of functions, types, and constants. 
+If you manually import everything, 
+it will make the header of the file too long. 
 On the other hand, using `from numojo import *` would import a lot of functions 
 that you never use and would pollute the naming space.
 
 This module tries to find out a balance by providing a list of things 
 that can be imported at one time. 
-The lists on contains those functions or types 
+The list contains the functions or types 
 that are the most essential for a user. 
 
 You can use the following code to import them:

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -1,0 +1,15 @@
+"""
+prelude
+=======
+
+Numojo comes a wide range of functions, types, and constants. If you have to manually import every thing, it would makes the header of the file too long. On the other hand, using `from numojo import *` would import a lot of functions that you never use and would pollute the naming space.
+
+This module tries to find out a balance by providing a list of things that can be imported at one time. The lists on contains those functions or types that are the most essential for a user. You can use the following code to import them:
+
+```mojo
+from numojo.prelude import *
+```
+"""
+
+from .core.ndarray import NDArray
+from .core.datatypes import i8, i16, i32, i64, u8, u16, u32, u64, f16, f32, f64

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -2,9 +2,18 @@
 prelude
 =======
 
-Numojo comes a wide range of functions, types, and constants. If you have to manually import every thing, it would makes the header of the file too long. On the other hand, using `from numojo import *` would import a lot of functions that you never use and would pollute the naming space.
+Numojo comes a wide range of functions, types, and constants. 
+If you have to manually import every thing, 
+it would makes the header of the file too long. 
+On the other hand, using `from numojo import *` would import a lot of functions 
+that you never use and would pollute the naming space.
 
-This module tries to find out a balance by providing a list of things that can be imported at one time. The lists on contains those functions or types that are the most essential for a user. You can use the following code to import them:
+This module tries to find out a balance by providing a list of things 
+that can be imported at one time. 
+The lists on contains those functions or types 
+that are the most essential for a user. 
+
+You can use the following code to import them:
 
 ```mojo
 from numojo.prelude import *


### PR DESCRIPTION
This idea comes from the Rust.

NuMojo comes a wide range of functions, types, and constants. If you manually import everything, it will make the header of the file too long. On the other hand, using `from numojo import *` would import a lot of functions that you never use and would pollute the naming space.

This module tries to find out a balance by providing a list of things that can be imported at one time. The list contains the functions or types that are the most essential for a user. 

You can use the following code to import them:

```mojo
from numojo.prelude import *


fn main() raises:
    var array = NDArray[i32](shape=List[Int](2, 3))
    print(array)
```

In this case `NDArray` and dtypes are automatically imported.