### PR TITLE
[Matrix][NDArray] Change data buffer of `Matrix` to `OwnData` and better `flags`

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-14"]
+        # os: ["ubuntu-22.04", "macos-14"]
+        os: ["ubuntu-22.04"]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -7,19 +7,27 @@
 - Auxiliary functions.
 """
 
-from numojo.core.ndarray import NDArray
+from algorithm import parallelize, vectorize
+from collections import Dict
 from memory import UnsafePointer, memcpy, memset_zero
 from random import random_float64
 from sys import simdwidthof
-from algorithm import parallelize, vectorize
 from python import PythonObject, Python
+
+from numojo.core.ndarray import NDArray
+from numojo.core.own_data import OwnData
+from numojo.core.utility import _update_flags
 
 # ===----------------------------------------------------------------------===#
 # Matrix struct
 # ===----------------------------------------------------------------------===#
 
 
-struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
+struct Matrix[dtype: DType = DType.float64](
+    CollectionElement, Sized, Stringable, Writable
+):
+    # TODO: Matrix[dtype: DType = DType.float64,
+    #               Buffer: Bufferable[dtype] = OwnData[dtype]]
     """
     `Matrix` is a special case of `NDArray` (2DArray) but has some targeted
     optimization since the number of dimensions is known at the compile time.
@@ -78,21 +86,23 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
     - [x] `Matrix.variance` and `mat.statistics.variance` (`var` is primitive)
     """
 
+    alias width: Int = simdwidthof[dtype]()  #
+    """Vector size of the data type."""
+
+    var _buf: OwnData[dtype]
+    """Data buffer of the items in the NDArray."""
+
     var shape: Tuple[Int, Int]
     """Shape of Matrix."""
 
-    # To be calculated at the initialization.
     var size: Int
     """Size of Matrix."""
+
     var strides: Tuple[Int, Int]
     """Strides of matrix."""
 
-    # To be filled by constructing functions.
-    var _buf: UnsafePointer[Scalar[dtype]]
-    """Data buffer of the items in the NDArray."""
-
-    alias width: Int = simdwidthof[dtype]()  #
-    """Vector size of the data type."""
+    var flags: Dict[String, Bool]
+    "Information about the memory layout of the array."
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -113,7 +123,11 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         self.shape = (shape[0], shape[1])
         self.strides = (shape[1], 1)
         self.size = shape[0] * shape[1]
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
+        self._buf = OwnData[dtype](size=self.size)
+        # Initialize information on memory layout
+        self.flags = Dict[String, Bool]()
+        _update_flags(self.flags, self.shape, self.strides)
+        self.flags["OWNDATA"] = True
 
     @always_inline("nodebug")
     fn __init__(
@@ -144,10 +158,15 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         else:
             raise Error(String("Shape too large to be a matrix."))
 
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(self.size)
+        self._buf = OwnData[dtype](self.size)
 
-        if (data.flags["C_CONTIGUOUS"]) or (data.ndim == 1):
-            memcpy(self._buf, data._buf.ptr, self.size)
+        # Initialize information on memory layout
+        self.flags = Dict[String, Bool]()
+        _update_flags(self.flags, self.shape, self.strides)
+        self.flags["OWNDATA"] = True
+
+        if data.flags["C_CONTIGUOUS"]:
+            memcpy(self._buf.ptr, data._buf.ptr, self.size)
         else:
             for i in range(data.shape[0]):
                 for j in range(data.shape[1]):
@@ -161,8 +180,9 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         self.shape = (other.shape[0], other.shape[1])
         self.strides = (other.strides[0], other.strides[1])
         self.size = other.size
-        self._buf = UnsafePointer[Scalar[dtype]]().alloc(other.size)
-        memcpy(self._buf, other._buf, other.size)
+        self._buf = OwnData[dtype](other.size)
+        memcpy(self._buf.ptr, other._buf.ptr, other.size)
+        self.flags = other.flags
 
     @always_inline("nodebug")
     fn __moveinit__(mut self, owned other: Self):
@@ -172,14 +192,21 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         self.shape = other.shape^
         self.strides = other.strides^
         self.size = other.size
-        self._buf = other._buf
+        self._buf = other._buf^
+        self.flags = other.flags^
 
     @always_inline("nodebug")
     fn __del__(owned self):
-        self._buf.free()
+        var owndata = True
+        try:
+            owndata = self.flags["OWNDATA"]
+        except:
+            print("Invalid `OWNDATA` flag. Treat as `True`.")
+        if owndata:
+            self._buf.ptr.free()
 
     # ===-------------------------------------------------------------------===#
-    # Dunder methods
+    # Slicing and indexing methods
     # ===-------------------------------------------------------------------===#
 
     fn __getitem__(self, owned x: Int, owned y: Int) raises -> Scalar[dtype]:
@@ -207,7 +234,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
                 ).format(x, y, self.shape[0], self.shape[1])
             )
 
-        return self._buf.load(x * self.strides[0] + y)
+        return self._buf.ptr.load(x * self.strides[0] + y)
 
     fn __getitem__(self, owned x: Int) raises -> Self:
         """
