### PR TITLE
Switch github runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-14"]
+        os: ["ubuntu-22.04", "macos-14"]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.github/workflows/test_pre_commit.yaml
+++ b/.github/workflows/test_pre_commit.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-22.04"
     timeout-minutes: 30
 
     defaults:


### PR DESCRIPTION
Github runner was having issues, so I am trying 22.04 since that is the version confirmed to work with Mojo.