### PR TITLE
[manipulation routines] Implement` broadcast_to()` for `NDArray`

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install magic
         run: |
-          curl -ssL https://magic.modular.com/ff414efd-16ac-4bf3-8efc-50b059272ab6 | bash
+          curl -ssL https://magic.modular.com/deb181c4-455c-4abe-a263-afcff49ccf67 | bash
       
       - name: Add path
         run: |

--- a/.github/workflows/test_pre_commit.yaml
+++ b/.github/workflows/test_pre_commit.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install magic
         run: |
-          curl -ssL https://magic.modular.com/ff414efd-16ac-4bf3-8efc-50b059272ab6 | bash
+          curl -ssL https://magic.modular.com/deb181c4-455c-4abe-a263-afcff49ccf67 | bash
     
       - name: Add path
         run: |

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -194,6 +194,7 @@ from numojo.routines.manipulation import (
     reshape,
     ravel,
     transpose,
+    broadcast_to,
     flip,
 )
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -75,6 +75,7 @@ from numojo.routines.manipulation import reshape, ravel
 #       RawData type is just a wrapper of `UnsafePointer`.
 #       RefData type has an extra property `indices`: getitem(i) -> A[I[i]].
 # TODO: Rename some variables or methods that should not be exposed to users.
+# TODO: Remove 0-d array. Raise errors if operations result in 0-d array.
 # ===----------------------------------------------------------------------===#
 
 
@@ -2323,10 +2324,7 @@ struct NDArray[dtype: DType = DType.float64](
                 min_value,
                 abs(val),
             )
-        number_of_digits = max(
-            int(log10(float(max_value))) + 1,
-            abs(int(log10(float(min_value)))) + 1,
-        )
+        number_of_digits = int(log10(float(max_value))) + 1
         number_of_digits_small_values = abs(int(log10(float(min_value)))) + 1
 
         if dtype.is_floating_point():

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -20,9 +20,11 @@ from numojo.prelude import *
 ```
 """
 
-from numojo.core.ndarray import NDArray
-from numojo.core.matrix import Matrix
+import numojo as nm
+
 from numojo.core.item import Item, item
+from numojo.core.matrix import Matrix
+from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import Shape, NDArrayShape
 
 from numojo.core.complex.complex_dtype import CDType

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -1,6 +1,12 @@
+# ===----------------------------------------------------------------------=== #
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+
 """
 Array manipulation routines.
-
 """
 
 from memory import UnsafePointer, memcpy
@@ -13,6 +19,11 @@ from numojo.core.ndstrides import NDArrayStrides
 import numojo.core.matrix as matrix
 from numojo.core.matrix import Matrix
 from numojo.core.utility import _list_of_flipped_range
+
+# ===----------------------------------------------------------------------=== #
+# TODO:
+# - When `OwnData` is supported, re-write `broadcast_to()`.`
+# ===----------------------------------------------------------------------=== #
 
 # ===----------------------------------------------------------------------=== #
 # Basic operations
@@ -269,6 +280,81 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
         for i in range(B.shape[0]):
             for j in range(B.shape[1]):
                 B._store(i, j, A._load(j, i))
