### PR TITLE
[update][core] Update several methods of `NDArray` type

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -21,8 +21,10 @@ t = "clear && magic run mojo test tests -I ./ && magic run mojo package numojo"
 # runs all final checks before a commit
 final = "magic run mojo test tests -I ./ && magic run mojo format ./ && magic run mojo package numojo"
 f = "clear && magic run mojo test tests -I ./ && magic run mojo format ./ && magic run mojo package numojo"
-# defaults tasks
+# compile the package
 package = "magic run mojo package numojo"
+p = "clear && magic run mojo package numojo"
+# format the package
 format = "magic run mojo format ./"
 
 [dependencies]

--- a/numojo/core/_array_funcs.mojo
+++ b/numojo/core/_array_funcs.mojo
@@ -33,10 +33,8 @@ fn math_func_1_array_in_one_array_out[
 
     @parameter
     fn closure[simd_width: Int](i: Int):
-        var simd_data = array.load[width=simd_width](i)
-        result_array.store[width=simd_width](
-            i, func[dtype, simd_width](simd_data)
-        )
+        var simd_data = array._buf.load[width=simd_width](i)
+        result_array._buf.store(i, func[dtype, simd_width](simd_data))
 
     vectorize[closure, width](array.num_elements())
 
@@ -75,9 +73,9 @@ fn math_func_2_array_in_one_array_out[
 
     @parameter
     fn closure[simd_width: Int](i: Int):
-        var simd_data1 = array1.load[width=simd_width](i)
-        var simd_data2 = array2.load[width=simd_width](i)
-        result_array.store[width=simd_width](
+        var simd_data1 = array1._buf.load[width=simd_width](i)
+        var simd_data2 = array2._buf.load[width=simd_width](i)
+        result_array._buf.store(
             i, func[dtype, simd_width](simd_data1, simd_data2)
         )
 
@@ -112,10 +110,8 @@ fn math_func_one_array_one_SIMD_in_one_array_out[
 
     @parameter
     fn closure[simd_width: Int](i: Int):
-        var simd_data1 = array.load[width=simd_width](i)
-        result_array.store[width=simd_width](
-            i, func[dtype, simd_width](simd_data1, scalar)
-        )
+        var simd_data1 = array._buf.load[width=simd_width](i)
+        result_array._buf.store(i, func[dtype, simd_width](simd_data1, scalar))
 
     vectorize[closure, width](result_array.num_elements())
     return result_array

--- a/numojo/core/_math_funcs.mojo
+++ b/numojo/core/_math_funcs.mojo
@@ -67,10 +67,10 @@ struct Vectorized(Backend):
         # var op_count:Int =0
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            var simd_data3 = array3.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            var simd_data3 = array3._buf.load[width=simdwidth](i)
+            result_array._buf.store(
                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
             )
             # op_count+=1
@@ -114,12 +114,10 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            # var simd_data3 = array3.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
-                i, SIMD.fma(simd_data1, simd_data2, simd)
-            )
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            # var simd_data3 = array3._buf.load[width=simdwidth](i)
+            result_array._buf.store(i, SIMD.fma(simd_data1, simd_data2, simd))
 
         vectorize[closure, width](array1.num_elements())
         return result_array
@@ -148,10 +146,8 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
-                i, func[dtype, simdwidth](simd_data)
-            )
+            var simd_data = array._buf.load[width=simdwidth](i)
+            result_array._buf.store(i, func[dtype, simdwidth](simd_data))
 
         vectorize[closure, width](array.num_elements())
 
@@ -193,9 +189,9 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data1, simd_data2)
             )
 
@@ -230,9 +226,9 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array.load[width=simdwidth](i)
+            var simd_data1 = array._buf.load[width=simdwidth](i)
             var simd_data2 = scalar
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data1, simd_data2)
             )
 
@@ -258,9 +254,9 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            # result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            # result_array._buf.store(
             #     i, func[dtype, simdwidth](simd_data1, simd_data2)
             # )
             bool_simd_store[simdwidth](
@@ -288,7 +284,7 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
             var simd_data2 = SIMD[dtype, simdwidth](scalar)
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
@@ -310,10 +306,8 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
-                i, func[dtype, simdwidth](simd_data)
-            )
+            var simd_data = array._buf.load[width=simdwidth](i)
+            result_array._buf.store(i, func[dtype, simdwidth](simd_data))
 
         vectorize[closure, width](array.num_elements())
         return result_array
@@ -329,9 +323,9 @@ struct Vectorized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
+            var simd_data = array._buf.load[width=simdwidth](i)
 
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data, intval)
             )
 
@@ -409,10 +403,10 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            var simd_data3 = array3.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            var simd_data3 = array3._buf.load[width=simdwidth](i)
+            result_array._buf.store(
                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
             )
 
@@ -455,12 +449,10 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
 
-            result_array.store[width=simdwidth](
-                i, SIMD.fma(simd_data1, simd_data2, simd)
-            )
+            result_array._buf.store(i, SIMD.fma(simd_data1, simd_data2, simd))
 
         vectorize[closure, width, unroll_factor=unroll_factor](
             array1.num_elements()
@@ -491,10 +483,8 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
-                i, func[dtype, simdwidth](simd_data)
-            )
+            var simd_data = array._buf.load[width=simdwidth](i)
+            result_array._buf.store(i, func[dtype, simdwidth](simd_data))
 
         vectorize[closure, width, unroll_factor=unroll_factor](
             array.num_elements()
@@ -537,9 +527,9 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data1, simd_data2)
             )
 
@@ -576,9 +566,9 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array.load[width=simdwidth](i)
+            var simd_data1 = array._buf.load[width=simdwidth](i)
             var simd_data2 = scalar
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data1, simd_data2)
             )
 
@@ -606,9 +596,9 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
-            var simd_data2 = array2.load[width=simdwidth](i)
-            # result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
+            var simd_data2 = array2._buf.load[width=simdwidth](i)
+            # result_array._buf.store(
             #     i, func[dtype, simdwidth](simd_data1, simd_data2)
             # )
             bool_simd_store[simdwidth](
@@ -637,7 +627,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i)
+            var simd_data1 = array1._buf.load[width=simdwidth](i)
             var simd_data2 = SIMD[dtype, simdwidth](scalar)
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
@@ -661,10 +651,8 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
-            result_array.store[width=simdwidth](
-                i, func[dtype, simdwidth](simd_data)
-            )
+            var simd_data = array._buf.load[width=simdwidth](i)
+            result_array._buf.store(i, func[dtype, simdwidth](simd_data))
 
         vectorize[closure, width, unroll_factor=unroll_factor](
             array.num_elements()
@@ -682,9 +670,9 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
+            var simd_data = array._buf.load[width=simdwidth](i)
 
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data, intval)
             )
 
