### PR TITLE
[io][formatting] Corrected scientific formatting and do this when `formatted_width > 14`

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2315,19 +2315,18 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             formatted_width = number_of_digits + int(negative_sign)
 
-        # FIXME: When format_floating_scientific is fixed
-        # change the value to 14
-        if formatted_width <= 99:
+        if formatted_width <= 14:
             print_options.formatted_width = formatted_width
         else:
             print_options.float_format = "scientific"
+            print_options.formatted_width = 7 + print_options.precision
 
         if self.ndim == 0:
             return str(self.item(0))
         if dimension == self.ndim - 1:
             var result: String = String("[") + padding
             var number_of_items = self.shape[dimension]
-            if number_of_items <= edge_items:  # Print all items
+            if number_of_items <= edge_items * 2:  # Print all items
                 for i in range(number_of_items):
                     var value = self.load[width=1](
                         offset + i * self.strides[dimension]
@@ -2361,7 +2360,7 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             var result: String = str("[")
             var number_of_items = self.shape[dimension]
-            if number_of_items <= edge_items:  # Print all items
+            if number_of_items <= edge_items * 2:  # Print all items
                 for i in range(number_of_items):
                     if i == 0:
                         result = result + self._array_to_string(

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2256,7 +2256,7 @@ struct NDArray[dtype: DType = DType.float64](
         self,
         dimension: Int,
         offset: Int,
-        mut print_options: PrintOptions,
+        owned print_options: PrintOptions,
     ) raises -> String:
         """
         Convert the array to a string.
@@ -2273,11 +2273,17 @@ struct NDArray[dtype: DType = DType.float64](
         # The following code get the max value and the min value
         # to determine the digits before decimals and the negative sign
         # and then determine the formatted withd
-        var negative_sign: Bool
-        var number_of_digits: Int
-        var formatted_width: Int
-        var max_value: Scalar[dtype] = self._buf.ptr[]
-        var min_value: Scalar[dtype] = self._buf.ptr[]
+        var negative_sign: Bool = False  # whether there should be a negative sign
+        var number_of_digits: Int  # number of digits before or after decimal point
+        var number_of_digits_small_values: Int  # number of digits after decimal point for small values
+        var formatted_width: Int  # formatted width based on precision and digits before decimal points
+        var max_value: Scalar[dtype] = abs(
+            self._buf.ptr[]
+        )  # maximum absolute value of the items
+        var min_value: Scalar[dtype] = abs(
+            self._buf.ptr[]
+        )  # minimum absolute value of the items
+        var val: Scalar[dtype]  # storage of value of the item
 
         var skip: Bool
         for index in range(self.size):
@@ -2293,18 +2299,24 @@ struct NDArray[dtype: DType = DType.float64](
                     continue
             if skip:
                 continue
+
+            val = self._buf.ptr[_get_offset(indices, self.strides)]
+            if val < 0:
+                negative_sign = True
             max_value = max(
-                max_value, self._buf.ptr[_get_offset(indices, self.strides)]
+                max_value,
+                abs(val),
             )
             min_value = min(
-                min_value, self._buf.ptr[_get_offset(indices, self.strides)]
+                min_value,
+                abs(val),
             )
-        if min_value < 0:
-            negative_sign = True
-        else:
-            negative_sign = False
-        max_value = max(max_value, abs(min_value))
-        number_of_digits = int(log10(float(max_value)) + 1)
+        number_of_digits = max(
+            int(log10(float(max_value))) + 1,
+            abs(int(log10(float(min_value)))) + 1,
+        )
+        number_of_digits_small_values = abs(int(log10(float(min_value)))) + 1
+
         if dtype.is_floating_point():
             formatted_width = (
                 print_options.precision
@@ -2315,8 +2327,12 @@ struct NDArray[dtype: DType = DType.float64](
         else:
             formatted_width = number_of_digits + int(negative_sign)
 
-        if formatted_width <= 14:
+        # If the number is not too wide,
+        # or digits after decimal point is not many
+        # format it as a floating point.
+        if (formatted_width <= 14) and (number_of_digits_small_values <= 2):
             print_options.formatted_width = formatted_width
+        # Otherwise, format it as a scientific number.
         else:
             print_options.float_format = "scientific"
             print_options.formatted_width = 7 + print_options.precision

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -221,7 +221,7 @@ fn format_floating_scientific[
         var exponent_threshold = GLOBAL_PRINT_OPTIONS.exponent_threshold
         var formatted_width = GLOBAL_PRINT_OPTIONS.formatted_width
 
-        if x == 0.0:
+        if x == 0:
             if sign:
                 var result: String = "+0." + "0" * precision + "e+00"
                 return result.rjust(formatted_width)
@@ -230,7 +230,7 @@ fn format_floating_scientific[
                 return result.rjust(formatted_width)
 
         var power: Int = int(mt.log10(abs(x)))
-        if Scalar[dtype](0.0) < x < Scalar[dtype](1.0):
+        if Scalar[dtype](0.0) < abs(x) < Scalar[dtype](1.0):
             power -= 1
         var mantissa: Scalar[dtype] = x / pow(10.0, power).cast[dtype]()
         var mantissa_without_sign_string = str(abs(mantissa))

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -230,7 +230,7 @@ fn format_floating_scientific[
                 return result.rjust(formatted_width)
 
         var power: Int = int(mt.log10(abs(x)))
-        if x < 1:
+        if Scalar[dtype](0.0) < x < Scalar[dtype](1.0):
             power -= 1
         var mantissa: Scalar[dtype] = x / pow(10.0, power).cast[dtype]()
         var mantissa_without_sign_string = str(abs(mantissa))

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -190,6 +190,9 @@ fn format_floating_scientific[
     """
     Format a float in scientific notation.
 
+    Notes: A scientific notation takes the form `-a.bbbbe+ii`. It will take
+    `7 + precision` letters in total.
+
     Parameters:
         dtype: Datatype of the float.
 
@@ -219,45 +222,49 @@ fn format_floating_scientific[
         var formatted_width = GLOBAL_PRINT_OPTIONS.formatted_width
 
         if x == 0.0:
-            var result: String = "0." + "0" * precision
-            return result.rjust(formatted_width)
+            if sign:
+                var result: String = "+0." + "0" * precision + "e+00"
+                return result.rjust(formatted_width)
+            else:
+                var result: String = " 0." + "0" * precision + "e+00"
+                return result.rjust(formatted_width)
 
         var power: Int = int(mt.log10(abs(x)))
+        if x < 1:
+            power -= 1
         var mantissa: Scalar[dtype] = x / pow(10.0, power).cast[dtype]()
-        var m_string: String = String("{0}").format(mantissa)
-        var result: String = m_string[0] + "."
+        var mantissa_without_sign_string = str(abs(mantissa))
 
-        for i in range(2, precision + 2):
-            if i >= len(m_string):
-                result += "0"
+        var result: String
+        if x < 0:
+            result = "-" + mantissa_without_sign_string[: 2 + precision]
+        else:
+            if sign:
+                result = "+" + mantissa_without_sign_string[: 2 + precision]
             else:
-                result += m_string[i]
+                result = " " + mantissa_without_sign_string[: 2 + precision]
 
         if suppress_scientific and abs(power) <= exponent_threshold:
             return format_floating_precision(x, precision, sign).rjust(
                 formatted_width
             )
 
-        var exponent_str: String
+        var exponent_string: String
         if power < 0:
-            exponent_str = String("e{0}").format(power)
+            if power > -10:
+                exponent_string = String("e-0{0}").format(-power)
+            else:
+                exponent_string = String("e-{0}").format(-power)
         else:
-            exponent_str = String("e+{0}").format(power)
+            if power < 10:
+                exponent_string = String("e+0{0}").format(power)
+            else:
+                exponent_string = String("e+{0}").format(power)
 
-        if x < 0:
-            return (
-                String("{0}{1}")
-                .format(result, exponent_str)
-                .rjust(formatted_width)
-            )
-        if sign:
-            return (
-                String("+{0}{1}")
-                .format(result, exponent_str)
-                .rjust(formatted_width)
-            )
         return (
-            String("{0}{1}").format(result, exponent_str).rjust(formatted_width)
+            String("{0}{1}")
+            .format(result, exponent_string)
+            .rjust(formatted_width)
         )
     except:
         raise Error("Failed to format float in scientific notation.")


### PR DESCRIPTION
Follow-up on PR #191. Align the printing behavior with numpy.

1. Corrected scientific formatting on negative values and value smaller than 1.
2. Print in scientific format when `formatted_width > 14` or values are below 1.

Example of very large values:
```mojo
import numojo as nm
from numojo.prelude import *
fn main() raises:
    a = nm.random.randn[f64](4, 4) * 100000000
    print(a)
    print(a.to_numpy())
```

```console
# numojo
[[ 2.1172e+07 -1.6633e+08 -5.1568e+07 -1.6496e+08]
 [ 1.6345e+06 -9.2600e+07 -7.0699e+07  9.9001e+07]
 [ 2.2619e+07 -1.1670e+08 -3.3015e+07 -3.8808e+07]
 [-1.1040e+08 -6.4122e+07  8.5955e+07  7.7721e+07]]
2D-array  Shape(4,4)  Strides(4,1)  DType: f64  C-cont: True  F-cont: False  own data: True

# numpy
[[ 2.1172e+07 -1.6634e+08 -5.1569e+07 -1.6497e+08]
 [ 1.6345e+06 -9.2601e+07 -7.0700e+07  9.9002e+07]
 [ 2.2619e+07 -1.1670e+08 -3.3016e+07 -3.8808e+07]
 [-1.1040e+08 -6.4122e+07  8.5956e+07  7.7721e+07]]

```

Example of very small values:
```mojo
import numojo as nm
from numojo.prelude import *
fn main() raises:
    a = nm.random.randn[f64](4, 4) / 100000000
    print(a)
    print(a.to_numpy())
```

```console
# numojo
[[ 5.5941e-09 -1.3932e-09  9.3190e-09  2.3805e-09]
 [-4.3917e-09 -5.8906e-09  1.5368e-08  1.3708e-09]
 [-1.3461e-09  6.9247e-10  1.3255e-08 -2.3566e-08]
 [-1.1234e-08  3.4609e-09 -1.7616e-08  3.7567e-09]]
2D-array  Shape(4,4)  Strides(4,1)  DType: f64  C-cont: True  F-cont: False  own data: True

# numpy
[[ 5.5941e-09 -1.3932e-09  9.3190e-09  2.3806e-09]
 [-4.3918e-09 -5.8907e-09  1.5369e-08  1.3708e-09]
 [-1.3462e-09  6.9248e-10  1.3256e-08 -2.3566e-08]
 [-1.1234e-08  3.4610e-09 -1.7617e-08  3.7567e-09]]
```

Example of normal big values:
```mojo
    a = nm.random.randn[f64](4, 4) * 1000
    print(a)
    print(a.to_numpy())
```

```console
# numojo
[[-1191.9973  -278.6145  -368.1659  1284.6693]
 [  493.1211   328.1780  -391.6168   775.5266]
 [ -231.8257  -301.7876  -346.1492  -553.1244]
 [-1132.1927 -1986.8903    13.4967  -391.9820]]
2D-array  Shape(4,4)  Strides(4,1)  DType: f64  C-cont: True  F-cont: False  own data: True

# numpy
[[-1191.9974  -278.6146  -368.1659  1284.6694]
 [  493.1211   328.1781  -391.6168   775.5266]
 [ -231.8258  -301.7877  -346.1492  -553.1244]
 [-1132.1927 -1986.8904    13.4967  -391.982 ]]
```

Example of normal small values:
```mojo
    a = nm.random.randn[f64](4, 4) / 1000
    print(a)
    print(a.to_numpy())
```

```console
# numojo
[[ 4.1938e-04 -5.0756e-04 -1.4611e-03 -1.7147e-05]
 [-6.7489e-04  1.8315e-03  8.8450e-05 -3.9422e-04]
 [-2.2025e-04 -3.9415e-04 -5.6021e-04  3.9770e-04]
 [ 4.4196e-04 -4.9839e-04 -9.3025e-04 -5.2764e-04]]
2D-array  Shape(4,4)  Strides(4,1)  DType: f64  C-cont: True  F-cont: False  own data: True

# numpy
[[ 4.1939e-04 -5.0757e-04 -1.4612e-03 -1.7148e-05]
 [-6.7489e-04  1.8316e-03  8.8451e-05 -3.9423e-04]
 [-2.2025e-04 -3.9416e-04 -5.6021e-04  3.9771e-04]
 [ 4.4196e-04 -4.9840e-04 -9.3026e-04 -5.2765e-04]]
```
