### PR TITLE
[update][manipulation routines] Refine functions `reshape`, `resize`, `flatten`, `ravel`

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -163,7 +163,6 @@ from numojo.routines.manipulation import (
     size,
     reshape,
     ravel,
-    flatten,
     transpose,
     flip,
 )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1703,6 +1703,8 @@ struct NDArray[dtype: DType = DType.float64](
                 + self.shape.__str__()
                 + "  DType: "
                 + self.dtype.__str__()
+                + "  order: "
+                + self.order
             )
         except e:
             writer.write("Cannot convert array to string")
@@ -2606,16 +2608,44 @@ struct NDArray[dtype: DType = DType.float64](
         return linalg.norms.trace[dtype](self, offset, axis1, axis2)
 
     # Technically it only changes the ArrayDescriptor and not the fundamental data
-    fn reshape(mut self, *shape: Int, order: String = "C") raises:
+    fn reshape(
+        mut self, shape: NDArrayShape, order: String = "C"
+    ) raises -> Self:
         """
-        Reshapes the NDArray to given Shape.
+        Returns an array of the same data with a new shape.
 
         Args:
-            shape: Variadic list of shape.
+            shape: Shape of returned array.
             order: Order of the array - Row major `C` or Column major `F`.
+
+        Returns:
+            Array of the same data with a new shape.
         """
-        var s: VariadicList[Int] = shape
-        reshape[dtype](self, s, order=order)
+        return reshape[dtype](self, shape=shape, order=order)
+
+    fn resize(mut self, shape: NDArrayShape) raises:
+        """
+        In-place change shape and size of array.
+
+        Notes:
+        To returns a new array, use `reshape`.
+
+        Args:
+            shape: Shape after resize.
+        """
+
+        if shape.size > self.size:
+            var other = Self(shape=shape, order=self.order)
+            memcpy(other._buf, self._buf, self.size)
+            for i in range(self.size, other.size):
+                (other._buf + i).init_pointee_copy(0)
+            self = other^
+        else:
+            self.shape = shape
+            self.ndim = shape.ndim
+            self.size = shape.size
+            self.strides = NDArrayStrides(shape, order=self.order)
+            self.coefficient = NDArrayStrides(shape, order=self.order)
 
     fn unsafe_ptr(self) -> UnsafePointer[Scalar[dtype]]:
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2610,9 +2610,7 @@ struct NDArray[dtype: DType = DType.float64](
         return linalg.norms.trace[dtype](self, offset, axis1, axis2)
 
     # Technically it only changes the ArrayDescriptor and not the fundamental data
-    fn reshape(
-        mut self, shape: NDArrayShape, order: String = "C"
-    ) raises -> Self:
+    fn reshape(self, shape: NDArrayShape, order: String = "C") raises -> Self:
         """
         Returns an array of the same data with a new shape.
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -54,7 +54,7 @@ from .utility import (
 )
 from numojo.core._math_funcs import Vectorized
 from numojo.routines.linalg.products import matmul_parallelized
-from numojo.routines.manipulation import reshape
+from numojo.routines.manipulation import reshape, ravel
 from numojo.core.ndshape import NDArrayShape
 from numojo.core.ndstrides import NDArrayStrides
 
@@ -2216,12 +2216,17 @@ struct NDArray[dtype: DType = DType.float64](
         for i in range(self.size):
             self._buf[i] = val
 
-    fn flatten(mut self) raises:
+    fn flatten(self, order: String = "C") raises -> Self:
         """
-        Convert shape of array to one dimensional.
+        Return a copy of the array collapsed into one dimension.
+
+        Args:
+            order: A NDArray.
+
+        Returns:
+            The 1 dimensional flattened NDArray.
         """
-        self.shape = NDArrayShape(self.size, size=self.size)
-        self.strides = NDArrayStrides(shape=self.shape, offset=0)
+        return ravel(self, order=order)
 
     fn item(self, *index: Int) raises -> SIMD[dtype, 1]:
         """
@@ -2550,11 +2555,8 @@ struct NDArray[dtype: DType = DType.float64](
         See `numojo.sorting.sort` for more information.
         """
         var I = NDArray[DType.index](self.shape)
-        self = flatten(self)
-        sorting._sort_inplace(
-            self,
-            I,
-        )
+        self = ravel(self)
+        sorting._sort_inplace(self, I, axis=0)
 
     fn sort(mut self, owned axis: Int) raises:
         """

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -44,7 +44,7 @@ fn fill_pointer[
 
 
 # ===----------------------------------------------------------------------=== #
-# GET INDEX FUNCIONS FOR NDARRAY
+# GET INDEX FUNCTIONS FOR NDARRAY
 # ===----------------------------------------------------------------------=== #
 # define a ndarray internal trait and remove multiple overloads of these _get_index
 fn _get_index(indices: List[Int], weights: NDArrayShape) raises -> Int:
@@ -492,3 +492,14 @@ fn is_booltype(dtype: DType) -> Bool:
     if dtype == DType.bool:
         return True
     return False
+
+
+fn _list_of_range(n: Int) -> List[Int]:
+    """
+    Generate a list of integers starting from 0 and of size n.
+    """
+
+    var l = List[Int]()
+    for i in range(n):
+        l.append(i)
+    return l

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -503,3 +503,14 @@ fn _list_of_range(n: Int) -> List[Int]:
     for i in range(n):
         l.append(i)
     return l
+
+
+fn _list_of_flipped_range(n: Int) -> List[Int]:
+    """
+    Generate a list of integers starting from n-1 to 0 and of size n.
+    """
+
+    var l = List[Int]()
+    for i in range(n - 1, -1, -1):
+        l.append(i)
+    return l

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -209,15 +209,15 @@ fn matmul_parallelized[
         return matmul_1d(A, B)
     elif A.ndim == 1:
         A_reshaped = A
-        A_reshaped.reshape(1, A_reshaped.shape[0])
+        A_reshaped = A_reshaped.reshape(Shape(1, A_reshaped.shape[0]))
         var res = A_reshaped @ B
-        res.reshape(B.shape[1])
+        res = res.reshape(Shape(B.shape[1]))
         return res
     elif B.ndim == 1:
         B_reshaped = B
-        B_reshaped.reshape(B_reshaped.shape[0], 1)
+        B_reshaped = B_reshaped.reshape(Shape(B_reshaped.shape[0], 1))
         var res = A @ B_reshaped
-        res.reshape(A.shape[0])
+        res = res.reshape(Shape(A.shape[0]))
         return res
 
     var C: NDArray[dtype] = zeros[dtype](Shape(A.shape[0], B.shape[1]))

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -8,7 +8,7 @@ from algorithm import vectorize
 
 from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import NDArrayShape
-from numojo.routines.manipulation import flatten, transpose
+from numojo.routines.manipulation import ravel, transpose
 
 """
 TODO:
@@ -196,7 +196,7 @@ fn sort[dtype: DType](owned A: NDArray[dtype]) raises -> NDArray[dtype]:
         A: NDArray.
     """
 
-    A = flatten(A)
+    A = ravel(A)
     var _I = NDArray[DType.index](A.shape)
     _sort_inplace(A, _I, axis=0)
     return A^
@@ -295,7 +295,7 @@ fn argsort[
         Indices that would sort an array.
     """
 
-    A = flatten(A)
+    A = ravel(A)
     var I = NDArray[DType.index](A.shape)
     _sort_inplace(A, I, axis=0)
     return I^

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -129,33 +129,10 @@ fn _sort_in_range(mut A: NDArray, mut I: NDArray, left: Int, right: Int) raises:
 
 fn _sort_inplace[
     dtype: DType
-](mut A: NDArray[dtype], mut I: NDArray[DType.index]) raises:
-    """
-    Sort in-place NDArray using quick sort method.
-    It is not guaranteed to be unstable.
-
-    When no axis is given, the array is flattened before sorting.
-
-    Parameters:
-        dtype: The input element type.
-
-    Args:
-        A: NDArray.
-        I: NDArray that stores the indices.
-    """
-
-    A = flatten(A)
-    _sort_in_range(A, I, 0, A.size - 1)
-
-
-fn _sort_inplace[
-    dtype: DType
 ](mut A: NDArray[dtype], mut I: NDArray[DType.index], owned axis: Int) raises:
     """
     Sort in-place NDArray along the given axis using quick sort method.
     It is not guaranteed to be unstable.
-
-    When no axis is given, the array is flattened before sorting.
 
     Parameters:
         dtype: The input element type.
@@ -219,9 +196,9 @@ fn sort[dtype: DType](owned A: NDArray[dtype]) raises -> NDArray[dtype]:
         A: NDArray.
     """
 
-    var _I = NDArray[DType.index](A.shape)
     A = flatten(A)
-    _sort_inplace(A, _I)
+    var _I = NDArray[DType.index](A.shape)
+    _sort_inplace(A, _I, axis=0)
     return A^
 
 
@@ -318,9 +295,9 @@ fn argsort[
         Indices that would sort an array.
     """
 
-    var I = NDArray[DType.index](A.shape)
     A = flatten(A)
-    _sort_inplace(A, I)
+    var I = NDArray[DType.index](A.shape)
+    _sort_inplace(A, I, axis=0)
     return I^
 
 

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -162,7 +162,7 @@ def test_fromstring_complicated():
 def test_diag():
     var np = Python.import_module("numpy")
     var x_nm = nm.arange[f32](0, 9, step=1)
-    x_nm.reshape(3, 3)
+    x_nm.resize(Shape(3, 3))
     var x_np = np.arange(0, 9, step=1).reshape(3, 3)
 
     x_nm_k0 = nm.diag[f32](x_nm, k=0)
@@ -189,7 +189,7 @@ def test_diag():
 def test_diagflat():
     var np = Python.import_module("numpy")
     var nm_arr = nm.arange[nm.i64](0, 9, 1)
-    nm_arr.reshape(3, 3)
+    nm_arr.resize(Shape(3, 3))
     var np_arr = np.arange(0, 9, 1).reshape(3, 3)
 
     var x_nm = nm.diagflat[nm.i64](nm_arr, k=0)
@@ -224,7 +224,7 @@ def test_tri():
 def test_tril():
     var np = Python.import_module("numpy")
     var nm_arr = nm.arange[nm.f32](0, 9, 1)
-    nm_arr.reshape(3, 3)
+    nm_arr.resize(Shape(3, 3))
     var np_arr = np.arange(0, 9, 1, dtype=np.float32).reshape(3, 3)
 
     var x_nm = nm.tril[nm.f32](nm_arr, k=0)
@@ -241,7 +241,7 @@ def test_tril():
 
     # Test with higher dimensional array
     var nm_arr_3d = nm.arange[nm.f32](0, 60, 1)
-    nm_arr_3d.reshape(3, 4, 5)
+    nm_arr_3d.resize(Shape(3, 4, 5))
     var np_arr_3d = np.arange(0, 60, 1, dtype=np.float32).reshape(3, 4, 5)
 
     var x_nm_3d = nm.tril[nm.f32](nm_arr_3d, k=0)
@@ -260,7 +260,7 @@ def test_tril():
 def test_triu():
     var np = Python.import_module("numpy")
     var nm_arr = nm.arange[nm.f32](0, 9, 1)
-    nm_arr.reshape(3, 3)
+    nm_arr.resize(Shape(3, 3))
     var np_arr = np.arange(0, 9, 1, dtype=np.float32).reshape(3, 3)
 
     var x_nm = nm.triu[nm.f32](nm_arr, k=0)
@@ -277,7 +277,7 @@ def test_triu():
 
     # Test with higher dimensional array
     var nm_arr_3d = nm.arange[nm.f32](0, 60, 1)
-    nm_arr_3d.reshape(3, 4, 5)
+    nm_arr_3d.resize(Shape(3, 4, 5))
     var np_arr_3d = np.arange(0, 60, 1, dtype=np.float32).reshape(3, 4, 5)
 
     var x_nm_3d = nm.triu[nm.f32](nm_arr_3d, k=0)

--- a/tests/test_array_manipulation.mojo
+++ b/tests/test_array_manipulation.mojo
@@ -18,19 +18,26 @@ def test_arr_manipulation():
     var np_flipped_A = np.flip(np_A)
     check_is_close(flipped_A, np_flipped_A, "Flip operation")
 
-    # Test reshape
-    A = A.reshape(Shape(2, 3))
-    np_A = np_A.reshape((2, 3))
-    check_is_close(A, np_A, "Reshape operation")
+    # Test reshape and ravel
+    var B = nm.random.randn(2, 3, 4)
+    var Bnp = B.to_numpy()
+    check_is_close(
+        nm.reshape(B, Shape(4, 3, 2), "C"),
+        np.reshape(Bnp, (4, 3, 2), "C"),
+        "`reshape` by C is broken",
+    )
+    check_is_close(
+        nm.reshape(B, Shape(4, 3, 2), "F"),
+        np.reshape(Bnp, (4, 3, 2), "F"),
+        "`reshape` by F is broken",
+    )
 
-    # # Test ravel
-    # var B = nm.arange[nm.i16](0, 12, 1)
-    # var np_B = np.arange(0, 12, 1, dtype=np.int16)
-    # B.reshape(3, 2, 2, order="F")
-    # np_B = np_B.reshape((3, 2, 2), order='F')
-    # var raveled_B = nm.ravel(B, order="C")
-    # var np_raveled_B = np.ravel(np_B, order='C')
-    # check_is_close(raveled_B, np_raveled_B, "Ravel operation")
+    check_is_close(
+        nm.ravel(B, "C"), np.ravel(Bnp, "C"), "`ravel` by C is broken"
+    )
+    check_is_close(
+        nm.ravel(B, "F"), np.ravel(Bnp, "F"), "`ravel` by F is broken"
+    )
 
 
 def test_transpose():

--- a/tests/test_array_manipulation.mojo
+++ b/tests/test_array_manipulation.mojo
@@ -19,7 +19,7 @@ def test_arr_manipulation():
     check_is_close(flipped_A, np_flipped_A, "Flip operation")
 
     # Test reshape
-    A.reshape(2, 3)
+    A = A.reshape(Shape(2, 3))
     np_A = np_A.reshape((2, 3))
     check_is_close(A, np_A, "Reshape operation")
 

--- a/tests/test_bool_masks.mojo
+++ b/tests/test_bool_masks.mojo
@@ -10,7 +10,7 @@ def test_bool_masks_gt():
     var np = Python.import_module("numpy")
     var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
     var A = nm.arange[nm.i16](0, 24)
-    A.reshape(3, 2, 4)
+    A = A.reshape(Shape(3, 2, 4))
 
     var np_gt = np_A > 10
     var gt = A > Scalar[nm.i16](10)
@@ -28,7 +28,7 @@ def test_bool_masks_lt():
     # Create NumPy and NuMojo arrays using arange and reshape
     var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
     var A = nm.arange[nm.i16](0, 24)
-    A.reshape(3, 2, 4)
+    A = A.reshape(Shape(3, 2, 4))
 
     # Test less than
     var np_lt = np_A < 10
@@ -47,7 +47,7 @@ def test_bool_masks_eq():
     # Create NumPy and NuMojo arrays using arange and reshape
     var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
     var A = nm.arange[nm.i16](0, 24)
-    A.reshape(3, 2, 4)
+    A = A.reshape(Shape(3, 2, 4))
 
     # Test equal
     # var np_eq = np_A == 10 # has a python interop problem.

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -92,7 +92,7 @@ def test_matmul_small():
 def test_matmul():
     var np = Python.import_module("numpy")
     var arr = nm.arange[nm.f64](0, 100)
-    arr.reshape(10, 10)
+    arr.resize(Shape(10, 10))
     var np_arr = np.arange(0, 100).reshape(10, 10)
     check_is_close(
         arr @ arr, np.matmul(np_arr, np_arr), "Dunder matmul is broken"

--- a/tests/test_slicing.mojo
+++ b/tests/test_slicing.mojo
@@ -10,7 +10,7 @@ def test_slicing_getter1():
 
     # Test C-order array slicing
     nm_arr = nm.arange[nm.f32](0.0, 24.0, step=1)
-    nm_arr.reshape(2, 3, 4, order="C")
+    nm_arr = nm_arr.reshape(Shape(2, 3, 4), order="C")
     np_arr = np.arange(0, 24, dtype=np.float32).reshape(2, 3, 4)
 
     # Test case 1: Slicing all dimensions
@@ -31,7 +31,7 @@ def test_slicing_getter2():
 
     # Test C-order array slicing
     nm_arr = nm.arange[nm.f32](0.0, 24.0, step=1)
-    nm_arr.reshape(2, 3, 4, order="C")
+    nm_arr = nm_arr.reshape(Shape(2, 3, 4), order="C")
     np_arr = np.arange(0, 24, dtype=np.float32).reshape(2, 3, 4)
 
     # Test case 2: Slicing with start and end indices
@@ -51,7 +51,7 @@ def test_slicing_getter3():
 
     # Test C-order array slicing
     nm_arr = nm.arange[nm.f32](0.0, 24.0, step=1)
-    nm_arr.reshape(2, 3, 4, order="C")
+    nm_arr = nm_arr.reshape(Shape(2, 3, 4), order="C")
     np_arr = np.arange(0, 24, dtype=np.float32).reshape(2, 3, 4)
 
     # Test case 3: Slicing with mixed start, end, and step values
@@ -73,7 +73,7 @@ def test_slicing_getter4():
 
     # Test C-order array slicing
     nm_arr = nm.arange[nm.f32](0.0, 24.0, step=1)
-    nm_arr.reshape(2, 3, 4, order="C")
+    nm_arr = nm_arr.reshape(Shape(2, 3, 4), order="C")
     np_arr = np.arange(0, 24, dtype=np.float32).reshape(2, 3, 4)
 
     # Test case 4: Slicing with step
@@ -95,7 +95,7 @@ def test_slicing_getter5():
 
     # Test C-order array slicing
     nm_arr = nm.arange[nm.f32](0.0, 24.0, step=1)
-    nm_arr.reshape(2, 3, 4, order="C")
+    nm_arr = nm_arr.reshape(Shape(2, 3, 4), order="C")
     np_arr = np.arange(0, 24, dtype=np.float32).reshape(2, 3, 4)
 
     # Test case 5: Slicing with combination of integer and slices

--- a/tests/test_sorting.mojo
+++ b/tests/test_sorting.mojo
@@ -5,9 +5,10 @@ from utils_for_test import check, check_is_close
 
 fn test_sorting() raises:
     var np = Python.import_module("numpy")
-    var A = nm.random.rand[nm.i8](10, min=0, max=100)
-    var B = nm.random.rand[nm.i8](2, 3, min=0, max=100)
-    var C = nm.random.rand[nm.i8](2, 3, 4, min=0, max=100)
+    var A = nm.random.randn(10)
+    var B = nm.random.randn(2, 3)
+    var C = nm.random.randn(2, 3, 4)
+    var S = nm.random.randn(3, 3, 3, 3, 3, 3)  # 6d array
 
     # Sort
     check(
@@ -27,7 +28,13 @@ fn test_sorting() raises:
         check(
             nm.sort(C, axis=i),
             np.sort(C.to_numpy(), axis=i),
-            String("`sort` 1d by axis {} is broken").format(i),
+            String("`sort` 3d by axis {} is broken").format(i),
+        )
+    for i in range(6):
+        check(
+            nm.sort(S, axis=i),
+            np.sort(S.to_numpy(), axis=i),
+            String("`sort` 6d by axis {} is broken").format(i),
         )
 
     # Argsort
@@ -50,5 +57,11 @@ fn test_sorting() raises:
         check_is_close(
             nm.argsort(C, axis=i),
             np.argsort(C.to_numpy(), axis=i),
-            String("`argsort` 1d by axis {} is broken").format(i),
+            String("`argsort` 3d by axis {} is broken").format(i),
+        )
+    for i in range(6):
+        check(
+            nm.argsort(S, axis=i),
+            np.argsort(S.to_numpy(), axis=i),
+            String("`argsort` 6d by axis {} is broken").format(i),
         )


### PR DESCRIPTION
I refined and fixed the functions `reshape` `resize` and methods `flatten` 'ravel` so that:

1. Refine the function `reshape` so that it is working on any dimensions and is working on both row-major and col-major. This also allows us to change the order with the code:
```mojo
A = nm.random.randn(Shape(2,3,4))
A.reshape(A.shape, "F"))
```
2. Add a new method `resize` that reshapes the array in-place. `reshape` method returns a copy of the array.
3. Refine the function `ravel` so that it allows to flatten the array by either row-major or col-major.
4. Update the method `flatten` which has the same behavior as `ravel`.
5. And two auxiliary functions that generate a list of integers given range, e.g., `[0,1,2,3]`.
6. Show order of the array during printing.

The functions are tested against 3darrays and against both "C" and "F" orders.