@@ -228,8 +255,8 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
             )
 
         var res = Self(shape=(1, self.shape[1]))
-        var ptr = self._buf.offset(x * self.shape[1])
-        memcpy(res._buf, ptr, res.size)
+        var ptr = self._buf.ptr.offset(x * self.shape[1])
+        memcpy(res._buf.ptr, ptr, res.size)
         return res
 
     fn __getitem__(self, x: Slice, y: Slice) -> Self:
@@ -254,7 +281,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         var c = 0
         for i in range_x:
             for j in range_y:
-                B._buf[c] = self._load(i, j)
+                B._buf.ptr[c] = self._load(i, j)
                 c += 1
 
         return B
@@ -278,7 +305,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         # Fill in the values at the corresponding index
         var c = 0
         for i in range_x:
-            B._buf[c] = self._load(i, y)
+            B._buf.ptr[c] = self._load(i, y)
             c += 1
 
         return B
@@ -302,7 +329,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         # Fill in the values at the corresponding index
         var c = 0
         for j in range_y:
-            B._buf[c] = self._load(x, j)
+            B._buf.ptr[c] = self._load(x, j)
             c += 1
 
         return B
@@ -324,7 +351,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         `__getitem__` with width.
         Unsafe: No boundary check!
         """
-        return self._buf.load[width=width](x * self.strides[0] + y)
+        return self._buf.ptr.load[width=width](x * self.strides[0] + y)
 
     fn __setitem__(self, x: Int, y: Int, value: Scalar[dtype]) raises:
         """
@@ -343,7 +370,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
                 ).format(x, y, self.shape[0], self.shape[1])
             )
 
-        self._buf.store(x * self.strides[0] + y, value)
+        self._buf.ptr.store(x * self.strides[0] + y, value)
 
     fn __setitem__(self, owned x: Int, value: Self) raises:
         """
@@ -381,8 +408,8 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
                 ).format(self.shape[1], value.shape[1])
             )
 
-        var ptr = self._buf.offset(x * self.shape[1])
-        memcpy(ptr, value._buf, value.size)
+        var ptr = self._buf.ptr.offset(x * self.shape[1])
+        memcpy(ptr, value._buf.ptr, value.size)
 
     fn _store[
         width: Int = 1
@@ -391,7 +418,52 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         `__setitem__` with width.
         Unsafe: No boundary check!
         """
-        self._buf.store(x * self.strides[0] + y, simd)
+        self._buf.ptr.store(x * self.strides[0] + y, simd)
+
+    # ===-------------------------------------------------------------------===#
+    # Other dunders and auxiliary methods
+    # ===-------------------------------------------------------------------===#
+
+    fn __iter__(self) raises -> _MatrixIter[__origin_of(self), dtype]:
+        """Iterate over elements of the Matrix, returning copied value.
+
+        Example:
+        ```mojo
+        from numojo import Matrix
+        var A = Matrix.rand((4,4))
+        for i in A:
+            print(i)
+        ```
+
+        Returns:
+            An iterator of Matrix elements.
+        """
+
+        return _MatrixIter[__origin_of(self), dtype](
+            matrix=self,
+            length=self.shape[0],
+        )
+
+    fn __len__(self) -> Int:
+        """
+        Returns length of 0-th dimension.
+        """
+        return self.shape[0]
+
+    fn __reversed__(
+        self,
+    ) raises -> _MatrixIter[__origin_of(self), dtype, forward=False]:
+        """Iterate backwards over elements of the Matrix, returning
+        copied value.
+
+        Returns:
+            A reversed iterator of Matrix elements.
+        """
+
+        return _MatrixIter[__origin_of(self), dtype, forward=False](
+            matrix=self,
+            length=self.shape[0],
+        )
 
     fn __str__(self) -> String:
         return String.write(self)
