### PR TITLE
[update ] `transpose` allow arbitrary dimensions and permutations of axes

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -164,6 +164,7 @@ from numojo.routines.manipulation import (
     reshape,
     ravel,
     flatten,
+    transpose,
     flip,
 )
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -11,10 +11,8 @@ Implements N-Dimensional Array
 # TODO
 1) Generalize mdot, rdot to take any IxJx...xKxL and LxMx...xNxP matrix and matmul it into IxJx..xKxMx...xNxP array.
 2) Add vectorization for _get_index
-3) Write more explanatory Error("") statements
-4) Create NDArrayView and remove coefficients.
-5) Reduce the number of `__init__`.
-6) Rename some variables or methods that should not be exposed to users.
+3) Create NDArrayView and remove coefficients.
+4) Rename some variables or methods that should not be exposed to users.
 """
 
 from builtin.type_aliases import Origin
@@ -2072,22 +2070,26 @@ struct NDArray[dtype: DType = DType.float64](
     # ===-------------------------------------------------------------------===#
     # Operations along an axis
     # ===-------------------------------------------------------------------===#
-    # TODO: implement for arbitrary axis1, and axis2
-    fn T(mut self) raises:
+    fn T(self, axes: List[Int]) raises -> Self:
         """
-        Transpose the array.
-        """
-        if self.ndim != 2:
-            raise Error("Only 2-D arrays can be transposed currently.")
-        var rows = self.shape[0]
-        var cols = self.shape[1]
+        Transpose array of any number of dimensions according to
+        arbitrary permutation of the axes.
 
-        var transposed = NDArray[dtype](Shape(cols, rows))
-        for i in range(rows):
-            for j in range(cols):
-                # the setitem is not working due to the symmetry issue of getter and setter
-                transposed.__setitem__(Idx(j, i), val=self.item(i, j))
-        self = transposed
+        If `axes` is not given, it is equal to flipping the axes.
+
+        Defined in `numojo.routines.manipulation.transpose`.
+        """
+        return numojo.routines.manipulation.transpose(self, axes)
+
+    fn T(self) raises -> Self:
+        """
+        (overload) Transpose the array when `axes` is not given.
+        If `axes` is not given, it is equal to flipping the axes.
+        See docstring of `transpose`.
+
+        Defined in `numojo.routines.manipulation.transpose`.
+        """
+        return numojo.routines.manipulation.transpose(self)
 
     fn all(self) raises -> Bool:
         """

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -3,6 +3,7 @@ Array manipulation routines.
 
 """
 
+from memory import memcpy
 from sys import simdwidthof
 from algorithm import vectorize
 from numojo.core.ndarray import NDArray
