### PR TITLE
[shape] Update `NDArrayShape`, making `size` a method

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -126,7 +126,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         self.ndim = shape.ndim
         self.shape = NDArrayShape(shape)
-        self.size = self.shape.size
+        self.size = self.shape.size_of_array()
         self.strides = NDArrayStrides(shape, order=order)
         self._buf = OwnData[dtype](self.size)
         # Initialize information on memory layout
@@ -180,7 +180,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         self.shape = NDArrayShape(shape)
         self.ndim = self.shape.ndim
-        self.size = self.shape.size
+        self.size = self.shape.size_of_array()
         self.strides = NDArrayStrides(strides=strides)
         self._buf = OwnData[dtype](self.size)
         memset_zero(self._buf.ptr, self.size)
@@ -202,7 +202,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.shape = shape
         self.strides = strides
         self.ndim = self.shape.ndim
-        self.size = self.shape.size
+        self.size = self.shape.size_of_array()
         self._buf = OwnData(ptr=buffer.offset(offset))
         # Initialize information on memory layout
         self.flags = Dict[String, Bool]()
@@ -2889,7 +2889,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var order = "C" if self.flags["C_CONTIGUOUS"] else "F"
 
-        if shape.size > self.size:
+        if shape.size_of_array() > self.size:
             var other = Self(shape=shape, order=order)
             memcpy(other._buf.ptr, self._buf.ptr, self.size)
             for i in range(self.size, other.size):
@@ -2898,7 +2898,7 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             self.shape = shape
             self.ndim = shape.ndim
-            self.size = shape.size
+            self.size = shape.size_of_array()
             self.strides = NDArrayStrides(shape, order=order)
 
     fn round(self) raises -> Self:

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -9,13 +9,11 @@ from memory import UnsafePointer, memcpy
 alias Shape = NDArrayShape
 
 
-@register_passable("trivial")
+@register_passable
 struct NDArrayShape(Stringable, Writable):
     """Implements the NDArrayShape."""
 
     # Fields
-    var size: Int
-    """Total number of elements of corresponding array."""
     var _buf: UnsafePointer[Int]
     """Data buffer."""
     var ndim: Int
@@ -30,7 +28,6 @@ struct NDArrayShape(Stringable, Writable):
             shape: Size of the array.
         """
         self.ndim = 1
-        self.size = shape
         self._buf = UnsafePointer[Int]().alloc(shape)
         self._buf.init_pointee_copy(shape)
 
@@ -42,12 +39,10 @@ struct NDArrayShape(Stringable, Writable):
         Args:
             shape: Variable number of integers representing the shape dimensions.
         """
-        self.size = 1
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            self.size *= shape[i]
 
     @always_inline("nodebug")
     fn __init__(out self, *shape: Int, size: Int) raises:
@@ -58,14 +53,11 @@ struct NDArrayShape(Stringable, Writable):
             shape: Variable number of integers representing the shape dimensions.
             size: The total number of elements in the array.
         """
-        self.size = size
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
-        var count: Int = 1
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            count *= shape[i]
-        if count != size:
+        if self.size_of_array() != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
@@ -76,12 +68,10 @@ struct NDArrayShape(Stringable, Writable):
         Args:
             shape: A list of integers representing the shape dimensions.
         """
-        self.size = 1
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            self.size *= shape[i]
 
     @always_inline("nodebug")
     fn __init__(out self, shape: List[Int], size: Int) raises:
@@ -92,16 +82,12 @@ struct NDArrayShape(Stringable, Writable):
             shape: A list of integers representing the shape dimensions.
             size: The specified size of the NDArrayShape.
         """
-        self.size = (
-            size  # maybe I should add a check here to make sure it matches
-        )
+
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
-        var count: Int = 1
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            count *= shape[i]
-        if count != size:
+        if self.size_of_array() != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
@@ -112,12 +98,10 @@ struct NDArrayShape(Stringable, Writable):
         Args:
             shape: A list of integers representing the shape dimensions.
         """
-        self.size = 1
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            self.size *= shape[i]
 
     @always_inline("nodebug")
     fn __init__(out self, shape: VariadicList[Int], size: Int) raises:
