### PR TITLE
[formatting] Auto-adjusted width of formatted values during `print`

### DIFF
--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -1533,18 +1533,16 @@ struct ComplexNDArray[
                         result = result + seperator
                 result = result + padding
             else:  # Print first 3 and last 3 items
-                for i in range(edge_items // 2):
+                for i in range(edge_items):
                     var value = self.load[width=1](
                         offset + i * self.strides[dimension]
                     )
                     var formatted_value = format_value(value, print_options)
                     result = result + formatted_value
-                    if i < (edge_items // 2 - 1):
+                    if i < (edge_items - 1):
                         result = result + seperator
                 result = result + seperator + "..." + seperator
-                for i in range(
-                    number_of_items - edge_items // 2, number_of_items
-                ):
+                for i in range(number_of_items - edge_items, number_of_items):
                     var value = self.load[width=1](
                         offset + i * self.strides[dimension]
                     )
@@ -1579,7 +1577,7 @@ struct ComplexNDArray[
                     if i < (number_of_items - 1):
                         result = result + "\n"
             else:  # Print first 3 and last 3 items
-                for i in range(edge_items // 2):
+                for i in range(edge_items):
                     if i == 0:
                         result = result + self._array_to_string(
                             dimension + 1,
@@ -1599,9 +1597,7 @@ struct ComplexNDArray[
                     if i < (number_of_items - 1):
                         result += "\n"
                 result = result + "...\n"
-                for i in range(
-                    number_of_items - edge_items // 2, number_of_items
-                ):
+                for i in range(number_of_items - edge_items, number_of_items):
                     result = (
                         result
                         + str(" ") * (dimension + 1)

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -92,7 +92,7 @@ fn arange[
     var size = int(stop)
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(size))
     for i in range(size):
-        (result._buf.ptr + i).init_pointee_copy(i)
+        (result._buf.ptr + i).init_pointee_copy(Scalar[dtype](i))
 
     return result
 

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -8,7 +8,7 @@ alias DEFAULT_PRECISION = 4
 alias DEFAULT_SUPPRESS_SMALL = False
 alias DEFAULT_SEPARATOR = " "
 alias DEFAULT_PADDING = ""
-alias DEFAULT_EDGE_ITEMS = 6
+alias DEFAULT_EDGE_ITEMS = 3
 alias DEFAULT_THRESHOLD = 10
 alias DEFAULT_LINE_WIDTH = 75
 alias DEFAULT_SIGN = False
@@ -183,7 +183,7 @@ fn set_printoptions(
     )
 
 
-# TODO: fix the problem where precision > number of digits in the mantissa results in a not so exact value.
+# FIXME: fix the problem where precision > number of digits in the mantissa results in a not so exact value.
 fn format_floating_scientific[
     dtype: DType = DType.float64
 ](x: Scalar[dtype], precision: Int = 10, sign: Bool = False) raises -> String:
@@ -246,7 +246,7 @@ fn format_floating_scientific[
 
         if x < 0:
             return (
-                String("-{0}{1}")
+                String("{0}{1}")
                 .format(result, exponent_str)
                 .rjust(formatted_width)
             )
@@ -272,7 +272,8 @@ fn format_floating_precision[
     Args:
         value: The value to format.
         precision: The number of decimal places to include.
-        sign: Whether to include the sign of the float in the result. Defaults to False.
+        sign: Whether to include the sign of the float in the result.
+            Defaults to False.
 
     Returns:
         The formatted value as a string.
@@ -304,6 +305,8 @@ fn format_floating_precision[
     var fractional_part = abs(rounded_value - integer_part)
 
     var result = str(integer_part)
+    if Scalar[dtype](0) > rounded_value > Scalar[dtype](-1):
+        result = "-" + result
 
     if precision > 0:
         result += "."


### PR DESCRIPTION
As a follow-up of PR#190, this PR makes the width of formatting automatically adapted to the numbers to be printed.

Also fix a bug where values between 0 and -1 are not properly printed (the minus sign are not printed)

(For future: when the bug in the scientific formatting is fixed, the values can be formatted as scientific numbers if their length is over 14 letter.)

See the comparison with numpy:

```mojo
fn main() raises:
    var a = nm.random.randn[f64](100, 100) * 1000
    print(a)
    print(a.to_numpy())

    var b = nm.arange[i32](10000).reshape(Shape(100, 100))
    print(b)
    print(b.to_numpy())

```

```console
# numojo
[[ -336.1702  -190.7101   300.1279 ...   509.2278   566.8533 -1450.7406]
 [ -856.5637 -1204.5281  1192.1241 ...  1555.7254   314.0418  -764.8215]
 [ -314.5754   607.5819  1085.7264 ...  1106.8583  -169.4235   297.6994]
...
 [ 1511.9094  1559.1313  2555.5482 ...  1048.1458   806.3315   367.3428]
 [  621.0625  -479.5163   255.7383 ...  -897.5236  2622.2105   698.5209]
 [ -762.2286   -82.9468   582.8229 ...   834.7087   343.3161 -1647.0168]]
2D-array  Shape(100,100)  Strides(100,1)  DType: f64  C-cont: True  F-cont: False  own data: True

#numpy
[[ -336.1702  -190.7102   300.1279 ...   509.2279   566.8534 -1450.7406]
 [ -856.5637 -1204.5282  1192.1242 ...  1555.7254   314.0419  -764.8215]
 [ -314.5755   607.582   1085.7265 ...  1106.8583  -169.4236   297.6994]
 ...
 [ 1511.9094  1559.1313  2555.5483 ...  1048.1459   806.3316   367.3429]
 [  621.0625  -479.5164   255.7383 ...  -897.5237  2622.2105   698.521 ]
 [ -762.2286   -82.9469   582.8229 ...   834.7088   343.3161 -1647.0168]]
```

```console
# numojo
[[   0    1    2 ...   97   98   99]
 [ 100  101  102 ...  197  198  199]
 [ 200  201  202 ...  297  298  299]
...
 [9700 9701 9702 ... 9797 9798 9799]
 [9800 9801 9802 ... 9897 9898 9899]
 [9900 9901 9902 ... 9997 9998 9999]]
2D-array  Shape(100,100)  Strides(100,1)  DType: i32  C-cont: True  F-cont: False  own data: True

#numpy
[[   0    1    2 ...   97   98   99]
 [ 100  101  102 ...  197  198  199]
 [ 200  201  202 ...  297  298  299]
 ...
 [9700 9701 9702 ... 9797 9798 9799]
 [9800 9801 9802 ... 9897 9898 9899]
 [9900 9901 9902 ... 9997 9998 9999]]
```