@@ -450,41 +522,6 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
             + str(self.shape[1])
             + "  DType: "
             + str(self.dtype)
-        )
-
-    fn __iter__(self) raises -> _MatrixIter[__origin_of(self), dtype]:
-        """Iterate over elements of the Matrix, returning copied value.
-
-        Example:
-        ```mojo
-        from numojo import Matrix
-        var A = Matrix.rand((4,4))
-        for i in A:
-            print(i)
-        ```
-
-        Returns:
-            An iterator of Matrix elements.
-        """
-
-        return _MatrixIter[__origin_of(self), dtype](
-            matrix=self,
-            length=self.shape[0],
-        )
-
-    fn __reversed__(
-        self,
-    ) raises -> _MatrixIter[__origin_of(self), dtype, forward=False]:
-        """Iterate backwards over elements of the Matrix, returning
-        copied value.
-
-        Returns:
-            A reversed iterator of Matrix elements.
-        """
-
-        return _MatrixIter[__origin_of(self), dtype, forward=False](
-            matrix=self,
-            length=self.shape[0],
         )
 
     # ===-------------------------------------------------------------------===#
@@ -640,7 +677,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         """Power of items."""
         var res = self
         for i in range(self.size):
-            res._buf[i] = self._buf[i].__pow__(rhs)
+            res._buf.ptr[i] = self._buf.ptr[i].__pow__(rhs)
         return res^
 
     fn __lt__(self, other: Self) raises -> Matrix[DType.bool]:
@@ -890,7 +927,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         """
         var res = Matrix[asdtype](shape=(self.shape[0], self.shape[1]))
         for i in range(self.size):
-            res._buf[i] = self._buf[i].cast[asdtype]()
+            res._buf.ptr[i] = self._buf.ptr[i].cast[asdtype]()
         return res^
 
     fn cumprod(self) -> Matrix[dtype]:
@@ -936,14 +973,14 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         See also function `mat.creation.full`.
         """
         for i in range(self.size):
-            self._buf[i] = fill_value
+            self._buf.ptr[i] = fill_value
 
     fn flatten(self) -> Self:
         """
         Return a flattened copy of the matrix.
         """
         var res = Self(shape=(1, self.size))
-        memcpy(res._buf, self._buf, res.size)
+        memcpy(res._buf.ptr, self._buf.ptr, res.size)
         return res^
 
     fn inv(self) raises -> Self:
@@ -1025,7 +1062,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
                 ).format(self.size, shape[0], shape[1])
             )
         var res = Self(shape=shape)
-        memcpy(res._buf, self._buf, res.size)
+        memcpy(res._buf.ptr, self._buf.ptr, res.size)
         return res^
 
     fn resize(mut self, shape: Tuple[Int, Int]):
@@ -1034,9 +1071,9 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         """
         if shape[0] * shape[1] > self.size:
             var other = Self(shape=shape)
-            memcpy(other._buf, self._buf, self.size)
+            memcpy(other._buf.ptr, self._buf.ptr, self.size)
             for i in range(self.size, other.size):
-                other._buf[i] = 0
+                other._buf.ptr[i] = 0
             self = other
         else:
             self.shape[0] = shape[0]
@@ -1143,7 +1180,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         var ndarray = NDArray[dtype](
             shape=List[Int](self.shape[0], self.shape[1]), order="C"
         )
-        memcpy(ndarray._buf.ptr, self._buf, ndarray.size)
+        memcpy(ndarray._buf.ptr, self._buf.ptr, ndarray.size)
 
         return ndarray
 
@@ -1186,7 +1223,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
             var pointer_d = numpyarray.__array_interface__["data"][
                 0
             ].unsafe_get_as_pointer[dtype]()
-            memcpy(pointer_d, self._buf, self.size)
+            memcpy(pointer_d, self._buf.ptr, self.size)
 
             return numpyarray^
 
@@ -1213,7 +1250,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
 
         var matrix = Matrix[dtype](shape)
         for i in range(shape[0] * shape[1]):
-            matrix._buf.store(i, fill_value)
+            matrix._buf.ptr.store(i, fill_value)
 
         return matrix^
 
@@ -1231,7 +1268,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         """
 
         var M = Matrix[dtype](shape)
