### PR TITLE
[core][strides][Idx] Remove `offset` property from the `Strides` type and more

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -178,7 +178,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.shape = NDArrayShape(shape)
         self.ndim = self.shape.ndim
         self.size = self.shape.size
-        self.strides = NDArrayStrides(strides=strides, offset=0)
+        self.strides = NDArrayStrides(strides=strides)
         self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
         memset_zero(self._buf, self.size)
         # Initialize information on memory layout

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -46,7 +46,7 @@ struct NDArrayStrides(Stringable):
         memcpy(self._buf, strides._buf, strides.ndim)
 
     @always_inline("nodebug")
-    fn __init__(out self, *shape: Int, order: String = "C") raises:
+    fn __init__(out self, *shape: Int, order: String) raises:
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         if order == "C":

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -13,33 +13,27 @@ struct NDArrayStrides(Stringable):
     """Implements the NDArrayStrides."""
 
     # Fields
-    var offset: Int
     var _buf: UnsafePointer[Int]
     """Data buffer."""
     var ndim: Int
     """Number of dimensions of array."""
 
     @always_inline("nodebug")
-    fn __init__(
-        out self, *strides: Int, offset: Int = 0
-    ):  # maybe we should add checks for offset?
-        self.offset = offset
+    fn __init__(out self, *strides: Int):
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(strides[i])
 
     @always_inline("nodebug")
-    fn __init__(out self, strides: List[Int], offset: Int = 0):
-        self.offset = offset
+    fn __init__(out self, strides: List[Int]):
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(strides[i])
 
     @always_inline("nodebug")
-    fn __init__(out self, strides: VariadicList[Int], offset: Int = 0):
-        self.offset = offset
+    fn __init__(out self, strides: VariadicList[Int]):
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
@@ -47,25 +41,12 @@ struct NDArrayStrides(Stringable):
 
     @always_inline("nodebug")
     fn __init__(out self, strides: NDArrayStrides):
-        self.offset = strides.offset
         self.ndim = strides.ndim
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         memcpy(self._buf, strides._buf, strides.ndim)
 
     @always_inline("nodebug")
-    fn __init__(
-        out self, strides: NDArrayStrides, offset: Int
-    ):  # separated two methods to remove if condition
-        self.offset = offset
-        self.ndim = strides.ndim
-        self._buf = UnsafePointer[Int]().alloc(self.ndim)
-        memcpy(self._buf, strides._buf, strides.ndim)
-
-    @always_inline("nodebug")
-    fn __init__(
-        out self, *shape: Int, offset: Int = 0, order: String = "C"
-    ) raises:
-        self.offset = offset
+    fn __init__(out self, *shape: Int, order: String = "C") raises:
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         if order == "C":
@@ -85,10 +66,7 @@ struct NDArrayStrides(Stringable):
             )
 
     @always_inline("nodebug")
-    fn __init__(
-        out self, shape: List[Int], offset: Int = 0, order: String = "C"
-    ) raises:
-        self.offset = offset
+    fn __init__(out self, shape: List[Int], order: String = "C") raises:
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         if order == "C":
@@ -111,10 +89,8 @@ struct NDArrayStrides(Stringable):
     fn __init__(
         out self,
         shape: VariadicList[Int],
-        offset: Int = 0,
         order: String = "C",
     ) raises:
-        self.offset = offset
         self.ndim = shape.__len__()
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         if order == "C":
@@ -137,10 +113,8 @@ struct NDArrayStrides(Stringable):
     fn __init__(
         out self,
         owned shape: NDArrayShape,
-        offset: Int = 0,
         order: String = "C",
     ) raises:
