### PR TITLE
[change + remove] Clean the array generation routine and wrap values in `NDArrayShape`.

### DIFF
--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -368,7 +368,9 @@ fn geomspace[
 # ===------------------------------------------------------------------------===#
 # Commonly used NDArray Generation routines
 # ===------------------------------------------------------------------------===#
-fn empty[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
+fn empty[
+    dtype: DType = DType.float64
+](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
     Generate a NDArray of given shape with arbitrary values.
 
@@ -384,7 +386,9 @@ fn empty[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     return NDArray[dtype](shape=shape)
 
 
-fn zeros[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
+fn zeros[
+    dtype: DType = DType.float64
+](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
     Generate a NDArray of zeros with given shape.
 
@@ -396,8 +400,11 @@ fn zeros[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
 
     Returns:
         A NDArray of `dtype` with given `shape`.
+
+    TODO: The fill step should be done via this function but not via `__init__`
+    of NDArray.
     """
-    return NDArray[dtype](shape, fill=SIMD[dtype, 1](0))
+    return NDArray[dtype](shape=shape, fill=SIMD[dtype, 1](0))
 
 
 fn eye[dtype: DType = DType.float64](N: Int, M: Int) raises -> NDArray[dtype]:
@@ -441,7 +448,9 @@ fn identity[dtype: DType = DType.float64](N: Int) raises -> NDArray[dtype]:
     return result
 
 
-fn ones[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
+fn ones[
+    dtype: DType = DType.float64
+](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
     Generate a NDArray of ones with given shape filled with ones.
 
@@ -454,8 +463,7 @@ fn ones[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     Returns:
         A NDArray of `dtype` with given `shape`.
     """
-    var tens_shape: VariadicList[Int] = shape
-    var res = NDArray[dtype](tens_shape)
+    var res = NDArray[dtype](shape)
     for i in range(res.num_elements()):
         res.store(i, SIMD[dtype, 1](1))
     return res
@@ -463,7 +471,7 @@ fn ones[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
 
 fn full[
     dtype: DType = DType.float64
-](*shape: Int, fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
+](shape: NDArrayShape, fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Generate a NDArray of `fill_value` with given shape.
 
@@ -476,28 +484,31 @@ fn full[
 
     Returns:
         A NDArray of `dtype` with given `shape`.
+
+    TODO: The fill step should be done via this function but not via `__init__`
+    of NDArray.
     """
-    return NDArray[dtype](shape, fill=fill_value)
+    return NDArray[dtype](shape=shape, fill=fill_value)
 
 
-fn full[
-    dtype: DType = DType.float64
-](shape: VariadicList[Int], fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
-    """
-    Generate a NDArray of `fill_value` with given shape.
+# fn full[
+#     dtype: DType = DType.float64
+# ](shape: VariadicList[Int], fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
+#     """
+#     Generate a NDArray of `fill_value` with given shape.
 
-    Parameters:
-        dtype: Datatype of the NDArray elements.
+#     Parameters:
+#         dtype: Datatype of the NDArray elements.
 
-    Args:
-        shape: Shape of the NDArray.
-        fill_value: Value to be splatted over the NDArray.
+#     Args:
+#         shape: Shape of the NDArray.
+#         fill_value: Value to be splatted over the NDArray.
 
-    Returns:
-        A NDArray of `dtype` with given `shape`.
-    """
-    var tens_value: SIMD[dtype, 1] = SIMD[dtype, 1](fill_value)
-    return NDArray[dtype](shape, fill=tens_value)
+#     Returns:
+#         A NDArray of `dtype` with given `shape`.
+#     """
+#     var tens_value: SIMD[dtype, 1] = SIMD[dtype, 1](fill_value)
+#     return NDArray[dtype](shape, fill=tens_value)
 
 
 fn diagflat[
@@ -698,120 +709,120 @@ fn array[
     return fromstring[dtype](text, order)
 
 
-fn array[
-    dtype: DType = DType.float64
-](
-    *shape: Int, fill: Optional[Scalar[dtype]] = None, order: String = "C"
-) raises -> NDArray[dtype]:
-    """
-    Array creation with given variadic shape and fill value.
+# fn array[
+#     dtype: DType = DType.float64
+# ](
+#     *shape: Int, fill: Optional[Scalar[dtype]] = None, order: String = "C"
+# ) raises -> NDArray[dtype]:
+#     """
+#     Array creation with given variadic shape and fill value.
 
-    Parameters:
-        dtype: Datatype of the NDArray elements.
+#     Parameters:
+#         dtype: Datatype of the NDArray elements.
 
-    Args:
-        shape: Variadic shape.
-        fill: Set all the values to this.
-        order: Memory order C or F.
+#     Args:
+#         shape: Variadic shape.
+#         fill: Set all the values to this.
+#         order: Memory order C or F.
 
-    Example:
-        ```mojo
-        import numojo as nm
-        nm.array[f16](3, 2, 4, fill=Scalar[f16](10))
-        ```
+#     Example:
+#         ```mojo
+#         import numojo as nm
+#         nm.array[f16](3, 2, 4, fill=Scalar[f16](10))
+#         ```
 
-    Returns:
-        An Array of given shape and fill value.
-    """
-    return NDArray[dtype](shape=shape, fill=fill, order=order)
-
-
-fn array[
-    dtype: DType = DType.float64
-](
-    shape: List[Int], fill: Optional[Scalar[dtype]] = None, order: String = "C"
-) raises -> NDArray[dtype]:
-    """
-    Array creation with given shape and fill value.
-
-    Parameters:
-        dtype: Datatype of the NDArray elements.
-
-    Args:
-        shape: List of shape.
-        fill: Set all the values to this.
-        order: Memory order C or F.
-
-    Example:
-        ```mojo
-        import numojo as nm
-        nm.array[f16](List[Int](3, 2, 4), fill=Scalar[f16](10))
-        ```
-
-    Returns:
-        An Array of given shape and fill value.
-    """
-    return NDArray[dtype](shape=shape, fill=fill, order=order)
+#     Returns:
+#         An Array of given shape and fill value.
+#     """
+#     return NDArray[dtype](shape=shape, fill=fill, order=order)
 
 
-fn array[
-    dtype: DType = DType.float64
-](
-    shape: VariadicList[Int],
-    fill: Optional[Scalar[dtype]] = None,
-    order: String = "C",
-) raises -> NDArray[dtype]:
-    """
-    Array creation with given shape and fill value.
+# fn array[
+#     dtype: DType = DType.float64
+# ](
+#     shape: List[Int], fill: Optional[Scalar[dtype]] = None, order: String = "C"
+# ) raises -> NDArray[dtype]:
+#     """
+#     Array creation with given shape and fill value.
 
-    Parameters:
-        dtype: Datatype of the NDArray elements.
+#     Parameters:
+#         dtype: Datatype of the NDArray elements.
 
-    Args:
-        shape: VariadicList of shape.
-        fill: Set all the values to this.
-        order: Memory order C or F.
+#     Args:
+#         shape: List of shape.
+#         fill: Set all the values to this.
+#         order: Memory order C or F.
 
-    Example:
-        ```mojo
-        import numojo as nm
-        nm.array[f16](List[Int](3, 2, 4), fill=Scalar[f16](10))
-        ```
+#     Example:
+#         ```mojo
+#         import numojo as nm
+#         nm.array[f16](List[Int](3, 2, 4), fill=Scalar[f16](10))
+#         ```
 
-    Returns:
-        An Array of given shape and fill value.
-    """
-    return NDArray[dtype](shape=shape, fill=fill, order=order)
+#     Returns:
+#         An Array of given shape and fill value.
+#     """
+#     return NDArray[dtype](shape=shape, fill=fill, order=order)
 
 
-fn array[
-    dtype: DType = DType.float64
-](
-    shape: NDArrayShape,
-    fill: Optional[Scalar[dtype]] = None,
-    order: String = "C",
-) raises -> NDArray[dtype]:
-    """
-    Array creation with given shape and fill value.
+# fn array[
+#     dtype: DType = DType.float64
+# ](
+#     shape: VariadicList[Int],
+#     fill: Optional[Scalar[dtype]] = None,
+#     order: String = "C",
+# ) raises -> NDArray[dtype]:
+#     """
+#     Array creation with given shape and fill value.
 
-    Parameters:
-        dtype: Datatype of the NDArray elements.
+#     Parameters:
+#         dtype: Datatype of the NDArray elements.
 
-    Args:
-        shape: NDArrayShape of the array.
-        fill: Set all the values to this.
-        order: Memory order C or F.
+#     Args:
+#         shape: VariadicList of shape.
+#         fill: Set all the values to this.
+#         order: Memory order C or F.
 
-    Example:
-        ```mojo
-        import numojo as nm
-        nm.array[f16](NDArrayShape(2, 3, 4), fill=Scalar[f16](10))
-        ```
+#     Example:
+#         ```mojo
+#         import numojo as nm
+#         nm.array[f16](List[Int](3, 2, 4), fill=Scalar[f16](10))
+#         ```
 
-    Returns:
-        An Array of given shape and fill value.
-    """
-    return NDArray[dtype](shape=shape, fill=fill, order=order)
+#     Returns:
+#         An Array of given shape and fill value.
+#     """
+#     return NDArray[dtype](shape=shape, fill=fill, order=order)
+
+# This is the same as `empty` or `full`.
+# fn array[
+#     dtype: DType = DType.float64
+# ](
+#     shape: NDArrayShape,
+#     fill: Optional[Scalar[dtype]] = None,
+#     order: String = "C",
+# ) raises -> NDArray[dtype]:
+#     """
+#     Array creation with given shape and fill value.
+
+#     Parameters:
+#         dtype: Datatype of the NDArray elements.
+
+#     Args:
+#         shape: NDArrayShape of the array.
+#         fill: Set all the values to this.
+#         order: Memory order C or F.
+
+#     Example:
+#         ```mojo
+#         import numojo as nm
+#         nm.array[f16](NDArrayShape(2, 3, 4), fill=Scalar[f16](10))
+#         ```
+
+#     Returns:
+#         An Array of given shape and fill value.
+#     """
+#     return NDArray[dtype](shape=shape, fill=fill, order=order)
 
 
 fn array[

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -10,6 +10,7 @@ from builtin.type_aliases import AnyLifetime
 
 alias Shp = NDArrayShape
 
+
 @register_passable("trivial")
 struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
     """Implements the NDArrayShape."""

--- a/numojo/math/linalg/solver.mojo
+++ b/numojo/math/linalg/solver.mojo
@@ -6,6 +6,7 @@ Provides:
     - Inverse of an invertible matrix.
 """
 
+from numojo.prelude import *
 from ...core.ndarray import NDArray
 from ...core.array_creation_routines import zeros, eye
 from algorithm import parallelize
@@ -323,8 +324,8 @@ fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var m = array.shape()[0]
 
     var Y = eye[dtype](m, m)
-    var Z = zeros[dtype](m, m)
-    var X = zeros[dtype](m, m)
+    var Z = zeros[dtype](Shp(m, m))
+    var X = zeros[dtype](Shp(m, m))
 
     @parameter
     fn calculate_X(col: Int) -> None:
@@ -411,8 +412,8 @@ fn solve[
     var m = A.shape()[0]
     var n = Y.shape()[1]
 
-    var Z = zeros[dtype](m, n)
-    var X = zeros[dtype](m, n)
+    var Z = zeros[dtype](Shp(m, n))
+    var X = zeros[dtype](Shp(m, n))
 
     ####################################################################
     # Parallelization

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -22,5 +22,5 @@ from numojo.prelude import *
 
 from .core.ndarray import NDArray
 from .core.index import Idx
-from .core.ndarrayshape import NDArrayShape
+from .core.ndshape import Shp, NDArrayShape
 from .core.datatypes import i8, i16, i32, i64, u8, u16, u32, u64, f16, f32, f64

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -1,4 +1,5 @@
 import numojo as nm
+from numojo.prelude import *
 from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
@@ -78,7 +79,7 @@ def test_geomspace():
 def test_zeros():
     var np = Python.import_module("numpy")
     check(
-        nm.zeros[nm.f64](10, 10, 10, 10),
+        nm.zeros[f64](Shp(10, 10, 10, 10)),
         np.zeros((10, 10, 10, 10), dtype=np.float64),
         "Zeros is broken",
     )
@@ -87,7 +88,7 @@ def test_zeros():
 def test_ones():
     var np = Python.import_module("numpy")
     check(
-        nm.ones[nm.f64](10, 10, 10, 10),
+        nm.ones[nm.f64](Shp(10, 10, 10, 10)),
         np.ones((10, 10, 10, 10), dtype=np.float64),
         "Ones is broken",
     )
@@ -96,7 +97,7 @@ def test_ones():
 def test_full():
     var np = Python.import_module("numpy")
     check(
-        nm.full[nm.f64](10, 10, 10, 10, fill_value=10),
+        nm.full[nm.f64](Shp(10, 10, 10, 10), fill_value=10),
         np.full((10, 10, 10, 10), 10, dtype=np.float64),
         "Full is broken",
     )


### PR DESCRIPTION
It is a step towards cleaner array generation routines. The core principle is to (1) remove excessive number of reloads for a single function, and (2) align with numpy.

(1) `array()` function only reads in an `object`, e.g., string, PyObject, List. Other reloads are removed.

(2) The argument `shape` only takes in the type `NDArrayShape`. To make it less verbose, an alias is created `Shp`. See the following example:

```mojo
zeros[f64](Shp(100, 100))
zeros[f32](shape=Shp(100, 100))
```

This is aligned with `numpy`. In `numpy`, the `shape` parameter should be wrapped in a tuple (or a single Int). In mojo, `tuple` is not iterable, so we wrap it in the `Shp` type (just like `Idx`).

Note that the following way of creating array is not possible anymore because it is not a numpy style:

```mojo
zeros[f64](100, 100)
```