### PR TITLE
[fix][math routines] Allow `cumsum` and `cumprod` by any axis

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -20,6 +20,7 @@ test = "magic run mojo test tests -I ./ && magic run mojo package numojo"
 t = "clear && magic run mojo test tests -I ./ && magic run mojo package numojo"
 # runs all final checks before a commit
 final = "magic run mojo test tests -I ./ && magic run mojo format ./ && magic run mojo package numojo"
+f = "clear && magic run mojo test tests -I ./ && magic run mojo format ./ && magic run mojo package numojo"
 # defaults tasks
 package = "magic run mojo package numojo"
 format = "magic run mojo format ./"

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -16,7 +16,8 @@ readme = "README.MD"
 
 [tasks]
 # test whether tests pass and the package can be built
-test = " magic run mojo test tests -I ./ && magic run mojo package numojo"
+test = "magic run mojo test tests -I ./ && magic run mojo package numojo"
+t = "clear && magic run mojo test tests -I ./ && magic run mojo package numojo"
 # runs all final checks before a commit
 final = "magic run mojo test tests -I ./ && magic run mojo format ./ && magic run mojo package numojo"
 # defaults tasks

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -86,7 +86,7 @@ from numojo.routines.math import maxT, minT, amin, amax, mimimum, maximum
 from numojo.routines.math import copysign
 from numojo.routines.math import acosh, asinh, atanh, cosh, sinh, tanh
 from numojo.routines.math import cbrt, rsqrt, sqrt, scalb