@@ -744,16 +732,16 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data3 = array3.load[width=simdwidth](
+                var simd_data3 = array3._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     SIMD.fma(simd_data1, simd_data2, simd_data3),
                 )
@@ -763,10 +751,10 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data1 = array1.load[width=simdwidth](i+remainder_offset)
-        #     var simd_data2 = array2.load[width=simdwidth](i+remainder_offset)
-        #     var simd_data3 = array3.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data1 = array1._buf.load[width=simdwidth](i+remainder_offset)
+        #     var simd_data2 = array2._buf.load[width=simdwidth](i+remainder_offset)
+        #     var simd_data3 = array3._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd_data3)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -810,14 +798,14 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
 
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     SIMD.fma(simd_data1, simd_data2, simd),
                 )
@@ -827,9 +815,9 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data1 = array1.load[width=simdwidth](i+remainder_offset)
-        #     var simd_data2 = array2.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data1 = array1._buf.load[width=simdwidth](i+remainder_offset)
+        #     var simd_data2 = array2._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, SIMD.fma(simd_data1,simd_data2,simd)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -863,10 +851,10 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data = array.load[width=simdwidth](
+                var simd_data = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
                 )
 
@@ -875,8 +863,8 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data = array.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data = array._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, func[dtype, simdwidth](simd_data)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -921,13 +909,13 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     func[dtype, simdwidth](simd_data1, simd_data2),
                 )
@@ -937,9 +925,9 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data1 = array1.load[width=simdwidth](i+remainder_offset)
-        #     var simd_data2 = array2.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data1 = array1._buf.load[width=simdwidth](i+remainder_offset)
+        #     var simd_data2 = array2._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, func[dtype, simdwidth](simd_data1, simd_data2)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -977,11 +965,11 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array.load[width=simdwidth](
+                var simd_data1 = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
                 var simd_data2 = scalar
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     func[dtype, simdwidth](simd_data1, simd_data2),
                 )
@@ -1014,13 +1002,13 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                # result_array.store[width=simdwidth](
+                # result_array._buf.store(
                 #     i + comps_per_core * j,
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
@@ -1035,9 +1023,9 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data1 = array1.load[width=simdwidth](i+remainder_offset)
-        #     var simd_data2 = array2.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data1 = array1._buf.load[width=simdwidth](i+remainder_offset)
+        #     var simd_data2 = array2._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, func[dtype, simdwidth](simd_data1, simd_data2)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -1062,11 +1050,11 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
                 var simd_data2 = SIMD[dtype, simdwidth](scalar)
-                # result_array.store[width=simdwidth](
+                # result_array._buf.store(
                 #     i + comps_per_core * j,
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
@@ -1096,10 +1084,10 @@ struct Parallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data = array.load[width=simdwidth](
+                var simd_data = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
                 )
 
@@ -1108,8 +1096,8 @@ struct Parallelized(Backend):
         parallelize[par_closure](num_cores)
         # @parameter
         # fn remainder_closure[simdwidth: Int](i: Int):
-        #     var simd_data = array.load[width=simdwidth](i+remainder_offset)
-        #     result_array.store[width=simdwidth](
+        #     var simd_data = array._buf.load[width=simdwidth](i+remainder_offset)
+        #     result_array._buf.store(
         #         i+remainder_offset, func[dtype, simdwidth](simd_data)
         #     )
         # vectorize[remainder_closure, width](comps_remainder)
@@ -1126,9 +1114,9 @@ struct Parallelized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
+            var simd_data = array._buf.load[width=simdwidth](i)
 
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data, intval)
             )
 
@@ -1188,16 +1176,16 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data3 = array3.load[width=simdwidth](
+                var simd_data3 = array3._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     SIMD.fma(simd_data1, simd_data2, simd_data3),
                 )
@@ -1208,10 +1196,16 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-            var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-            var simd_data3 = array3.load[width=simdwidth](i + remainder_offset)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            var simd_data2 = array2._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            var simd_data3 = array3._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            result_array._buf.store(
                 i + remainder_offset,
                 SIMD.fma(simd_data1, simd_data2, simd_data3),
             )
@@ -1259,14 +1253,14 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
 
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     SIMD.fma(simd_data1, simd_data2, simd),
                 )
@@ -1277,9 +1271,13 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-            var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            var simd_data2 = array2._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            result_array._buf.store(
                 i + remainder_offset, SIMD.fma(simd_data1, simd_data2, simd)
             )
 
@@ -1316,10 +1314,10 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data = array.load[width=simdwidth](
+                var simd_data = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
                 )
 
@@ -1329,8 +1327,10 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i + remainder_offset)
-            result_array.store[width=simdwidth](
+            var simd_data = array._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            result_array._buf.store(
                 i + remainder_offset, func[dtype, simdwidth](simd_data)
             )
 
@@ -1378,13 +1378,13 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     func[dtype, simdwidth](simd_data1, simd_data2),
                 )
@@ -1395,9 +1395,13 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-            var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-            result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            var simd_data2 = array2._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            result_array._buf.store(
                 i + remainder_offset,
                 func[dtype, simdwidth](simd_data1, simd_data2),
             )
@@ -1439,11 +1443,11 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array.load[width=simdwidth](
+                var simd_data1 = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
                 var simd_data2 = scalar
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j,
                     func[dtype, simdwidth](simd_data1, simd_data2),
                 )
@@ -1454,9 +1458,11 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array.load[width=simdwidth](i + remainder_offset)
+            var simd_data1 = array._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
             var simd_data2 = scalar
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i + remainder_offset,
                 func[dtype, simdwidth](simd_data1, simd_data2),
             )
