### PR TITLE
[ndarray][iterator] Return view instead of copy for iterator of `NDArray`

### DIFF
--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -22,7 +22,7 @@ struct NDArrayShape(Stringable, Writable):
     """Number of dimensions of array."""
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: Int):
+    fn __init__(out self, shape: Int):
         """
         Initializes the NDArrayShape with one dimension.
 
@@ -35,7 +35,7 @@ struct NDArrayShape(Stringable, Writable):
         self._buf.init_pointee_copy(shape)
 
     @always_inline("nodebug")
-    fn __init__(mut self, *shape: Int):
+    fn __init__(out self, *shape: Int):
         """
         Initializes the NDArrayShape with variable shape dimensions.
 
@@ -50,7 +50,7 @@ struct NDArrayShape(Stringable, Writable):
             self.size *= shape[i]
 
     @always_inline("nodebug")
-    fn __init__(mut self, *shape: Int, size: Int) raises:
+    fn __init__(out self, *shape: Int, size: Int) raises:
         """
         Initializes the NDArrayShape with variable shape dimensions and a specified size.
 
@@ -69,7 +69,7 @@ struct NDArrayShape(Stringable, Writable):
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: List[Int]):
+    fn __init__(out self, shape: List[Int]):
         """
         Initializes the NDArrayShape with a list of shape dimensions.
 
@@ -84,7 +84,7 @@ struct NDArrayShape(Stringable, Writable):
             self.size *= shape[i]
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: List[Int], size: Int) raises:
+    fn __init__(out self, shape: List[Int], size: Int) raises:
         """
         Initializes the NDArrayShape with a list of shape dimensions and a specified size.
 
@@ -105,7 +105,7 @@ struct NDArrayShape(Stringable, Writable):
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: VariadicList[Int]):
+    fn __init__(out self, shape: VariadicList[Int]):
         """
         Initializes the NDArrayShape with a list of shape dimensions.
 
@@ -120,7 +120,7 @@ struct NDArrayShape(Stringable, Writable):
             self.size *= shape[i]
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: VariadicList[Int], size: Int) raises:
+    fn __init__(out self, shape: VariadicList[Int], size: Int) raises:
         """
         Initializes the NDArrayShape with a list of shape dimensions and a specified size.
 
@@ -141,7 +141,7 @@ struct NDArrayShape(Stringable, Writable):
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
-    fn __init__(mut self, shape: NDArrayShape) raises:
+    fn __init__(out self, shape: NDArrayShape) raises:
         """
         Initializes the NDArrayShape with another NDArrayShape.
 
@@ -178,7 +178,7 @@ struct NDArrayShape(Stringable, Writable):
             self._buf[self.ndim + index] = val
 
     @always_inline("nodebug")
-    fn len(self) -> Int:
+    fn __len__(self) -> Int:
         """
         Get number of dimensions of the array described by arrayshape.
         """
@@ -281,6 +281,23 @@ struct NDArrayShape(Stringable, Writable):
         shape._buf[shape.ndim - 1] = value
         return shape
 
+    fn _pop(self, axis: Int) -> Self:
+        """
+        drop information of certain axis.
+        """
+        var res = Self()
+        var buffer = UnsafePointer[Int].alloc(self.ndim - 1)
+        memcpy(dest=buffer, src=self._buf, count=axis)
+        memcpy(
+            dest=buffer + axis,
+            src=self._buf.offset(axis + 1),
+            count=self.ndim - axis - 1,
+        )
+        res.ndim = self.ndim - 1
+        res.size = self.size // self._buf[axis]
+        res._buf = buffer
+        return res
+
     # # can be used for vectorized index calculation
     # @always_inline("nodebug")
     # fn load[width: Int = 1](self, index: Int) raises -> SIMD[dtype, width]:
@@ -295,7 +312,7 @@ struct NDArrayShape(Stringable, Writable):
     # @always_inline("nodebug")
     # fn store[
     #     width: Int = 1
-    # ](mut self, index: Int, val: SIMD[dtype, width]) raises:
+    # ](out self, index: Int, val: SIMD[dtype, width]) raises:
     #     """
     #     SIMD store dimensional information.
     #     """

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -155,7 +155,7 @@ struct NDArrayStrides(Stringable):
             self._buf[self.ndim + index] = val
 
     @always_inline("nodebug")
-    fn len(self) -> Int:
+    fn __len__(self) -> Int:
         return self.ndim
 
     @always_inline("nodebug")
@@ -243,6 +243,22 @@ struct NDArrayStrides(Stringable):
             strides._buf[i] = strides._buf[i + 1]
         strides._buf[strides.ndim - 1] = value
         return strides
+
+    fn _pop(self, axis: Int) -> Self:
+        """
+        drop information of certain axis.
+        """
+        var res = Self()
+        var buffer = UnsafePointer[Int].alloc(self.ndim - 1)
+        memcpy(dest=buffer, src=self._buf, count=axis)
+        memcpy(
+            dest=buffer + axis,
+            src=self._buf.offset(axis + 1),
+            count=self.ndim - axis - 1,
+        )
+        res.ndim = self.ndim - 1
+        res._buf = buffer
+        return res
 
 
 # @always_inline("nodebug")


### PR DESCRIPTION
Return view instead of copy for iterator of `NDArray`.

```mojo
>>> var a = nm.random.arange[nm.i8](2 * 3 * 4).reshape(nm.Shape(2, 3, 4))
>>> for i in a:
...     print(i)
[[      0       1       2       3       ]
 [      4       5       6       7       ]
 [      8       9       10      11      ]]
2-D array  Shape: [3, 4]  DType: int8  C-cont: True  F-cont: False  own data: False
[[      12      13      14      15      ]
 [      16      17      18      19      ]
 [      20      21      22      23      ]]
2-D array  Shape: [3, 4]  DType: int8  C-cont: True  F-cont: False  own data: False
```