@@ -128,16 +112,12 @@ struct NDArrayShape(Stringable, Writable):
             shape: A list of integers representing the shape dimensions.
             size: The specified size of the NDArrayShape.
         """
-        self.size = (
-            size  # maybe I should add a check here to make sure it matches
-        )
+
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
-        var count: Int = 1
         for i in range(self.ndim):
             (self._buf + i).init_pointee_copy(shape[i])
-            count *= shape[i]
-        if count != size:
+        if self.size_of_array() != size:
             raise Error("Cannot create NDArray: shape and size mismatch")
 
     @always_inline("nodebug")
@@ -148,10 +128,21 @@ struct NDArrayShape(Stringable, Writable):
         Args:
             shape: Another NDArrayShape to initialize from.
         """
-        self.size = shape.size
         self.ndim = shape.ndim
         self._buf = UnsafePointer[Int]().alloc(shape.ndim)
         memcpy(self._buf, shape._buf, shape.ndim)
+
+    @always_inline("nodebug")
+    fn __copyinit__(out self, other: Self):
+        """
+        Initializes the NDArrayShape from another NDArrayShape.
+
+        Args:
+            other: Another NDArrayShape to initialize from.
+        """
+        self.ndim = other.ndim
+        self._buf = UnsafePointer[Int]().alloc(other.ndim)
+        memcpy(self._buf, other._buf, other.ndim)
 
     @always_inline("nodebug")
     fn __getitem__(self, index: Int) raises -> Int:
@@ -229,6 +220,19 @@ struct NDArrayShape(Stringable, Writable):
         return False
 
     # ===-------------------------------------------------------------------===#
+    # Other methods
+    # ===-------------------------------------------------------------------===#
+
+    fn size_of_array(self) -> Int:
+        """
+        Returns the total number of elements in the array.
+        """
+        var size = 1
+        for i in range(self.ndim):
+            size *= self._buf[i]
+        return size
+
+    # ===-------------------------------------------------------------------===#
     # Other private methods
     # ===-------------------------------------------------------------------===#
 
@@ -294,7 +298,6 @@ struct NDArrayShape(Stringable, Writable):
             count=self.ndim - axis - 1,
         )
         res.ndim = self.ndim - 1
-        res.size = self.size // self._buf[axis]
         res._buf = buffer
         return res
 

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -8,7 +8,7 @@ from utils import Variant
 from memory import UnsafePointer, memcpy
 
 
-@register_passable("trivial")
+@register_passable
 struct NDArrayStrides(Stringable):
     """Implements the NDArrayStrides."""
 
@@ -135,6 +135,12 @@ struct NDArrayStrides(Stringable):
                 "Invalid order: Only C style row major `C` & Fortran style"
                 " column major `F` are supported"
             )
+
+    @always_inline("nodebug")
+    fn __copyinit__(out self, other: Self):
+        self.ndim = other.ndim
+        self._buf = UnsafePointer[Int]().alloc(other.ndim)
+        memcpy(self._buf, other._buf, other.ndim)
 
     @always_inline("nodebug")
     fn __getitem__(self, index: Int) raises -> Int:

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -89,7 +89,7 @@ fn reshape[
         Array of the same data with a new shape.
     """
 
-    if A.size != shape.size:
+    if A.size != shape.size_of_array():
         raise Error("Cannot reshape: Number of elements do not match.")
 
     var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"


### PR DESCRIPTION
This PR makes some updates to the `NDArrayShape` and `NDArrayStrides`.

1. Make `NDArrayShape` and `NDArrayStrides` `@register_passable` instead of `@register_passable("trivial")`.

Reason: This is to prevent implicit copy by reference. For example, before change, the following code is not what we want and is prone to mistakes.

```mojo
>>>var a = nm.NDArrayShape(1, 2, 3)
>>>var b = a
>>>b[0] = 10
>>>print(a)
# Shape: [10, 2, 3]
# Not what we want
```

After change, this is avoided.

```mojo
>>>var a = nm.NDArrayShape(1, 2, 3)
>>>var b = a
>>>b[0] = 10
>>>print(a)
# Shape: [1, 2, 3]
# It is better now
```

2. Change the `size` property into `size_of_array` method for `NDArrayShape`.

Reason: The size information is only used when we want to know the size of array from the shape. If it is a property, it must be calculated at the initialization of the shape, causing unnecessary costs. Moreover, it makes it difficult when we want to change the ith-value of the `Shape`, or making a `Shape` object by joining two `shapes`, because the size is not automatically updated.

By using `size_of_array` method, we ensure that the value is calculated only when it is needed.