@@ -1489,13 +1495,13 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                var simd_data2 = array2.load[width=simdwidth](
+                var simd_data2 = array2._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                # result_array.store[width=simdwidth](
+                # result_array._buf.store(
                 #     i + comps_per_core * j,
                 #     func[dtype, simdwidth](simd_data1, simd_data2),
                 # )
@@ -1511,9 +1517,13 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-            var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-            # result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            var simd_data2 = array2._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            # result_array._buf.store(
             #     i + remainder_offset,
             #     func[dtype, simdwidth](simd_data1, simd_data2),
             # )
@@ -1547,7 +1557,7 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data1 = array1.load[width=simdwidth](
+                var simd_data1 = array1._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
                 var simd_data2 = SIMD[dtype, simdwidth](scalar)
@@ -1563,7 +1573,9 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
+            var simd_data1 = array1._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
             var simd_data2 = SIMD[dtype, simdwidth](scalar)
             bool_simd_store[simdwidth](
                 result_array.unsafe_ptr(),
@@ -1591,10 +1603,10 @@ struct VectorizedParallelized(Backend):
         fn par_closure(j: Int):
             @parameter
             fn closure[simdwidth: Int](i: Int):
-                var simd_data = array.load[width=simdwidth](
+                var simd_data = array._buf.load[width=simdwidth](
                     i + comps_per_core * j
                 )
-                result_array.store[width=simdwidth](
+                result_array._buf.store(
                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
                 )
 
@@ -1604,8 +1616,10 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn remainder_closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i + remainder_offset)
-            result_array.store[width=simdwidth](
+            var simd_data = array._buf.load[width=simdwidth](
+                i + remainder_offset
+            )
+            result_array._buf.store(
                 i + remainder_offset, func[dtype, simdwidth](simd_data)
             )
 
@@ -1623,9 +1637,9 @@ struct VectorizedParallelized(Backend):
 
         @parameter
         fn closure[simdwidth: Int](i: Int):
-            var simd_data = array.load[width=simdwidth](i)
+            var simd_data = array._buf.load[width=simdwidth](i)
 
-            result_array.store[width=simdwidth](
+            result_array._buf.store(
                 i, func[dtype, simdwidth](simd_data, intval)
             )
 
@@ -1692,16 +1706,16 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array1.load[width=simdwidth](
+#                 var simd_data1 = array1._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 var simd_data2 = array2.load[width=simdwidth](
+#                 var simd_data2 = array2._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 var simd_data3 = array3.load[width=simdwidth](
+#                 var simd_data3 = array3._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j,
 #                     SIMD.fma(simd_data1, simd_data2, simd_data3),
 #                 )
@@ -1713,10 +1727,10 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-#             var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-#             var simd_data3 = array3.load[width=simdwidth](i + remainder_offset)
-#             result_array.store[width=simdwidth](
+#             var simd_data1 = array1._buf.load[width=simdwidth](i + remainder_offset)
+#             var simd_data2 = array2._buf.load[width=simdwidth](i + remainder_offset)
+#             var simd_data3 = array3._buf.load[width=simdwidth](i + remainder_offset)
+#             result_array._buf.store(
 #                 i + remainder_offset,
 #                 SIMD.fma(simd_data1, simd_data2, simd_data3),
 #             )
@@ -1766,14 +1780,14 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array1.load[width=simdwidth](
+#                 var simd_data1 = array1._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 var simd_data2 = array2.load[width=simdwidth](
+#                 var simd_data2 = array2._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
 
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j,
 #                     SIMD.fma(simd_data1, simd_data2, simd),
 #                 )
@@ -1784,9 +1798,9 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-#             var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-#             result_array.store[width=simdwidth](
+#             var simd_data1 = array1._buf.load[width=simdwidth](i + remainder_offset)
+#             var simd_data2 = array2._buf.load[width=simdwidth](i + remainder_offset)
+#             result_array._buf.store(
 #                 i + remainder_offset, SIMD.fma(simd_data1, simd_data2, simd)
 #             )
 
@@ -1823,10 +1837,10 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data = array.load[width=simdwidth](
+#                 var simd_data = array._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
 #                 )
 
@@ -1836,8 +1850,8 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data = array.load[width=simdwidth](i + remainder_offset)
-#             result_array.store[width=simdwidth](
+#             var simd_data = array._buf.load[width=simdwidth](i + remainder_offset)
+#             result_array._buf.store(
 #                 i + remainder_offset, func[dtype, simdwidth](simd_data)
 #             )
 
@@ -1885,13 +1899,13 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array1.load[width=simdwidth](
+#                 var simd_data1 = array1._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 var simd_data2 = array2.load[width=simdwidth](
+#                 var simd_data2 = array2._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j,
 #                     func[dtype, simdwidth](simd_data1, simd_data2),
 #                 )
@@ -1902,9 +1916,9 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-#             var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-#             result_array.store[width=simdwidth](
+#             var simd_data1 = array1._buf.load[width=simdwidth](i + remainder_offset)
+#             var simd_data2 = array2._buf.load[width=simdwidth](i + remainder_offset)
+#             result_array._buf.store(
 #                 i + remainder_offset,
 #                 func[dtype, simdwidth](simd_data1, simd_data2),
 #             )
@@ -1944,11 +1958,11 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array.load[width=simdwidth](
+#                 var simd_data1 = array._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
 #                 var simd_data2 = scalar
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j,
 #                     func[dtype, simdwidth](simd_data1, simd_data2),
 #                 )
@@ -1959,9 +1973,9 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array.load[width=simdwidth](i + remainder_offset)
+#             var simd_data1 = array._buf.load[width=simdwidth](i + remainder_offset)
 #             var simd_data2 = scalar
-#             result_array.store[width=simdwidth](
+#             result_array._buf.store(
 #                 i + remainder_offset,
 #                 func[dtype, simdwidth](simd_data1, simd_data2),
 #             )
@@ -1994,13 +2008,13 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array1.load[width=simdwidth](
+#                 var simd_data1 = array1._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 var simd_data2 = array2.load[width=simdwidth](
+#                 var simd_data2 = array2._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 # result_array.store[width=simdwidth](
+#                 # result_array._buf.store(
 #                 #     i + comps_per_core * j,
 #                 #     func[dtype, simdwidth](simd_data1, simd_data2),
 #                 # )
@@ -2016,9 +2030,9 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
-#             var simd_data2 = array2.load[width=simdwidth](i + remainder_offset)
-#             # result_array.store[width=simdwidth](
+#             var simd_data1 = array1._buf.load[width=simdwidth](i + remainder_offset)
+#             var simd_data2 = array2._buf.load[width=simdwidth](i + remainder_offset)
+#             # result_array._buf.store(
 #             #     i + remainder_offset,
 #             #     func[dtype, simdwidth](simd_data1, simd_data2),
 #             # )
@@ -2052,7 +2066,7 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data1 = array1.load[width=simdwidth](
+#                 var simd_data1 = array1._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
 #                 var simd_data2 = SIMD[dtype, simdwidth](scalar)
@@ -2068,7 +2082,7 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data1 = array1.load[width=simdwidth](i + remainder_offset)
+#             var simd_data1 = array1._buf.load[width=simdwidth](i + remainder_offset)
 #             var simd_data2 = SIMD[dtype, simdwidth](scalar)
 #             bool_simd_store[simdwidth](
 #                 result_array.unsafe_ptr(),
@@ -2098,10 +2112,10 @@ struct VectorizedParallelized(Backend):
 #         fn par_closure(j: Int):
 #             @parameter
 #             fn closure[simdwidth: Int](i: Int):
-#                 var simd_data = array.load[width=simdwidth](
+#                 var simd_data = array._buf.load[width=simdwidth](
 #                     i + comps_per_core * j
 #                 )
-#                 result_array.store[width=simdwidth](
+#                 result_array._buf.store(
 #                     i + comps_per_core * j, func[dtype, simdwidth](simd_data)
 #                 )
 
@@ -2111,8 +2125,8 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn remainder_closure[simdwidth: Int](i: Int):
-#             var simd_data = array.load[width=simdwidth](i + remainder_offset)
-#             result_array.store[width=simdwidth](
+#             var simd_data = array._buf.load[width=simdwidth](i + remainder_offset)
+#             result_array._buf.store(
 #                 i + remainder_offset, func[dtype, simdwidth](simd_data)
 #             )
 
@@ -2130,9 +2144,9 @@ struct VectorizedParallelized(Backend):
 
 #         @parameter
 #         fn closure[simdwidth: Int](i: Int):
-#             var simd_data = array.load[width=simdwidth](i)
+#             var simd_data = array._buf.load[width=simdwidth](i)
 
-#             result_array.store[width=simdwidth](
+#             result_array._buf.store(
 #                 i, func[dtype, simdwidth](simd_data, intval)
 #             )
 
@@ -2184,9 +2198,9 @@ struct Naive(Backend):
         alias width = simdwidthof[dtype]()
 
         for i in range(array1.num_elements()):
-            var simd_data1 = array1.load[width=1](i)
-            var simd_data2 = array2.load[width=1](i)
-            var simd_data3 = array3.load[width=1](i)
+            var simd_data1 = array1._buf.load[width=1](i)
+            var simd_data2 = array2._buf.load[width=1](i)
+            var simd_data3 = array3._buf.load[width=1](i)
             result_array.store[width=1](
                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
             )
@@ -2225,8 +2239,8 @@ struct Naive(Backend):
         alias width = simdwidthof[dtype]()
 
         for i in range(array1.num_elements()):
-            var simd_data1 = array1.load[width=1](i)
-            var simd_data2 = array2.load[width=1](i)
+            var simd_data1 = array1._buf.load[width=1](i)
+            var simd_data2 = array2._buf.load[width=1](i)
 
             result_array.store[width=1](
                 i, SIMD.fma(simd_data1, simd_data2, simd)
@@ -2255,7 +2269,7 @@ struct Naive(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
-            var simd_data = func[dtype, 1](array.load[width=1](i))
+            var simd_data = func[dtype, 1](array._buf.load[width=1](i))
             result_array.store[width=1](i, simd_data)
         return result_array
 
@@ -2292,8 +2306,8 @@ struct Naive(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
 
         for i in range(array1.num_elements()):
-            var simd_data1 = array1.load[width=1](i)
-            var simd_data2 = array2.load[width=1](i)
+            var simd_data1 = array1._buf.load[width=1](i)
+            var simd_data2 = array2._buf.load[width=1](i)
             result_array.store[width=1](
                 i, func[dtype, 1](simd_data1, simd_data2)
             )
@@ -2324,7 +2338,7 @@ struct Naive(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
-            var simd_data1 = array.load[width=1](i)
+            var simd_data1 = array._buf.load[width=1](i)
             var simd_data2 = scalar
             result_array.store[width=1](
                 i, func[dtype, 1](simd_data1, simd_data2)
@@ -2348,8 +2362,8 @@ struct Naive(Backend):
         )
 
         for i in range(array1.num_elements()):
-            var simd_data1 = array1.load[width=1](i)
-            var simd_data2 = array2.load[width=1](i)
+            var simd_data1 = array1._buf.load[width=1](i)
+            var simd_data2 = array2._buf.load[width=1](i)
             # result_array.store[width=1](
             #     i, func[dtype, 1](simd_data1, simd_data2)
             # )
@@ -2373,7 +2387,7 @@ struct Naive(Backend):
         )
 
         for i in range(array1.num_elements()):
-            var simd_data1 = array1.load[width=1](i)
+            var simd_data1 = array1._buf.load[width=1](i)
             var simd_data2 = scalar
             bool_simd_store[1](
                 result_array.unsafe_ptr(),
@@ -2391,7 +2405,7 @@ struct Naive(Backend):
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
 
         for i in range(array.num_elements()):
-            var simd_data = func[dtype, 1](array.load[width=1](i))
+            var simd_data = func[dtype, 1](array._buf.load[width=1](i))
             result_array.store[width=1](i, simd_data)
         return result_array
 
@@ -2404,7 +2418,7 @@ struct Naive(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
 
         for i in range(array.num_elements()):
-            var simd_data1 = array.load[width=1](i)
+            var simd_data1 = array._buf.load[width=1](i)
             result_array.store[width=1](i, func[dtype, 1](simd_data1, intval))
         return result_array
 
@@ -2453,9 +2467,9 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
-            var simd_data2 = array2.load[width=width](i)
-            var simd_data3 = array3.load[width=width](i)
+            var simd_data1 = array1._buf.load[width=width](i)
+            var simd_data2 = array2._buf.load[width=width](i)
+            var simd_data3 = array3._buf.load[width=width](i)
             result_array.store[width=width](
                 i, SIMD.fma(simd_data1, simd_data2, simd_data3)
             )
@@ -2465,9 +2479,9 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
-                var simd_data2 = array2.load[width=1](i)
-                var simd_data3 = array3.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
+                var simd_data2 = array2._buf.load[width=1](i)
+                var simd_data3 = array3._buf.load[width=1](i)
                 result_array.store[width=1](
                     i, SIMD.fma(simd_data1, simd_data2, simd_data3)
                 )
@@ -2505,8 +2519,8 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
-            var simd_data2 = array2.load[width=width](i)
+            var simd_data1 = array1._buf.load[width=width](i)
+            var simd_data2 = array2._buf.load[width=width](i)
 
             result_array.store[width=width](
                 i, SIMD.fma(simd_data1, simd_data2, simd)
@@ -2517,8 +2531,8 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
-                var simd_data2 = array2.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
+                var simd_data2 = array2._buf.load[width=1](i)
 
                 result_array.store[width=1](
                     i, SIMD.fma(simd_data1, simd_data2, simd)
@@ -2547,7 +2561,7 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
-            var simd_data = array.load[width=width](i)
+            var simd_data = array._buf.load[width=width](i)
             result_array.store[width=width](i, func[dtype, width](simd_data))
 
         if array.num_elements() % width != 0:
@@ -2555,7 +2569,7 @@ struct VectorizedVerbose(Backend):
                 width * (array.num_elements() // width),
                 array.num_elements(),
             ):
-                var simd_data = func[dtype, 1](array.load[width=1](i))
+                var simd_data = func[dtype, 1](array._buf.load[width=1](i))
                 result_array.store[width=1](i, simd_data)
         return result_array
 
@@ -2592,8 +2606,8 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
-            var simd_data2 = array2.load[width=width](i)
+            var simd_data1 = array1._buf.load[width=width](i)
+            var simd_data2 = array2._buf.load[width=width](i)
             result_array.store[width=width](
                 i, func[dtype, width](simd_data1, simd_data2)
             )
@@ -2603,8 +2617,8 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
-                var simd_data2 = array2.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
+                var simd_data2 = array2._buf.load[width=1](i)
                 result_array.store[width=1](
                     i, func[dtype, 1](simd_data1, simd_data2)
                 )
@@ -2635,7 +2649,7 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
-            var simd_data1 = array.load[width=width](i)
+            var simd_data1 = array._buf.load[width=width](i)
             var simd_data2 = scalar
             result_array.store[width=width](
                 i, func[dtype, width](simd_data1, simd_data2)
@@ -2646,7 +2660,7 @@ struct VectorizedVerbose(Backend):
                 width * (array.num_elements() // width),
                 array.num_elements(),
             ):
-                var simd_data1 = array.load[width=1](i)
+                var simd_data1 = array._buf.load[width=1](i)
                 var simd_data2 = scalar
                 result_array.store[width=1](
                     i, func[dtype, 1](simd_data1, simd_data2)
@@ -2670,9 +2684,9 @@ struct VectorizedVerbose(Backend):
         )
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
-            var simd_data2 = array2.load[width=width](i)
-            # result_array.store[width=simdwidth](
+            var simd_data1 = array1._buf.load[width=width](i)
+            var simd_data2 = array2._buf.load[width=width](i)
+            # result_array._buf.store(
             #     i, func[dtype, width](simd_data1, simd_data2)
             # )
             bool_simd_store[width](
@@ -2685,8 +2699,8 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
-                var simd_data2 = array2.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
+                var simd_data2 = array2._buf.load[width=1](i)
                 # result_array.store[width=1](
                 #     i, func[dtype, 1](simd_data1, simd_data2)
                 # )
@@ -2710,7 +2724,7 @@ struct VectorizedVerbose(Backend):
         )
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
+            var simd_data1 = array1._buf.load[width=width](i)
             var simd_data2 = SIMD[dtype, width](scalar)
             bool_simd_store[width](
                 result_array.unsafe_ptr(),
@@ -2722,7 +2736,7 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
                 var simd_data2 = SIMD[dtype, 1](scalar)
                 bool_simd_store[1](
                     result_array.unsafe_ptr(),
@@ -2740,7 +2754,7 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array.num_elements() // width), width):
-            var simd_data = array.load[width=width](i)
+            var simd_data = array._buf.load[width=width](i)
             result_array.store[width=width](i, func[dtype, width](simd_data))
 
         if array.num_elements() % width != 0:
@@ -2748,7 +2762,7 @@ struct VectorizedVerbose(Backend):
                 width * (array.num_elements() // width),
                 array.num_elements(),
             ):
-                var simd_data = func[dtype, 1](array.load[width=1](i))
+                var simd_data = func[dtype, 1](array._buf.load[width=1](i))
                 result_array.store[width=1](i, simd_data)
         return result_array
 
@@ -2761,7 +2775,7 @@ struct VectorizedVerbose(Backend):
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
         for i in range(0, width * (array1.num_elements() // width), width):
-            var simd_data1 = array1.load[width=width](i)
+            var simd_data1 = array1._buf.load[width=width](i)
 
             result_array.store[width=width](
                 i, func[dtype, width](simd_data1, intval)
@@ -2772,7 +2786,7 @@ struct VectorizedVerbose(Backend):
                 width * (array1.num_elements() // width),
                 array1.num_elements(),
             ):
-                var simd_data1 = array1.load[width=1](i)
+                var simd_data1 = array1._buf.load[width=1](i)
                 result_array.store[width=1](
                     i, func[dtype, 1](simd_data1, intval)
                 )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1719,9 +1719,11 @@ struct NDArray[dtype: DType = DType.float64](
             print("Cannot convert array to string", e)
             return ""
 
-    # Should len be size or number of dimensions instead of the first dimension shape?
-    fn __len__(self) -> Int:
-        return int(self.size)
+    fn __len__(self) raises -> Int:
+        """
+        Returns length of 0-th dimension.
+        """
+        return self.shape[0]
 
     fn __iter__(self) raises -> _NDArrayIter[__origin_of(self), dtype]:
         """Iterate over elements of the NDArray, returning copied value.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1245,7 +1245,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         """
         if (self.size == 1) or (self.ndim == 0):
-            return int(self.get(0))
+            return int(self.load(0))
         else:
             raise (
                 "Only 0-D arrays or length-1 arrays can be converted to scalars"
@@ -1792,7 +1792,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var sum = Scalar[dtype](0)
         for i in range(self.size):
-            sum = sum + self.get(i) * other.get(i)
+            sum = sum + self.load(i) * other.load(i)
         return sum
 
     fn mdot(self, other: Self) raises -> Self:
@@ -1843,7 +1843,7 @@ struct NDArray[dtype: DType = DType.float64](
         var width = self.shape[1]
         var buffer = Self(Shape(width))
         for i in range(width):
-            buffer.set(i, self._buf.load[width=1](i + id * width))
+            buffer.store(i, self._buf.load[width=1](i + id * width))
         return buffer
 
     fn col(self, id: Int) raises -> Self:
@@ -1860,7 +1860,7 @@ struct NDArray[dtype: DType = DType.float64](
         var height = self.shape[0]
         var buffer = Self(Shape(height))
         for i in range(height):
-            buffer.set(i, self._buf.load[width=1](id + i * width))
+            buffer.store(i, self._buf.load[width=1](id + i * width))
         return buffer
 
     # # * same as mdot
@@ -1890,7 +1890,7 @@ struct NDArray[dtype: DType = DType.float64](
         var new_matrix = Self(Shape(self.shape[0], other.shape[1]))
         for row in range(self.shape[0]):
             for col in range(other.shape[1]):
-                new_matrix.set(
+                new_matrix.store(
                     col + row * other.shape[1],
                     self.row(row).vdot(other.col(col)),
                 )

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -181,15 +181,16 @@ fn _traverse_buffer_according_to_shape_and_strides(
     previous_sum: Int = 0,
 ) raises:
     """
-    Traverses buffer according to new shape and strides.
+    Store sequence of indices according to shape and strides into the pointer
+    given in the arguments.
+
+    It is auxiliary functions that get or set values according to new shape
+    and strides for variadic number of dimensions.
 
     UNSAFE: Raw pointer is used!
 
-    It is auxiliary functions that set values according to new shape
-    and strides for variadic number of dimensions.
-
     Args:
-        ptr: Pointer to buffer of 1-d index array, uninitialized.
+        ptr: Pointer to buffer of uninitialized 1-d index array.
         shape: NDArrayShape.
         strides: NDArrayStrides.
         current_dim: Temporarily save the current dimension.
@@ -197,17 +198,15 @@ fn _traverse_buffer_according_to_shape_and_strides(
 
     Example:
     ```console
-    var A = nm.random.randn(2, 3, 4)
+    # A is a 2x3x4 array
     var I = nm.NDArray[DType.index](nm.Shape(A.size))
     var ptr = I._buf
     _traverse_buffer_according_to_shape_and_strides(
         ptr, A.shape._flip(), A.strides._flip()
     )
-    print(I)
-    # This prints:
-    # [       0       12      4       ...     19      11      23      ]
-    # 1-D array  Shape: [24]  DType: index  order: C
+    # I = [       0       12      4       ...     19      11      23      ]
     ```
+
     """
     for index_of_axis in range(shape[current_dim]):
         var current_sum = previous_sum + index_of_axis * strides[current_dim]

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -43,15 +43,15 @@ fn cross[
         var array3: NDArray[dtype] = NDArray[dtype](NDArrayShape(3))
         array3.store(
             0,
-            (array1.get(1) * array2.get(2) - array1.get(2) * array2.get(1)),
+            (array1.load(1) * array2.load(2) - array1.load(2) * array2.load(1)),
         )
         array3.store(
             1,
-            (array1.get(2) * array2.get(0) - array1.get(0) * array2.get(2)),
+            (array1.load(2) * array2.load(0) - array1.load(0) * array2.load(2)),
         )
         array3.store(
             2,
-            (array1.get(0) * array2.get(1) - array1.get(1) * array2.get(0)),
+            (array1.load(0) * array2.load(1) - array1.load(1) * array2.load(0)),
         )
         return array3
     else:

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -90,10 +90,10 @@ fn dot[
 
         @parameter
         fn vectorized_dot[simd_width: Int](idx: Int) -> None:
-            result.store[width=simd_width](
+            result._buf.store(
                 idx,
-                array1.load[width=simd_width](idx)
-                * array2.load[width=simd_width](idx),
+                array1._buf.load[width=simd_width](idx)
+                * array2._buf.load[width=simd_width](idx),
             )
 
         vectorize[vectorized_dot, width](array1.size)
@@ -136,11 +136,11 @@ fn matmul_tiled_unrolled_parallelized[
 
                 @parameter
                 fn dot[simd_width: Int](n: Int):
-                    C.store(
+                    C._buf.store(
                         m * t2 + (n + x),
-                        val=C.load[simd_width](m * t2 + (n + x))
-                        + A.load(m * t1 + k)
-                        * B.load[simd_width](k * t2 + (n + x)),
+                        val=C._buf.load[width=simd_width](m * t2 + (n + x))
+                        + A._buf.load(m * t1 + k)
+                        * B._buf.load[width=simd_width](k * t2 + (n + x)),
                     )
 
                 alias unroll_factor = tile_x // width

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -227,19 +227,23 @@ fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     fn calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
-            var _temp = Y.load(i * m + col)
+            var _temp = Y._buf.load(i * m + col)
             for j in range(i):  # col of L
-                _temp = _temp - L.load(i * m + j) * Z.load(j * m + col)
-            _temp = _temp / L.load(i * m + i)
-            Z.store(i * m + col, _temp)
+                _temp = _temp - L._buf.load(i * m + j) * Z._buf.load(
+                    j * m + col
+                )
+            _temp = _temp / L._buf.load(i * m + i)
+            Z._buf.store(i * m + col, _temp)
 
         # Solve `UZ = Z` for `X` for each col
         for i in range(m - 1, -1, -1):
-            var _temp2 = Z.load(i * m + col)
+            var _temp2 = Z._buf.load(i * m + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U.load(i * m + j) * X.load(j * m + col)
-            _temp2 = _temp2 / U.load(i * m + i)
-            X.store(i * m + col, _temp2)
+                _temp2 = _temp2 - U._buf.load(i * m + j) * X._buf.load(
+                    j * m + col
+                )
+            _temp2 = _temp2 / U._buf.load(i * m + i)
+            X._buf.store(i * m + col, _temp2)
 
     parallelize[calculate_X](m, m)
 
@@ -324,19 +328,23 @@ fn solve[
     fn calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
-            var _temp = Y.load(i * n + col)
+            var _temp = Y._buf.load(i * n + col)
             for j in range(i):  # col of L
-                _temp = _temp - L.load(i * m + j) * Z.load(j * n + col)
-            _temp = _temp / L.load(i * m + i)
-            Z.store(i * n + col, _temp)
+                _temp = _temp - L._buf.load(i * m + j) * Z._buf.load(
+                    j * n + col
+                )
+            _temp = _temp / L._buf.load(i * m + i)
+            Z._buf.store(i * n + col, _temp)
 
         # Solve `UZ = Z` for `X` for each col
         for i in range(m - 1, -1, -1):
-            var _temp2 = Z.load(i * n + col)
+            var _temp2 = Z._buf.load(i * n + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U.load(i * m + j) * X.load(j * n + col)
-            _temp2 = _temp2 / U.load(i * m + i)
-            X.store(i * n + col, _temp2)
+                _temp2 = _temp2 - U._buf.load(i * m + j) * X._buf.load(
+                    j * n + col
+                )
+            _temp2 = _temp2 / U._buf.load(i * m + i)
+            X._buf.store(i * n + col, _temp2)
 
     parallelize[calculate_X](n, n)
 
@@ -359,18 +367,18 @@ fn solve[
     # for col in range(n):
     #     # Solve `LZ = Y` for `Z` for each col
     #     for i in range(m):  # row of L
-    #         var _temp = Y.load(i * n + col)
+    #         var _temp = Y._buf.load(i * n + col)
     #         for j in range(i):  # col of L
-    #             _temp = _temp - L.load(i * m + j) * Z.load(j * n + col)
-    #         _temp = _temp / L.load(i * m + i)
-    #         Z.store(i * n + col, _temp)
+    #             _temp = _temp - L._buf.load(i * m + j) * Z._buf.load(j * n + col)
+    #         _temp = _temp / L._buf.load(i * m + i)
+    #         Z._buf.store(i * n + col, _temp)
 
     #     # Solve `UZ = Z` for `X` for each col
     #     for i in range(m - 1, -1, -1):
-    #         var _temp2 = Z.load(i * n + col)
+    #         var _temp2 = Z._buf.load(i * n + col)
     #         for j in range(i + 1, m):
-    #             _temp2 = _temp2 - U.load(i * m + j) * X.load(j * n + col)
-    #         _temp2 = _temp2 / U.load(i * m + i)
-    #         X.store(i * n + col, _temp2)
+    #             _temp2 = _temp2 - U._buf.load(i * m + j) * X._buf.load(j * n + col)
+    #         _temp2 = _temp2 / U._buf.load(i * m + i)
+    #         X._buf.store(i * n + col, _temp2)
 
     # return X

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -45,7 +45,7 @@ fn forward_substitution[
             value_on_hold = value_on_hold - L.item(i, j) * x.item(j)
         value_on_hold = value_on_hold / L.item(i, i)
 
-        x.set(i, value_on_hold)
+        x.store(i, value_on_hold)
 
     return x
 
@@ -77,7 +77,7 @@ fn back_substitution[
         for j in range(i + 1, m):
             value_on_hold = value_on_hold - U.item(i, j) * x.item(j)
         value_on_hold = value_on_hold / U.item(i, i)
-        x.set(i, value_on_hold)
+        x.store(i, value_on_hold)
 
     return x
 
@@ -174,7 +174,7 @@ fn inv_raw[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     for i in range(m):
         # Each time, one of the item is changed to 1
         y = zeros[dtype](Shape(m))
-        y.set(i, Scalar[dtype](1))
+        y.store(i, Scalar[dtype](1))
 
         # Solve `Lz = y` for `z`
         z = forward_substitution(L, y)

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -49,7 +49,7 @@ fn isinf[
 
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size):
-        result_array.store(i, math.isinf(array.get(i)))
+        result_array.store(i, math.isinf(array.load(i)))
     return result_array
 
 
@@ -72,7 +72,7 @@ fn isfinite[
     # return backend().math_func_is[dtype, math.isfinite](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size):
-        result_array.store(i, math.isfinite(array.get(i)))
+        result_array.store(i, math.isfinite(array.load(i)))
     return result_array
 
 
@@ -95,5 +95,5 @@ fn isnan[
     # return backend().math_func_is[dtype, math.isnan](array)
     var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
     for i in range(result_array.size):
-        result_array.store(i, math.isnan(array.get(i)))
+        result_array.store(i, math.isnan(array.load(i)))
     return result_array

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -28,7 +28,7 @@ fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
     for i in range(array.size):
-        result |= array.get(i)
+        result |= array.load(i)
     return result
 
 
@@ -52,5 +52,5 @@ fn allt(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     # vectorize[vectorize_sum, opt_nelts](array.num_elements())
     # return result
     for i in range(array.size):
-        result &= array.get(i)
+        result &= array.load(i)
     return result

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -214,7 +214,7 @@ fn diff[
         NDArrayShape(array.num_elements())
     )
     for i in range(array.num_elements()):
-        array1.store(i, array.get(i))
+        array1.store(i, array.load(i))
 
     for num in range(n):
         var result: NDArray[dtype] = NDArray[dtype](

--- a/numojo/routines/math/differences.mojo
+++ b/numojo/routines/math/differences.mojo
@@ -41,27 +41,28 @@ fn gradient[
     var space: NDArray[dtype] = arange[dtype](
         1, x.num_elements() + 1, step=spacing
     )
-    var hu: Scalar[dtype] = space.get(1)
-    var hd: Scalar[dtype] = space.get(0)
+    var hu: Scalar[dtype] = space.load(1)
+    var hd: Scalar[dtype] = space.load(0)
     result.store(
         0,
-        (x.get(1) - x.get(0)) / (hu - hd),
+        (x.load(1) - x.load(0)) / (hu - hd),
     )
 
-    hu = space.get(x.num_elements() - 1)
-    hd = space.get(x.num_elements() - 2)
+    hu = space.load(x.num_elements() - 1)
+    hd = space.load(x.num_elements() - 2)
     result.store(
         x.num_elements() - 1,
-        (x.get(x.num_elements() - 1) - x.get(x.num_elements() - 2)) / (hu - hd),
+        (x.load(x.num_elements() - 1) - x.load(x.num_elements() - 2))
+        / (hu - hd),
     )
 
     for i in range(1, x.num_elements() - 1):
-        var hu: Scalar[dtype] = space.get(i + 1) - space.get(i)
-        var hd: Scalar[dtype] = space.get(i) - space.get(i - 1)
+        var hu: Scalar[dtype] = space.load(i + 1) - space.load(i)
+        var hd: Scalar[dtype] = space.load(i) - space.load(i - 1)
         var fi: Scalar[dtype] = (
-            hd**2 * x.get(i + 1)
-            + (hu**2 - hd**2) * x.get(i)
-            - hu**2 * x.get(i - 1)
+            hd**2 * x.load(i + 1)
+            + (hu**2 - hd**2) * x.load(i)
+            - hu**2 * x.load(i - 1)
         ) / (hu * hd * (hu + hd))
         result.store(i, fi)
 
@@ -102,6 +103,8 @@ fn trapz[
 
     var integral: Scalar[dtype] = 0.0
     for i in range(x.num_elements() - 1):
-        var temp = (x.get(i + 1) - x.get(i)) * (y.get(i) + y.get(i + 1)) / 2.0
+        var temp = (x.load(i + 1) - x.load(i)) * (
+            y.load(i) + y.load(i + 1)
+        ) / 2.0
         integral += temp
     return integral

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -53,10 +53,10 @@ fn maxT[
 
     vectorize[vectorized_max, width](array.num_elements())
 
-    var result: Scalar[dtype] = Scalar[dtype](max_value.get(0))
+    var result: Scalar[dtype] = Scalar[dtype](max_value.load(0))
     for i in range(max_value.__len__()):
-        if max_value.get(i) > result:
-            result = max_value.get(i)
+        if max_value.load(i) > result:
+            result = max_value.load(i)
     return result
 
 
@@ -92,10 +92,10 @@ fn minT[
 
     vectorize[vectorized_min, width](array.num_elements())
 
-    var result: Scalar[dtype] = Scalar[dtype](min_value.get(0))
+    var result: Scalar[dtype] = Scalar[dtype](min_value.load(0))
     for i in range(min_value.__len__()):
-        if min_value.get(i) < result:
-            result = min_value.get(i)
+        if min_value.load(i) < result:
+            result = min_value.load(i)
 
     return result
 

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -43,11 +43,11 @@ fn maxT[
 
     @parameter
     fn vectorized_max[simd_width: Int](idx: Int) -> None:
-        max_value.store[width=simd_width](
+        max_value._buf.store(
             0,
             max(
-                max_value.load[width=simd_width](0),
-                array.load[width=simd_width](idx),
+                max_value._buf.load[width=simd_width](0),
+                array._buf.load[width=simd_width](idx),
             ),
         )
 
@@ -82,11 +82,11 @@ fn minT[
 
     @parameter
     fn vectorized_min[simd_width: Int](idx: Int) -> None:
-        min_value.store[width=simd_width](
+        min_value._buf.store(
             0,
             min(
-                min_value.load[width=simd_width](0),
-                array.load[width=simd_width](idx),
+                min_value._buf.load[width=simd_width](0),
+                array._buf.load[width=simd_width](idx),
             ),
         )
 
@@ -195,11 +195,11 @@ fn minimum[
 
     @parameter
     fn vectorized_min[simd_width: Int](idx: Int) -> None:
-        result.store[width=simd_width](
+        result._buf.store(
             idx,
             min(
-                array1.load[width=simd_width](idx),
-                array2.load[width=simd_width](idx),
+                array1._buf.load[width=simd_width](idx),
+                array2._buf.load[width=simd_width](idx),
             ),
         )
 
@@ -230,11 +230,11 @@ fn maximum[
 
     @parameter
     fn vectorized_max[simd_width: Int](idx: Int) -> None:
-        result.store[width=simd_width](
+        result._buf.store(
             idx,
             max(
-                array1.load[width=simd_width](idx),
-                array2.load[width=simd_width](idx),
+                array1._buf.load[width=simd_width](idx),
+                array2._buf.load[width=simd_width](idx),
             ),
         )
 

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -30,10 +30,10 @@ fn argmax[dtype: DType](array: NDArray[dtype]) raises -> Int:
         raise Error("array is empty")
 
     var idx: Int = 0
-    var max_val: Scalar[dtype] = array.get(0)
+    var max_val: Scalar[dtype] = array.load(0)
     for i in range(1, array.num_elements()):
-        if array.get(i) > max_val:
-            max_val = array.get(i)
+        if array.load(i) > max_val:
+            max_val = array.load(i)
             idx = i
     return idx
 
@@ -53,10 +53,10 @@ fn argmin[dtype: DType](array: NDArray[dtype]) raises -> Int:
         raise Error("array is empty")
 
     var idx: Int = 0
-    var min_val: Scalar[dtype] = array.get(0)
+    var min_val: Scalar[dtype] = array.load(0)
 
     for i in range(1, array.num_elements()):
-        if array.get(i) < min_val:
-            min_val = array.get(i)
+        if array.load(i) < min_val:
+            min_val = array.load(i)
             idx = i
     return idx

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -259,14 +259,14 @@ fn binary_sort[
 
     var result: NDArray[dtype] = NDArray[dtype](array.shape)
     for i in range(array.size):
-        result.store(i, array.get(i).cast[dtype]())
+        result.store(i, array.load(i).cast[dtype]())
 
     var n = array.num_elements()
     for end in range(n, 1, -1):
         for i in range(1, end):
             if result[i - 1] > result[i]:
-                var temp: Scalar[dtype] = result.get(i - 1)
-                result.set(i - 1, result.get(i))
+                var temp: Scalar[dtype] = result.load(i - 1)
+                result.store(i - 1, result.load(i))
                 result.store(i, temp)
     return result
 

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -251,7 +251,7 @@ fn cumpvariance[
     var result = Scalar[dtype]()
 
     for i in range(array.num_elements()):
-        result += (array.get(i) - mean_value) ** 2
+        result += (array.load(i) - mean_value) ** 2
 
     return sqrt(result / (array.num_elements()))
 

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -283,7 +283,7 @@ fn cumvariance[
 
     var result = Scalar[dtype]()
     for i in range(array.num_elements()):
-        result += (array.get(i) - mean_value) ** 2
+        result += (array.load(i) - mean_value) ** 2
 
     return sqrt(result / (array.num_elements() - 1))
 

--- a/tests/test_array_indexing_and_slicing.mojo
+++ b/tests/test_array_indexing_and_slicing.mojo
@@ -9,7 +9,7 @@ def test_getitem_scalar():
     var np = Python.import_module("numpy")
 
     var A = nm.arange(8)
-    assert_true(A.get(0) == 0, msg=String("`get` fails"))
+    assert_true(A.load(0) == 0, msg=String("`get` fails"))
 
 
 def test_setitem():


### PR DESCRIPTION
1. Remove the property `coefficient` as it is not effectively in use but takes extra memory.
2. Update the `__len__` method to return the size of the 0-th dimension.
3. Make 'load' and 'store' methods safer by adding boundary checks. For unsafe uses, `A._buf.load` and `A._buf.store` would work.
4. `get` and `set` methods have similar behavior as `load` and `store`, i.e., getting values at certain index from the underlying buffer. So, just rename `get` and `set` as `load` and `store` to achieve consistency.
5. Some cleaning work for docstrings.