### PR TITLE
[fix] Fix mistakes in `matmul` due to initialization of the zero matrix

### DIFF
--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -10,6 +10,7 @@ from builtin.type_aliases import AnyLifetime
 
 alias Shp = NDArrayShape
 
+
 @register_passable("trivial")
 struct NDArrayShape[dtype: DType = DType.int32](Stringable, Formattable):
     """Implements the NDArrayShape."""

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -86,7 +86,7 @@ fn matmul_parallelized[
 
     alias width = max(simdwidthof[dtype](), 16)
 
-    var C: NDArray[dtype] = NDArray[dtype](
+    var C: NDArray[dtype] = zeros[dtype](
         A.ndshape.load_int(0), B.ndshape.load_int(1)
     )
     var t0 = A.ndshape.load_int(0)
@@ -125,7 +125,7 @@ fn matmul_naive[
     """
     Matrix multiplication with three nested loops.
     """
-    var C: NDArray[dtype] = NDArray[dtype](
+    var C: NDArray[dtype] = zeros[dtype](
         A.ndshape.load_int(0), B.ndshape.load_int(1)
     )
     for m in range(C.ndshape.load_int(0)):

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -22,5 +22,5 @@ from numojo.prelude import *
 
 from .core.ndarray import NDArray
 from .core.index import Idx
-from .core.ndarrayshape import NDArrayShape
+from .core.ndshape import NDArrayShape
 from .core.datatypes import i8, i16, i32, i64, u8, u16, u32, u64, f16, f32, f64

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -1,4 +1,5 @@
 import numojo as nm
+from numojo.prelude import *
 from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
@@ -56,6 +57,17 @@ def test_sin_par():
 
 
 # ! MATMUL RESULTS IN A SEGMENTATION FAULT EXCEPT FOR NAIVE ONE, BUT NAIVE OUTPUTS WRONG VALUES
+
+
+def test_matmul_small():
+    var np = Python.import_module("numpy")
+    var arr = nm.ones[i8](4, 4)
+    var np_arr = np.ones((4, 4), dtype=np.int8)
+    check_is_close(
+        arr @ arr, np.matmul(np_arr, np_arr), "Dunder matmul is broken"
+    )
+
+
 def test_matmul():
     var np = Python.import_module("numpy")
     var arr = nm.arange[nm.f64](0, 100)


### PR DESCRIPTION
The `matmul` returns wrong results for small matrices. The reason is that the initialization on the `C` is not filled with `0` but uninitilized.

This PR is a quick fix on this.