### PR TITLE
[fix] Fix an error in `fromstring` where the negative signs are not read.

### DIFF
--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -712,7 +712,7 @@ fn fromstring[
                 shape.append(0)
             shape[level - 1] = 0
 
-        if isdigit(b) or chr(int(b)) == ".":
+        if isdigit(b) or (chr(int(b)) == ".") or (chr(int(b)) == "-"):
             number_as_str = number_as_str + chr(int(b))
         if (chr(int(b)) == ",") or (chr(int(b)) == "]"):
             if number_as_str != "":


### PR DESCRIPTION
There is an error in `fromstring` that the negative signs are not read.

Now a valid numeric should start with a digit, a dot, or a hyhen.