### PR TITLE
[core][ndarray] `flags` replaces `order` property. Remove `datatype` property.

### DIFF
--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -412,7 +412,8 @@ fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
         elif dtype == DType.bool:
             np_dtype = np.bool_
 
-        numpyarray = np.empty(np_arr_dim, dtype=np_dtype, order=array.order)
+        var order = "C" if array.flags["C_CONTIGUOUS"] else "F"
+        numpyarray = np.empty(np_arr_dim, dtype=np_dtype, order=order)
         var pointer_d = numpyarray.__array_interface__["data"][
             0
         ].unsafe_get_as_pointer[dtype]()

--- a/numojo/mat/matrix.mojo
+++ b/numojo/mat/matrix.mojo
@@ -149,7 +149,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
 
         self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
 
-        if (data.order == "C") or (data.ndim == 1):
+        if (data.flags["C_CONTIGUOUS"]) or (data.ndim == 1):
             memcpy(self._buf, data._buf, self.size)
         else:
             for i in range(data.shape[0]):

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -1015,7 +1015,8 @@ fn astype[
         A NDArray with the same shape and strides as `a`
         but with elements casted to `target`.
     """
-    var res = NDArray[target](a.shape, order=a.order)
+    var array_order = "C" if a.flags["C_CONTIGUOUS"] else "F"
+    var res = NDArray[target](a.shape, order=array_order)
 
     @parameter
     if target == DType.bool:

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -154,7 +154,8 @@ fn _sort_inplace[
             )
         )
 
-    var continous_axis = A.ndim - 1 if A.order == "C" else A.ndim - 2
+    var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+    var continous_axis = A.ndim - 1 if array_order == "C" else A.ndim - 2
     """Continuously stored axis. -1 if row-major, -2 if col-major."""
 
     if axis == continous_axis:  # Last axis


### PR DESCRIPTION
- Create `flags` property (a `Dict`) to store memory layout of the array (c-continuous, f-continuous, own data). This is the approach by `numpy`.
- Remove property `datatype`. The `dtype` can be retrieved simply by `a.dtype`.
- Refine the `__init__` overloads to match `numpy`'s order of arguments.