### PR TITLE
[fix] Update the `sum` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,14 +7,20 @@
 *.html
 *.css
 *.py
-mojo
-numojo.mojopkg
-bench.mojo
-test_ndarray.ipynb
-/venv# pixi environments
-.pixi
 *.egg-info
 *.pyc
 
 # magic environments
 .magic
+
+# pixi environments
+.pixi
+/venv
+
+# Miscellaneous files
+mojo
+numojo.mojopkg
+bench.mojo
+test_ndarray.ipynb
+test.mojo
+tempCodeRunnerFile.mojo

--- a/numojo/core/datatypes.mojo
+++ b/numojo/core/datatypes.mojo
@@ -17,6 +17,8 @@ alias i32 = DType.int32
 """Data type alias for DType.int32"""
 alias i64 = DType.int64
 """Data type alias for DType.int64"""
+alias isize = DType.index
+"""Data type alias for DType.index"""
 alias u8 = DType.uint8
 """Data type alias for DType.uint8"""
 alias u16 = DType.uint16

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -1,7 +1,7 @@
 """
 Implements NDArrayShape type.
 
-`NDArrayShape` is a series of `DType.int32` on the heap.
+`NDArrayShape` is a series of `DType.index` on the heap.
 """
 
 from memory import UnsafePointer, memset_zero, memcpy
@@ -13,7 +13,7 @@ alias shape = NDArrayShape
 
 
 @register_passable("trivial")
-struct NDArrayShape[dtype: DType = DType.int32](Stringable, Writable):
+struct NDArrayShape[dtype: DType = DType.index](Stringable, Writable):
     """Implements the NDArrayShape."""
 
     # Fields

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -1,7 +1,7 @@
 """
 Implements NDArrayStrides type.
 
-`NDArrayStrides` is a series of `DType.int32` on the heap.
+`NDArrayStrides` is a series of `DType.index` on the heap.
 """
 
 from utils import Variant
@@ -10,7 +10,7 @@ from memory import UnsafePointer, memset_zero, memcpy
 
 
 @register_passable("trivial")
-struct NDArrayStrides[dtype: DType = DType.int32](Stringable):
+struct NDArrayStrides[dtype: DType = DType.index](Stringable):
     """Implements the NDArrayStrides."""
 
     # Fields

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -42,6 +42,5 @@ from .bitwise import *
 from .constants import Constants
 from .creation import *
 from .manipulation import *
-from .random import *
 from .sorting import *
 from .searching import argmax, argmin

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -15,7 +15,7 @@ import numojo.core._math_funcs as _mf
 from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import NDArrayShape, Shape
 from numojo.routines.creation import zeros
