### PR TITLE
[change] Rename the data buffer from `data` to `_buffer`

### DIFF
--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -53,7 +53,7 @@ fn arange[
     var num: Int = ((stop - start) / step).__int__()
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(num, size=num))
     for idx in range(num):
-        result.data[idx] = start + step * idx
+        result._buffer[idx] = start + step * idx
 
     return result
 
@@ -125,12 +125,12 @@ fn _linspace_serial[
     if endpoint:
         var step: SIMD[dtype, 1] = (stop - start) / (num - 1)
         for i in range(num):
-            result.data[i] = start + step * i
+            result._buffer[i] = start + step * i
 
     else:
         var step: SIMD[dtype, 1] = (stop - start) / num
         for i in range(num):
-            result.data[i] = start + step * i
+            result._buffer[i] = start + step * i
 
     return result
 
@@ -164,7 +164,7 @@ fn _linspace_parallel[
 
         @parameter
         fn parallelized_linspace(idx: Int) -> None:
-            result.data[idx] = start + step * idx
+            result._buffer[idx] = start + step * idx
 
         parallelize[parallelized_linspace](num)
 
@@ -173,7 +173,7 @@ fn _linspace_parallel[
 
         @parameter
         fn parallelized_linspace1(idx: Int) -> None:
-            result.data[idx] = start + step * idx
+            result._buffer[idx] = start + step * idx
 
         parallelize[parallelized_linspace1](num)
 
@@ -262,11 +262,11 @@ fn _logspace_serial[
     if endpoint:
         var step: Scalar[dtype] = (stop - start) / (num - 1)
         for i in range(num):
-            result.data[i] = base ** (start + step * i)
+            result._buffer[i] = base ** (start + step * i)
     else:
         var step: Scalar[dtype] = (stop - start) / num
         for i in range(num):
-            result.data[i] = base ** (start + step * i)
+            result._buffer[i] = base ** (start + step * i)
     return result
 
 
@@ -302,7 +302,7 @@ fn _logspace_parallel[
 
         @parameter
         fn parallelized_logspace(idx: Int) -> None:
-            result.data[idx] = base ** (start + step * idx)
+            result._buffer[idx] = base ** (start + step * idx)
 
         parallelize[parallelized_logspace](num)
 
@@ -311,7 +311,7 @@ fn _logspace_parallel[
 
         @parameter
         fn parallelized_logspace1(idx: Int) -> None:
-            result.data[idx] = base ** (start + step * idx)
+            result._buffer[idx] = base ** (start + step * idx)
 
         parallelize[parallelized_logspace1](num)
 
@@ -354,7 +354,7 @@ fn geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num - 1)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result.data[i] = a * r**i
+            result._buffer[i] = a * r**i
         return result
 
     else:
@@ -363,7 +363,7 @@ fn geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result.data[i] = a * r**i
+            result._buffer[i] = a * r**i
         return result
 
 
@@ -531,7 +531,7 @@ fn full[
         A NDArray of `dtype` with given `shape`.
     """
     var A = NDArray[dtype](shape=shape)
-    fill_pointer[dtype](A.data, A.ndshape.ndsize, fill_value)
+    fill_pointer[dtype](A._buffer, A.ndshape.ndsize, fill_value)
     return A
 
 
@@ -571,15 +571,15 @@ fn diagflat[
 
     for i in range(n):
         print(n * i + i + k)
-        result.store(n * i + i + k, v.data[i])
+        result.store(n * i + i + k, v._buffer[i])
     if k > 0:
         for i in range(n):
-            result.store(n * i + i + k, v.data[i])
+            result.store(n * i + i + k, v._buffer[i])
     else:
         for i in range(n):
             result.store(
                 result.ndshape.ndsize - 1 - (n * i + i + abs(k)),
-                v.data[v.ndshape.ndsize - 1 - i],
+                v._buffer[v.ndshape.ndsize - 1 - i],
             )
     return result
 
@@ -628,7 +628,7 @@ fn tri[
 #     for j in range(m.ndshape[-2]):
 #         var idx: Int = _get_index(index, m.ndshape)
 #         if i >= j - k:
-#             m.data[idx] = Scalar[dtype](0)
+#             m._buffer[idx] = Scalar[dtype](0)
 #         index[-2] += 1
 
 # fn triu():

--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -53,7 +53,7 @@ fn arange[
     var num: Int = ((stop - start) / step).__int__()
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(num, size=num))
     for idx in range(num):
-        result._buffer[idx] = start + step * idx
+        result._buf[idx] = start + step * idx
 
     return result
 
@@ -125,12 +125,12 @@ fn _linspace_serial[
     if endpoint:
         var step: SIMD[dtype, 1] = (stop - start) / (num - 1)
         for i in range(num):
-            result._buffer[i] = start + step * i
+            result._buf[i] = start + step * i
 
     else:
         var step: SIMD[dtype, 1] = (stop - start) / num
         for i in range(num):
-            result._buffer[i] = start + step * i
+            result._buf[i] = start + step * i
 
     return result
 
@@ -164,7 +164,7 @@ fn _linspace_parallel[
 
         @parameter
         fn parallelized_linspace(idx: Int) -> None:
-            result._buffer[idx] = start + step * idx
+            result._buf[idx] = start + step * idx
 
         parallelize[parallelized_linspace](num)
 
@@ -173,7 +173,7 @@ fn _linspace_parallel[
 
         @parameter
         fn parallelized_linspace1(idx: Int) -> None:
-            result._buffer[idx] = start + step * idx
+            result._buf[idx] = start + step * idx
 
         parallelize[parallelized_linspace1](num)
 
@@ -262,11 +262,11 @@ fn _logspace_serial[
     if endpoint:
         var step: Scalar[dtype] = (stop - start) / (num - 1)
         for i in range(num):
-            result._buffer[i] = base ** (start + step * i)
+            result._buf[i] = base ** (start + step * i)
     else:
         var step: Scalar[dtype] = (stop - start) / num
         for i in range(num):
-            result._buffer[i] = base ** (start + step * i)
+            result._buf[i] = base ** (start + step * i)
     return result
 
 
@@ -302,7 +302,7 @@ fn _logspace_parallel[
 
         @parameter
         fn parallelized_logspace(idx: Int) -> None:
-            result._buffer[idx] = base ** (start + step * idx)
+            result._buf[idx] = base ** (start + step * idx)
 
         parallelize[parallelized_logspace](num)
 
@@ -311,7 +311,7 @@ fn _logspace_parallel[
 
         @parameter
         fn parallelized_logspace1(idx: Int) -> None:
-            result._buffer[idx] = base ** (start + step * idx)
+            result._buf[idx] = base ** (start + step * idx)
 
         parallelize[parallelized_logspace1](num)
 
@@ -354,7 +354,7 @@ fn geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num - 1)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result._buffer[i] = a * r**i
+            result._buf[i] = a * r**i
         return result
 
     else:
@@ -363,7 +363,7 @@ fn geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result._buffer[i] = a * r**i
+            result._buf[i] = a * r**i
         return result
 
 
@@ -531,7 +531,7 @@ fn full[
         A NDArray of `dtype` with given `shape`.
     """
     var A = NDArray[dtype](shape=shape)
-    fill_pointer[dtype](A._buffer, A.ndshape.ndsize, fill_value)
+    fill_pointer[dtype](A._buf, A.ndshape.ndsize, fill_value)
     return A
 
 
@@ -571,15 +571,15 @@ fn diagflat[
 
     for i in range(n):
         print(n * i + i + k)
-        result.store(n * i + i + k, v._buffer[i])
+        result.store(n * i + i + k, v._buf[i])
     if k > 0:
         for i in range(n):
-            result.store(n * i + i + k, v._buffer[i])
+            result.store(n * i + i + k, v._buf[i])
     else:
         for i in range(n):
             result.store(
                 result.ndshape.ndsize - 1 - (n * i + i + abs(k)),
-                v._buffer[v.ndshape.ndsize - 1 - i],
+                v._buf[v.ndshape.ndsize - 1 - i],
             )
     return result
 
@@ -628,7 +628,7 @@ fn tri[
 #     for j in range(m.ndshape[-2]):
 #         var idx: Int = _get_index(index, m.ndshape)
 #         if i >= j - k:
-#             m._buffer[idx] = Scalar[dtype](0)
+#             m._buf[idx] = Scalar[dtype](0)
 #         index[-2] += 1
 
 # fn triu():

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -122,8 +122,8 @@ fn where[
 
     """
     for i in range(x.ndshape.ndsize):
-        if mask.data[i] == True:
-            x.data.store(i, scalar)
+        if mask._buffer[i] == True:
+            x._buffer.store(i, scalar)
 
 
 # TODO: do it with vectorization
@@ -148,8 +148,8 @@ fn where[
     if x.ndshape != y.ndshape:
         raise Error("Shape mismatch error: x and y must have the same shape")
     for i in range(x.ndshape.ndsize):
-        if mask.data[i] == True:
-            x.data.store(i, y.data[i])
+        if mask._buffer[i] == True:
+            x._buffer.store(i, y._buffer[i])
 
 
 fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -172,7 +172,7 @@ fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         shape=array.ndshape, order=array.order
     )
     for i in range(array.ndshape.ndsize):
-        result.data.store(i, array.data[array.ndshape.ndsize - i - 1])
+        result._buffer.store(i, array._buffer[array.ndshape.ndsize - i - 1])
     return result
 
 
@@ -195,8 +195,8 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 
     @parameter
     fn vectorized_flatten[simd_width: Int](index: Int) -> None:
-        res.data.store[width=simd_width](
-            index, array.data.load[width=simd_width](index)
+        res._buffer.store[width=simd_width](
+            index, array._buffer.load[width=simd_width](index)
         )
 
     vectorize[vectorized_flatten, width](array.ndshape.ndsize)
@@ -238,6 +238,8 @@ fn trace[
     for i in range(diag_length):
         var row = i if offset >= 0 else i - offset
         var col = i + offset if offset >= 0 else i
-        result.data.store(0, result.data.load(0) + array.data[row * cols + col])
+        result._buffer.store(
+            0, result._buffer.load(0) + array._buffer[row * cols + col]
+        )
 
     return result

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -122,8 +122,8 @@ fn where[
 
     """
     for i in range(x.ndshape.ndsize):
-        if mask._buffer[i] == True:
-            x._buffer.store(i, scalar)
+        if mask._buf[i] == True:
+            x._buf.store(i, scalar)
 
 
 # TODO: do it with vectorization
@@ -148,8 +148,8 @@ fn where[
     if x.ndshape != y.ndshape:
         raise Error("Shape mismatch error: x and y must have the same shape")
     for i in range(x.ndshape.ndsize):
-        if mask._buffer[i] == True:
-            x._buffer.store(i, y._buffer[i])
+        if mask._buf[i] == True:
+            x._buf.store(i, y._buf[i])
 
 
 fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -172,7 +172,7 @@ fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         shape=array.ndshape, order=array.order
     )
     for i in range(array.ndshape.ndsize):
-        result._buffer.store(i, array._buffer[array.ndshape.ndsize - i - 1])
+        result._buf.store(i, array._buf[array.ndshape.ndsize - i - 1])
     return result
 
 
@@ -195,8 +195,8 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 
     @parameter
     fn vectorized_flatten[simd_width: Int](index: Int) -> None:
-        res._buffer.store[width=simd_width](
-            index, array._buffer.load[width=simd_width](index)
+        res._buf.store[width=simd_width](
+            index, array._buf.load[width=simd_width](index)
         )
 
     vectorize[vectorized_flatten, width](array.ndshape.ndsize)
@@ -238,8 +238,6 @@ fn trace[
     for i in range(diag_length):
         var row = i if offset >= 0 else i - offset
         var col = i + offset if offset >= 0 else i
-        result._buffer.store(
-            0, result._buffer.load(0) + array._buffer[row * cols + col]
-        )
+        result._buf.store(0, result._buf.load(0) + array._buf[row * cols + col])
 
     return result

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -139,7 +139,7 @@ struct NDArray[dtype: DType = DType.float64](
         6. The order of the array: Row vs Columns major
     """
 
-    var data: UnsafePointer[Scalar[dtype]]
+    var _buffer: UnsafePointer[Scalar[dtype]]
     """Data buffer of the items in the NDArray."""
     var ndim: Int
     """Number of Dimensions."""
@@ -188,11 +188,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self.data, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buffer, self.ndshape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -220,11 +220,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self.data, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buffer, self.ndshape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -252,11 +252,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self.data, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buffer, self.ndshape.ndsize, fill.value())
 
     @always_inline("nodebug")
     fn __init__(
@@ -284,11 +284,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, order=order)
         self.coefficient = NDArrayStride(shape, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
         self.datatype = dtype
         self.order = order
         if fill is not None:
-            fill_pointer[dtype](self.data, self.ndshape.ndsize, fill.value())
+            fill_pointer[dtype](self._buffer, self.ndshape.ndsize, fill.value())
 
     fn __init__(
         inout self,
@@ -315,11 +315,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
         self.datatype = dtype
         self.order = order
         for i in range(self.ndshape.ndsize):
-            self.data[i] = data[i]
+            self._buffer[i] = data[i]
 
     fn __init__(inout self, data: PythonObject, order: String = "C") raises:
         """
@@ -347,12 +347,14 @@ struct NDArray[dtype: DType = DType.float64](
         self.ndshape = NDArrayShape(shape)
         self.stride = NDArrayStride(shape, offset=0, order=order)
         self.coefficient = NDArrayStride(shape, offset=0, order=order)
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
-        memset_zero(self.data, self.ndshape.ndsize)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(self.ndshape.ndsize)
+        memset_zero(self._buffer, self.ndshape.ndsize)
         self.order = order
         self.datatype = dtype
         for i in range(self.ndshape.ndsize):
-            self.data[i] = data.item(PythonObject(i)).to_float64().cast[dtype]()
+            self._buffer[i] = (
+                data.item(PythonObject(i)).to_float64().cast[dtype]()
+            )
 
     # Why do  these last two constructors exist?
     # constructor when rank, ndim, weights, first_index(offset) are known
@@ -375,8 +377,8 @@ struct NDArray[dtype: DType = DType.float64](
         self.coefficient = NDArrayStride(stride=coefficient, offset=offset)
         self.datatype = dtype
         self.order = order
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(size)
-        memset_zero(self.data, size)
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(size)
+        memset_zero(self._buffer, size)
 
     # for creating views
     fn __init__(
@@ -400,7 +402,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
         self.datatype = dtype
         self.order = order
-        self.data = data + self.stride.ndoffset
+        self._buffer = data + self.stride.ndoffset
 
     @always_inline("nodebug")
     fn __copyinit__(inout self, other: Self):
@@ -413,8 +415,10 @@ struct NDArray[dtype: DType = DType.float64](
         self.coefficient = other.coefficient
         self.datatype = other.datatype
         self.order = other.order
-        self.data = UnsafePointer[Scalar[dtype]]().alloc(other.ndshape.size())
-        memcpy(self.data, other.data, other.ndshape.size())
+        self._buffer = UnsafePointer[Scalar[dtype]]().alloc(
+            other.ndshape.size()
+        )
+        memcpy(self._buffer, other._buffer, other.ndshape.size())
 
     @always_inline("nodebug")
     fn __moveinit__(inout self, owned existing: Self):
@@ -427,11 +431,11 @@ struct NDArray[dtype: DType = DType.float64](
         self.coefficient = existing.coefficient
         self.datatype = existing.datatype
         self.order = existing.order
-        self.data = existing.data
+        self._buffer = existing._buffer
 
     @always_inline("nodebug")
     fn __del__(owned self):
-        self.data.free()
+        self._buffer.free()
 
     # ===-------------------------------------------------------------------===#
     # Setter dunders
@@ -458,9 +462,9 @@ struct NDArray[dtype: DType = DType.float64](
         if index >= self.ndshape.ndsize:
             raise Error("Invalid index: index out of bound")
         if index >= 0:
-            return self.data.store[width=1](index, val)
+            return self._buffer.store[width=1](index, val)
         else:
-            return self.data.store[width=1](index + self.ndshape.ndsize, val)
+            return self._buffer.store[width=1](index + self.ndshape.ndsize, val)
 
     # TODO: add support for different dtypes
     fn __setitem__(inout self, idx: Int, val: NDArray[dtype]) raises:
@@ -471,7 +475,7 @@ struct NDArray[dtype: DType = DType.float64](
             `arr[1]` returns the second row of the array.
         """
         if self.ndim == 0 and val.ndim == 0:
-            self.data.store[width=1](0, val.data.load[width=1](0))
+            self._buffer.store[width=1](0, val._buffer.load[width=1](0))
 
         var slice_list = List[Slice]()
         slice_list.append(Slice(idx, idx + 1))
@@ -570,7 +574,7 @@ struct NDArray[dtype: DType = DType.float64](
             if index[i] >= self.ndshape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
         var idx: Int = _get_index(index, self.coefficient)
-        self.data.store[width=1](idx, val)
+        self._buffer.store[width=1](idx, val)
 
     # compiler doesn't accept this
     # fn __setitem__(
@@ -585,9 +589,9 @@ struct NDArray[dtype: DType = DType.float64](
     #         raise Error("Mask and array must have the same shape")
 
     #     for i in range(mask.ndshape.ndsize):
-    #         if mask.data.load[width=1](i):
+    #         if mask._buffer.load[width=1](i):
     #             print(value)
-    #             self.data.store[width=1](i, value)
+    #             self._buffer.store[width=1](i, value)
 
     fn __setitem__(
         inout self, owned *slices: Slice, val: NDArray[dtype]
@@ -764,8 +768,8 @@ struct NDArray[dtype: DType = DType.float64](
             raise Error("Mask and array must have the same shape")
 
         for i in range(mask.ndshape.ndsize):
-            if mask.data.load[width=1](i):
-                self.data.store[width=1](i, val.data.load[width=1](i))
+            if mask._buffer.load[width=1](i):
+                self._buffer.store[width=1](i, val._buffer.load[width=1](i))
 
     # ===-------------------------------------------------------------------===#
     # Getter dunders
@@ -791,9 +795,9 @@ struct NDArray[dtype: DType = DType.float64](
         if index >= self.ndshape.ndsize:
             raise Error("Invalid index: index out of bound")
         if index >= 0:
-            return self.data.load[width=1](index)
+            return self._buffer.load[width=1](index)
         else:
-            return self.data.load[width=1](index + self.ndshape.ndsize)
+            return self._buffer.load[width=1](index + self.ndshape.ndsize)
 
     fn __getitem__(self, idx: Int) raises -> Self:
         """
@@ -834,7 +838,7 @@ struct NDArray[dtype: DType = DType.float64](
             if index[i] >= self.ndshape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
         var idx: Int = _get_index(index, self.coefficient)
-        return self.data.load[width=1](idx)
+        return self._buffer.load[width=1](idx)
 
     fn _adjust_slice_(self, slice_list: List[Slice]) raises -> List[Slice]:
         """
@@ -1294,7 +1298,7 @@ struct NDArray[dtype: DType = DType.float64](
         # Fill in the values
         for i in range(len(index)):
             for j in range(size_per_item):
-                result.data.store[width=1](
+                result._buffer.store[width=1](
                     i * size_per_item + j, self[int(index[i])].item(j)
                 )
 
@@ -1348,12 +1352,12 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var true: List[Int] = List[Int]()
         for i in range(mask.ndshape.ndsize):
-            if mask.data.load[width=1](i):
+            if mask._buffer.load[width=1](i):
                 true.append(i)
 
         var result = Self(true.__len__())
         for i in range(true.__len__()):
-            result.data.store[width=1](i, self.get(true[i]))
+            result._buffer.store[width=1](i, self.get(true[i]))
 
         return result
 
@@ -1630,9 +1634,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         @parameter
         fn vectorized_pow[simd_width: Int](index: Int) -> None:
-            result.data.store[width=simd_width](
+            result._buffer.store[width=simd_width](
                 index,
-                self.data.load[width=simd_width](index)
+                self._buffer.load[width=simd_width](index)
                 ** p.load[width=simd_width](index),
             )
 
@@ -1647,8 +1651,8 @@ struct NDArray[dtype: DType = DType.float64](
 
         @parameter
         fn array_scalar_vectorize[simd_width: Int](index: Int) -> None:
-            new_vec.data.store[width=simd_width](
-                index, pow(self.data.load[width=simd_width](index), p)
+            new_vec._buffer.store[width=simd_width](
+                index, pow(self._buffer.load[width=simd_width](index), p)
             )
 
         vectorize[array_scalar_vectorize, self.width](self.ndshape.ndsize)
@@ -1973,7 +1977,7 @@ struct NDArray[dtype: DType = DType.float64](
         var width = self.ndshape[1]
         var buffer = Self(width)
         for i in range(width):
-            buffer.set(i, self.data.load[width=1](i + id * width))
+            buffer.set(i, self._buffer.load[width=1](i + id * width))
         return buffer
 
     fn col(self, id: Int) raises -> Self:
@@ -1986,7 +1990,7 @@ struct NDArray[dtype: DType = DType.float64](
         var height = self.ndshape[0]
         var buffer = Self(height)
         for i in range(height):
-            buffer.set(i, self.data.load[width=1](id + i * width))
+            buffer.set(i, self._buffer.load[width=1](id + i * width))
         return buffer
 
     # # * same as mdot
@@ -2039,7 +2043,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Loads a SIMD element of size `width` at the given index `index`.
         """
-        return self.data.load[width=width](index)
+        return self._buffer.load[width=width](index)
 
     # # TODO: we should add checks to make sure user don't load out of bound indices, but that will overhead, figure out later
     fn load[width: Int = 1](self, *index: Int) raises -> SIMD[dtype, width]:
@@ -2047,13 +2051,13 @@ struct NDArray[dtype: DType = DType.float64](
         Loads a SIMD element of size `width` at given variadic indices argument.
         """
         var idx: Int = _get_index(index, self.coefficient)
-        return self.data.load[width=width](idx)
+        return self._buffer.load[width=width](idx)
 
     fn store[width: Int](inout self, index: Int, val: SIMD[dtype, width]):
         """
         Stores the SIMD element of size `width` at index `index`.
         """
-        self.data.store[width=width](index, val)
+        self._buffer.store[width=width](index, val)
 
     fn store[
         width: Int = 1
@@ -2062,7 +2066,7 @@ struct NDArray[dtype: DType = DType.float64](
         Stores the SIMD element of size `width` at the given variadic indices argument.
         """
         var idx: Int = _get_index(index, self.coefficient)
-        self.data.store[width=width](idx, val)
+        self._buffer.store[width=width](idx, val)
 
     # # not urgent: argpartition, byteswap, choose, conj, dump, getfield
     # # partition, put, repeat, searchsorted, setfield, squeeze, swapaxes, take,
@@ -2102,7 +2106,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         fn vectorized_all[simd_width: Int](idx: Int) -> None:
             result = result and allb(
-                (self.data + idx).strided_load[width=simd_width](1)
+                (self._buffer + idx).strided_load[width=simd_width](1)
             )
 
         vectorize[vectorized_all, self.width](self.ndshape.ndsize)
@@ -2120,7 +2124,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         fn vectorized_any[simd_width: Int](idx: Int) -> None:
             result = result or anyb(
-                (self.data + idx).strided_load[width=simd_width](1)
+                (self._buffer + idx).strided_load[width=simd_width](1)
             )
 
         vectorize[vectorized_any, self.width](self.ndshape.ndsize)
@@ -2192,7 +2196,7 @@ struct NDArray[dtype: DType = DType.float64](
                 ](idx: Int) -> None:
                     narr.store[simd_width](
                         idx,
-                        (self.data + idx)
+                        (self._buffer + idx)
                         .strided_load[width=simd_width](1)
                         .cast[type](),
                     )
@@ -2249,7 +2253,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         @parameter
         fn vectorized_fill[simd_width: Int](index: Int) -> None:
-            self.data.store[width=simd_width](index, val)
+            self._buffer.store[width=simd_width](index, val)
 
         vectorize[vectorized_fill, self.width](self.ndshape.ndsize)
 
@@ -2337,11 +2341,11 @@ struct NDArray[dtype: DType = DType.float64](
                         var coordinate = idx // c_stride[i]
                         idx = idx - c_stride[i] * coordinate
                         c_coordinates.append(coordinate)
-                    return self.data.load[width=1](
+                    return self._buffer.load[width=1](
                         _get_index(c_coordinates, self.stride)
                     )
 
-                return self.data.load[width=1](index[0])
+                return self._buffer.load[width=1](index[0])
             else:
                 raise Error("Error: Elements of `index` exceed the array size")
 
@@ -2351,7 +2355,7 @@ struct NDArray[dtype: DType = DType.float64](
         for i in range(index.__len__()):
             if index[i] >= self.ndshape[i]:
                 raise Error("Error: Elements of `index` exceed the array shape")
-        return self.data.load[width=1](_get_index(index, self.stride))
+        return self._buffer.load[width=1](_get_index(index, self.stride))
 
     fn itemset(
         inout self, index: Variant[Int, List[Int]], item: Scalar[dtype]
@@ -2413,11 +2417,11 @@ struct NDArray[dtype: DType = DType.float64](
                         var coordinate = idx // c_stride[i]
                         idx = idx - c_stride[i] * coordinate
                         c_coordinates.append(coordinate)
-                    self.data.store[width=1](
+                    self._buffer.store[width=1](
                         _get_index(c_coordinates, self.stride), item
                     )
 
-                self.data.store[width=1](idx, item)
+                self._buffer.store[width=1](idx, item)
             else:
                 raise Error("Error: Elements of `index` exceed the array size")
 
@@ -2431,7 +2435,7 @@ struct NDArray[dtype: DType = DType.float64](
                     raise Error(
                         "Error: Elements of `index` exceed the array shape"
                     )
-            self.data.store[width=1](_get_index(indices, self.stride), item)
+            self._buffer.store[width=1](_get_index(indices, self.stride), item)
 
     fn max(self, axis: Int = 0) raises -> Self:
         """
@@ -2575,7 +2579,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var result: List[Scalar[dtype]] = List[Scalar[dtype]]()
         for i in range(self.ndshape.ndsize):
-            result.append(self.data[i])
+            result.append(self._buffer[i])
         return result
 
     # TODO: add axis parameter
@@ -2611,7 +2615,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Retreive pointer without taking ownership.
         """
-        return self.data
+        return self._buffer
 
     fn to_numpy(self) raises -> PythonObject:
         """

--- a/numojo/core/random.mojo
+++ b/numojo/core/random.mojo
@@ -61,7 +61,7 @@ fn int_rand_func[
         max: The maximum value of the random integers.
     """
     random.randint[dtype](
-        ptr=result._buffer,
+        ptr=result._buf,
         size=result.ndshape.ndsize,
         low=int(min),
         high=int(max),
@@ -87,7 +87,7 @@ fn float_rand_func[
         var temp: Scalar[dtype] = random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
-        result._buffer[i] = temp
+        result._buf[i] = temp
 
 
 fn rand[
@@ -205,7 +205,7 @@ fn randn[
     random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
-        ptr=result._buffer,
+        ptr=result._buf,
         size=result.ndshape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
@@ -241,7 +241,7 @@ fn randn[
     random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
-        ptr=result._buffer,
+        ptr=result._buf,
         size=result.ndshape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
@@ -276,7 +276,7 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = random.random_float64().cast[dtype]()
-        result._buffer[i] = -mt.log(1 - u) / rate
+        result._buf[i] = -mt.log(1 - u) / rate
 
     return result^
 
@@ -308,6 +308,6 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = random.random_float64().cast[dtype]()
-        result._buffer[i] = -mt.log(1 - u) / rate
+        result._buf[i] = -mt.log(1 - u) / rate
 
     return result^

--- a/numojo/core/random.mojo
+++ b/numojo/core/random.mojo
@@ -61,7 +61,7 @@ fn int_rand_func[
         max: The maximum value of the random integers.
     """
     random.randint[dtype](
-        ptr=result.data,
+        ptr=result._buffer,
         size=result.ndshape.ndsize,
         low=int(min),
         high=int(max),
@@ -87,7 +87,7 @@ fn float_rand_func[
         var temp: Scalar[dtype] = random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
-        result.data[i] = temp
+        result._buffer[i] = temp
 
 
 fn rand[
@@ -205,7 +205,7 @@ fn randn[
     random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
-        ptr=result.data,
+        ptr=result._buffer,
         size=result.ndshape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
@@ -241,7 +241,7 @@ fn randn[
     random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
-        ptr=result.data,
+        ptr=result._buffer,
         size=result.ndshape.ndsize,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
@@ -276,7 +276,7 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = random.random_float64().cast[dtype]()
-        result.data[i] = -mt.log(1 - u) / rate
+        result._buffer[i] = -mt.log(1 - u) / rate
 
     return result^
 
@@ -308,6 +308,6 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = random.random_float64().cast[dtype]()
-        result.data[i] = -mt.log(1 - u) / rate
+        result._buffer[i] = -mt.log(1 - u) / rate
 
     return result^

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -51,10 +51,14 @@ fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 
     for i in range(length):
         for j in range(length - i - 1):
-            if result.data.load[width=1](j) > result.data.load[width=1](j + 1):
-                var temp = result.data.load[width=1](j)
-                result.data.store[width=1](j, result.data.load[width=1](j + 1))
-                result.data.store[width=1](j + 1, temp)
+            if result._buffer.load[width=1](j) > result._buffer.load[width=1](
+                j + 1
+            ):
+                var temp = result._buffer.load[width=1](j)
+                result._buffer.store[width=1](
+                    j, result._buffer.load[width=1](j + 1)
+                )
+                result._buffer.store[width=1](j + 1, temp)
 
     return result
 

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -51,14 +51,10 @@ fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 
     for i in range(length):
         for j in range(length - i - 1):
-            if result._buffer.load[width=1](j) > result._buffer.load[width=1](
-                j + 1
-            ):
-                var temp = result._buffer.load[width=1](j)
-                result._buffer.store[width=1](
-                    j, result._buffer.load[width=1](j + 1)
-                )
-                result._buffer.store[width=1](j + 1, temp)
+            if result._buf.load[width=1](j) > result._buf.load[width=1](j + 1):
+                var temp = result._buf.load[width=1](j)
+                result._buf.store[width=1](j, result._buf.load[width=1](j + 1))
+                result._buf.store[width=1](j + 1, temp)
 
     return result
 

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -208,9 +208,7 @@ fn _traverse_iterative[
         except:
             return
 
-        narr._buffer.store[width=1](
-            narr_idx, orig._buffer.load[width=1](orig_idx)
-        )
+        narr._buf.store[width=1](narr_idx, orig._buf.load[width=1](orig_idx))
 
         for d in range(ndim.__len__() - 1, -1, -1):
             index[d] += 1
@@ -259,9 +257,7 @@ fn _traverse_iterative_setter[
         except:
             return
 
-        narr._buffer.store[width=1](
-            orig_idx, orig._buffer.load[width=1](narr_idx)
-        )
+        narr._buf.store[width=1](orig_idx, orig._buf.load[width=1](narr_idx))
 
         for d in range(ndim.__len__() - 1, -1, -1):
             index[d] += 1
@@ -293,9 +289,9 @@ fn bool_to_numeric[
     for i in range(array.size()):
         var t: Bool = array.item(i)
         if t:
-            res._buffer[i] = 1
+            res._buf[i] = 1
         else:
-            res._buffer[i] = 0
+            res._buf[i] = 0
     return res
 
 

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -208,7 +208,9 @@ fn _traverse_iterative[
         except:
             return
 
-        narr.data.store[width=1](narr_idx, orig.data.load[width=1](orig_idx))
+        narr._buffer.store[width=1](
+            narr_idx, orig._buffer.load[width=1](orig_idx)
+        )
 
         for d in range(ndim.__len__() - 1, -1, -1):
             index[d] += 1
@@ -257,7 +259,9 @@ fn _traverse_iterative_setter[
         except:
             return
 
-        narr.data.store[width=1](orig_idx, orig.data.load[width=1](narr_idx))
+        narr._buffer.store[width=1](
+            orig_idx, orig._buffer.load[width=1](narr_idx)
+        )
 
         for d in range(ndim.__len__() - 1, -1, -1):
             index[d] += 1
@@ -289,9 +293,9 @@ fn bool_to_numeric[
     for i in range(array.size()):
         var t: Bool = array.item(i)
         if t:
-            res.data[i] = 1
+            res._buffer[i] = 1
         else:
-            res.data[i] = 0
+            res._buffer[i] = 0
     return res
 
 

--- a/numojo/io/files.mojo
+++ b/numojo/io/files.mojo
@@ -45,4 +45,4 @@ fn savetxt[
         for i in range(array.ndshape.ndsize):
             if i % 10 == 0:
                 file.write(str("\n"))
-            file.write(str(array.data[i]) + ",")
+            file.write(str(array._buffer[i]) + ",")

--- a/numojo/io/files.mojo
+++ b/numojo/io/files.mojo
@@ -45,4 +45,4 @@ fn savetxt[
         for i in range(array.ndshape.ndsize):
             if i % 10 == 0:
                 file.write(str("\n"))
-            file.write(str(array._buffer[i]) + ",")
+            file.write(str(array._buf[i]) + ",")

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -82,20 +82,20 @@ fn _interp1d_linear_interpolate[
     """
     var result = NDArray[dtype](xi.shape())
     for i in range(xi.num_elements()):
-        if xi.data[i] <= x.data[0]:
-            result.data.store[width=1](i, y.data[0])
-        elif xi.data[i] >= x.data[x.num_elements() - 1]:
-            result.data.store[width=1](i, y.data[y.num_elements() - 1])
+        if xi._buffer[i] <= x._buffer[0]:
+            result._buffer.store[width=1](i, y._buffer[0])
+        elif xi._buffer[i] >= x._buffer[x.num_elements() - 1]:
+            result._buffer.store[width=1](i, y._buffer[y.num_elements() - 1])
         else:
             var j = 0
-            while xi.data[i] > x.data[j]:
+            while xi._buffer[i] > x._buffer[j]:
                 j += 1
-            var x0 = x.data[j - 1]
-            var x1 = x.data[j]
-            var y0 = y.data[j - 1]
-            var y1 = y.data[j]
-            var t = (xi.data[i] - x0) / (x1 - x0)
-            result.data.store[width=1](i, y0 + t * (y1 - y0))
+            var x0 = x._buffer[j - 1]
+            var x1 = x._buffer[j]
+            var y0 = y._buffer[j - 1]
+            var y1 = y._buffer[j]
+            var t = (xi._buffer[i] - x0) / (x1 - x0)
+            result._buffer.store[width=1](i, y0 + t * (y1 - y0))
     return result
 
 
@@ -117,26 +117,34 @@ fn _interp1d_linear_extrapolate[
     """
     var result = NDArray[dtype](xi.shape())
     for i in range(xi.num_elements()):
-        if xi.data.load[width=1](i) <= x.data.load[width=1](0):
-            var slope = (y.data[1] - y.data[0]) / (x.data[1] - x.data[0])
-            result.data[i] = y.data[0] + slope * (xi.data[i] - x.data[0])
-        elif xi.data[i] >= x.data[x.num_elements() - 1]:
+        if xi._buffer.load[width=1](i) <= x._buffer.load[width=1](0):
+            var slope = (y._buffer[1] - y._buffer[0]) / (
+                x._buffer[1] - x._buffer[0]
+            )
+            result._buffer[i] = y._buffer[0] + slope * (
+                xi._buffer[i] - x._buffer[0]
+            )
+        elif xi._buffer[i] >= x._buffer[x.num_elements() - 1]:
             var slope = (
-                y.data[y.num_elements() - 1] - y.data[y.num_elements() - 2]
-            ) / (x.data[x.num_elements() - 1] - x.data[x.num_elements() - 2])
-            result.data[i] = y.data[y.num_elements() - 1] + slope * (
-                xi.data[i] - x.data[x.num_elements() - 1]
+                y._buffer[y.num_elements() - 1]
+                - y._buffer[y.num_elements() - 2]
+            ) / (
+                x._buffer[x.num_elements() - 1]
+                - x._buffer[x.num_elements() - 2]
+            )
+            result._buffer[i] = y._buffer[y.num_elements() - 1] + slope * (
+                xi._buffer[i] - x._buffer[x.num_elements() - 1]
             )
         else:
             var j = 0
-            while xi.data[i] > x.data[j]:
+            while xi._buffer[i] > x._buffer[j]:
                 j += 1
-            var x0 = x.data[j - 1]
-            var x1 = x.data[j]
-            var y0 = y.data[j - 1]
-            var y1 = y.data[j]
-            var t = (xi.data[i] - x0) / (x1 - x0)
-            result.data[i] = y0 + t * (y1 - y0)
+            var x0 = x._buffer[j - 1]
+            var x1 = x._buffer[j]
+            var y0 = y._buffer[j - 1]
+            var y1 = y._buffer[j]
+            var t = (xi._buffer[i] - x0) / (x1 - x0)
+            result._buffer[i] = y0 + t * (y1 - y0)
     return result
 
 

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -82,20 +82,20 @@ fn _interp1d_linear_interpolate[
     """
     var result = NDArray[dtype](xi.shape())
     for i in range(xi.num_elements()):
-        if xi._buffer[i] <= x._buffer[0]:
-            result._buffer.store[width=1](i, y._buffer[0])
-        elif xi._buffer[i] >= x._buffer[x.num_elements() - 1]:
-            result._buffer.store[width=1](i, y._buffer[y.num_elements() - 1])
+        if xi._buf[i] <= x._buf[0]:
+            result._buf.store[width=1](i, y._buf[0])
+        elif xi._buf[i] >= x._buf[x.num_elements() - 1]:
+            result._buf.store[width=1](i, y._buf[y.num_elements() - 1])
         else:
             var j = 0
-            while xi._buffer[i] > x._buffer[j]:
+            while xi._buf[i] > x._buf[j]:
                 j += 1
-            var x0 = x._buffer[j - 1]
-            var x1 = x._buffer[j]
-            var y0 = y._buffer[j - 1]
-            var y1 = y._buffer[j]
-            var t = (xi._buffer[i] - x0) / (x1 - x0)
-            result._buffer.store[width=1](i, y0 + t * (y1 - y0))
+            var x0 = x._buf[j - 1]
+            var x1 = x._buf[j]
+            var y0 = y._buf[j - 1]
+            var y1 = y._buf[j]
+            var t = (xi._buf[i] - x0) / (x1 - x0)
+            result._buf.store[width=1](i, y0 + t * (y1 - y0))
     return result
 
 
@@ -117,34 +117,26 @@ fn _interp1d_linear_extrapolate[
     """
     var result = NDArray[dtype](xi.shape())
     for i in range(xi.num_elements()):
-        if xi._buffer.load[width=1](i) <= x._buffer.load[width=1](0):
-            var slope = (y._buffer[1] - y._buffer[0]) / (
-                x._buffer[1] - x._buffer[0]
-            )
-            result._buffer[i] = y._buffer[0] + slope * (
-                xi._buffer[i] - x._buffer[0]
-            )
-        elif xi._buffer[i] >= x._buffer[x.num_elements() - 1]:
+        if xi._buf.load[width=1](i) <= x._buf.load[width=1](0):
+            var slope = (y._buf[1] - y._buf[0]) / (x._buf[1] - x._buf[0])
+            result._buf[i] = y._buf[0] + slope * (xi._buf[i] - x._buf[0])
+        elif xi._buf[i] >= x._buf[x.num_elements() - 1]:
             var slope = (
-                y._buffer[y.num_elements() - 1]
-                - y._buffer[y.num_elements() - 2]
-            ) / (
-                x._buffer[x.num_elements() - 1]
-                - x._buffer[x.num_elements() - 2]
-            )
-            result._buffer[i] = y._buffer[y.num_elements() - 1] + slope * (
-                xi._buffer[i] - x._buffer[x.num_elements() - 1]
+                y._buf[y.num_elements() - 1] - y._buf[y.num_elements() - 2]
+            ) / (x._buf[x.num_elements() - 1] - x._buf[x.num_elements() - 2])
+            result._buf[i] = y._buf[y.num_elements() - 1] + slope * (
+                xi._buf[i] - x._buf[x.num_elements() - 1]
             )
         else:
             var j = 0
-            while xi._buffer[i] > x._buffer[j]:
+            while xi._buf[i] > x._buf[j]:
                 j += 1
-            var x0 = x._buffer[j - 1]
-            var x1 = x._buffer[j]
-            var y0 = y._buffer[j - 1]
-            var y1 = y._buffer[j]
-            var t = (xi._buffer[i] - x0) / (x1 - x0)
-            result._buffer[i] = y0 + t * (y1 - y0)
+            var x0 = x._buf[j - 1]
+            var x1 = x._buf[j]
+            var y0 = y._buf[j - 1]
+            var y1 = y._buf[j]
+            var t = (xi._buf[i] - x0) / (x1 - x0)
+            result._buf[i] = y0 + t * (y1 - y0)
     return result
 
 

--- a/numojo/math/signal/signal.mojo
+++ b/numojo/math/signal/signal.mojo
@@ -33,7 +33,7 @@ fn convolve2d[
     var in2_mirrored = in2
     var length = in2.size()
     for i in range(length):
-        in2_mirrored.data[i] = in2.data[length - i - 1]
+        in2_mirrored._buffer[i] = in2._buffer[length - i - 1]
 
     var in1_height = in1.shape()[0]
     var in1_width = in1.shape()[1]

--- a/numojo/math/signal/signal.mojo
+++ b/numojo/math/signal/signal.mojo
@@ -33,7 +33,7 @@ fn convolve2d[
     var in2_mirrored = in2
     var length = in2.size()
     for i in range(length):
-        in2_mirrored._buffer[i] = in2._buffer[length - i - 1]
+        in2_mirrored._buf[i] = in2._buf[length - i - 1]
 
     var in1_height = in1.shape()[0]
     var in1_width = in1.shape()[1]

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -71,7 +71,7 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
 
     var result = Scalar[array.dtype](0)
     for i in range(array.ndshape.ndsize):
-        result[0] += array.data[i]
+        result[0] += array._buffer[i]
     return result
 
 
@@ -136,7 +136,7 @@ fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
 
     var result = Scalar[array.dtype](1)
     for i in range(array.ndshape.ndsize):
-        result[0] *= array.data[i]
+        result[0] *= array._buffer[i]
     return result
 
 

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -71,7 +71,7 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
 
     var result = Scalar[array.dtype](0)
     for i in range(array.ndshape.ndsize):
-        result[0] += array._buffer[i]
+        result[0] += array._buf[i]
     return result
 
 
@@ -136,7 +136,7 @@ fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
 
     var result = Scalar[array.dtype](1)
     for i in range(array.ndshape.ndsize):
-        result[0] *= array._buffer[i]
+        result[0] *= array._buf[i]
     return result
 
 

--- a/test.mojo
+++ b/test.mojo
@@ -303,7 +303,7 @@ fn test_rand_funcs[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     if dtype.is_integral():
         randint[dtype](
-            ptr=result._buffer,
+            ptr=result._buf,
             size=result.ndshape.ndsize,
             low=int(min),
             high=int(max),

--- a/test.mojo
+++ b/test.mojo
@@ -303,7 +303,7 @@ fn test_rand_funcs[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     if dtype.is_integral():
         randint[dtype](
-            ptr=result.data,
+            ptr=result._buffer,
             size=result.ndshape.ndsize,
             low=int(min),
             high=int(max),

--- a/tests/test_random.mojo
+++ b/tests/test_random.mojo
@@ -194,12 +194,12 @@ def test_rand_exponential():
     # Test that all values are non-negative
     for i in range(arr_variadic.num_elements()):
         assert_true(
-            arr_variadic._buffer[i] >= 0,
+            arr_variadic._buf[i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )
 
     for i in range(arr_list.num_elements()):
         assert_true(
-            arr_list._buffer[i] >= 0,
+            arr_list._buf[i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )

--- a/tests/test_random.mojo
+++ b/tests/test_random.mojo
@@ -194,12 +194,12 @@ def test_rand_exponential():
     # Test that all values are non-negative
     for i in range(arr_variadic.num_elements()):
         assert_true(
-            arr_variadic.data[i] >= 0,
+            arr_variadic._buffer[i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )
 
     for i in range(arr_list.num_elements()):
         assert_true(
-            arr_list.data[i] >= 0,
+            arr_list._buffer[i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )


### PR DESCRIPTION
The data buffer of `NDArray` is an `unsafepointer`. We should not expose it to the users. So it is renamed to `_buffer` with an underscore.