### PR TITLE
[matrix][linalg] Add Householder-based QR decomposition

### DIFF
--- a/numojo/mat/linalg.mojo
+++ b/numojo/mat/linalg.mojo
@@ -150,6 +150,18 @@ fn lu_decomposition[
 fn qr[
     dtype: DType
 ](owned A: Matrix[dtype]) raises -> Tuple[Matrix[dtype], Matrix[dtype]]:
+    """
+    Compute the QR decomposition of a matrix.
+
+    Decompose the matrix `A` as `QR`, where `Q` is orthonormal and `R` is upper-triangular.
+    This function is similar to `numpy.linalg.qr`.
+
+    Args:
+        A (Matrix[dtype]): The input matrix to be factorized.
+
+    Returns:
+        Tuple[Matrix[dtype], Matrix[dtype]]: A tuple containing the orthonormal matrix `Q` and the upper-triangular matrix `R`.
+    """
     var m = A.shape[0]
     var n = A.shape[1]
 

--- a/numojo/mat/linalg.mojo
+++ b/numojo/mat/linalg.mojo
@@ -157,10 +157,11 @@ fn qr[
     This function is similar to `numpy.linalg.qr`.
 
     Args:
-        A (Matrix[dtype]): The input matrix to be factorized.
+        A: The input matrix to be factorized.
 
     Returns:
-        Tuple[Matrix[dtype], Matrix[dtype]]: A tuple containing the orthonormal matrix `Q` and the upper-triangular matrix `R`.
+        A tuple containing the orthonormal matrix `Q` and
+        the upper-triangular matrix `R`.
     """
     var m = A.shape[0]
     var n = A.shape[1]

--- a/tests/test_matrix.mojo
+++ b/tests/test_matrix.mojo
@@ -211,7 +211,7 @@ def test_qr_decomposition():
 
     Q, R = numojo.mat.linalg.qr(A)
 
-    # Check if Q^T Q is close to the identity matrix, i.e Q is orthogonal
+    # Check if Q^T Q is close to the identity matrix, i.e Q is orthonormal
     var id = Q.transpose() @ Q
     assert_true(np.allclose(id.to_numpy(), np.eye(Q.shape[0]), atol=1e-14))  
 

--- a/tests/test_matrix.mojo
+++ b/tests/test_matrix.mojo
@@ -203,8 +203,8 @@ def test_linalg():
             "Trace is broken",
         )
 
-def test_qr_decomposition():
 
+def test_qr_decomposition():
     A = mat.rand[f64]((20, 20))
 
     var np = Python.import_module("numpy")
@@ -213,14 +213,15 @@ def test_qr_decomposition():
 
     # Check if Q^T Q is close to the identity matrix, i.e Q is orthonormal
     var id = Q.transpose() @ Q
-    assert_true(np.allclose(id.to_numpy(), np.eye(Q.shape[0]), atol=1e-14))  
+    assert_true(np.allclose(id.to_numpy(), np.eye(Q.shape[0]), atol=1e-14))
 
     # Check if R is upper triangular
-    assert_true(np.allclose(R.to_numpy(), np.triu(R.to_numpy()), atol=1e-14))   
+    assert_true(np.allclose(R.to_numpy(), np.triu(R.to_numpy()), atol=1e-14))
 
     # Check if A = QR
     var A_test = Q @ R
     assert_true(np.allclose(A_test.to_numpy(), A.to_numpy(), atol=1e-14))
+
 
 # ===-----------------------------------------------------------------------===#
 # Mathematics

--- a/tests/test_matrix.mojo
+++ b/tests/test_matrix.mojo
@@ -31,6 +31,35 @@ fn check_values_close[
     var np = Python.import_module("numpy")
     assert_true(np.isclose(value, np_sol, atol=0.01), st)
 
+fn are_close[
+    dtype: DType
+](A: mat.Matrix[dtype], B: mat.Matrix[dtype]) raises -> Bool:
+    """
+    Check if all elements of matrices A and B are close within a tolerance of 10^-14.
+    """
+    if A.shape[0] != B.shape[0] or A.shape[1] != B.shape[1]:
+        return False
+
+    var tolerance: SIMD[dtype, 1] = 1e-14
+    for i in range(A.shape[0]):
+        for j in range(A.shape[1]):
+            if abs(A[i, j] - B[i, j]) >= tolerance:
+                return False
+    return True
+
+fn is_upper_triangular[
+    dtype: DType
+](A: mat.Matrix[dtype]) raises -> Bool:
+    """
+    Check if the matrix A is upper triangular.
+    """
+    var tolerance: SIMD[dtype, 1] = 1e-14
+    for i in range(A.shape[0]):
+        for j in range(i):
+            if abs(A[i, j]) >= tolerance:
+                return False
+    return True
+
 
 # ===-----------------------------------------------------------------------===#
 # Manipulation
@@ -203,6 +232,20 @@ def test_linalg():
             "Trace is broken",
         )
 
+def test_qr_decomposition():
+
+    A = mat.rand[f64]((100, 100))
+
+    Q, R = numojo.mat.linalg.qr(A)
+
+    # Check if Q^T Q is close to the identity matrix, i.e Q is orthogonal
+    assert_true(are_close(Q.transpose() @ Matrix(mat.identity(A.shape[0])), Matrix(mat.identity(A.shape[0]))), "Q^T Q is not close to identity matrix")
+
+    # Check if R is upper triangular
+    assert_true(is_upper_triangular(R), "R is not upper triangular")
+
+    # Check if A is close to Q R
+    assert_true(are_close(A, Q @ R), "A is not close to Q R")
 
 # ===-----------------------------------------------------------------------===#
 # Mathematics

--- a/tests/test_matrix.mojo
+++ b/tests/test_matrix.mojo
@@ -239,7 +239,7 @@ def test_qr_decomposition():
     Q, R = numojo.mat.linalg.qr(A)
 
     # Check if Q^T Q is close to the identity matrix, i.e Q is orthogonal
-    assert_true(are_close(Q.transpose() @ Matrix(mat.identity(A.shape[0])), Matrix(mat.identity(A.shape[0]))), "Q^T Q is not close to identity matrix")
+    assert_true(are_close(Q.transpose() @ Q, mat.Matrix(mat.identity(A.shape[0]))), "Q^T Q is not close to identity matrix")
 
     # Check if R is upper triangular
     assert_true(is_upper_triangular(R), "R is not upper triangular")


### PR DESCRIPTION
This pull request adds a Householder-based QR decomposition. I have added a test to verify that the resulting matrices Q and R have the properties:

- Q is orthonormal
- R is upper triangular
- A=Q*R


For improved performance on bigger matrices, adopting a blocked/tiled QR factorization and leveraging SIMD or parallelization would be beneficial.