-from numojo.routines.math.sums import sumall
+from numojo.routines.math.sums import sum
 
 
 fn cross[
@@ -182,7 +182,7 @@ fn matmul_1d[
 
     var C: NDArray[dtype] = zeros[dtype](Shape(1, 1))
 
-    C.store(0, val=sumall(A * B))
+    C.store(0, val=sum(A * B))
 
     return C^
 

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -57,24 +57,21 @@ fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
 
     var ndim: Int = A.ndim
-    var shape: List[Int] = List[Int]()
-    for i in range(ndim):
-        shape.append(A.shape[i])
     if axis > ndim - 1:
         raise Error(
             String("axis {} greater than ndim of array {}").format(axis, ndim)
         )
     var result_shape: List[Int] = List[Int]()
-    var axis_size: Int = shape[axis]
+    var size_of_axis: Int = A.shape[axis]
     var slices: List[Slice] = List[Slice]()
     for i in range(ndim):
         if i != axis:
-            result_shape.append(shape[i])
-            slices.append(Slice(0, shape[i]))
+            result_shape.append(A.shape[i])
+            slices.append(Slice(0, A.shape[i]))
         else:
             slices.append(Slice(0, 0))
     var result = zeros[dtype](NDArrayShape(result_shape))
-    for i in range(axis_size):
+    for i in range(size_of_axis):
         slices[axis] = Slice(i, i + 1)
         var arr_slice = A[slices]
         result += arr_slice

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -2,26 +2,68 @@ from sys import simdwidthof
 from algorithm import parallelize, vectorize
 
 from numojo.core.ndarray import NDArray
+from numojo.routines.creation import zeros
 from numojo.routines.math.arithmetic import mul
 
 
-fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
-    """Sum of array elements over a given axis.
+fn sum[dtype: DType](A: NDArray[dtype]) -> Scalar[dtype]:
+    """Sum of all items in the array.
+
+    Example:
+    ```console
+    > print(A)
+    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
+     [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
+     [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
+    2-D array  Shape: [3, 3]  DType: float32
+    > print(nm.sum(A))
+    3.5140917301177979
+    ```
 
     Args:
-        array: NDArray.
+        A: NDArray.
+
+    Returns:
+        Scalar.
+    """
+
+    var res = Scalar[dtype](0)
+    alias width: Int = simdwidthof[dtype]()
+
+    @parameter
+    fn cal_vec[width: Int](i: Int):
+        res = res + A._buf.load[width=width](i).reduce_add()
+
+    vectorize[cal_vec, width](A.size)
+    return res
+
+
+fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+    """Sum of array elements over a given axis.
+
+    Example:
+    ```mojo
+    import numojo as nm
+    var A = nm.random.randn(100, 100)
+    print(nm.sum(A, axis=0))
+    ```
+
+    Args:
+        A: NDArray.
         axis: The axis along which the sum is performed.
 
     Returns:
         An NDArray.
     """
 
-    var ndim: Int = array.ndim
+    var ndim: Int = A.ndim
     var shape: List[Int] = List[Int]()
     for i in range(ndim):
-        shape.append(array.shape[i])
+        shape.append(A.shape[i])
     if axis > ndim - 1:
-        raise Error("axis cannot be greater than the rank of the array")
+        raise Error(
+            String("axis {} greater than ndim of array {}").format(axis, ndim)
+        )
     var result_shape: List[Int] = List[Int]()
     var axis_size: Int = shape[axis]
     var slices: List[Slice] = List[Slice]()
@@ -31,41 +73,12 @@ fn sum(array: NDArray, axis: Int = 0) raises -> NDArray[array.dtype]:
             slices.append(Slice(0, shape[i]))
         else:
             slices.append(Slice(0, 0))
-    var result: NDArray[array.dtype] = NDArray[array.dtype](
-        NDArrayShape(result_shape)
-    )
+    var result = zeros[dtype](NDArrayShape(result_shape))
     for i in range(axis_size):
         slices[axis] = Slice(i, i + 1)
-        var arr_slice = array[slices]
+        var arr_slice = A[slices]
         result += arr_slice
 
-    return result
-
-
-fn sumall(array: NDArray) raises -> Scalar[array.dtype]:
-    """Sum of all items in the array.
-
-    Example:
-    ```console
-    > print(A)
-    [[      0.1315377950668335      0.458650141954422       0.21895918250083923     ]
-    [      0.67886471748352051     0.93469291925430298     0.51941639184951782     ]
-    [      0.034572109580039978    0.52970021963119507     0.007698186207562685    ]]
-    2-D array  Shape: [3, 3]  DType: float32
-    > print(nm.math.stats.sumall(A))
-    3.5140917301177979
-    ```
-
-    Args:
-        array: NDArray.
-
-    Returns:
-        Scalar.
-    """
-
-    var result = Scalar[array.dtype](0)
-    for i in range(array.size):
-        result[0] += array._buf[i]
     return result
 
 

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -7,7 +7,7 @@ Random values array generation.
 # ===----------------------------------------------------------------------=== #
 
 import math as mt
-from random import random
+from random import random as builtin_random
 from builtin.tuple import Tuple
 
 from numojo.core.ndarray import NDArray
@@ -40,7 +40,9 @@ fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
             " `rand(*shape, min, max)` instead."
         )
     for i in range(result.size):
-        var temp: Scalar[dtype] = random.random_float64(0, 1).cast[dtype]()
+        var temp: Scalar[dtype] = builtin_random.random_float64(0, 1).cast[
+            dtype
+        ]()
         result.set(i, temp)
     return result^
 
@@ -60,7 +62,7 @@ fn int_rand_func[
         min: The minimum value of the random integers.
         max: The maximum value of the random integers.
     """
-    random.randint[dtype](
+    builtin_random.randint[dtype](
         ptr=result._buf,
         size=result.size,
         low=int(min),
@@ -84,7 +86,7 @@ fn float_rand_func[
         max: The maximum value of the random floating-point numbers.
     """
     for i in range(result.size):
-        var temp: Scalar[dtype] = random.random_float64(
+        var temp: Scalar[dtype] = builtin_random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
         result._buf[i] = temp
@@ -116,7 +118,7 @@ fn rand[
         The generated NDArray of type `dtype` filled with random values between `min` and `max`.
     """
     var result: NDArray[dtype] = NDArray[dtype](shape)
-    random.seed()
+    builtin_random.seed()
 
     @parameter
     if is_floattype[dtype]():
@@ -161,7 +163,7 @@ fn rand[
         The generated NDArray of type `dtype` filled with random values between `min` and `max`.
     """
     var result: NDArray[dtype] = NDArray[dtype](shape)
-    random.seed()
+    builtin_random.seed()
 
     @parameter
     if is_floattype[dtype]():
@@ -202,9 +204,9 @@ fn randn[
     Returns:
         The generated NDArray of type `dtype` filled with random values having a mean and variance.
     """
-    random.seed()
+    builtin_random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
-    random.randn[dtype](
+    builtin_random.randn[dtype](
         ptr=result._buf,
         size=result.size,
         mean=mean.cast[DType.float64](),
@@ -238,9 +240,9 @@ fn randn[
     Returns:
         The generated NDArray of type `dtype` filled with random values having a mean and variance.
     """
-    random.seed()
+    builtin_random.seed()
     var result: NDArray[dtype] = NDArray[dtype](shape)
-    random.randn[dtype](
+    builtin_random.randn[dtype](
         ptr=result._buf,
         size=result.size,
         mean=mean.cast[DType.float64](),
@@ -271,11 +273,11 @@ fn rand_exponential[
     Returns:
         The generated NDArray of type `dtype` filled with random values from an exponential distribution.
     """
-    random.seed()
+    builtin_random.seed()
     var result = NDArray[dtype](NDArrayShape(shape))
 
     for i in range(result.num_elements()):
-        var u = random.random_float64().cast[dtype]()
+        var u = builtin_random.random_float64().cast[dtype]()
         result._buf[i] = -mt.log(1 - u) / rate
 
     return result^
@@ -303,11 +305,11 @@ fn rand_exponential[
     Returns:
         The generated NDArray of type `dtype` filled with random values from an exponential distribution.
     """
-    random.seed()
+    builtin_random.seed()
     var result = NDArray[dtype](shape)
 
     for i in range(result.num_elements()):
-        var u = random.random_float64().cast[dtype]()
+        var u = builtin_random.random_float64().cast[dtype]()
         result._buf[i] = -mt.log(1 - u) / rate
 
     return result^

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -13,7 +13,7 @@ from numojo.core.utility import bool_to_numeric
 from numojo.routines.logic.comparison import greater, less
 from numojo.routines.math.arithmetic import add
 from numojo.routines.sorting import binary_sort
-from numojo.routines.math.sums import sum, sumall, cumsum
+from numojo.routines.math.sums import sum, cumsum
 import numojo.routines.math.misc as misc
 
 
@@ -53,7 +53,7 @@ fn meanall(array: NDArray) raises -> Float64:
     """
 
     return (
-        sumall(array).cast[DType.float64]()
+        sum(array).cast[DType.float64]()
         / Int32(array.size).cast[DType.float64]()
     )
 

--- a/numojo/science/signal.mojo
+++ b/numojo/science/signal.mojo
@@ -8,7 +8,7 @@ from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import Shape
 from numojo.core.index import Idx
 from numojo.routines.creation import fromstring, zeros
-from numojo.routines.math.sums import sumall
+from numojo.routines.math.sums import sum
 
 
 fn convolve2d[
@@ -51,7 +51,7 @@ fn convolve2d[
 
     for i in range(output_height):
         for j in range(output_width):
-            output[Idx(i, j)] = sumall(
+            output[Idx(i, j)] = sum(
                 in1[i : i + in2_height, j : j + in2_width] * in2_mirrored
             )
 

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -1,7 +1,6 @@
 import numojo as nm
 from numojo.prelude import *
 from numojo.prelude import *
-from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
 from testing.testing import assert_raises

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -1,8 +1,29 @@
 import numojo as nm
 from numojo.prelude import *
-from time import now
 from python import Python, PythonObject
-from utils_for_test import check, check_is_close
+from utils_for_test import check, check_is_close, check_values_close
+
+# ===-----------------------------------------------------------------------===#
+# Sums, products, differences
+# ===-----------------------------------------------------------------------===#
+
+
+def test_sum():
+    var np = Python.import_module("numpy")
+    var A = nm.random.randn(6, 6, 6)
+    var Anp = A.to_numpy()
+
+    check_values_close(
+        nm.sum(A),
+        np.sum(Anp),
+        String("`sum` fails. {} vs {}."),
+    )
+    for i in range(3):
+        check_is_close(
+            nm.sum(A, axis=i),
+            np.sum(Anp, axis=i),
+            String("`sum` by axis {} fails.".format(i)),
+        )
 
 
 def test_add_array():

--- a/tests/test_matrix.mojo
+++ b/tests/test_matrix.mojo
@@ -1,7 +1,6 @@
 import numojo as nm
 from numojo import mat
 from numojo.prelude import *
-from time import now
 from python import Python, PythonObject
 from testing.testing import assert_raises, assert_true
 

--- a/tests/test_random.mojo
+++ b/tests/test_random.mojo
@@ -1,6 +1,4 @@
 import numojo as nm
-from numojo.routines import random
-from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
 from testing.testing import assert_true, assert_almost_equal
@@ -8,7 +6,7 @@ from testing.testing import assert_true, assert_almost_equal
 
 def test_rand():
     """Test random array generation with specified shape."""
-    var arr = random.rand[nm.f64](3, 5, 2)
+    var arr = nm.random.rand[nm.f64](3, 5, 2)
     assert_true(arr.shape[0] == 3, "Shape of random array")
     assert_true(arr.shape[1] == 5, "Shape of random array")
     assert_true(arr.shape[2] == 2, "Shape of random array")
@@ -16,8 +14,8 @@ def test_rand():
 
 def test_randminmax():
     """Test random array generation with min and max values."""
-    var arr_variadic = random.rand[nm.f64](10, 10, 10, min=1, max=2)
-    var arr_list = random.rand[nm.f64](List[Int](10, 10, 10), min=3, max=4)
+    var arr_variadic = nm.random.rand[nm.f64](10, 10, 10, min=1, max=2)
+    var arr_list = nm.random.rand[nm.f64](List[Int](10, 10, 10), min=3, max=4)
     var arr_variadic_mean = nm.cummean(arr_variadic)
     var arr_list_mean = nm.cummean(arr_list)
     assert_almost_equal(
@@ -36,13 +34,13 @@ def test_randminmax():
 
 def test_randn():
     """Test random array generation with normal distribution."""
-    var arr_variadic_01 = random.randn[nm.f64](
+    var arr_variadic_01 = nm.random.randn[nm.f64](
         20, 20, 20, mean=0.0, variance=1.0
     )
-    var arr_variadic_31 = random.randn[nm.f64](
+    var arr_variadic_31 = nm.random.randn[nm.f64](
         20, 20, 20, mean=3.0, variance=1.0
     )
-    var arr_variadic_12 = random.randn[nm.f64](
+    var arr_variadic_12 = nm.random.randn[nm.f64](
         20, 20, 20, mean=1.0, variance=3.0
     )
 
@@ -94,13 +92,13 @@ def test_randn():
 
 def test_randn_list():
     """Test random array generation with normal distribution."""
-    var arr_list_01 = random.randn[nm.f64](
+    var arr_list_01 = nm.random.randn[nm.f64](
         List[Int](20, 20, 20), mean=0.0, variance=1.0
     )
-    var arr_list_31 = random.randn[nm.f64](
+    var arr_list_31 = nm.random.randn[nm.f64](
         List[Int](20, 20, 20), mean=3.0, variance=1.0
     )
-    var arr_list_12 = random.randn[nm.f64](
+    var arr_list_12 = nm.random.randn[nm.f64](
         List[Int](20, 20, 20), mean=1.0, variance=2.0
     )
 
@@ -152,8 +150,8 @@ def test_randn_list():
 
 def test_rand_exponential():
     """Test random array generation with exponential distribution."""
-    var arr_variadic = random.rand_exponential[nm.f64](20, 20, 20, rate=2.0)
-    var arr_list = random.rand_exponential[nm.f64](
+    var arr_variadic = nm.random.rand_exponential[nm.f64](20, 20, 20, rate=2.0)
+    var arr_list = nm.random.rand_exponential[nm.f64](
         List[Int](20, 20, 20), rate=0.5
     )
 

--- a/tests/test_signal.mojo
+++ b/tests/test_signal.mojo
@@ -1,6 +1,5 @@
 import numojo as nm
 from numojo.prelude import *
-from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
 from testing.testing import assert_raises

--- a/tests/test_sort.mojo
+++ b/tests/test_sort.mojo
@@ -1,5 +1,4 @@
 import numojo as nm
-from time import now
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
 

--- a/tests/utils_for_test.mojo
+++ b/tests/utils_for_test.mojo
@@ -15,3 +15,10 @@ fn check_is_close[
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.isclose(array.to_numpy(), np_sol, atol=0.1)), st)
+
+
+fn check_values_close[
+    dtype: DType
+](value: Scalar[dtype], np_sol: PythonObject, st: String) raises:
+    var np = Python.import_module("numpy")
+    assert_true(np.isclose(value, np_sol, atol=0.01), st)


### PR DESCRIPTION
Update the `numojo.routines.math.sums.sum` function:

1. Merge `sumall` into `sum`. If no `axis` is given, then function returns a scalar, otherwise an array.
2. Fix un-initialization issue with `sum`.
3. Add test for `sum` for 3 axis's.
4. Remove `from time import now`.
5. Rename builtin `random` module as `builtin_random` during import, avoiding leaks in namespace.
6. Change `dtype` of `NDArrayShape` and `NDArrayStrides` to `DType.index` to ensure no overflow during casting.