-        memset_zero(M._buf, M.size)
+        memset_zero(M._buf.ptr, M.size)
         return M^
 
     @staticmethod
@@ -1262,7 +1299,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
 
         var matrix = Matrix.zeros[dtype]((len, len))
         for i in range(len):
-            matrix._buf.store(i * matrix.strides[0] + i, 1)
+            matrix._buf.ptr.store(i * matrix.strides[0] + i, 1)
         return matrix^
 
     @staticmethod
@@ -1285,7 +1322,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
         """
         var result = Matrix[dtype](shape)
         for i in range(result.size):
-            result._buf.store(i, random_float64(0, 1).cast[dtype]())
+            result._buf.ptr.store(i, random_float64(0, 1).cast[dtype]())
         return result^
 
     @staticmethod
@@ -1308,7 +1345,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
 
         if (shape[0] == 0) and (shape[1] == 0):
             var M = Matrix[dtype](shape=(1, object.size))
-            memcpy(M._buf, object.data, M.size)
+            memcpy(M._buf.ptr, object.data, M.size)
             return M^
 
         if shape[0] * shape[1] != object.size:
@@ -1317,7 +1354,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
             ).format(object.size, shape[0], shape[1])
             raise Error(message)
         var M = Matrix[dtype](shape=shape)
-        memcpy(M._buf, object.data, M.size)
+        memcpy(M._buf.ptr, object.data, M.size)
         return M^
 
     @staticmethod
@@ -1387,7 +1424,7 @@ struct Matrix[dtype: DType = DType.float64](Stringable, Writable):
 
         var result = Matrix[dtype](shape=shape)
         for i in range(len(data)):
-            result._buf[i] = data[i]
+            result._buf.ptr[i] = data[i]
         return result^
 
 
@@ -1439,6 +1476,14 @@ struct _MatrixIter[
             self.index -= 1
             return self.matrix[current_index]
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        @parameter
+        if forward:
+            return self.index < self.length
+        else:
+            return self.index > 0
+
     fn __len__(self) -> Int:
         @parameter
         if forward:
@@ -1476,11 +1521,11 @@ fn _arithmetic_func_matrix_matrix_to_matrix[
 
     @parameter
     fn vec_func[simd_width: Int](i: Int):
-        C._buf.store(
+        C._buf.ptr.store(
             i,
             simd_func(
-                A._buf.load[width=simd_width](i),
-                B._buf.load[width=simd_width](i),
+                A._buf.ptr.load[width=simd_width](i),
+                B._buf.ptr.load[width=simd_width](i),
             ),
         )
 
@@ -1506,7 +1551,7 @@ fn _arithmetic_func_matrix_to_matrix[
 
     @parameter
     fn vec_func[simd_width: Int](i: Int):
-        C._buf.store(i, simd_func(A._buf.load[width=simd_width](i)))
+        C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
 
     vectorize[vec_func, simd_width](A.size)
 
@@ -1598,11 +1643,15 @@ fn broadcast_to[
         B = Matrix.full[dtype](shape, A[0, 0])
     elif (A.shape[0] == 1) and (A.shape[1] == shape[1]):
         for i in range(shape[0]):
-            memcpy(dest=B._buf.offset(shape[1] * i), src=A._buf, count=shape[1])
+            memcpy(
+                dest=B._buf.ptr.offset(shape[1] * i),
+                src=A._buf.ptr,
+                count=shape[1],
+            )
     elif (A.shape[1] == 1) and (A.shape[0] == shape[0]):
         for i in range(shape[0]):
             for j in range(shape[1]):
-                B._store(i, j, A._buf[i])
+                B._store(i, j, A._buf.ptr[i])
     else:
         var message = String(
             "Cannot broadcast shape {}x{} to shape {}x{}!"

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -114,7 +114,7 @@ struct Matrix[dtype: DType = DType.float64](
         shape: Tuple[Int, Int],
     ):
         """
-        Matrix NDArray initialization.
+        Construct a matrix without initializing data.
 
         Args:
             shape: List of shape.
@@ -134,7 +134,9 @@ struct Matrix[dtype: DType = DType.float64](
         mut self,
         data: Self,
     ):
