### PR TITLE
[change] Unify the array creation functions

### DIFF
--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -587,28 +587,53 @@ fn zeros_like[
 
 fn full[
     dtype: DType = DType.float64
-](shape: NDArrayShape, fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
-    """Overload of function `full` that reads a list of ints."""
-    return NDArray[dtype](shape=shape, fill=fill_value)
+](
+    shape: NDArrayShape, fill_value: Scalar[dtype], order: String = "C"
+) raises -> NDArray[dtype]:
+    """Initialize an NDArray of certain shape fill it with a given value.
+
+    Args:
+        shape: Shape of the array.
+        fill_value: Set all the values to this.
+        order: Memory order C or F.
+
+    Example:
+        ```mojo
+        import numojo as nm
+        from numojo.prelude import *
+        var a = nm.full(Shape(2,3,4), fill_value=10)
+        ```
+    """
+
+    var A = NDArray[dtype](shape=shape, order=order)
+    fill_pointer[dtype](A._buf, A.shape.ndsize, fill_value)
+
+    return A
 
 
 fn full[
     dtype: DType = DType.float64
-](shape: List[Int], fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
+](
+    shape: List[Int], fill_value: Scalar[dtype], order: String = "C"
+) raises -> NDArray[dtype]:
     """Overload of function `full` that reads a list of ints."""
-    return full[dtype](shape=Shape(shape), fill_value=fill_value)
+    return full[dtype](shape=Shape(shape), fill_value=fill_value, order=order)
 
 
 fn full[
     dtype: DType = DType.float64
-](shape: VariadicList[Int], fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
+](
+    shape: VariadicList[Int], fill_value: Scalar[dtype], order: String = "C"
+) raises -> NDArray[dtype]:
     """Overload of function `full` that reads a variadic list of ints."""
-    return full[dtype](shape=Shape(shape), fill_value=fill_value)
+    return full[dtype](shape=Shape(shape), fill_value=fill_value, order=order)
 
 
 fn full_like[
     dtype: DType = DType.float64
-](array: NDArray[dtype], fill_value: Scalar[dtype]) raises -> NDArray[dtype]:
+](
+    array: NDArray[dtype], fill_value: Scalar[dtype], order: String = "C"
+) raises -> NDArray[dtype]:
     """
     Generate a NDArray of the same shape as `a` filled with `fill_value`.
 
@@ -618,11 +643,12 @@ fn full_like[
     Args:
         array: NDArray to be used as a reference for the shape.
         fill_value: Value to fill the NDArray with.
+        order: Memory order C or F.
 
     Returns:
         A NDArray of `dtype` with the same shape as `a` filled with `fill_value`.
     """
-    return full[dtype](shape=array.shape, fill_value=fill_value)
+    return full[dtype](shape=array.shape, fill_value=fill_value, order=order)
 
 
 # ===------------------------------------------------------------------------===#