@@ -139,6 +140,131 @@ fn flatten[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 
     vectorize[vectorized_flatten, width](array.size)
     return res
+
+
+# ===----------------------------------------------------------------------=== #
+# Transpose-like operations
+# ===----------------------------------------------------------------------=== #
+
+
+fn _set_values_according_to_new_shape_and_strides(
+    mut I: NDArray[DType.index],
+    mut index: Int,
+    current_dim: Int,
+    previous_sum: Int,
+    new_shape: NDArrayShape,
+    new_strides: NDArrayStrides,
+) raises:
+    """
+    Auxiliary function for `transpose` that set values according to new shape
+    and strides for variadic number of dimensions.
+    """
+    for index_of_axis in range(new_shape[current_dim]):
+        var current_sum = previous_sum + index_of_axis * new_strides[
+            current_dim
+        ]
+        if current_dim >= new_shape.ndim - 1:
+            I._buf[index] = current_sum
+            index = index + 1
+        else:
+            _set_values_according_to_new_shape_and_strides(
+                I,
+                index,
+                current_dim + 1,
+                current_sum,
+                new_shape,
+                new_strides,
+            )
+
+
+fn transpose[
+    dtype: DType
+](A: NDArray[dtype], axes: List[Int]) raises -> NDArray[dtype]:
+    """
+    Transpose array of any number of dimensions according to
+    arbitrary permutation of the axes.
+
+    If `axes` is not given, it is equal to flipping the axes.
+    ```mojo
+    import numojo as nm
+    var A = nm.random.rand(2,3,4,5)
+    nm.transpose(A)  # A is a 4darray.
+    nm.transpose(A, axes=List(3,2,1,0))
+    ```
+
+    Examples.
+    ```mojo
+    import numojo as nm
+    # A is a 2darray
+    nm.transpose(A, axes=List(0, 1))  # equal to transpose of matrix
+    # A is a 3darray
+    nm.transpose(A, axes=List(2, 1, 0))  # transpose 0-th and 2-th dimensions
+    ```
+    """
+    if len(axes) != A.ndim:
+        raise Error(
+            String("Length of axes {} does not match ndim of A {}").format(
+                len(axes), A.ndim
+            )
+        )
+
+    for i in range(A.ndim):
+        if i not in axes:
+            raise Error(
+                String(
+                    "`axes` is not a valid permutation of axes of the array. "
+                    "It does not contain index {}"
+                ).format(i)
+            )
+
+    var _shape = List[Int]()
+    var _strides = List[Int]()
+
+    for i in range(A.ndim):
+        _shape.append(A.shape[axes[i]])
+    var new_shape = NDArrayShape(shape=_shape)
+
+    for i in range(A.ndim):
+        _strides.append(A.strides[axes[i]])
+    var new_strides = NDArrayStrides(strides=_strides)
+
+    var _index = 0
+    var I = NDArray[DType.index](shape=new_shape)
+
+    _set_values_according_to_new_shape_and_strides(
+        I, _index, 0, 0, new_shape, new_strides
+    )
+
+    var B = NDArray[dtype](I.shape)
+    for i in range(B.size):
+        B._buf[i] = A._buf[I._buf[i]]
+    return B^
+
+
+fn transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
+    """
+    (overload) Transpose the array when `axes` is not given.
+    If `axes` is not given, it is equal to flipping the axes.
+    See docstring of `transpose`.
+    """
+
+    if A.ndim == 1:
+        return A
+    if A.ndim == 2:
+        var B = NDArray[dtype](Shape(A.shape[1], A.shape[0]))
+        if A.shape[0] == 1 or A.shape[1] == 1:
+            memcpy(B._buf, A._buf, A.size)
+        else:
+            for i in range(B.shape[0]):
+                for j in range(B.shape[1]):
+                    B.__setitem__(Idx(i, j), val=A.__getitem__(Idx(j, i)))
+        return B^
+    else:
+        flipped_axes = List[Int]()
+        for i in range(A.ndim - 1, -1, -1):
+            flipped_axes.append(i)
+
+        return transpose(A, axes=flipped_axes)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/tests/test_array_manipulation.mojo
+++ b/tests/test_array_manipulation.mojo
@@ -33,6 +33,38 @@ def test_arr_manipulation():
     # check_is_close(raveled_B, np_raveled_B, "Ravel operation")
 
 
+def test_transpose():
+    var np = Python.import_module("numpy")
+    var A = nm.random.randn(2)
+    var Anp = A.to_numpy()
+    check_is_close(
+        nm.transpose(A), np.transpose(Anp), "1-d `transpose` is broken."
+    )
+    A = nm.random.randn(2, 3)
+    Anp = A.to_numpy()
+    check_is_close(
+        nm.transpose(A), np.transpose(Anp), "2-d `transpose` is broken."
+    )
+    A = nm.random.randn(2, 3, 4)
+    Anp = A.to_numpy()
+    check_is_close(
+        nm.transpose(A), np.transpose(Anp), "3-d `transpose` is broken."
+    )
+    A = nm.random.randn(2, 3, 4, 5)
+    Anp = A.to_numpy()
+    check_is_close(
+        nm.transpose(A), np.transpose(Anp), "4-d `transpose` is broken."
+    )
+    check_is_close(
+        A.T(), np.transpose(Anp), "4-d `transpose` with `.T` is broken."
+    )
+    check_is_close(
+        nm.transpose(A, axes=List(1, 3, 0, 2)),
+        np.transpose(Anp, [1, 3, 0, 2]),
+        "4-d `transpose` with arbitrary `axes` is broken.",
+    )
+
+
 def test_setitem():
     var np = Python.import_module("numpy")
     var arr = nm.NDArray(Shape(4, 4))


### PR DESCRIPTION
This PR updates the `transpose` function and allow:

(1) Arbitrary dimensions of arrays (>2).
(2) Arbitrary permutations of axes as extra argument. if `axes` is not given, then it is defaulted to the flipping of the axes.

An example of 4darray.

```mojo
A = nm.random.randn(2, 3, 4, 5)
nm.transpose(A) # transpose over axes = (3, 2, 1, 0)
nm.transpose(A, axes=List(1, 3, 0, 2)) # arbitrary axes
```