-        """Create a matrix from a matrix."""
+        """
+        Construct a matrix from matrix.
+        """
 
         self = data
 
@@ -144,7 +146,7 @@ struct Matrix[dtype: DType = DType.float64](
         data: NDArray[dtype],
     ) raises:
         """
-        Create Matrix from NDArray.
+        Construct a matrix from array.
         """
 
         if data.ndim == 1:
@@ -166,11 +168,16 @@ struct Matrix[dtype: DType = DType.float64](
         self.flags["OWNDATA"] = True
 
         if data.flags["C_CONTIGUOUS"]:
-            memcpy(self._buf.ptr, data._buf.ptr, self.size)
+            for i in range(data.shape[0]):
+                memcpy(
+                    self._buf.ptr.offset(i * self.shape[0]),
+                    data._buf.ptr.offset(i * data.shape[0]),
+                    self.shape[0],
+                )
         else:
             for i in range(data.shape[0]):
                 for j in range(data.shape[1]):
-                    self._store(i, j, data.load(i, j))
+                    self._store(i, j, data._getitem(i, j))
 
     @always_inline("nodebug")
     fn __copyinit__(mut self, other: Self):

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -27,6 +27,7 @@ from numojo.core.own_data import OwnData
 from numojo.core._math_funcs import Vectorized
 from numojo.core.utility import (
     _get_offset,
+    _update_flags,
     _traverse_iterative,
     _traverse_iterative_setter,
     to_numpy,
@@ -186,6 +187,12 @@ struct NDArray[dtype: DType = DType.float64](
         memset_zero(self._buf.ptr, self.size)
         # Initialize information on memory layout
         self.flags = Dict[String, Bool]()
+        # FIXME: Create a function that updates flags
+        # according to strides and shape.
+        # flags["C_CONTIGUOUS"] = (
+        #    True if (self.strides[self.ndim - 1] == 1)
+        #    or (self.shape[self.ndim - 1] == 1)
+        #    else False)
         self.flags["C_CONTIGUOUS"] = (
             True if self.strides[self.ndim - 1] == 1 else False
         )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -131,10 +131,9 @@ struct NDArray[dtype: DType = DType.float64](
         self._buf = OwnData[dtype](self.size)
         # Initialize information on memory layout
         self.flags = Dict[String, Bool]()
-        self.flags["C_CONTIGUOUS"] = (
-            True if self.strides[self.ndim - 1] == 1 else False
+        _update_flags(
+            self.flags, shape=self.shape, strides=self.strides, ndim=self.ndim
         )
-        self.flags["F_CONTIGUOUS"] = True if self.strides[0] == 1 else False
         self.flags["OWNDATA"] = True
 
     @always_inline("nodebug")
@@ -187,16 +186,9 @@ struct NDArray[dtype: DType = DType.float64](
         memset_zero(self._buf.ptr, self.size)
         # Initialize information on memory layout
         self.flags = Dict[String, Bool]()
-        # FIXME: Create a function that updates flags
-        # according to strides and shape.
-        # flags["C_CONTIGUOUS"] = (
-        #    True if (self.strides[self.ndim - 1] == 1)
-        #    or (self.shape[self.ndim - 1] == 1)
-        #    else False)
-        self.flags["C_CONTIGUOUS"] = (
-            True if self.strides[self.ndim - 1] == 1 else False
+        _update_flags(
+            self.flags, shape=self.shape, strides=self.strides, ndim=self.ndim
         )
-        self.flags["F_CONTIGUOUS"] = True if self.strides[0] == 1 else False
         self.flags["OWNDATA"] = True
 
     # for creating views (unsafe!)
@@ -214,10 +206,9 @@ struct NDArray[dtype: DType = DType.float64](
         self._buf = OwnData(ptr=buffer.offset(offset))
         # Initialize information on memory layout
         self.flags = Dict[String, Bool]()
-        self.flags["C_CONTIGUOUS"] = (
-            True if self.strides[self.ndim - 1] == 1 else False
+        _update_flags(
+            self.flags, shape=self.shape, strides=self.strides, ndim=self.ndim
         )
-        self.flags["F_CONTIGUOUS"] = True if self.strides[0] == 1 else False
         self.flags["OWNDATA"] = False
 
     @always_inline("nodebug")

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -7,6 +7,7 @@ Implements N-DIMENSIONAL ARRAY UTILITY FUNCTIONS
 # ===----------------------------------------------------------------------=== #
 
 from algorithm.functional import vectorize
+from collections import Dict
 from python import Python, PythonObject
 from memory import UnsafePointer, memcpy
 from sys import simdwidthof
@@ -135,8 +136,22 @@ fn _get_offset(indices: VariadicList[Int], strides: VariadicList[Int]) -> Int:
     return idx
 
 
+fn _get_offset(indices: Tuple[Int, Int], strides: Tuple[Int, Int]) -> Int:
+    """
+    Get the index of matrix from a list of indices and strides.
+
+    Args:
+        indices: The list of indices.
+        strides: The strides of the indices.
+
+    Returns:
+        Offset of continuous memory layout.
+    """
+    return indices[0] * strides[0] + indices[1] * strides[1]
+
+
 # ===----------------------------------------------------------------------=== #
-# Funcitons to traverse a multi-dimensional array
+# Functions to traverse a multi-dimensional array
 # ===----------------------------------------------------------------------=== #
 
 
@@ -534,3 +549,38 @@ fn _list_of_flipped_range(n: Int) -> List[Int]:
     for i in range(n - 1, -1, -1):
         l.append(i)
     return l
+
+
+fn _update_flags(
+    mut flags: Dict[String, Bool],
+    shape: NDArrayShape,
+    strides: NDArrayStrides,
+    ndim: Int,
+) raises:
+    """
+    Update C_CONTIGUOUS and F_CONTIGUOUS of flags
+    according the shape and strides information.
+    """
+    flags["C_CONTIGUOUS"] = (
+        True if (strides[ndim - 1] == 1) or (shape[ndim - 1] == 1) else False
+    )
+    flags["F_CONTIGUOUS"] = (
+        True if (strides[0] == 1) or (shape[0] == 1) else False
+    )
+
+
+fn _update_flags(
+    mut flags: Dict[String, Bool],
+    shape: Tuple[Int, Int],
+    strides: Tuple[Int, Int],
+):
+    """
+    Update C_CONTIGUOUS and F_CONTIGUOUS of flags
+    according the shape and strides information.
+    """
+    flags["C_CONTIGUOUS"] = (
+        True if (strides[1] == 1) or (shape[1] == 1) else False
+    )
+    flags["F_CONTIGUOUS"] = (
+        True if (strides[0] == 1) or (shape[0] == 1) else False
+    )

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -23,7 +23,7 @@ fn all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
 
     @parameter
     fn cal_and[width: Int](i: Int):
-        res = res & A._buf.load[width=width](i).reduce_and()
+        res = res & A._buf.ptr.load[width=width](i).reduce_and()
 
     vectorize[cal_and, width](A.size)
     return res
@@ -133,7 +133,7 @@ fn any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
 
     @parameter
     fn cal_and[width: Int](i: Int):
-        res = res | A._buf.load[width=width](i).reduce_or()
+        res = res | A._buf.ptr.load[width=width](i).reduce_or()
 
     vectorize[cal_and, width](A.size)
     return res

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -264,7 +264,7 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]))
 
     if A.shape[0] == 1 or A.shape[1] == 1:
-        memcpy(B._buf, A._buf, A.size)
+        memcpy(B._buf.ptr, A._buf.ptr, A.size)
     else:
         for i in range(B.shape[0]):
             for j in range(B.shape[1]):

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -120,11 +120,11 @@ fn _max[
         )
 
     var max_index: Scalar[DType.index] = start
-    var max_value = A._buf[start]
+    var max_value = A._buf.ptr[start]
 
     for i in range(start, end + 1):
-        if A._buf[i] > max_value:
-            max_value = A._buf[i]
+        if A._buf.ptr[i] > max_value:
+            max_value = A._buf.ptr[i]
             max_index = i
 
     return (max_value, max_index)
@@ -266,11 +266,11 @@ fn _min[
         )
 
     var min_index: Scalar[DType.index] = start
-    var min_value = A._buf[start]
+    var min_value = A._buf.ptr[start]
 
     for i in range(start, end + 1):
-        if A._buf[i] < min_value:
-            min_value = A._buf[i]
+        if A._buf.ptr[i] < min_value:
+            min_value = A._buf.ptr[i]
             min_index = i
 
     return (min_value, min_index)

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -92,7 +92,7 @@ fn prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
 
     @parameter
     fn cal_vec[width: Int](i: Int):
-        res = res * A._buf.load[width=width](i).reduce_mul()
+        res = res * A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[cal_vec, width](A.size)
     return res
@@ -238,7 +238,7 @@ fn cumprod[dtype: DType](owned A: Matrix[dtype]) -> Matrix[dtype]:
     A.resize(shape=(1, A.size))
 
     for i in range(1, A.size):
-        A._buf[i] *= A._buf[i - 1]
+        A._buf.ptr[i] *= A._buf.ptr[i - 1]
 
     return A^
 

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -22,7 +22,7 @@ fn round[
     # It will be fixed in future.
 
     for i in range(A.size):
-        A._buf[i] = builtin_math.round(A._buf[i], ndigits=decimals)
+        A._buf.ptr[i] = builtin_math.round(A._buf.ptr[i], ndigits=decimals)
 
     return A^
 

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -104,7 +104,7 @@ fn sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
 
     @parameter
     fn cal_vec[width: Int](i: Int):
-        res = res + A._buf.load[width=width](i).reduce_add()
+        res = res + A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[cal_vec, width](A.size)
     return res
@@ -252,7 +252,7 @@ fn cumsum[dtype: DType](owned A: Matrix[dtype]) -> Matrix[dtype]:
     A.resize(shape=(1, A.size))
 
     for i in range(1, A.size):
-        A._buf[i] += A._buf[i - 1]
+        A._buf.ptr[i] += A._buf.ptr[i - 1]
 
     return A^
 

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -154,21 +154,39 @@ fn _sort_partition(
             ).format(left, right, pivot_index, A.size)
         )
 
-    var pivot_value = A._buf[pivot_index]
+    var pivot_value = A._buf.ptr[pivot_index]
 
-    A._buf[pivot_index], A._buf[right] = A._buf[right], A._buf[pivot_index]
-    I._buf[pivot_index], I._buf[right] = I._buf[right], I._buf[pivot_index]
+    A._buf.ptr[pivot_index], A._buf.ptr[right] = (
+        A._buf.ptr[right],
+        A._buf.ptr[pivot_index],
+    )
+    I._buf.ptr[pivot_index], I._buf.ptr[right] = (
+        I._buf.ptr[right],
+        I._buf.ptr[pivot_index],
+    )
 
     var store_index = left
 
     for i in range(left, right):
-        if A._buf[i] < pivot_value:
-            A._buf[store_index], A._buf[i] = A._buf[i], A._buf[store_index]
-            I._buf[store_index], I._buf[i] = I._buf[i], I._buf[store_index]
+        if A._buf.ptr[i] < pivot_value:
+            A._buf.ptr[store_index], A._buf.ptr[i] = (
+                A._buf.ptr[i],
+                A._buf.ptr[store_index],
+            )
+            I._buf.ptr[store_index], I._buf.ptr[i] = (
+                I._buf.ptr[i],
+                I._buf.ptr[store_index],
+            )
             store_index = store_index + 1
 
-    A._buf[store_index], A._buf[right] = A._buf[right], A._buf[store_index]
-    I._buf[store_index], I._buf[right] = I._buf[right], I._buf[store_index]
+    A._buf.ptr[store_index], A._buf.ptr[right] = (
+        A._buf.ptr[right],
+        A._buf.ptr[store_index],
+    )
+    I._buf.ptr[store_index], I._buf.ptr[right] = (
+        I._buf.ptr[right],
+        I._buf.ptr[store_index],
+    )
 
     return store_index
 
@@ -452,7 +470,7 @@ fn argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.index]:
     """
     var I = Matrix[DType.index](shape=(1, A.size))
     for i in range(I.size):
-        I._buf[i] = i
+        I._buf.ptr[i] = i
     var B = A.flatten()
     _sort_inplace(B, I, 0, A.size - 1)
 


### PR DESCRIPTION
1. Update the underlying data buffer of `Matrix` type to `OwnData`, aligned with `NDArray`.
2. Introduce an internal function `_update_flags` that determines the C/F-CONTINUOUS information from strides and shape of the array.
3. The "continuous" information should also be determined by shape of array.