### PR TITLE
[change] Rename some attributes and make `size` an attribute

### DIFF
--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -4,7 +4,7 @@
 from .ndarray import *
 from .index import Idx
 from .ndshape import NDArrayShape
-from .ndstride import NDArrayStride
+from .ndstrides import NDArrayStrides
 
 from .array_creation_routines import *
 from .array_manipulation_routines import *

--- a/numojo/core/array_creation_routines.mojo
+++ b/numojo/core/array_creation_routines.mojo
@@ -606,7 +606,7 @@ fn full[
     """
 
     var A = NDArray[dtype](shape=shape, order=order)
-    fill_pointer[dtype](A._buf, A.shape.ndsize, fill_value)
+    fill_pointer[dtype](A._buf, A.size, fill_value)
 
     return A
 
@@ -671,7 +671,7 @@ fn diag[
         A 1-D NDArray with the diagonal of the input NDArray.
     """
     if v.ndim == 1:
-        var n: Int = v.shape.ndsize
+        var n: Int = v.size
         var result: NDArray[dtype] = zeros[dtype](shape(n + abs(k), n + abs(k)))
         if k >= 0:
             for i in range(n):
@@ -680,7 +680,7 @@ fn diag[
         else:
             for i in range(n):
                 result._buf[
-                    result.shape.ndsize - 1 - i * (result.shape[1] + 1) + k
+                    result.size - 1 - i * (result.shape[1] + 1) + k
                 ] = v._buf[n - 1 - i]
         return result^
     elif v.ndim == 2:
@@ -693,7 +693,7 @@ fn diag[
         else:
             for i in range(n - abs(k)):
                 result._buf[m - abs(k) - 1 - i] = v._buf[
-                    v.shape.ndsize - 1 - i * (v.shape[1] + 1) + k
+                    v.size - 1 - i * (v.shape[1] + 1) + k
                 ]
         return result^
     else:
@@ -716,7 +716,7 @@ fn diagflat[
     Returns:
         A 2-D NDArray with the flattened input as the diagonal.
     """
-    var n: Int = v.shape.ndsize
+    var n: Int = v.size
     var result: NDArray[dtype] = zeros[dtype](shape(n + abs(k), n + abs(k)))
     if k >= 0:
         for i in range(n):
@@ -724,8 +724,8 @@ fn diagflat[
     else:
         for i in range(n):
             result.store(
-                result.shape.ndsize - 1 - (n + abs(k) + 1) * i + k,
-                v._buf[v.shape.ndsize - 1 - i],
+                result.size - 1 - (n + abs(k) + 1) * i + k,
+                v._buf[v.size - 1 - i],
             )
     return result^
 
@@ -857,7 +857,7 @@ fn vander[
     if x.ndim != 1:
         raise Error("x must be a 1-D array")
 
-    var n_rows = x.shape.ndsize
+    var n_rows = x.size
     var n_cols = N.value() if N else n_rows
     var result: NDArray[dtype] = ones[dtype](NDArrayShape(n_rows, n_cols))
     for i in range(n_rows):
@@ -1007,7 +1007,7 @@ fn array[
     """
 
     A = NDArray[dtype](Shape(shape), order)
-    for i in range(A.shape.ndsize):
+    for i in range(A.size):
         A._buf[i] = data[i]
     return A
 
@@ -1046,8 +1046,8 @@ fn array[
             continue
         shape.append(int(data.shape[i]))
     A = NDArray[dtype](Shape(shape), order=order)
-    A._buf = UnsafePointer[Scalar[dtype]]().alloc(A.shape.ndsize)
-    memset_zero(A._buf, A.shape.ndsize)
-    for i in range(A.shape.ndsize):
+    A._buf = UnsafePointer[Scalar[dtype]]().alloc(A.size)
+    memset_zero(A._buf, A.size)
+    for i in range(A.size):
         A._buf[i] = data.item(PythonObject(i)).to_float64().cast[dtype]()
     return A

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -86,7 +86,7 @@ fn reshape[
 
     array.ndim = ndim_new
     array.shape = NDArrayShape(shape=shape_new)
-    array.stride = NDArrayStride(shape=shape_new, order=order)
+    array.strides = NDArrayStrides(shape=shape_new, order=order)
     array.order = order
 
 

--- a/numojo/core/array_manipulation_routines.mojo
+++ b/numojo/core/array_manipulation_routines.mojo
@@ -74,7 +74,7 @@ fn reshape[
         num_elements_new *= i
         ndim_new += 1
 
-    if array.shape.ndsize != num_elements_new:
+    if array.size != num_elements_new:
         raise Error("Cannot reshape: Number of elements do not match.")
 
     var shape_new: List[Int] = List[Int]()
@@ -99,9 +99,9 @@ fn ravel[dtype: DType](inout array: NDArray[dtype], order: String = "C") raises:
         return
     else:
         if order == "C":
-            reshape[dtype](array, array.shape.ndsize, order="C")
+            reshape[dtype](array, array.size, order="C")
         else:
-            reshape[dtype](array, array.shape.ndsize, order="F")
+            reshape[dtype](array, array.size, order="F")
 
 
 fn where[
@@ -121,7 +121,7 @@ fn where[
         mask: A NDArray.
 
     """
-    for i in range(x.shape.ndsize):
+    for i in range(x.size):
         if mask._buf[i] == True:
             x._buf.store(i, scalar)
 
@@ -147,7 +147,7 @@ fn where[
     """
     if x.shape != y.shape:
         raise Error("Shape mismatch error: x and y must have the same shape")
-    for i in range(x.shape.ndsize):
+    for i in range(x.size):
         if mask._buf[i] == True:
             x._buf.store(i, y._buf[i])
 
@@ -171,8 +171,8 @@ fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var result: NDArray[dtype] = NDArray[dtype](
         shape=array.shape, order=array.order
     )
-    for i in range(array.shape.ndsize):
-        result._buf.store(i, array._buf[array.shape.ndsize - i - 1])
+    for i in range(array.size):
+        result._buf.store(i, array._buf[array.size - i - 1])
     return result
 
 
@@ -190,7 +190,7 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         The 1 dimensional flattened NDArray.
     """
 
-    var res: NDArray[dtype] = NDArray[dtype](Shape(array.shape.ndsize))
+    var res: NDArray[dtype] = NDArray[dtype](Shape(array.size))
     alias width: Int = simdwidthof[dtype]()
 
     @parameter
@@ -199,7 +199,7 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
             index, array._buf.load[width=simd_width](index)
         )
 
-    vectorize[vectorized_flatten, width](array.shape.ndsize)
+    vectorize[vectorized_flatten, width](array.size)
     return res
 
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -77,9 +77,12 @@ struct NDArray[dtype: DType = DType.float64](
         1. The data buffer of all items.
         2. The shape of the array.
         3. The stride in each dimension
-        4. The number of dimensions
-        5. The datatype of the elements
-        6. The order of the array: Row vs Columns major
+        4. The datatype of the elements
+
+    The following attributes are also helpful:
+        - The number of dimensions
+        - Size of the array (number of items)
+        - The order of the array: Row vs Columns major
     """
 
     var _buf: UnsafePointer[Scalar[dtype]]
@@ -88,6 +91,8 @@ struct NDArray[dtype: DType = DType.float64](
     """Number of Dimensions."""
     var shape: NDArrayShape
     """Size and shape of NDArray."""
+    var size: Int
+    """Size of NDArray."""
     var stride: NDArrayStride
     """Contains offset, strides."""
     var coefficient: NDArrayStride
@@ -97,7 +102,7 @@ struct NDArray[dtype: DType = DType.float64](
     var order: String
     "Memory layout of array C (C order row major) or F (Fortran order col major)."
 
-    alias width: Int = simdwidthof[dtype]()  #
+    alias width: Int = simdwidthof[dtype]()
     """Vector size of the data type."""
 
     # ===-------------------------------------------------------------------===#
@@ -122,11 +127,12 @@ struct NDArray[dtype: DType = DType.float64](
             order: Memory order C or F.
         """
 
-        self.ndim = shape.ndlen
+        self.ndim = shape.ndim
         self.shape = NDArrayShape(shape)
+        self.size = self.shape.size
         self.stride = NDArrayStride(shape, order=order)
         self.coefficient = NDArrayStride(shape, order=order)
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
         self.datatype = dtype
         self.order = order
 
@@ -184,14 +190,14 @@ struct NDArray[dtype: DType = DType.float64](
     #         ```
     #     """
 
-    #     self.ndim = shape.ndlen
+    #     self.ndim = shape.ndim
     #     self.shape = NDArrayShape(shape)
     #     self.stride = NDArrayStride(shape, offset=0, order=order)
     #     self.coefficient = NDArrayStride(shape, offset=0, order=order)
-    #     self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
+    #     self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
     #     self.datatype = dtype
     #     self.order = order
-    #     for i in range(self.shape.ndsize):
+    #     for i in range(self.size):
     #         self._buf[i] = data[i]
 
     ########################
@@ -223,11 +229,11 @@ struct NDArray[dtype: DType = DType.float64](
     #     self.shape = NDArrayShape(shape)
     #     self.stride = NDArrayStride(shape, offset=0, order=order)
     #     self.coefficient = NDArrayStride(shape, offset=0, order=order)
-    #     self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.shape.ndsize)
-    #     memset_zero(self._buf, self.shape.ndsize)
+    #     self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
+    #     memset_zero(self._buf, self.size)
     #     self.order = order
     #     self.datatype = dtype
-    #     for i in range(self.shape.ndsize):
+    #     for i in range(self.size):
     #         self._buf[i] = data.item(PythonObject(i)).to_float64().cast[dtype]()
 
     # Why do  these last two constructors exist?
@@ -247,6 +253,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         self.ndim = ndim
         self.shape = NDArrayShape(shape)
+        self.size = size
         self.stride = NDArrayStride(stride=strides, offset=0)
         self.coefficient = NDArrayStride(stride=coefficient, offset=offset)
         self.datatype = dtype
@@ -270,13 +277,14 @@ struct NDArray[dtype: DType = DType.float64](
         """
         self.ndim = ndim
         self.shape = NDArrayShape(shape)
+        self.size = self.shape.size
         self.stride = NDArrayStride(strides, offset=0, order=order)
         self.coefficient = NDArrayStride(
             coefficient, offset=offset, order=order
         )
         self.datatype = dtype
         self.order = order
-        self._buf = data + self.stride.ndoffset
+        self._buf = data + self.stride.offset
 
     @always_inline("nodebug")
     fn __copyinit__(inout self, other: Self):
@@ -285,12 +293,13 @@ struct NDArray[dtype: DType = DType.float64](
         """
         self.ndim = other.ndim
         self.shape = other.shape
+        self.size = other.size
         self.stride = other.stride
         self.coefficient = other.coefficient
         self.datatype = other.datatype
         self.order = other.order
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(other.shape.size())
-        memcpy(self._buf, other._buf, other.shape.size())
+        self._buf = UnsafePointer[Scalar[dtype]]().alloc(other.size)
+        memcpy(self._buf, other._buf, other.size)
 
     @always_inline("nodebug")
     fn __moveinit__(inout self, owned existing: Self):
@@ -299,10 +308,11 @@ struct NDArray[dtype: DType = DType.float64](
         """
         self.ndim = existing.ndim
         self.shape = existing.shape
+        self.size = existing.size
         self.stride = existing.stride
         self.coefficient = existing.coefficient
         self.datatype = existing.datatype
-        self.order = existing.order
+        self.order = existing.order^
         self._buf = existing._buf
 
     @always_inline("nodebug")
@@ -331,17 +341,17 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
-        if index >= self.shape.ndsize:
+        if index >= self.size:
             var message = String(
                 "Invalid index: index out of bound. \n"
                 "The index is {}. \n"
                 "The size is {}"
-            ).format(index, self.shape.ndsize)
+            ).format(index, self.size)
             raise Error(message)
         if index >= 0:
             return self._buf.store[width=1](index, val)
         else:
-            return self._buf.store[width=1](index + self.shape.ndsize, val)
+            return self._buf.store[width=1](index + self.size, val)
 
     # TODO: add support for different dtypes
     fn __setitem__(inout self, idx: Int, val: NDArray[dtype]) raises:
@@ -489,7 +499,7 @@ struct NDArray[dtype: DType = DType.float64](
     #     ):  # this behavious could be removed potentially
     #         raise Error("Mask and array must have the same shape")
 
-    #     for i in range(mask.shape.ndsize):
+    #     for i in range(mask.size):
     #         if mask._buf.load[width=1](i):
     #             print(value)
     #             self._buf.store[width=1](i, value)
@@ -684,7 +694,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
             raise Error(message)
 
-        for i in range(mask.shape.ndsize):
+        for i in range(mask.size):
             if mask._buf.load[width=1](i):
                 self._buf.store[width=1](i, val._buf.load[width=1](i))
 
@@ -709,18 +719,18 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
-        if index >= self.shape.ndsize:
+        if index >= self.size:
             raise Error(
                 String(
                     "Invalid index: index out of bound!\n"
                     "The index is {}."
                     "The size of the array is {}"
-                ).format(index, self.shape.ndsize)
+                ).format(index, self.size)
             )
         if index >= 0:
             return self._buf.load[width=1](index)
         else:
-            return self._buf.load[width=1](index + self.shape.ndsize)
+            return self._buf.load[width=1](index + self.size)
 
     fn __getitem__(self, idx: Int) raises -> Self:
         """
@@ -1228,11 +1238,11 @@ struct NDArray[dtype: DType = DType.float64](
         # So just change the first number of the ndshape
         var ndshape = self.shape
         ndshape[0] = len(index)
-        ndshape.ndsize = 1
-        for i in range(ndshape.ndlen):
-            ndshape.ndsize *= int(ndshape._buf[i])
+        ndsize = 1
+        for i in range(ndshape.ndim):
+            ndsize *= int(ndshape._buf[i])
         var result = NDArray[dtype](ndshape)
-        var size_per_item = ndshape.ndsize // len(index)
+        var size_per_item = ndsize // len(index)
 
         # Fill in the values
         for i in range(len(index)):
@@ -1290,7 +1300,7 @@ struct NDArray[dtype: DType = DType.float64](
             NDArray with items from the mask.
         """
         var true: List[Int] = List[Int]()
-        for i in range(mask.shape.ndsize):
+        for i in range(mask.size):
             if mask._buf.load[width=1](i):
                 true.append(i)
 
@@ -1342,7 +1352,7 @@ struct NDArray[dtype: DType = DType.float64](
             Int representation of the array.
 
         """
-        if (self.size() == 1) or (self.ndim == 0):
+        if (self.size == 1) or (self.ndim == 0):
             return int(self.get(0))
         else:
             raise (
@@ -1566,13 +1576,13 @@ struct NDArray[dtype: DType = DType.float64](
         return self._elementwise_pow(p)
 
     fn __pow__(self, p: Self) raises -> Self:
-        if self.shape.ndsize != p.shape.ndsize:
+        if self.size != p.size:
             raise Error(
                 String(
                     "Both arrays must have same number of elements! \n"
                     "Self array has {} elements. \n"
                     "Other array has {} elements"
-                ).format(self.shape.ndsize, p.shape.ndsize)
+                ).format(self.size, p.size)
             )
 
         var result = Self(self.shape)
@@ -1585,7 +1595,7 @@ struct NDArray[dtype: DType = DType.float64](
                 ** p.load[width=simd_width](index),
             )
 
-        vectorize[vectorized_pow, self.width](self.shape.ndsize)
+        vectorize[vectorized_pow, self.width](self.size)
         return result
 
     fn __ipow__(inout self, p: Int):
@@ -1600,7 +1610,7 @@ struct NDArray[dtype: DType = DType.float64](
                 index, pow(self._buf.load[width=simd_width](index), p)
             )
 
-        vectorize[array_scalar_vectorize, self.width](self.shape.ndsize)
+        vectorize[array_scalar_vectorize, self.width](self.size)
         return new_vec
 
     fn __truediv__(self, other: SIMD[dtype, 1]) raises -> Self:
@@ -1734,7 +1744,7 @@ struct NDArray[dtype: DType = DType.float64](
             var result: String = str("NDArray[DType.") + str(self.dtype) + str(
                 "](List[Scalar[DType."
             ) + str(self.dtype) + str("]](")
-            if self.size() > 6:
+            if self.size > 6:
                 for i in range(6):
                     result = result + str(self.load[width=1](i)) + str(",")
                 result = result + " ... "
@@ -1742,7 +1752,7 @@ struct NDArray[dtype: DType = DType.float64](
                 for i in self:
                     result = result + str(i) + str(",")
             result = result + str("), shape=List[Int](")
-            for i in range(self.shape.ndlen):
+            for i in range(self.shape.ndim):
                 result = result + str(self.shape._buf[i]) + ","
             result = result + str("))")
             return result
@@ -1752,7 +1762,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     # Should len be size or number of dimensions instead of the first dimension shape?
     fn __len__(self) -> Int:
-        return int(self.shape.ndsize)
+        return int(self.size)
 
     fn __iter__(self) raises -> _NDArrayIter[__lifetime_of(self), dtype]:
         """Iterate over elements of the NDArray, returning copied value.
@@ -1881,11 +1891,11 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Inner product of two vectors.
         """
-        if self.shape.ndsize != other.shape.ndsize:
+        if self.size != other.size:
             raise Error("The lengths of two vectors do not match.")
 
         var sum = Scalar[dtype](0)
-        for i in range(self.shape.ndsize):
+        for i in range(self.size):
             sum = sum + self.get(i) * other.get(i)
         return sum
 
@@ -1990,17 +2000,11 @@ struct NDArray[dtype: DType = DType.float64](
                 )
         return new_matrix
 
-    fn size(self) -> Int:
-        """
-        Function to retreive size.
-        """
-        return self.shape.ndsize
-
     fn num_elements(self) -> Int:
         """
         Function to retreive size (compatability).
         """
-        return self.shape.ndsize
+        return self.size
 
     # should this return the List[Int] shape and self.shape be used instead of making it a no input function call?
     # * We fix return dtype of this array shape for the linalg solve module.
@@ -2082,7 +2086,7 @@ struct NDArray[dtype: DType = DType.float64](
                 (self._buf + idx).strided_load[width=simd_width](1)
             )
 
-        vectorize[vectorized_all, self.width](self.shape.ndsize)
+        vectorize[vectorized_all, self.width](self.size)
         return result
 
     fn any(self) raises -> Bool:
@@ -2100,7 +2104,7 @@ struct NDArray[dtype: DType = DType.float64](
                 (self._buf + idx).strided_load[width=simd_width](1)
             )
 
-        vectorize[vectorized_any, self.width](self.shape.ndsize)
+        vectorize[vectorized_any, self.width](self.size)
         return result
 
     fn argmax(self) -> Int:
@@ -2109,7 +2113,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var result: Int = 0
         var max_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.shape.ndsize):
+        for i in range(1, self.size):
             var temp: SIMD[dtype, 1] = self.load[width=1](i)
             if temp > max_val:
                 max_val = temp
@@ -2122,7 +2126,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var result: Int = 0
         var min_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.shape.ndsize):
+        for i in range(1, self.size):
             var temp: SIMD[dtype, 1] = self.load[width=1](i)
             if temp < min_val:
                 min_val = temp
@@ -2157,7 +2161,7 @@ struct NDArray[dtype: DType = DType.float64](
                     self.load[simd_width](idx).cast[type](), 1
                 )
 
-            vectorize[vectorized_astype, self.width](self.shape.ndsize)
+            vectorize[vectorized_astype, self.width](self.size)
         else:
 
             @parameter
@@ -2174,9 +2178,7 @@ struct NDArray[dtype: DType = DType.float64](
                         .cast[type](),
                     )
 
-                vectorize[vectorized_astypenb_from_b, self.width](
-                    self.shape.ndsize
-                )
+                vectorize[vectorized_astypenb_from_b, self.width](self.size)
             else:
 
                 @parameter
@@ -2185,7 +2187,7 @@ struct NDArray[dtype: DType = DType.float64](
                         idx, self.load[simd_width](idx).cast[type]()
                     )
 
-                vectorize[vectorized_astypenb, self.width](self.shape.ndsize)
+                vectorize[vectorized_astypenb, self.width](self.size)
 
         return narr
 
@@ -2228,7 +2230,7 @@ struct NDArray[dtype: DType = DType.float64](
         fn vectorized_fill[simd_width: Int](index: Int) -> None:
             self._buf.store[width=simd_width](index, val)
 
-        vectorize[vectorized_fill, self.width](self.shape.ndsize)
+        vectorize[vectorized_fill, self.width](self.size)
 
         return self
 
@@ -2236,7 +2238,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Convert shape of array to one dimensional.
         """
-        self.shape = NDArrayShape(self.shape.ndsize, size=self.shape.ndsize)
+        self.shape = NDArrayShape(self.size, size=self.size)
         self.stride = NDArrayStride(shape=self.shape, offset=0)
 
     fn item(self, *index: Int) raises -> SIMD[dtype, 1]:
@@ -2299,7 +2301,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # If one index is given
         if index.__len__() == 1:
-            if index[0] < self.size():
+            if index[0] < self.size:
                 if (
                     self.order == "F"
                 ):  # column-major should be converted to row-major
@@ -2308,7 +2310,7 @@ struct NDArray[dtype: DType = DType.float64](
                     var c_stride = NDArrayStride(shape=self.shape)
                     var c_coordinates = List[Int]()
                     var idx: Int = index[0]
-                    for i in range(c_stride.ndlen):
+                    for i in range(c_stride.ndim):
                         var coordinate = idx // c_stride[i]
                         idx = idx - c_stride[i] * coordinate
                         c_coordinates.append(coordinate)
@@ -2322,7 +2324,7 @@ struct NDArray[dtype: DType = DType.float64](
                     String(
                         "Error: Elements of `index` ({}) \n"
                         "exceed the array size ({})"
-                    ).format(index[0], self.size())
+                    ).format(index[0], self.size)
                 )
 
         # If more than one index is given
@@ -2392,7 +2394,7 @@ struct NDArray[dtype: DType = DType.float64](
         # If one index is given
         if index.isa[Int]():
             var idx = index._get_ptr[Int]()[]
-            if idx < self.size():
+            if idx < self.size:
                 if (
                     self.order == "F"
                 ):  # column-major should be converted to row-major
@@ -2400,7 +2402,7 @@ struct NDArray[dtype: DType = DType.float64](
                     # convert any index to coordinates according to the order
                     var c_stride = NDArrayStride(shape=self.shape)
                     var c_coordinates = List[Int]()
-                    for i in range(c_stride.ndlen):
+                    for i in range(c_stride.ndim):
                         var coordinate = idx // c_stride[i]
                         idx = idx - c_stride[i] * coordinate
                         c_coordinates.append(coordinate)
@@ -2414,7 +2416,7 @@ struct NDArray[dtype: DType = DType.float64](
                     String(
                         "Error: Elements of `index` ({}) \n"
                         "exceed the array size ({})."
-                    ).format(idx, self.size())
+                    ).format(idx, self.size)
                 )
 
         else:
@@ -2560,7 +2562,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Sort the array inplace using quickstort.
         """
-        sort.quick_sort_inplace[dtype](self, 0, self.size() - 1)
+        sort.quick_sort_inplace[dtype](self, 0, self.size - 1)
 
     fn sum(self: Self, axis: Int) raises -> Self:
         """
@@ -2580,7 +2582,7 @@ struct NDArray[dtype: DType = DType.float64](
             A 1-D List.
         """
         var result: List[Scalar[dtype]] = List[Scalar[dtype]]()
-        for i in range(self.shape.ndsize):
+        for i in range(self.size):
             result.append(self._buf[i])
         return result
 

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -1,7 +1,7 @@
 """
-Implements NDArrayStride type.
+Implements NDArrayStrides type.
 
-`NDArrayStride` is a series of `DType.int32` on the heap.
+`NDArrayStrides` is a series of `DType.int32` on the heap.
 """
 
 from utils import Variant
@@ -10,8 +10,8 @@ from memory import memset_zero, memcpy
 
 
 @register_passable("trivial")
-struct NDArrayStride[dtype: DType = DType.int32](Stringable, Formattable):
-    """Implements the NDArrayStride."""
+struct NDArrayStrides[dtype: DType = DType.int32](Stringable, Formattable):
+    """Implements the NDArrayStrides."""
 
     # Fields
     var offset: Int
@@ -20,49 +20,49 @@ struct NDArrayStride[dtype: DType = DType.int32](Stringable, Formattable):
 
     @always_inline("nodebug")
     fn __init__(
-        inout self, *stride: Int, offset: Int = 0
+        inout self, *strides: Int, offset: Int = 0
     ):  # maybe we should add checks for offset?
         self.offset = offset
-        self.ndim = stride.__len__()
-        self.strides = UnsafePointer[Scalar[dtype]]().alloc(stride.__len__())
-        for i in range(stride.__len__()):
-            self.strides[i] = stride[i]
+        self.ndim = strides.__len__()
+        self.strides = UnsafePointer[Scalar[dtype]]().alloc(strides.__len__())
+        for i in range(strides.__len__()):
+            self.strides[i] = strides[i]
 
     @always_inline("nodebug")
-    fn __init__(inout self, stride: List[Int], offset: Int = 0):
+    fn __init__(inout self, strides: List[Int], offset: Int = 0):
         self.offset = offset
-        self.ndim = stride.__len__()
+        self.ndim = strides.__len__()
         self.strides = UnsafePointer[Scalar[dtype]]().alloc(self.ndim)
         memset_zero(self.strides, self.ndim)
         for i in range(self.ndim):
-            self.strides[i] = stride[i]
+            self.strides[i] = strides[i]
 
     @always_inline("nodebug")
-    fn __init__(inout self, stride: VariadicList[Int], offset: Int = 0):
+    fn __init__(inout self, strides: VariadicList[Int], offset: Int = 0):
         self.offset = offset
-        self.ndim = stride.__len__()
+        self.ndim = strides.__len__()
         self.strides = UnsafePointer[Scalar[dtype]]().alloc(self.ndim)
         memset_zero(self.strides, self.ndim)
         for i in range(self.ndim):
-            self.strides[i] = stride[i]
+            self.strides[i] = strides[i]
 
     @always_inline("nodebug")
-    fn __init__(inout self, stride: NDArrayStride[dtype]):
-        self.offset = stride.offset
-        self.ndim = stride.ndim
-        self.strides = UnsafePointer[Scalar[dtype]]().alloc(stride.ndim)
+    fn __init__(inout self, strides: NDArrayStrides[dtype]):
+        self.offset = strides.offset
+        self.ndim = strides.ndim
+        self.strides = UnsafePointer[Scalar[dtype]]().alloc(strides.ndim)
         for i in range(self.ndim):
-            self.strides[i] = stride.strides[i]
+            self.strides[i] = strides.strides[i]
 
     @always_inline("nodebug")
     fn __init__(
-        inout self, stride: NDArrayStride[dtype], offset: Int = 0
+        inout self, strides: NDArrayStrides[dtype], offset: Int = 0
     ):  # separated two methods to remove if condition
         self.offset = offset
-        self.ndim = stride.ndim
-        self.strides = UnsafePointer[Scalar[dtype]]().alloc(stride.ndim)
+        self.ndim = strides.ndim
+        self.strides = UnsafePointer[Scalar[dtype]]().alloc(strides.ndim)
         for i in range(self.ndim):
-            self.strides[i] = stride.strides[i]
+            self.strides[i] = strides.strides[i]
 
     @always_inline("nodebug")
     fn __init__(

--- a/numojo/core/random.mojo
+++ b/numojo/core/random.mojo
@@ -39,7 +39,7 @@ fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
             "Integral values cannot be sampled between 0 and 1. Use"
             " `rand(*shape, min, max)` instead."
         )
-    for i in range(result.shape.ndsize):
+    for i in range(result.size):
         var temp: Scalar[dtype] = random.random_float64(0, 1).cast[dtype]()
         result.set(i, temp)
     return result^
@@ -62,7 +62,7 @@ fn int_rand_func[
     """
     random.randint[dtype](
         ptr=result._buf,
-        size=result.shape.ndsize,
+        size=result.size,
         low=int(min),
         high=int(max),
     )
@@ -83,7 +83,7 @@ fn float_rand_func[
         min: The minimum value of the random floating-point numbers.
         max: The maximum value of the random floating-point numbers.
     """
-    for i in range(result.shape.ndsize):
+    for i in range(result.size):
         var temp: Scalar[dtype] = random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
@@ -206,7 +206,7 @@ fn randn[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
         ptr=result._buf,
-        size=result.shape.ndsize,
+        size=result.size,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
     )
@@ -242,7 +242,7 @@ fn randn[
     var result: NDArray[dtype] = NDArray[dtype](shape)
     random.randn[dtype](
         ptr=result._buf,
-        size=result.shape.ndsize,
+        size=result.size,
         mean=mean.cast[DType.float64](),
         variance=variance.cast[DType.float64](),
     )

--- a/numojo/core/sort.mojo
+++ b/numojo/core/sort.mojo
@@ -47,7 +47,7 @@ fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
         The sorted NDArray.
     """
     var result: NDArray[dtype] = ndarray
-    var length = ndarray.size()
+    var length = ndarray.size
 
     for i in range(length):
         for j in range(length - i - 1):
@@ -147,7 +147,7 @@ fn quick_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
     """
 
     var result: NDArray[dtype] = ndarray
-    var length = ndarray.size()
+    var length = ndarray.size
     quick_sort_inplace(result, 0, length - 1)
 
     return result
@@ -186,7 +186,7 @@ fn binary_sort[
         alias dtype = array.dtype
 
     var result: NDArray[dtype] = NDArray[dtype](array.shape)
-    for i in range(array.shape.ndsize):
+    for i in range(array.size):
         result.store(i, array.get(i).cast[dtype]())
 
     var n = array.num_elements()
@@ -313,7 +313,7 @@ fn argsort[
     """
 
     var array: NDArray[dtype] = ndarray
-    var length = array.size()
+    var length = array.size
 
     var idx_array = NDArray[DType.index](Shape(length))
     for i in range(length):

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -55,7 +55,7 @@ fn _get_index(indices: List[Int], weights: NDArrayShape) raises -> Int:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndlen):
+    for i in range(weights.ndim):
         idx += indices[i] * weights[i]
     return idx
 
@@ -72,7 +72,7 @@ fn _get_index(indices: VariadicList[Int], weights: NDArrayShape) raises -> Int:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndlen):
+    for i in range(weights.ndim):
         idx += indices[i] * weights[i]
     return idx
 
@@ -89,7 +89,7 @@ fn _get_index(indices: List[Int], weights: NDArrayStride) raises -> Int:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndlen):
+    for i in range(weights.ndim):
         idx += indices[i] * weights[i]
     return idx
 
@@ -106,7 +106,7 @@ fn _get_index(indices: Idx, weights: NDArrayStride) raises -> Int:
         The scalar index of the multi-dimensional array.
     """
     var index: Int = 0
-    for i in range(weights.ndlen):
+    for i in range(weights.ndim):
         index += indices[i] * weights[i]
     return index
 
@@ -123,7 +123,7 @@ fn _get_index(indices: VariadicList[Int], weights: NDArrayStride) raises -> Int:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndlen):
+    for i in range(weights.ndim):
         idx += indices[i] * weights[i]
     return idx
 
@@ -196,7 +196,7 @@ fn _traverse_iterative[
         index: The list of indices.
         depth: The depth of the indices.
     """
-    var total_elements = narr.shape.ndsize
+    var total_elements = narr.size
 
     # # parallelized version was slower xD
     for _ in range(total_elements):
@@ -246,7 +246,7 @@ fn _traverse_iterative_setter[
         offset: The offset to the first element of the original NDArray.
         index: The list of indices.
     """
-    var total_elements = narr.shape.ndsize
+    var total_elements = narr.size
 
     for _ in range(total_elements):
         var orig_idx = offset + _get_index(index, coefficients)
@@ -286,7 +286,7 @@ fn bool_to_numeric[
     """
     # Can't use simd becuase of bit packing error
     var res: NDArray[dtype] = NDArray[dtype](array.shape)
-    for i in range(array.size()):
+    for i in range(array.size):
         var t: Bool = array.item(i)
         if t:
             res._buf[i] = 1

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -10,7 +10,7 @@ from algorithm.functional import vectorize
 
 from python import Python, PythonObject
 from .ndshape import NDArrayShape
-from .ndstride import NDArrayStride
+from .ndstrides import NDArrayStrides
 from .ndarray import NDArray
 
 
@@ -77,7 +77,7 @@ fn _get_index(indices: VariadicList[Int], weights: NDArrayShape) raises -> Int:
     return idx
 
 
-fn _get_index(indices: List[Int], weights: NDArrayStride) raises -> Int:
+fn _get_index(indices: List[Int], weights: NDArrayStrides) raises -> Int:
     """
     Get the index of a multi-dimensional array from a list of indices and weights.
 
@@ -94,7 +94,7 @@ fn _get_index(indices: List[Int], weights: NDArrayStride) raises -> Int:
     return idx
 
 
-fn _get_index(indices: Idx, weights: NDArrayStride) raises -> Int:
+fn _get_index(indices: Idx, weights: NDArrayStrides) raises -> Int:
     """
     Get the index of a multi-dimensional array from a list of indices and weights.
 
@@ -111,7 +111,9 @@ fn _get_index(indices: Idx, weights: NDArrayStride) raises -> Int:
     return index
 
 
-fn _get_index(indices: VariadicList[Int], weights: NDArrayStride) raises -> Int:
+fn _get_index(
+    indices: VariadicList[Int], weights: NDArrayStrides
+) raises -> Int:
     """
     Get the index of a multi-dimensional array from a list of indices and weights.
 

--- a/numojo/io/files.mojo
+++ b/numojo/io/files.mojo
@@ -32,9 +32,9 @@ fn savetxt[
     dtype: DType = f64
 ](filename: String, array: NDArray[dtype], delimiter: String = ",") raises:
     var shape: String = "ndshape=["
-    for i in range(array.shape.ndlen):
+    for i in range(array.ndim):
         shape += str(array.shape[i])
-        if i != array.shape.ndlen - 1:
+        if i != array.ndim - 1:
             shape = shape + ", "
     shape = shape + "]"
     print(shape)
@@ -42,7 +42,7 @@ fn savetxt[
     with open(filename, "w") as file:
         file.write(shape + "\n")
         file.write("ndim=[" + str(array.ndim) + "]\n")
-        for i in range(array.shape.ndsize):
+        for i in range(array.size):
             if i % 10 == 0:
                 file.write(str("\n"))
             file.write(str(array._buf[i]) + ",")

--- a/numojo/mat/linalg.mojo
+++ b/numojo/mat/linalg.mojo
@@ -43,14 +43,17 @@ fn matmul[
             )
         )
 
-    var t0 = A.shape[0]
-    var t1 = A.shape[1]
-    var t2 = B.shape[1]
-    var C: Matrix[dtype] = zeros[dtype](shape=(t0, t2))
+    # Multiplication by partitions for big matrices
+    # var cut_of_size = 200
+    # if A.shape[1] >= cut_of_size:
+    #     var block_shape = A.shape[1] // 2
+    #     return A[:, :block_shape] @ B[:block_shape, :] + A[:, block_shape: ] @ B[block_shape: ,: ]
+
+    var C: Matrix[dtype] = zeros[dtype](shape=(A.shape[0], B.shape[1]))
 
     @parameter
     fn calculate_CC(m: Int):
-        for k in range(t1):
+        for k in range(A.shape[1]):
 
             @parameter
             fn dot[simd_width: Int](n: Int):
@@ -61,13 +64,10 @@ fn matmul[
                     + A._load(m, k) * B._load[simd_width](k, n),
                 )
 
-            vectorize[dot, width](t2)
+            vectorize[dot, width](B.shape[1])
 
-    parallelize[calculate_CC](t0, t0)
+    parallelize[calculate_CC](A.shape[0], A.shape[0])
 
-    var _t0 = t0
-    var _t1 = t1
-    var _t2 = t2
     var _A = A
     var _B = B
 

--- a/numojo/mat/matrix.mojo
+++ b/numojo/mat/matrix.mojo
@@ -1144,7 +1144,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Formattable):
         var ndarray = NDArray[dtype](
             shape=List[Int](self.shape[0], self.shape[1]), order="C"
         )
-        memcpy(ndarray._buf, self._buf, ndarray.size())
+        memcpy(ndarray._buf, self._buf, ndarray.size)
 
         return ndarray
 

--- a/numojo/math/check.mojo
+++ b/numojo/math/check.mojo
@@ -49,7 +49,7 @@ fn isinf[
     # return backend().math_func_is[dtype, math.isinf](array)
 
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
-    for i in range(result_array.size()):
+    for i in range(result_array.size):
         result_array.store(i, math.isinf(array.get(i)))
     return result_array
 
@@ -72,7 +72,7 @@ fn isfinite[
     """
     # return backend().math_func_is[dtype, math.isfinite](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
-    for i in range(result_array.size()):
+    for i in range(result_array.size):
         result_array.store(i, math.isfinite(array.get(i)))
     return result_array
 
@@ -95,7 +95,7 @@ fn isnan[
     """
     # return backend().math_func_is[dtype, math.isnan](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
-    for i in range(result_array.size()):
+    for i in range(result_array.size):
         result_array.store(i, math.isnan(array.get(i)))
     return result_array
 
@@ -119,7 +119,7 @@ fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
 
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
-    for i in range(array.size()):
+    for i in range(array.size):
         result |= array.get(i)
     return result
 
@@ -143,6 +143,6 @@ fn allt(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
 
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
-    for i in range(array.size()):
+    for i in range(array.size):
         result &= array.get(i)
     return result

--- a/numojo/math/linalg/linalg.mojo
+++ b/numojo/math/linalg/linalg.mojo
@@ -35,9 +35,7 @@ fn cross[
         The cross product of two arrays.
     """
 
-    if (array1.shape.ndsize == array2.shape.ndsize == 3) and (
-        array1.shape.ndlen == array2.shape.ndlen == 1
-    ):
+    if (array1.size == array2.size == 3) and (array1.ndim == array2.ndim == 1):
         var array3: NDArray[dtype] = NDArray[dtype](NDArrayShape(3))
         array3.store(
             0,
@@ -83,10 +81,8 @@ fn dot[
     """
 
     alias width = simdwidthof[dtype]()
-    if array1.shape.ndlen == array2.shape.ndlen == 1:
-        var result: NDArray[dtype] = NDArray[dtype](
-            NDArrayShape(array1.shape.ndsize)
-        )
+    if array1.ndim == array2.ndim == 1:
+        var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(array1.size))
 
         @parameter
         fn vectorized_dot[simd_width: Int](idx: Int) -> None:
@@ -96,7 +92,7 @@ fn dot[
                 * array2.load[width=simd_width](idx),
             )
 
-        vectorize[vectorized_dot, width](array1.shape.ndsize)
+        vectorize[vectorized_dot, width](array1.size)
         return result^
     else:
         raise Error(

--- a/numojo/math/linalg/matmul.mojo
+++ b/numojo/math/linalg/matmul.mojo
@@ -84,7 +84,7 @@ fn matmul_1d[
         )
 
     try:
-        if A.size() != B.size():
+        if A.size != B.size:
             raise Error("Size error!")
     except e:
         print(e)

--- a/numojo/math/signal/signal.mojo
+++ b/numojo/math/signal/signal.mojo
@@ -31,7 +31,7 @@ fn convolve2d[
     """
 
     var in2_mirrored = in2
-    var length = in2.size()
+    var length = in2.size
     for i in range(length):
         in2_mirrored._buf[i] = in2._buf[length - i - 1]
 

--- a/numojo/math/statistics/stats.mojo
+++ b/numojo/math/statistics/stats.mojo
@@ -70,7 +70,7 @@ fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
     """
 
     var result = Scalar[array.dtype](0)
-    for i in range(array.shape.ndsize):
+    for i in range(array.size):
         result[0] += array._buf[i]
     return result
 
@@ -135,7 +135,7 @@ fn prodall(array: NDArray) raises -> Scalar[array.dtype]:
     """
 
     var result = Scalar[array.dtype](1)
-    for i in range(array.shape.ndsize):
+    for i in range(array.size):
         result[0] *= array._buf[i]
     return result
 
@@ -177,7 +177,7 @@ fn meanall(array: NDArray) raises -> Float64:
 
     return (
         sumall(array).cast[DType.float64]()
-        / Int32(array.shape.ndsize).cast[DType.float64]()
+        / Int32(array.size).cast[DType.float64]()
     )
 
 

--- a/test.mojo
+++ b/test.mojo
@@ -18,7 +18,7 @@ fn test_constructors1() raises:
     print("shape: ", arr1.shape)
     print("strides: ", arr1.stride)
     print("size: ", arr1.shape.ndsize)
-    print("offset: ", arr1.stride.ndoffset)
+    print("offset: ", arr1.stride.offset)
     print("dtype: ", arr1.dtype)
 
     var arr2 = NDArray[f32](VariadicList[Int](3, 4, 5))
@@ -27,7 +27,7 @@ fn test_constructors1() raises:
     print("shape: ", arr2.shape)
     print("strides: ", arr2.stride)
     print("size: ", arr2.shape.ndsize)
-    print("offset: ", arr2.stride.ndoffset)
+    print("offset: ", arr2.stride.offset)
     print("dtype: ", arr2.dtype)
 
     var arr3 = NDArray[f32](VariadicList[Int](3, 4, 5), fill=Scalar[f32](10.0))
@@ -36,7 +36,7 @@ fn test_constructors1() raises:
     print("shape: ", arr3.shape)
     print("strides: ", arr3.stride)
     print("size: ", arr3.shape.ndsize)
-    print("offset: ", arr3.stride.ndoffset)
+    print("offset: ", arr3.stride.offset)
     print("dtype: ", arr3.dtype)
 
     var arr4 = NDArray[f32](List[Int](3, 4, 5))
@@ -45,7 +45,7 @@ fn test_constructors1() raises:
     print("shape: ", arr4.shape)
     print("strides: ", arr4.stride)
     print("size: ", arr4.shape.ndsize)
-    print("offset: ", arr4.stride.ndoffset)
+    print("offset: ", arr4.stride.offset)
     print("dtype: ", arr4.dtype)
 
     var arr5 = NDArray[f32](NDArrayShape(3, 4, 5))
@@ -54,7 +54,7 @@ fn test_constructors1() raises:
     print("shape: ", arr5.shape)
     print("strides: ", arr5.stride)
     print("size: ", arr5.shape.ndsize)
-    print("offset: ", arr5.stride.ndoffset)
+    print("offset: ", arr5.stride.offset)
     print("dtype: ", arr5.dtype)
 
     var arr6 = NDArray[f32](
@@ -66,7 +66,7 @@ fn test_constructors1() raises:
     print("shape: ", arr6.shape)
     print("strides: ", arr6.stride)
     print("size: ", arr6.shape.ndsize)
-    print("offset: ", arr6.stride.ndoffset)
+    print("offset: ", arr6.stride.offset)
     print("dtype: ", arr6.dtype)
 
     var arr7 = nm.NDArray[nm.f32](String("[[1.0,0,1], [0,2,1], [1,1,1]]"))

--- a/tests/test_constructors.mojo
+++ b/tests/test_constructors.mojo
@@ -11,7 +11,7 @@ def test_constructors():
     assert_true(arr1.shape[0] == 3, "NDArray constructor: shape element 0")
     assert_true(arr1.shape[1] == 4, "NDArray constructor: shape element 1")
     assert_true(arr1.shape[2] == 5, "NDArray constructor: shape element 2")
-    assert_true(arr1.shape.ndsize == 60, "NDArray constructor: size")
+    assert_true(arr1.size == 60, "NDArray constructor: size")
     assert_true(arr1.dtype == DType.float32, "NDArray constructor: dtype")
 
     var arr2 = NDArray[f32](VariadicList[Int](3, 4, 5))


### PR DESCRIPTION
Rename some attributes to be consistent with [numpy](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html)
- `ndlen`->`ndim`
- `ndshape`->`shape`
- `ndstride`->`strides`
- `stride`->`strides`
- `ndsize`->`size`

Make `size` an attribute instead of a method.