-        self.offset = offset
         self.ndim = shape.ndim
         self._buf = UnsafePointer[Int]().alloc(shape.ndim)
         if order == "C":

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -44,127 +44,94 @@ fn fill_pointer[
 
 
 # ===----------------------------------------------------------------------=== #
-# GET INDEX FUNCTIONS FOR NDARRAY
+# GET OFFSET FUNCTIONS FOR NDARRAY
 # ===----------------------------------------------------------------------=== #
-# define a ndarray internal trait and remove multiple overloads of these _get_index
-fn _get_index(indices: List[Int], weights: NDArrayShape) raises -> Int:
+
+
+fn _get_offset(indices: List[Int], strides: NDArrayStrides) raises -> Int:
     """
-    Get the index of a multi-dimensional array from a list of indices and weights.
+    Get the index of a multi-dimensional array from a list of indices and strides.
 
     Args:
         indices: The list of indices.
-        weights: The weights of the indices.
+        strides: The strides of the indices.
 
     Returns:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndim):
-        idx += indices[i] * weights[i]
+    for i in range(strides.ndim):
+        idx += indices[i] * strides[i]
     return idx
 
 
-fn _get_index(indices: VariadicList[Int], weights: NDArrayShape) raises -> Int:
+fn _get_offset(indices: Idx, strides: NDArrayStrides) raises -> Int:
     """
-    Get the index of a multi-dimensional array from a list of indices and weights.
+    Get the index of a multi-dimensional array from a list of indices and strides.
 
     Args:
         indices: The list of indices.
-        weights: The weights of the indices.
-
-    Returns:
-        The scalar index of the multi-dimensional array.
-    """
-    var idx: Int = 0
-    for i in range(weights.ndim):
-        idx += indices[i] * weights[i]
-    return idx
-
-
-fn _get_index(indices: List[Int], weights: NDArrayStrides) raises -> Int:
-    """
-    Get the index of a multi-dimensional array from a list of indices and weights.
-
-    Args:
-        indices: The list of indices.
-        weights: The weights of the indices.
-
-    Returns:
-        The scalar index of the multi-dimensional array.
-    """
-    var idx: Int = 0
-    for i in range(weights.ndim):
-        idx += indices[i] * weights[i]
-    return idx
-
-
-fn _get_index(indices: Idx, weights: NDArrayStrides) raises -> Int:
-    """
-    Get the index of a multi-dimensional array from a list of indices and weights.
-
-    Args:
-        indices: The list of indices.
-        weights: The weights of the indices.
+        strides: The strides of the indices.
 
     Returns:
         The scalar index of the multi-dimensional array.
     """
     var index: Int = 0
-    for i in range(weights.ndim):
-        index += indices[i] * weights[i]
+    for i in range(strides.ndim):
+        index += indices[i] * strides[i]
     return index
 
 
-fn _get_index(
-    indices: VariadicList[Int], weights: NDArrayStrides
+fn _get_offset(
+    indices: VariadicList[Int], strides: NDArrayStrides
 ) raises -> Int:
     """
-    Get the index of a multi-dimensional array from a list of indices and weights.
+    Get the index of a multi-dimensional array from a list of indices and strides.
 
     Args:
         indices: The list of indices.
-        weights: The weights of the indices.
+        strides: The strides of the indices.
 
     Returns:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.ndim):
-        idx += indices[i] * weights[i]
+    for i in range(strides.ndim):
+        idx += indices[i] * strides[i]
     return idx
 
 
-fn _get_index(indices: List[Int], weights: List[Int]) -> Int:
+fn _get_offset(indices: List[Int], strides: List[Int]) -> Int:
     """
-    Get the index of a multi-dimensional array from a list of indices and weights.
+    Get the index of a multi-dimensional array from a list of indices and strides.
 
     Args:
         indices: The list of indices.
-        weights: The weights of the indices.
+        strides: The strides of the indices.
 
     Returns:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.__len__()):
-        idx += indices[i] * weights[i]
+    for i in range(strides.__len__()):
+        idx += indices[i] * strides[i]
     return idx
 
 
-fn _get_index(indices: VariadicList[Int], weights: VariadicList[Int]) -> Int:
+fn _get_offset(indices: VariadicList[Int], strides: VariadicList[Int]) -> Int:
     """
-    Get the index of a multi-dimensional array from a list of indices and weights.
+    Get the index of a multi-dimensional array from a list of indices and strides.
 
     Args:
         indices: The list of indices.
-        weights: The weights of the indices.
+        strides: The strides of the indices.
 
     Returns:
         The scalar index of the multi-dimensional array.
     """
     var idx: Int = 0
-    for i in range(weights.__len__()):
-        idx += indices[i] * weights[i]
+    for i in range(strides.__len__()):
+        idx += indices[i] * strides[i]
     return idx
 
 
@@ -258,8 +225,8 @@ fn _traverse_iterative[
 
     # # parallelized version was slower xD
     for _ in range(total_elements):
-        var orig_idx = offset + _get_index(index, coefficients)
-        var narr_idx = _get_index(index, strides)
+        var orig_idx = offset + _get_offset(index, coefficients)
+        var narr_idx = _get_offset(index, strides)
         try:
             if narr_idx >= total_elements:
                 raise Error("Invalid index: index out of bound")
@@ -307,8 +274,8 @@ fn _traverse_iterative_setter[
     # # parallelized version was slower xD
     var total_elements = narr.size
     for _ in range(total_elements):
-        var orig_idx = offset + _get_index(index, coefficients)
-        var narr_idx = _get_index(index, strides)
+        var orig_idx = offset + _get_offset(index, coefficients)
+        var narr_idx = _get_offset(index, strides)
         try:
             if narr_idx >= total_elements:
                 raise Error("Invalid index: index out of bound")

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -39,7 +39,7 @@ from memory import UnsafePointer, memset_zero, memset
 
 from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import NDArrayShape
-from numojo.core.utility import _get_index
+from numojo.core.utility import _get_offset
 
 
 # ===------------------------------------------------------------------------===#


### PR DESCRIPTION
- Remove `offset` property from `Strides` type. `offset` is used when constructing a view/copy of array, but not a property of array or strides.
- Rename the underlying buffer of `Idx` type to `_buf`.
- Rename `_get_index` as `_get_offset` because it is *de facto* obtaining the offset (in item size) of the underlying buffer given indices and strides. Remove the overloads which reads in `Shape` because the result is not meaningful.