### PR TITLE
[routines][linalg] Add `det` function and auxiliary partial pilot

### DIFF
--- a/numojo/routines/linalg/__init__.mojo
+++ b/numojo/routines/linalg/__init__.mojo
@@ -1,4 +1,4 @@
 from .decompositions import lu_decomposition
-from .norms import trace
+from .norms import det, trace
 from .products import cross, dot, matmul
 from .solving import inv, solve

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -2,6 +2,40 @@
 # Norms and other numbers
 # ===----------------------------------------------------------------------=== #
 
+from numojo.core.ndarray import NDArray
+from numojo.routines.linalg.decompositions import partial_pivoting
+
+
+fn det[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
+    """
+    Find the determinant of A using LUP decomposition.
+    """
+
+    if A.ndim != 2:
+        raise Error(String("Array must be 2d."))
+    if A.shape[0] != A.shape[1]:
+        raise Error(String("Matrix is not square."))
+
+    var det_L: Scalar[dtype] = 1
+    var det_U: Scalar[dtype] = 1
+    var n = A.shape[0]  # Dimension of the matrix
+
+    var A_pivoted: NDArray[dtype]
+    var U: NDArray[dtype]
+    var L: NDArray[dtype]
+    var s: Int
+    A_pivoted, _, s = partial_pivoting(A)
+    L, U = lu_decomposition[dtype](A_pivoted)
+
+    for i in range(n):
+        det_L = det_L * L.item(i, i)
+        det_U = det_U * U.item(i, i)
+
+    if s % 2 == 0:
+        return det_L * det_U
+    else:
+        return -det_L * det_U
+
 
 # TODO: implement for arbitrary axis
 fn trace[

--- a/tests/test_linalg.mojo
+++ b/tests/test_linalg.mojo
@@ -96,3 +96,12 @@ def test_solve():
         np.linalg.solve(A_np, B_np),
         "Solve is broken",
     )
+
+
+def norms():
+    var np = Python.import_module("numpy")
+    var arr = nm.core.random.rand(20, 20)
+    var np_arr = arr.to_numpy()
+    check_values_close(
+        nm.math.linalg.det(arr), np.linalg.det(np_arr), "`det` is broken"
+    )


### PR DESCRIPTION
- Add `det` function in `numojo.routines.linalg.norms`.
- And auxiliary `partial_pivoting` function in `numojo.routines.linalg.decompositions`. This, combined with `lu_decomposition`, can be used as LUP decomposition.