-from numojo.routines.math import prod, prodall, cumprod
+from numojo.routines.math import prod, cumprod
 from numojo.routines.math import (
     tabs,
     tfloor,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2524,17 +2524,24 @@ struct NDArray[dtype: DType = DType.float64](
     # fn nonzero(self):
     #     pass
 
+    fn prod(self: Self) raises -> Scalar[dtype]:
+        """
+        Product of all array elements.
+        Returns:
+            Scalar.
+        """
+        return sum(self)
+
     fn prod(self: Self, axis: Int) raises -> Self:
         """
         Product of array elements over a given axis.
         Args:
-            array: NDArray.
             axis: The axis along which the product is performed.
         Returns:
             An NDArray.
         """
 
-        return prod(self, axis)
+        return prod(self, axis=axis)
 
     fn round(self) raises -> Self:
         """
@@ -2570,6 +2577,14 @@ struct NDArray[dtype: DType = DType.float64](
         var I = NDArray[DType.index](self.shape)
         sorting._sort_inplace(self, I, axis=axis)
 
+    fn sum(self: Self) raises -> Scalar[dtype]:
+        """
+        Sum of all array elements.
+        Returns:
+            Scalar.
+        """
+        return sum(self)
+
     fn sum(self: Self, axis: Int) raises -> Self:
         """
         Sum of array elements over a given axis.
@@ -2578,7 +2593,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An NDArray.
         """
-        return sum(self, axis)
+        return sum(self, axis=axis)
 
     fn tolist(self) -> List[Scalar[dtype]]:
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2187,14 +2187,27 @@ struct NDArray[dtype: DType = DType.float64](
     # fn copy(self):
     #     pass
 
-    fn cumprod(self) -> Scalar[dtype]:
+    fn cumprod(self) raises -> NDArray[dtype]:
         """
-        Cumulative product of an array.
+        Returns cumprod of all items of an array.
+        The array is flattened before cumprod.
 
         Returns:
-            The cumulative product of the array as a SIMD Value of `dtype`.
+            Cumprod of all items of an array.
         """
         return cumprod[dtype](self)
+
+    fn cumprod(self, axis: Int) raises -> NDArray[dtype]:
+        """
+        Returns cumprod of array by axis.
+
+        Args:
+            axis: Axis.
+
+        Returns:
+            Cumprod of array by axis.
+        """
+        return cumprod[dtype](self, axis=axis)
 
     fn cumsum(self) raises -> NDArray[dtype]:
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -283,7 +283,7 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             return self._buf.store(index + self.size, val)
 
-    fn _setitem(self, *indices: Int, val: Scalar[dtype]) raises:
+    fn _setitem(self, *indices: Int, val: Scalar[dtype]):
         """
         (UNSAFE! for internal use only.)
         Get item at indices and bypass all boundary checks.
@@ -296,7 +296,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var index_of_buffer: Int = 0
         for i in range(self.ndim):
-            index_of_buffer += indices[i] * self.strides[i]
+            index_of_buffer += indices[i] * self.strides._buf[i]
         self._buf[index_of_buffer] = val
 
     # TODO: add support for different dtypes
@@ -692,7 +692,7 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             return self._buf.load[width=1](index + self.size)
 
-    fn _getitem(self, *indices: Int) raises -> Scalar[dtype]:
+    fn _getitem(self, *indices: Int) -> Scalar[dtype]:
         """
         (UNSAFE! for internal use only.)
         Get item at indices and bypass all boundary checks.
@@ -705,7 +705,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         var index_of_buffer: Int = 0
         for i in range(self.ndim):
-            index_of_buffer += indices[i] * self.strides[i]
+            index_of_buffer += indices[i] * self.strides._buf[i]
         return self._buf[index_of_buffer]
 
     fn __getitem__(self, idx: Int) raises -> Self:
@@ -1446,13 +1446,13 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return comparison.greater_equal[dtype](self, other)
 
-    fn __add__(mut self, other: SIMD[dtype, 1]) raises -> Self:
+    fn __add__(self, other: SIMD[dtype, 1]) raises -> Self:
         """
         Enables `array + scalar`.
         """
         return math.add[dtype](self, other)
 
-    fn __add__(mut self, other: Self) raises -> Self:
+    fn __add__(self, other: Self) raises -> Self:
         """
         Enables `array + array`.
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2189,21 +2189,34 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn cumprod(self) -> Scalar[dtype]:
         """
-        Cumulative product of a array.
+        Cumulative product of an array.
 
         Returns:
             The cumulative product of the array as a SIMD Value of `dtype`.
         """
         return cumprod[dtype](self)
 
-    fn cumsum(self) -> Scalar[dtype]:
+    fn cumsum(self) raises -> NDArray[dtype]:
         """
-        Cumulative Sum of a array.
+        Returns cumsum of all items of an array.
+        The array is flattened before cumsum.
 
         Returns:
-            The cumulative sum of the array as a SIMD Value of `dtype`.
+            Cumsum of all items of an array.
         """
         return cumsum[dtype](self)
+
+    fn cumsum(self, axis: Int) raises -> NDArray[dtype]:
+        """
+        Returns cumsum of array by axis.
+
+        Args:
+            axis: Axis.
+
+        Returns:
+            Cumsum of array by axis.
+        """
+        return cumsum[dtype](self, axis=axis)
 
     fn diagonal(self):
         pass

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -280,6 +280,10 @@ struct NDArrayShape(Stringable, Writable):
             axis += self.ndim
 
         var shape = NDArrayShape(self)
+
+        if axis == self.ndim - 1:
+            return shape
+
         var value = shape[axis]
         for i in range(axis, shape.ndim - 1):
             shape._buf[i] = shape._buf[i + 1]

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -22,6 +22,19 @@ struct NDArrayShape(Stringable, Writable):
     """Number of dimensions of array."""
 
     @always_inline("nodebug")
+    fn __init__(mut self, shape: Int):
+        """
+        Initializes the NDArrayShape with one dimension.
+
+        Args:
+            shape: Size of the array.
+        """
+        self.ndim = 1
+        self.size = shape
+        self._buf = UnsafePointer[Int]().alloc(shape)
+        self._buf.init_pointee_copy(shape)
+
+    @always_inline("nodebug")
     fn __init__(mut self, *shape: Int):
         """
         Initializes the NDArrayShape with variable shape dimensions.
@@ -223,6 +236,55 @@ struct NDArrayShape(Stringable, Writable):
             if self[i] == val:
                 return True
         return False
+
+    # ===-------------------------------------------------------------------===#
+    # Other private methods
+    # ===-------------------------------------------------------------------===#
+
+    fn _flip(self) raises -> Self:
+        """
+        Returns a new shape by flipping the items.
+
+        UNSAFE! No boundary check!
+
+        Example:
+        ```mojo
+        import numojo as nm
+        var A = nm.random.randn(2, 3, 4)
+        print(A.shape)          # Shape: [2, 3, 4]
+        print(A.shape._flip())  # Shape: [4, 3, 2]
+        ```
+        """
+
+        var shape = NDArrayShape(self)
+        for i in range(shape.ndim):
+            shape._buf[i] = self._buf[self.ndim - 1 - i]
+        return shape
+
+    fn _move_axis_to_end(self, owned axis: Int) raises -> Self:
+        """
+        Returns a new shape by moving the value of axis to the end.
+
+        UNSAFE! No boundary check!
+
+        Example:
+        ```mojo
+        import numojo as nm
+        var A = nm.random.randn(2, 3, 4)
+        print(A.shape._move_axis_to_end(0))  # Shape: [3, 4, 2]
+        print(A.shape._move_axis_to_end(1))  # Shape: [2, 4, 3]
+        ```
+        """
+
+        if axis < 0:
+            axis += self.ndim
+
+        var shape = NDArrayShape(self)
+        var value = shape[axis]
+        for i in range(axis, shape.ndim - 1):
+            shape._buf[i] = shape._buf[i + 1]
+        shape._buf[shape.ndim - 1] = value
+        return shape
 
     # # can be used for vectorized index calculation
     # @always_inline("nodebug")

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -266,6 +266,10 @@ struct NDArrayStrides(Stringable):
             axis += self.ndim
 
         var strides = NDArrayStrides(self)
+
+        if axis == self.ndim - 1:
+            return strides
+
         var value = strides[axis]
         for i in range(axis, strides.ndim - 1):
             strides._buf[i] = strides._buf[i + 1]

--- a/numojo/routines/math/__init__.mojo
+++ b/numojo/routines/math/__init__.mojo
@@ -5,7 +5,7 @@ from .extrema import maxT, minT, amin, amax, mimimum, maximum
 from .floating import copysign
 from .hyper import acosh, asinh, atanh, cosh, sinh, tanh
 from .misc import cbrt, rsqrt, sqrt, scalb
-from .products import prod, prodall, cumprod
+from .products import prod, cumprod
 from .rounding import tabs, tfloor, tceil, ttrunc, tround, roundeven, nextafter
 from .sums import sum, cumsum
 from .trig import acos, asin, atan, atan2, cos, sin, tan, hypot, hypot_fma

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -3,11 +3,11 @@ from algorithm import parallelize, vectorize
 
 from numojo.core.ndarray import NDArray
 from numojo.routines.creation import zeros
-from numojo.routines.math.arithmetic import mul
 
 
 fn sum[dtype: DType](A: NDArray[dtype]) -> Scalar[dtype]:
-    """Sum of all items in the array.
+    """
+    Returns sum of all items in the array.
 
     Example:
     ```console
@@ -27,19 +27,22 @@ fn sum[dtype: DType](A: NDArray[dtype]) -> Scalar[dtype]:
         Scalar.
     """
 
-    var res = Scalar[dtype](0)
     alias width: Int = simdwidthof[dtype]()
+    var res = Scalar[dtype](0)
 
     @parameter
     fn cal_vec[width: Int](i: Int):
-        res = res + A._buf.load[width=width](i).reduce_add()
+        res += A._buf.load[width=width](i).reduce_add()
 
     vectorize[cal_vec, width](A.size)
     return res
 
 
-fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
-    """Sum of array elements over a given axis.
+fn sum[
+    dtype: DType
+](A: NDArray[dtype], owned axis: Int) raises -> NDArray[dtype]:
+    """
+    Returns sums of array elements over a given axis.
 
     Example:
     ```mojo
@@ -57,7 +60,9 @@ fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
 
     var ndim: Int = A.ndim
-    if axis > ndim - 1:
+    if axis < 0:
+        axis += ndim
+    if (axis < 0) or (axis >= ndim):
         raise Error(
             String("axis {} greater than ndim of array {}").format(axis, ndim)
         )
@@ -69,7 +74,7 @@ fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
             result_shape.append(A.shape[i])
             slices.append(Slice(0, A.shape[i]))
         else:
-            slices.append(Slice(0, 0))
+            slices.append(Slice(0, 0))  # Temp value
     var result = zeros[dtype](NDArrayShape(result_shape))
     for i in range(size_of_axis):
         slices[axis] = Slice(i, i + 1)

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -165,7 +165,7 @@ fn cummean[
     Returns:
         The mean of all of the member values of array as a SIMD Value of `dtype`.
     """
-    return cumsum[dtype](array) / (array.num_elements())
+    return sum[dtype](array) / (array.num_elements())
 
 
 fn mode[

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -10,7 +10,7 @@ from utils_for_test import check, check_is_close, check_values_close
 
 def test_sum_prod():
     var np = Python.import_module("numpy")
-    var A = nm.random.randn(4, 4, 4)
+    var A = nm.random.randn(2, 3, 4)
     var Anp = A.to_numpy()
 
     check_values_close(
@@ -49,6 +49,18 @@ def test_sum_prod():
             String("`prod` by axis {} fails.".format(i)),
         )
 
+    check_is_close(
+        nm.cumprod(A),
+        np.cumprod(Anp, axis=None),
+        String("`cumprod` fails."),
+    )
+    for i in range(3):
+        check_is_close(
+            nm.cumprod(A, axis=i),
+            np.cumprod(Anp, axis=i),
+            String("`cumprod` by axis {} fails.".format(i)),
+        )
+
 
 def test_add_array():
     var np = Python.import_module("numpy")
@@ -64,16 +76,16 @@ def test_add_array():
 
 def test_add_array_par():
     var np = Python.import_module("numpy")
-    var arr = nm.arange[nm.f64](0, 500)
+    var arr = nm.arange[nm.f64](0, 20)
 
     check(
         nm.add[nm.f64, backend = nm.core._math_funcs.Vectorized](arr, 5.0),
-        np.arange(0, 500) + 5,
+        np.arange(0, 20) + 5,
         "Add array + scalar",
     )
     check(
         nm.add[nm.f64, backend = nm.core._math_funcs.Vectorized](arr, arr),
-        np.arange(0, 500) + np.arange(0, 500),
+        np.arange(0, 20) + np.arange(0, 20),
         "Add array + array",
     )
 

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -8,21 +8,32 @@ from utils_for_test import check, check_is_close, check_values_close
 # ===-----------------------------------------------------------------------===#
 
 
-def test_sum():
+def test_sum_prod():
     var np = Python.import_module("numpy")
-    var A = nm.random.randn(6, 6, 6)
+    var A = nm.random.randn(4, 4, 4)
     var Anp = A.to_numpy()
 
     check_values_close(
         nm.sum(A),
-        np.sum(Anp),
-        String("`sum` fails. {} vs {}."),
+        np.sum(Anp, axis=None),
+        String("`sum` fails."),
     )
     for i in range(3):
         check_is_close(
             nm.sum(A, axis=i),
             np.sum(Anp, axis=i),
             String("`sum` by axis {} fails.".format(i)),
+        )
+    check_values_close(
+        nm.prod(A),
+        np.prod(Anp, axis=None),
+        String("`prod` fails."),
+    )
+    for i in range(3):
+        check_is_close(
+            nm.prod(A, axis=i),
+            np.prod(Anp, axis=i),
+            String("`prod` by axis {} fails.".format(i)),
         )
 
 

--- a/tests/test_math.mojo
+++ b/tests/test_math.mojo
@@ -24,6 +24,19 @@ def test_sum_prod():
             np.sum(Anp, axis=i),
             String("`sum` by axis {} fails.".format(i)),
         )
+
+    check_is_close(
+        nm.cumsum(A),
+        np.cumsum(Anp, axis=None),
+        String("`cumsum` fails."),
+    )
+    for i in range(3):
+        check_is_close(
+            nm.cumsum(A, axis=i),
+            np.cumsum(Anp, axis=i),
+            String("`cumsum` by axis {} fails.".format(i)),
+        )
+
     check_values_close(
         nm.prod(A),
         np.prod(Anp, axis=None),


### PR DESCRIPTION
This PR:

- Fixes `cumsum` and `cumprod` so it returns array instead of number.
- Allows `cumsum` and `cumprod` by any axis.
- Adds an auxiliary function in utility module `_traverse_buffer_according_to_shape_and_strides` that traverse array with shape and strides.
- Removes `mut` keyword from `NDArray.__add__`
- Adds auxiliary methods `_flip`, `_move_axis_to_end` for `NDArrayShape` and `NDArrayStrides`.