+    return B^
+
+
+# ===----------------------------------------------------------------------=== #
+# Changing number of dimensions
+# ===----------------------------------------------------------------------=== #
+
+
+fn broadcast_to[
+    dtype: DType
+](A: Matrix[dtype], shape: Tuple[Int, Int]) raises -> Matrix[dtype]:
+    """
+    Broadcasts the vector to the given shape.
+
+    Example:
+
+    ```console
+    > from numojo import Matrix
+    > a = Matrix.fromstring("1 2 3", shape=(1, 3))
+    > print(mat.broadcast_to(a, (3, 3)))
+    [[1.0   2.0     3.0]
+     [1.0   2.0     3.0]
+     [1.0   2.0     3.0]]
+    > a = Matrix.fromstring("1 2 3", shape=(3, 1))
+    > print(mat.broadcast_to(a, (3, 3)))
+    [[1.0   1.0     1.0]
+     [2.0   2.0     2.0]
+     [3.0   3.0     3.0]]
+    > a = Matrix.fromstring("1", shape=(1, 1))
+    > print(mat.broadcast_to(a, (3, 3)))
+    [[1.0   1.0     1.0]
+     [1.0   1.0     1.0]
+     [1.0   1.0     1.0]]
+    > a = Matrix.fromstring("1 2", shape=(1, 2))
+    > print(mat.broadcast_to(a, (1, 2)))
+    [[1.0   2.0]]
+    > a = Matrix.fromstring("1 2 3 4", shape=(2, 2))
+    > print(mat.broadcast_to(a, (4, 2)))
+    Unhandled exception caught during execution: Cannot broadcast shape 2x2 to shape 4x2!
+    ```
+    """
+
+    var B = Matrix[dtype](shape)
+    if (A.shape[0] == shape[0]) and (A.shape[1] == shape[1]):
+        B = A
+    elif (A.shape[0] == 1) and (A.shape[1] == 1):
+        B = Matrix.full[dtype](shape, A[0, 0])
+    elif (A.shape[0] == 1) and (A.shape[1] == shape[1]):
+        for i in range(shape[0]):
+            memcpy(
+                dest=B._buf.ptr.offset(shape[1] * i),
+                src=A._buf.ptr,
+                count=shape[1],
+            )
+    elif (A.shape[1] == 1) and (A.shape[0] == shape[0]):
+        for i in range(shape[0]):
+            for j in range(shape[1]):
+                B._store(i, j, A._buf.ptr[i])
+    else:
+        var message = String(
+            "Cannot broadcast shape {}x{} to shape {}x{}!"
+        ).format(A.shape[0], A.shape[1], shape[0], shape[1])
+        raise Error(message)
+    return B^
+
+
+fn broadcast_to[
+    dtype: DType
+](A: Scalar[dtype], shape: Tuple[Int, Int]) raises -> Matrix[dtype]:
+    """
+    Broadcasts the scalar to the given shape.
+    """
+
+    var B = Matrix[dtype](shape)
+    B = Matrix.full[dtype](shape, A)
     return B^
 
 

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -75,3 +75,19 @@ def test_transpose():
         np.transpose(Anp, [1, 3, 0, 2]),
         "4-d `transpose` with arbitrary `axes` is broken.",
     )
+
+
+def test_broadcast():
+    var np = Python.import_module("numpy")
+    var a = nm.random.rand(Shape(2, 1, 3))
+    var Anp = a.to_numpy()
+    check(
+        nm.broadcast_to(a, Shape(2, 2, 3)),
+        np.broadcast_to(a.to_numpy(), (2, 2, 3)),
+        "`broadcast_to` fails.",
+    )
+    check(
+        nm.broadcast_to(a, Shape(2, 2, 2, 3)),
+        np.broadcast_to(a.to_numpy(), (2, 2, 2, 3)),
+        "`broadcast_to` fails.",
+    )


### PR DESCRIPTION
Implements `broadcast_to()` for `NDArray`. Add tests.

It can broadcast an ndarray of any shape to any compatible shape. The data will be copied into the new array. An example goes as follows.

```mojo
from numojo.prelude import *
from python import Python
fn main() raises:
    var np = Python.import_module("numpy")
    var a = nm.random.rand(Shape(2, 3))
    print(a)
    print(nm.routines.manipulation.broadcast_to(a, Shape(2, 2, 3)))
    print(np.broadcast_to(a.to_numpy(), (2, 2, 3)))
```

```console
[[0.8073 0.5361 0.4442]
 [0.9378 0.1910 0.2421]]
2D-array  Shape(2,3)  Strides(3,1)  DType: f64  C-cont: True  F-cont: False  own data: True

[[[0.8073 0.5361 0.4442]
  [0.9378 0.1910 0.2421]]
 [[0.8073 0.5361 0.4442]
  [0.9378 0.1910 0.2421]]]
3D-array  Shape(2,2,3)  Strides(6,3,1)  DType: f64  C-cont: True  F-cont: False  own data: True

[[[0.8074 0.5361 0.4442]
  [0.9378 0.1911 0.2421]]
 [[0.8074 0.5361 0.4442]
  [0.9378 0.1911 0.2421]]]
```