### PR TITLE
[ndarray] Better string presentation and print for `NDArray`

### DIFF
--- a/numojo/core/datatypes.mojo
+++ b/numojo/core/datatypes.mojo
@@ -207,3 +207,33 @@ struct TypeCoercion:
         elif T1.is_floating_point() and T2.is_integral():
             return TypeCoercion.coerce_mixed[T2, T1]()
         return T1
+
+
+fn _concise_dtype_str(dtype: DType) -> String:
+    """Returns a concise string representation of the data type."""
+    if dtype == i8:
+        return "i8"
+    elif dtype == i16:
+        return "i16"
+    elif dtype == i32:
+        return "i32"
+    elif dtype == i64:
+        return "i64"
+    elif dtype == isize:
+        return "index"
+    elif dtype == u8:
+        return "u8"
+    elif dtype == u16:
+        return "u16"
+    elif dtype == u32:
+        return "u32"
+    elif dtype == u64:
+        return "u64"
+    elif dtype == f16:
+        return "f16"
+    elif dtype == f32:
+        return "f32"
+    elif dtype == f64:
+        return "f64"
+    else:
+        return "Unknown"

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2100,6 +2100,7 @@ struct NDArray[dtype: DType = DType.float64](
         offset: Int,
         seperator: String = "\t",
         padding: String = "\t",
+        items_to_display: Int = 6,
     ) raises -> String:
         """
         Convert the array to a string.
@@ -2109,13 +2110,14 @@ struct NDArray[dtype: DType = DType.float64](
             offset: The offset of the current dimension.
             seperator: The seperator between elements.
             padding: The padding between elements and brackets.
+            items_to_display: The number of items to display.
         """
         if self.ndim == 0:
             return str(self.item(0))
         if dimension == self.ndim - 1:
             var result: String = String("[") + padding
             var number_of_items = self.shape[dimension]
-            if number_of_items <= 6:  # Print all items
+            if number_of_items <= items_to_display:  # Print all items
                 for i in range(number_of_items):
                     result = (
                         result
@@ -2127,17 +2129,19 @@ struct NDArray[dtype: DType = DType.float64](
                         result = result + seperator
                 result = result + padding
             else:  # Print first 3 and last 3 items
-                for i in range(3):
+                for i in range(items_to_display // 2):
                     result = (
                         result
                         + self.load[width=1](
                             offset + i * self.strides[dimension]
                         ).__str__()
                     )
-                    if i < (3 - 1):
+                    if i < (items_to_display // 2 - 1):
                         result = result + seperator
-                result = result + padding + "..." + padding
-                for i in range(number_of_items - 3, number_of_items):
+                result = result + seperator + "..." + seperator
+                for i in range(
+                    number_of_items - items_to_display // 2, number_of_items
+                ):
                     result = (
                         result
                         + self.load[width=1](
@@ -2152,7 +2156,7 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             var result: String = str("[")
             var number_of_items = self.shape[dimension]
-            if number_of_items <= 6:  # Print all items
+            if number_of_items <= items_to_display:  # Print all items
                 for i in range(number_of_items):
                     if i == 0:
                         result = result + self._array_to_string(
@@ -2160,6 +2164,7 @@ struct NDArray[dtype: DType = DType.float64](
                             offset + i * self.strides[dimension].__int__(),
                             seperator,
                             padding,
+                            items_to_display,
                         )
                     if i > 0:
                         result = (
@@ -2170,18 +2175,20 @@ struct NDArray[dtype: DType = DType.float64](
                                 offset + i * self.strides[dimension].__int__(),
                                 seperator,
                                 padding,
+                                items_to_display,
                             )
                         )
                     if i < (number_of_items - 1):
                         result = result + "\n"
             else:  # Print first 3 and last 3 items
-                for i in range(3):
+                for i in range(items_to_display // 2):
                     if i == 0:
                         result = result + self._array_to_string(
                             dimension + 1,
                             offset + i * self.strides[dimension].__int__(),
                             seperator,
                             padding,
+                            items_to_display,
                         )
                     if i > 0:
                         result = (
@@ -2192,12 +2199,15 @@ struct NDArray[dtype: DType = DType.float64](
                                 offset + i * self.strides[dimension].__int__(),
                                 seperator,
                                 padding,
+                                items_to_display,
                             )
                         )
                     if i < (number_of_items - 1):
                         result += "\n"
                 result = result + "...\n"
-                for i in range(number_of_items - 3, number_of_items):
+                for i in range(
+                    number_of_items - items_to_display // 2, number_of_items
+                ):
                     result = (
                         result
                         + str(" ") * (dimension + 1)
@@ -2206,6 +2216,7 @@ struct NDArray[dtype: DType = DType.float64](
                             offset + i * self.strides[dimension].__int__(),
                             seperator,
                             padding,
+                            items_to_display,
                         )
                     )
                     if i < (number_of_items - 1):


### PR DESCRIPTION
This PR aims to improve the string presentation of ndarray.

## A better `_array_to_string` method

Now there are three more arguments:
1. `separator` controls the symbols between items.
2. `padding` controls the symbols between items and brackets.
3. `items_to_display` controls number of items to print

Example:
```console
>>>var b = nm.arange[nm.i8](10, 46).reshape(Shape(6, 6))
>>>print(b._array_to_string(0, 0, ",", " ", items_to_display=4))
[[ 10,11,...,14,15 ]
 [ 16,17,...,20,21 ]
...
 [ 34,35,...,38,39 ]
 [ 40,41,...,44,45 ]]
```

## Modified `str`, `repr`, and `write_to`

Now `str`, `repr`, and `write_to` are modified to show different things.

`str(array)` only print the items.

```console
[[      10      11      12      13      14      15       ]
 [      16      17      18      19      20      21       ]
 [      22      23      24      25      26      27       ]
 [      28      29      30      31      32      33       ]
 [      34      35      36      37      38      39       ]
 [      40      41      42      43      44      45       ]]
```

`print(array)` shows one more line with information of array
```console
[[      10      11      12      13      14      15       ]
 [      16      17      18      19      20      21       ]
 [      22      23      24      25      26      27       ]
 [      28      29      30      31      32      33       ]
 [      34      35      36      37      38      39       ]
 [      40      41      42      43      44      45       ]]
2D-array  Shape(8,10)  Strides(10,1)  DType: i8  C-cont: True  F-cont: False  own data: True
```

`repr(array)` shows a string that can be use to construct the array:

```console
numojo.array[i8](
"""
[[10, 11, 12, 13, 14, 15]
 [16, 17, 18, 19, 20, 21]
 [22, 23, 24, 25, 26, 27]
 [28, 29, 30, 31, 32, 33]
 [34, 35, 36, 37, 38, 39]
 [40, 41, 42, 43, 44, 45]]
"""
)
```