### PR TITLE
[fix][ndarray] Fix overflow due to negative `index` argument for `get` and `set` of `NDArray`

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -253,9 +253,11 @@ struct NDArray[dtype: DType = DType.float64](
     # Setter dunders
     # ===-------------------------------------------------------------------===#
 
-    fn set(self, index: Int, val: SIMD[dtype, 1]) raises:
+    fn set(self, owned index: Int, val: Scalar[dtype]) raises:
         """
-        Linearly retreive a value from the underlying Pointer.
+        Safely retrieve a value from the underlying buffer.
+
+        `A.set(i, a)` differs from `A._buf[i] = a` due to boundary check.
 
         Example:
         ```console
@@ -271,17 +273,18 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
+
+        if index < 0:
+            index += self.size
+
         if index >= self.size:
-            var message = String(
-                "Invalid index: index out of bound. \n"
-                "The index is {}. \n"
-                "The size is {}"
-            ).format(index, self.size)
-            raise Error(message)
-        if index >= 0:
-            return self._buf.store(index, val)
-        else:
-            return self._buf.store(index + self.size, val)
+            raise Error(
+                String("Invalid index: index {} out of bound [0, {}).").format(
+                    index, self.size
+                )
+            )
+
+        self._buf[index] = val
 
     fn _setitem(self, *indices: Int, val: Scalar[dtype]) raises:
         """
@@ -661,9 +664,11 @@ struct NDArray[dtype: DType = DType.float64](
     # ===-------------------------------------------------------------------===#
     # Getter dunders
     # ===-------------------------------------------------------------------===#
-    fn get(self, index: Int) raises -> SIMD[dtype, 1]:
+    fn get(self, owned index: Int) raises -> Scalar[dtype]:
         """
-        Linearly retreive a value from the underlying Pointer.
+        Safely retrieve a value from the underlying buffer.
+
+        `A.get(i)` differs from `A._buf[i]` due to boundary check.
 
         Example:
         ```console
@@ -679,18 +684,18 @@ struct NDArray[dtype: DType = DType.float64](
         > A.item(3)  # Row 1, Col 0
         ```
         """
+
+        if index < 0:
+            index += self.size
+
         if index >= self.size:
             raise Error(
-                String(
-                    "Invalid index: index out of bound!\n"
-                    "The index is {}."
-                    "The size of the array is {}"
-                ).format(index, self.size)
+                String("Invalid index: index {} out of bound [0, {}).").format(
+                    index, self.size
+                )
             )
-        if index >= 0:
-            return self._buf.load[width=1](index)
-        else:
-            return self._buf.load[width=1](index + self.size)
+
+        return self._buf[index]
 
     fn _getitem(self, *indices: Int) raises -> Scalar[dtype]:
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -250,12 +250,12 @@ struct NDArray[dtype: DType = DType.float64](
         self._buf.free()
 
     # ===-------------------------------------------------------------------===#
-    # Setter dunders
+    # Setter dunders and other getter methods
     # ===-------------------------------------------------------------------===#
 
     fn set(self, owned index: Int, val: Scalar[dtype]) raises:
         """
-        Safely retrieve a value from the underlying buffer.
+        Safely retrieve i-th item from the underlying buffer.
 
         `A.set(i, a)` differs from `A._buf[i] = a` due to boundary check.
 
@@ -277,10 +277,10 @@ struct NDArray[dtype: DType = DType.float64](
         if index < 0:
             index += self.size
 
-        if index >= self.size:
+        if (index >= self.size) or (index < 0):
             raise Error(
-                String("Invalid index: index {} out of bound [0, {}).").format(
-                    index, self.size
+                String("Invalid index: index out of bound [0, {}).").format(
+                    self.size
                 )
             )
 
@@ -662,11 +662,11 @@ struct NDArray[dtype: DType = DType.float64](
                 self._buf.store(i, val._buf.load(i))
 
     # ===-------------------------------------------------------------------===#
-    # Getter dunders
+    # Getter dunders and other getter methods
     # ===-------------------------------------------------------------------===#
     fn get(self, owned index: Int) raises -> Scalar[dtype]:
         """
-        Safely retrieve a value from the underlying buffer.
+        Safely retrieve i-th item from the underlying buffer.
 
         `A.get(i)` differs from `A._buf[i]` due to boundary check.
 
@@ -688,10 +688,10 @@ struct NDArray[dtype: DType = DType.float64](
         if index < 0:
             index += self.size
 
-        if index >= self.size:
+        if (index >= self.size) or (index < 0):
             raise Error(
-                String("Invalid index: index {} out of bound [0, {}).").format(
-                    index, self.size
+                String("Invalid index: index out of bound [0, {}).").format(
+                    self.size
                 )
             )
 

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -33,22 +33,25 @@ fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     Returns:
         The generated NDArray of type `dtype` filled with random values.
     """
-    var result: NDArray[dtype] = NDArray[dtype](shape)
+
     if dtype.is_integral():
         raise Error(
             "Integral values cannot be sampled between 0 and 1. Use"
             " `rand(*shape, min, max)` instead."
         )
+
+    var result: NDArray[dtype] = NDArray[dtype](shape)
+
     for i in range(result.size):
         var temp: Scalar[dtype] = builtin_random.random_float64(0, 1).cast[
             dtype
         ]()
-        result.set(i, temp)
+        (result._buf + i).init_pointee_copy(temp)
     return result^
 
 
 @parameter
-fn int_rand_func[
+fn _int_rand_func[
     dtype: DType
 ](mut result: NDArray[dtype], min: Scalar[dtype], max: Scalar[dtype]):
     """
@@ -71,7 +74,7 @@ fn int_rand_func[
 
 
 @parameter
-fn float_rand_func[
+fn _float_rand_func[
     dtype: DType
 ](mut result: NDArray[dtype], min: Scalar[dtype], max: Scalar[dtype]):
     """
@@ -89,7 +92,7 @@ fn float_rand_func[
         var temp: Scalar[dtype] = builtin_random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
-        result._buf[i] = temp
+        (result._buf + i).init_pointee_copy(temp)
 
 
 fn rand[
@@ -122,9 +125,9 @@ fn rand[
 
     @parameter
     if is_floattype[dtype]():
-        float_rand_func[dtype](result, min, max)
+        _float_rand_func[dtype](result, min, max)
     elif is_inttype[dtype]():
-        int_rand_func[dtype](result, min, max)
+        _int_rand_func[dtype](result, min, max)
     else:
         raise Error(
             "Invalid type provided. dtype must be either an integral or"
@@ -167,9 +170,9 @@ fn rand[
 
     @parameter
     if is_floattype[dtype]():
-        float_rand_func[dtype](result, min, max)
+        _float_rand_func[dtype](result, min, max)
     elif is_inttype[dtype]():
-        int_rand_func[dtype](result, min, max)
+        _int_rand_func[dtype](result, min, max)
     else:
         raise Error(
             "Invalid type provided. dtype must be either an integral or"
@@ -278,7 +281,7 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = builtin_random.random_float64().cast[dtype]()
-        result._buf[i] = -mt.log(1 - u) / rate
+        (result._buf + i).init_pointee_copy(-mt.log(1 - u) / rate)
 
     return result^
 
@@ -310,6 +313,6 @@ fn rand_exponential[
 
     for i in range(result.num_elements()):
         var u = builtin_random.random_float64().cast[dtype]()
-        result._buf[i] = -mt.log(1 - u) / rate
+        (result._buf + i).init_pointee_copy(-mt.log(1 - u) / rate)
 
     return result^

--- a/tests/test_array_creation.mojo
+++ b/tests/test_array_creation.mojo
@@ -1,9 +1,14 @@
 import numojo as nm
 from numojo.prelude import *
 from numojo.prelude import *
+from testing.testing import (
+    assert_true,
+    assert_almost_equal,
+    assert_equal,
+    assert_raises,
+)
 from python import Python, PythonObject
 from utils_for_test import check, check_is_close
-from testing.testing import assert_raises
 
 
 def test_arange():
@@ -321,3 +326,24 @@ def test_vander():
     var x_nm_int = nm.vander[nm.i32](nm_arr_int)
     var x_np_int = np.vander(np_arr_int)
     check(x_nm_int, x_np_int, "Vander is broken (int32)")
+
+
+def test_arr_manipulation():
+    var np = Python.import_module("numpy")
+    var arr6 = nm.array[f32](
+        data=List[SIMD[f32, 1]](1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+        shape=List[Int](2, 5),
+    )
+    assert_true(
+        arr6.shape[0] == 2,
+        "NDArray constructor with data and shape: shape element 0",
+    )
+    assert_true(
+        arr6.shape[1] == 5,
+        "NDArray constructor with data and shape: shape element 1",
+    )
+    assert_equal(
+        arr6[idx(1, 4)],
+        10.0,
+        "NDArray constructor with data: value check",
+    )

--- a/tests/test_array_indexing_and_slicing.mojo
+++ b/tests/test_array_indexing_and_slicing.mojo
@@ -5,6 +5,13 @@ from utils_for_test import check, check_is_close
 from python import Python
 
 
+def test_getitem_scalar():
+    var np = Python.import_module("numpy")
+
+    var A = nm.arange(8)
+    assert_true(A.get(0) == 0, msg=String("`get` fails"))
+
+
 def test_slicing_getter1():
     var np = Python.import_module("numpy")
 

--- a/tests/test_array_methods.mojo
+++ b/tests/test_array_methods.mojo
@@ -58,21 +58,3 @@ def test_constructors():
         arr5.shape[2] == 5,
         "NDArray constructor with NDArrayShape: shape element 2",
     )
-
-    var arr6 = nm.array[f32](
-        data=List[SIMD[f32, 1]](1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
-        shape=List[Int](2, 5),
-    )
-    assert_true(
-        arr6.shape[0] == 2,
-        "NDArray constructor with data and shape: shape element 0",
-    )
-    assert_true(
-        arr6.shape[1] == 5,
-        "NDArray constructor with data and shape: shape element 1",
-    )
-    assert_equal(
-        arr6[idx(1, 4)],
-        10.0,
-        "NDArray constructor with data: value check",
-    )


### PR DESCRIPTION
The methods `get` and `set` of `NDArray` does not check against big negative index values and this leads to overflows.

I fixed it by adding more boundary checks.

Moreover, (1) I renamed two private functions with prefix `_`. (2) I used `init_pointee_copy` for functions in `random` module to avoid unintended behaviors.