@@ -935,7 +961,7 @@ fn fromstring[
                 raise ("Unmatched left and right brackets!")
             if level > 0:
                 shape[level - 1] = shape[level - 1] + 1
-    var result: NDArray[dtype] = NDArray[dtype](
+    var result: NDArray[dtype] = array[dtype](
         data=data, shape=shape, order=order
     )
     return result^
@@ -979,7 +1005,11 @@ fn array[
     Returns:
         An Array of given data, shape and order.
     """
-    return NDArray[dtype](data=data, shape=shape, order=order)
+
+    A = NDArray[dtype](Shape(shape), order)
+    for i in range(A.shape.ndsize):
+        A._buf[i] = data[i]
+    return A
 
 
 fn array[
@@ -998,12 +1028,26 @@ fn array[
     Example:
         ```mojo
         import numojo as nm
+        from numojo.prelude import *
+        from python import Python
         var np = Python.import_module("numpy")
         var np_arr = np.array([1, 2, 3, 4])
-        nm.array[f16](data=np_arr, order="C")
+        A = nm.array[f16](data=np_arr, order="C")
         ```
 
     Returns:
         An Array of given data, shape and order.
     """
-    return NDArray[dtype](data=data, order=order)
+
+    var len = int(len(data.shape))
+    var shape: List[Int] = List[Int]()
+    for i in range(len):
+        if int(data.shape[i]) == 1:
+            continue
+        shape.append(int(data.shape[i]))
+    A = NDArray[dtype](Shape(shape), order=order)
+    A._buf = UnsafePointer[Scalar[dtype]]().alloc(A.shape.ndsize)
+    memset_zero(A._buf, A.shape.ndsize)
+    for i in range(A.shape.ndsize):
+        A._buf[i] = data.item(PythonObject(i)).to_float64().cast[dtype]()
+    return A

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -190,7 +190,7 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         The 1 dimensional flattened NDArray.
     """
 
-    var res: NDArray[dtype] = NDArray[dtype](array.shape.ndsize)
+    var res: NDArray[dtype] = NDArray[dtype](Shape(array.shape.ndsize))
     alias width: Int = simdwidthof[dtype]()
 
     @parameter
@@ -228,7 +228,7 @@ fn trace[
         raise Error("Trace is currently only supported for 2D arrays")
     if axis1 > array.ndim - 1 or axis2 > array.ndim - 1:
         raise Error("axis cannot be greater than the rank of the array")
-    var result: NDArray[dtype] = NDArray[dtype](1)
+    var result: NDArray[dtype] = NDArray[dtype](Shape(1))
     var rows = array.shape[0]
     var cols = array.shape[1]
     var diag_length = min(rows, cols - offset) if offset >= 0 else min(

--- a/numojo/core/mat/creation.mojo
+++ b/numojo/core/mat/creation.mojo
@@ -107,13 +107,13 @@ fn matrix[dtype: DType](object: NDArray[dtype]) raises -> Matrix[dtype]:
     except e:
         print(e)
 
-    var matrix = Matrix[dtype](shape=(object.ndshape[0], object.ndshape[1]))
+    var matrix = Matrix[dtype](shape=(object.shape[0], object.shape[1]))
 
     if object.order == "C":
         memcpy(matrix._buf, object._buf, matrix.size)
     else:
-        for i in range(object.ndshape[0]):
-            for j in range(object.ndshape[1]):
+        for i in range(object.shape[0]):
+            for j in range(object.shape[1]):
                 matrix._store(i, j, object.load(i, j))
     return matrix
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -60,63 +60,6 @@ from .array_manipulation_routines import reshape
 from .ndshape import NDArrayShape
 from .ndstride import NDArrayStride
 
-
-# ===----------------------------------------------------------------------===#
-# NDArrayIterator
-# ===----------------------------------------------------------------------===#
-
-
-@value
-struct _NDArrayIter[
-    is_mutable: Bool, //,
-    lifetime: AnyLifetime[is_mutable].type,
-    dtype: DType,
-    forward: Bool = True,
-]:
-    """Iterator for NDArray.
-
-    Parameters:
-        is_mutable: Whether the iterator is mutable.
-        lifetime: The lifetime of the underlying NDArray data.
-        dtype: The data type of the item.
-        forward: The iteration direction. `False` is backwards.
-    """
-
-    var index: Int
-    var array: NDArray[dtype]
-    var length: Int
-
-    fn __init__(
-        inout self,
-        array: NDArray[dtype],
-        length: Int,
-    ):
-        self.index = 0 if forward else length
-        self.length = length
-        self.array = array
-
-    fn __iter__(self) -> Self:
-        return self
-
-    fn __next__(inout self) raises -> NDArray[dtype]:
-        @parameter
-        if forward:
-            var current_index = self.index
-            self.index += 1
-            return self.array.__getitem__(current_index)
-        else:
-            var current_index = self.index
-            self.index -= 1
-            return self.array.__getitem__(current_index)
-
-    fn __len__(self) -> Int:
-        @parameter
-        if forward:
-            return self.length - self.index
-        else:
-            return self.index
-
-
 # ===----------------------------------------------------------------------===#
 # NDArray
 # ===----------------------------------------------------------------------===#
@@ -2614,3 +2557,59 @@ struct NDArray[dtype: DType = DType.float64](
         Convert to a numpy array.
         """
         return to_numpy(self)
+
+
+# ===----------------------------------------------------------------------===#
+# NDArrayIterator
+# ===----------------------------------------------------------------------===#
+
+
+@value
+struct _NDArrayIter[
+    is_mutable: Bool, //,
+    lifetime: AnyLifetime[is_mutable].type,
+    dtype: DType,
+    forward: Bool = True,
+]:
+    """Iterator for NDArray.
+
+    Parameters:
+        is_mutable: Whether the iterator is mutable.
+        lifetime: The lifetime of the underlying NDArray data.
+        dtype: The data type of the item.
+        forward: The iteration direction. `False` is backwards.
+    """
+
+    var index: Int
+    var array: NDArray[dtype]
+    var length: Int
+
+    fn __init__(
+        inout self,
+        array: NDArray[dtype],
+        length: Int,
+    ):
+        self.index = 0 if forward else length
+        self.length = length
+        self.array = array
+
+    fn __iter__(self) -> Self:
+        return self
+
+    fn __next__(inout self) raises -> NDArray[dtype]:
+        @parameter
+        if forward:
+            var current_index = self.index
+            self.index += 1
+            return self.array.__getitem__(current_index)
+        else:
+            var current_index = self.index
+            self.index -= 1
+            return self.array.__getitem__(current_index)
+
+    fn __len__(self) -> Int:
+        @parameter
+        if forward:
+            return self.length - self.index
+        else:
+            return self.index

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -165,6 +165,38 @@ struct NDArray[dtype: DType = DType.float64](
     ########################
     # Use nm.array instead #
     ########################
+    # fn __init__(
+    #     inout self,
+    #     data: List[SIMD[dtype, 1]],
+    #     shape: NDArrayShape,
+    #     order: String = "C",
+    # ) raises:
+    #     """
+    #     NDArray initialization from list of data.
+    #     Args:
+    #         data: List of data.
+    #         shape: List of shape.
+    #         order: Memory order C or F.
+    #     Example:
+    #         ```mojo
+    #         import numojo as nm
+    #         nm.array[f16](data=List[Scalar[f16]](1, 2, 3, 4), shape=List[Int](2, 2))
+    #         ```
+    #     """
+
+    #     self.ndim = shape.ndlen
+    #     self.shape = NDArrayShape(shape)
+    #     self.stride = NDArrayStride(shape, offset=0, order=order)
+    #     self.coefficient = NDArrayStride(shape, offset=0, order=order)
+    #     self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
+    #     self.datatype = dtype
+    #     self.order = order
+    #     for i in range(self.shape.ndsize):
+    #         self._buf[i] = data[i]
+
+    ########################
+    # Use nm.array instead #
+    ########################
     # fn __init__(inout self, data: PythonObject, order: String = "C") raises:
     #     """
     #     NDArray initialization from Numpy arrays.

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -315,7 +315,7 @@ fn argsort[
     var array: NDArray[dtype] = ndarray
     var length = array.size()
 
-    var idx_array = NDArray[DType.index](length)
+    var idx_array = NDArray[DType.index](Shape(length))
     for i in range(length):
         idx_array.set(i, SIMD[DType.index, 1](i))
 

--- a/numojo/io/files.mojo
+++ b/numojo/io/files.mojo
@@ -25,7 +25,7 @@ fn loadtxt[
             if string[i].isdigit():
                 var number: String = string[i]
                 data.append(atof(number).cast[dtype]())
-        return NDArray[dtype](data=data, shape=ndshape, order="C")
+        return array[dtype](data=data, shape=ndshape, order="C")
 
 
 fn savetxt[

--- a/numojo/math/interpolate.mojo
+++ b/numojo/math/interpolate.mojo
@@ -61,7 +61,7 @@ fn interp1d[
 
     else:
         print("Invalid interpolation method: " + type)
-        return NDArray[dtype]()
+        return NDArray[dtype](Shape())
 
 
 fn _interp1d_linear_interpolate[

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -32,8 +32,8 @@ fn matmul_tiled_unrolled_parallelized[
     Matrix multiplication vectorized, tiled, unrolled, and parallelized.
     """
     alias width = max(simdwidthof[dtype](), 16)
-    var C: NDArray[dtype] = NDArray[dtype](
-        A.shape.load_int(0), B.shape.load_int(1)
+    var C: NDArray[dtype] = zeros[dtype](
+        Shape(A.shape.load_int(0), B.shape.load_int(1))
     )
     var t0 = A.shape.load_int(0)
     var t1 = A.shape.load_int(1)

--- a/numojo/math/linalg/solver.mojo
+++ b/numojo/math/linalg/solver.mojo
@@ -84,8 +84,8 @@ fn lu_decomposition[
     # var A = array.astype[dtype]()
 
     # Initiate upper and lower triangular matrices
-    var U = NDArray[dtype](shape=shape_of_array, fill=SIMD[dtype, 1](0))
-    var L = NDArray[dtype](shape=shape_of_array, fill=SIMD[dtype, 1](0))
+    var U = full[dtype](shape=shape_of_array, fill_value=SIMD[dtype, 1](0))
+    var L = full[dtype](shape=shape_of_array, fill_value=SIMD[dtype, 1](0))
 
     # Fill in L and U
     # @parameter
@@ -141,7 +141,7 @@ fn forward_substitution[
     var m = L.shape[0]
 
     # Initialize x
-    var x = NDArray[dtype](m, fill=SIMD[dtype, 1](0))
+    var x = full[dtype](Shape(m), fill_value=SIMD[dtype, 1](0))
 
     for i in range(m):
         var value_on_hold: Scalar[dtype] = y.item(i)
@@ -174,7 +174,7 @@ fn back_substitution[
     # length of U
     var m = U.shape[0]
     # Initialize x
-    var x = NDArray[dtype](m, fill=SIMD[dtype, 1](0))
+    var x = full[dtype](Shape(m), fill_value=SIMD[dtype, 1](0))
 
     for i in range(m - 1, -1, -1):
         var value_on_hold: Scalar[dtype] = y.item(i)
@@ -271,13 +271,13 @@ fn inv_raw[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var inversed = NDArray[dtype](shape=array.shape)
 
     # Initialize vectors
-    var y = NDArray[dtype](m)
-    var z = NDArray[dtype](m)
-    var x = NDArray[dtype](m)
+    var y = NDArray[dtype](Shape(m))
+    var z = NDArray[dtype](Shape(m))
+    var x = NDArray[dtype](Shape(m))
 
     for i in range(m):
         # Each time, one of the item is changed to 1
-        y = NDArray[dtype](m, fill=Scalar[dtype](0))
+        y = zeros[dtype](Shape(m))
         y.set(i, Scalar[dtype](1))
 
         # Solve `Lz = y` for `z`

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -7,16 +7,6 @@ from utils_for_test import check, check_is_close
 from testing.testing import assert_raises
 
 
-def test_list_creation_methods():
-    var np = Python.import_module("numpy")
-    var fill_val: Scalar[nm.i32] = 5
-    check(
-        nm.NDArray(nm.shape(5, 5, 5), fill=fill_val),
-        np.zeros([5, 5, 5], dtype=np.float64) + 5,
-        "*shape broken",
-    )
-
-
 def test_arange():
     var np = Python.import_module("numpy")
     check(

--- a/tests/test_array_manipulation.mojo
+++ b/tests/test_array_manipulation.mojo
@@ -35,7 +35,7 @@ def test_arr_manipulation():
 
 def test_setitem():
     var np = Python.import_module("numpy")
-    var arr = nm.NDArray(4, 4)
+    var arr = nm.NDArray(Shape(4, 4))
     var np_arr = arr.to_numpy()
     arr.itemset(List(2, 2), 1000)
     np_arr[(2, 2)] = 1000

--- a/tests/test_constructors.mojo
+++ b/tests/test_constructors.mojo
@@ -6,7 +6,7 @@ from utils_for_test import check, check_is_close
 
 def test_constructors():
     # Test NDArray constructor with different input types
-    var arr1 = NDArray[f32](3, 4, 5)
+    var arr1 = NDArray[f32](Shape(3, 4, 5))
     assert_true(arr1.ndim == 3, "NDArray constructor: ndim")
     assert_true(arr1.shape[0] == 3, "NDArray constructor: shape element 0")
     assert_true(arr1.shape[1] == 4, "NDArray constructor: shape element 1")
@@ -28,7 +28,7 @@ def test_constructors():
         "NDArray constructor with VariadicList: shape element 2",
     )
 
-    var arr3 = NDArray[f32](VariadicList[Int](3, 4, 5), fill=Scalar[f32](10.0))
+    var arr3 = nm.full[f32](Shape(3, 4, 5), fill_value=Scalar[f32](10.0))
     # maybe it's better to return a scalar for arr[0, 0, 0]
     assert_equal(
         arr3[idx(0, 0, 0)], 10.0, "NDArray constructor with fill value"
@@ -59,7 +59,7 @@ def test_constructors():
         "NDArray constructor with NDArrayShape: shape element 2",
     )
 
-    var arr6 = NDArray[f32](
+    var arr6 = nm.array[f32](
         data=List[SIMD[f32, 1]](1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
         shape=List[Int](2, 5),
     )


### PR DESCRIPTION
It is related to discussion #90 and #110. Because `NDArray()` does not provide any hints on parameters, it is always nice to use functions in `array_creation_routine` to create arrays.

The array creation functions are unified in such a way:

- `NDAarray.__init__()` reads in `shape` information and initializes an empty ndarray.
- All other creation routines are implemented by the functions in the `array_creation_routine` module. For example, to create an array with filled value, the function `nm.full` should be used. To create an array from a list, the function `nm.array` should be used.