### PR TITLE
[ndarray][doc] Improve behaviors of 0darray + more docstring

### DIFF
--- a/numojo/core/_math_funcs.mojo
+++ b/numojo/core/_math_funcs.mojo
@@ -144,6 +144,13 @@ struct Vectorized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
+
+        # For 0darray (numojo scalar)
+        # Treat it as a scalar and apply the function
+        if array.ndim == 0:
+            var result_array = _0darray(val=func[dtype, 1](array._buf.ptr[]))
+            return result_array
+
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()
 
@@ -234,9 +241,7 @@ struct Vectorized(Backend):
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
-            var result_array = _0darray(
-                val=func[dtype, 1](array._buf.ptr[], scalar)
-            )
+            var result_array = _0darray(val=func[dtype, 1](array[], scalar))
             return result_array
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
@@ -265,6 +270,14 @@ struct Vectorized(Backend):
             raise Error(
                 "Shape Mismatch error shapes must match for this function"
             )
+
+        # For 0darray (numojo scalar)
+        # Treat it as a scalar and apply the function
+        if array2.ndim == 0:
+            return self.math_func_compare_array_and_scalar[dtype, func](
+                array1, array2[]
+            )
+
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
             array1.shape
         )
@@ -295,6 +308,12 @@ struct Vectorized(Backend):
     ](
         self: Self, array1: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[DType.bool]:
+        # For 0darray (numojo scalar)
+        # Treat it as a scalar and apply the function
+        if array1.ndim == 0:
+            var result_array = _0darray(val=func[dtype, 1](array1[], scalar))
+            return result_array
+
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
             array1.shape
         )

--- a/numojo/core/_math_funcs.mojo
+++ b/numojo/core/_math_funcs.mojo
@@ -14,6 +14,7 @@ from memory import UnsafePointer
 
 from numojo.core.traits.backend import Backend
 from numojo.core.ndarray import NDArray
+from numojo.routines.creation import _0darray
 
 # TODO Add string method to give name
 
@@ -222,6 +223,14 @@ struct Vectorized(Backend):
         Returns:
             A a new NDArray that is NDArray with the function func applied.
         """
+
+        # For 0darray (numojo scalar)
+        # Treat it as a scalar and apply the function
+        if array.ndim == 0:
+            var result_array = _0darray(
+                val=func[dtype, 1](array._buf.ptr[], scalar)
+            )
+            return result_array
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         alias width = simdwidthof[dtype]()

--- a/numojo/core/_math_funcs.mojo
+++ b/numojo/core/_math_funcs.mojo
@@ -187,6 +187,13 @@ struct Vectorized(Backend):
                 "Shape Mismatch error shapes must match for this function"
             )
 
+        # For 0darray (numojo scalar)
+        # Treat it as a scalar and apply the function
+        if array2.ndim == 0:
+            return self.math_func_1_array_1_scalar_in_one_array_out[
+                dtype, func
+            ](array1, array2[])
+
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         alias width = simdwidthof[dtype]()
 

--- a/numojo/core/datatypes.mojo
+++ b/numojo/core/datatypes.mojo
@@ -235,5 +235,9 @@ fn _concise_dtype_str(dtype: DType) -> String:
         return "f32"
     elif dtype == f64:
         return "f64"
+    elif dtype == boolean:
+        return "boolean"
+    elif dtype == isize:
+        return "isize"
     else:
         return "Unknown"

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -133,9 +133,10 @@ struct Item(CollectionElement):
 
         if normalized_idx < 0 or normalized_idx >= self.ndim:
             raise Error(
-                String("Index ({}) out of range [{}, {})").format(
-                    index(idx), -self.ndim, self.ndim - 1
-                )
+                String(
+                    "Error in `numojo.Item.__getitem__()`: \n"
+                    "Index ({}) out of range [{}, {})\n"
+                ).format(index(idx), -self.ndim, self.ndim - 1)
             )
 
         return self._buf[normalized_idx]
@@ -159,9 +160,10 @@ struct Item(CollectionElement):
 
         if normalized_idx < 0 or normalized_idx >= self.ndim:
             raise Error(
-                String("Index ({}) out of range [{}, {})").format(
-                    index(idx), -self.ndim, self.ndim - 1
-                )
+                String(
+                    "Error in `numojo.Item.__getitem__()`: \n"
+                    "Index ({}) out of range [{}, {})\n"
+                ).format(index(idx), -self.ndim, self.ndim - 1)
             )
 
         self._buf[normalized_idx] = index(val)

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -831,6 +831,7 @@ struct NDArray[dtype: DType = DType.float64](
                 "The number of dimensions is {}."
             ).format(index.__len__(), self.ndim)
             raise Error(message)
+
         for i in range(index.__len__()):
             if index[i] >= self.shape[i]:
                 var message = String(
@@ -870,16 +871,18 @@ struct NDArray[dtype: DType = DType.float64](
                 "Cannot slice a 0-d array.\n"
             )
 
-        if self.ndim > 1:
+        var narr: Self
+
+        # If the ndim is 1
+        if self.ndim == 1:
+            narr = creation._0darray[dtype](self._buf.ptr[idx])
+
+        else:
             for i in range(1, self.ndim):
                 var size_at_dim: Int = self.shape[i]
                 slice_list.append(Slice(0, size_at_dim, 1))
 
-        var narr: Self = self.__getitem__(slice_list)
-
-        if self.ndim == 1:
-            narr.ndim = 0
-            narr.shape._buf[0] = 0
+            narr = self.__getitem__(slice_list)
 
         return narr
 
@@ -1218,9 +1221,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         var narr: Self = self.__getitem__(slice_list)
 
+        # Number of ints equals to nidm, it returns a 0-D array.
         if count_int == self.ndim:
-            narr.ndim = 0
-            narr.shape._buf[0] = 0
+            narr = creation._0darray[dtype](narr._buf.ptr[])
 
         return narr
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -107,7 +107,7 @@ struct NDArray[dtype: DType = DType.float64](
     var strides: NDArrayStrides
     """Contains offset, strides."""
     var flags: Dict[String, Bool]
-    "Information about the memory layout of the array."
+    """Information about the memory layout of the array."""
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -184,6 +184,11 @@ struct NDArray[dtype: DType = DType.float64](
     ) raises:
         """
         Extremely specific NDArray initializer.
+
+        Args:
+            shape: List of shape.
+            offset: Offset value.
+            strides: List of strides.
         """
         self.shape = NDArrayShape(shape)
         self.ndim = self.shape.ndim
@@ -206,6 +211,15 @@ struct NDArray[dtype: DType = DType.float64](
         offset: Int,
         strides: NDArrayStrides,
     ) raises:
+        """
+        Initialize an NDArray view with given shape, buffer, offset, and strides.
+
+        Args:
+            shape: Shape of the array.
+            buffer: Unsafe pointer to the buffer.
+            offset: Offset value.
+            strides: Strides of the array.
+        """
         self.shape = shape
         self.strides = strides
         self.ndim = self.shape.ndim
@@ -222,8 +236,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn __copyinit__(mut self, other: Self):
         """
         Copy other into self.
-
         It is a deep copy. So the new array owns the data.
+
+        Args:
+            other: The NDArray to copy from.
         """
         self.ndim = other.ndim
         self.shape = other.shape
@@ -238,6 +254,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn __moveinit__(mut self, owned existing: Self):
         """
         Move other into self.
+
+        Args:
+            existing: The NDArray to move from.
         """
         self.ndim = existing.ndim
         self.shape = existing.shape
@@ -268,8 +287,13 @@ struct NDArray[dtype: DType = DType.float64](
     fn _setitem(self, *indices: Int, val: Scalar[dtype]):
         """
         (UNSAFE! for internal use only.)
-        Get item at indices and bypass all boundary checks.
+        Set item at indices and bypass all boundary checks.
 
+        Args:
+            indices: Indices to set the value.
+            val: Value to set.
+
+        Example:
         ```mojo
         import numojo
         var A = numojo.ones(numojo.Shape(2,3,4))
@@ -284,6 +308,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn __setitem__(mut self, idx: Int, val: Self) raises:
         """
         Set a slice of array with given array.
+
+        Args:
+            idx: Index to set.
+            val: Value to set.
 
         Example:
         ```mojo
@@ -398,6 +426,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn __setitem__(mut self, index: Item, val: Scalar[dtype]) raises:
         """
         Set the value at the index list.
+
+        Args:
+            index: Index list.
+            val: Value to set.
         """
         if index.__len__() != self.ndim:
             var message = String(
@@ -425,6 +457,10 @@ struct NDArray[dtype: DType = DType.float64](
     ) raises:
         """
         Set the value of the array at the indices where the mask is true.
+
+        Args:
+            mask: Boolean mask array.
+            value: Value to set.
         """
         if (
             mask.shape != self.shape
@@ -437,7 +473,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn __setitem__(mut self, *slices: Slice, val: Self) raises:
         """
-        Retreive slices of an array from variadic slices.
+        Retrieve slices of an array from variadic slices.
+
+        Args:
+            slices: Variadic slices.
+            val: Value to set.
 
         Example:
             `arr[1:3, 2:4]` returns the corresponding sliced array (2 x 2).
@@ -450,6 +490,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn __setitem__(mut self, slices: List[Slice], val: Self) raises:
         """
         Sets the slices of an array from list of slices and array.
+
+        Args:
+            slices: List of slices.
+            val: Value to set.
 
         Example:
         ```console
@@ -569,6 +613,10 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Get items by a series of either slices or integers.
 
+        Args:
+            slices: Variadic slices or integers.
+            val: Value to set.
+
         Example:
         ```console
         >>> var a = nm.arange[i8](16).reshape(Shape(4, 4))
@@ -613,7 +661,9 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Returns the items of the array from an array of indices.
 
-        Refer to `__getitem__(self, index: List[Int])`.
+        Args:
+            index: Array of indices.
+            val: Value to set.
 
         Example:
         ```console
@@ -638,6 +688,10 @@ struct NDArray[dtype: DType = DType.float64](
     ) raises:
         """
         Set the value of the array at the indices where the mask is true.
+
+        Args:
+            mask: Boolean mask array.
+            val: Value to set.
 
         Example:
         ```
@@ -686,6 +740,10 @@ struct NDArray[dtype: DType = DType.float64](
         (UNSAFE! for internal use only.)
         Get item at indices and bypass all boundary checks.
 
+        Args:
+            indices: Indices to get the value.
+
+        Example:
         ```mojo
         import numojo
         var A = numojo.ones(numojo.Shape(2,3,4))
@@ -699,7 +757,13 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn __getitem__(self, index: Item) raises -> SIMD[dtype, 1]:
         """
-        Set the value at the index list.
+        Get the value at the index list.
+
+        Args:
+            index: Index list.
+
+        Returns:
+            The value at the index list.
         """
         if index.__len__() != self.ndim:
             var message = String(
@@ -723,7 +787,13 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn __getitem__(self, idx: Int) raises -> Self:
         """
-        Retreive a slice of the array corresponding to the index at the first dimension.
+        Retrieve a slice of the array corresponding to the index at the first dimension.
+
+        Args:
+            idx: Index to get the slice.
+
+        Returns:
+            A slice of the array.
 
         Example:
             `arr[1]` returns the second row of the array.
@@ -751,7 +821,13 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn __getitem__(self, owned *slices: Slice) raises -> Self:
         """
-        Retreive slices of an array from variadic slices.
+        Retrieve slices of an array from variadic slices.
+
+        Args:
+            slices: Variadic slices.
+
+        Returns:
+            A slice of the array.
 
         Example:
             `arr[1:3, 2:4]` returns the corresponding sliced array (2 x 2).
@@ -773,7 +849,13 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn __getitem__(self, owned slice_list: List[Slice]) raises -> Self:
         """
-        Retreive slices of an array from list of slices.
+        Retrieve slices of an array from list of slices.
+
+        Args:
+            slice_list: List of slices.
+
+        Returns:
+            A slice of the array.
 
         Example:
             `arr[1:3, 2:4]` returns the corresponding sliced array (2 x 2).
@@ -1081,10 +1163,15 @@ struct NDArray[dtype: DType = DType.float64](
     fn __getitem__(self, indices: NDArray[DType.index]) raises -> Self:
         """
         Get items from 0-th dimension of an ndarray of indices.
-
         If the original array is of shape (i,j,k) and
         the indices array is of shape (l,m,n), then the output array
         will be of shape (l,m,n,j,k).
+
+        Args:
+            indices: Array of indices.
+
+        Returns:
+            NDArray with items from the array of indices.
 
         Example:
         ```console
@@ -1111,13 +1198,7 @@ struct NDArray[dtype: DType = DType.float64](
          [[     6       7       8       ]
           [     9       10      11      ]]]
         3-D array  Shape: [3, 2, 3]  DType: int8  C-cont: True  F-cont: False  own data: True
-        ```
-
-        Args:
-            indices: Array of intable values.
-
-        Returns:
-            NDArray with items from the array of indices.
+        ```.
         """
 
         # Get the shape of resulted array
@@ -1148,6 +1229,12 @@ struct NDArray[dtype: DType = DType.float64](
         Get items from 0-th dimension of an array. It is an overload of
         `__getitem__(self, indices: NDArray[DType.index]) raises -> Self`.
 
+        Args:
+            indices: A list of Int.
+
+        Returns:
+            NDArray with items from the list of indices.
+
         Example:
         ```console
         >>>var a = nm.arange[i8](6)
@@ -1173,13 +1260,7 @@ struct NDArray[dtype: DType = DType.float64](
          [[     6       7       8       ]
           [     9       10      11      ]]]
         3-D array  Shape: [3, 2, 3]  DType: int8  C-cont: True  F-cont: False  own data: True
-        ```
-
-        Args:
-            indices: A list of Int.
-
-        Returns:
-            NDArray with items from the list of indices.
+        ```.
         """
 
         var indices_array = NDArray[DType.index](shape=Shape(len(indices)))
@@ -1192,12 +1273,16 @@ struct NDArray[dtype: DType = DType.float64](
         # TODO: Extend the mask into multiple dimensions.
         """
         Get item from an array according to a mask array.
-
         If array shape is equal to mask shape, it returns a flattened array of
         the values where mask is True.
-
         If array shape is not equal to mask shape, it returns items from the
         0-th dimension of the array where mask is True.
+
+        Args:
+            mask: NDArray with Dtype.bool.
+
+        Returns:
+            NDArray with items from the mask.
 
         Example:
         ```console
@@ -1220,13 +1305,7 @@ struct NDArray[dtype: DType = DType.float64](
         [[[     6       7       8       ]
           [     9       10      11      ]]]
         3-D array  Shape: [1, 2, 3]  DType: int8  C-cont: True  F-cont: True  own data: True
-        ```
-
-        Args:
-            mask: NDArray with Dtype.bool.
-
-        Returns:
-            NDArray with items from the mask.
+        ```.
         """
 
         # CASE 1:
@@ -1299,6 +1378,12 @@ struct NDArray[dtype: DType = DType.float64](
         Get items from 0-th dimension of an array according to mask.
         __getitem__(self, mask: NDArray[DType.bool]) raises -> Self.
 
+        Args:
+            mask: A list of boolean values.
+
+        Returns:
+            NDArray with items from the mask.
+
         Example:
         ```console
         >>>var a = nm.arange[i8](6)
@@ -1320,13 +1405,7 @@ struct NDArray[dtype: DType = DType.float64](
         [[[     6       7       8       ]
           [     9       10      11      ]]]
         3-D array  Shape: [1, 2, 3]  DType: int8  C-cont: True  F-cont: True  own data: True
-        ```
-
-        Args:
-            mask: A list of boolean values.
-
-        Returns:
-            NDArray with items from the mask.
+        ```.
         """
 
         var mask_array = NDArray[DType.bool](shape=Shape(len(mask)))
@@ -2173,7 +2252,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Example:
         ```
-        >>> var a = nm.random.arange[nm.i8](2 * 3 * 4).reshape(nm.Shape(2, 3, 4))
+        >>> var a = nm.random.arange[nm.i8](2, 3, 4).reshape(nm.Shape(2, 3, 4))
         >>> for i in a:
         ...     print(i)
         [[      0       1       2       3       ]
@@ -2216,6 +2295,12 @@ struct NDArray[dtype: DType = DType.float64](
     fn _adjust_slice(self, slice_list: List[Slice]) raises -> List[Slice]:
         """
         Adjusts the slice values to lie within 0 and dim.
+
+        Args:
+            slice_list: List of slices.
+
+        Returns:
+            Adjusted list of slices.
         """
         var n_slices: Int = slice_list.__len__()
         var slices = List[Slice]()
@@ -2270,6 +2355,9 @@ struct NDArray[dtype: DType = DType.float64](
             dimension: The current dimension.
             offset: The offset of the current dimension.
             print_options: The print options.
+
+        Returns:
+            String representation of the array.
         """
         var seperator = print_options.separator
         var padding = print_options.padding
@@ -2441,6 +2529,12 @@ struct NDArray[dtype: DType = DType.float64](
     fn vdot(self, other: Self) raises -> SIMD[dtype, 1]:
         """
         Inner product of two vectors.
+
+        Args:
+            other: The other vector.
+
+        Returns:
+            The inner product of the two vectors.
         """
         if self.size != other.size:
             raise Error("The lengths of two vectors do not match.")
@@ -2455,6 +2549,12 @@ struct NDArray[dtype: DType = DType.float64](
         Dot product of two matrix.
         Matrix A: M * N.
         Matrix B: N * L.
+
+        Args:
+            other: The other matrix.
+
+        Returns:
+            The dot product of the two matrices.
         """
 
         if (self.ndim != 2) or (other.ndim != 2):
@@ -2486,7 +2586,14 @@ struct NDArray[dtype: DType = DType.float64](
         return new_matrix
 
     fn row(self, id: Int) raises -> Self:
-        """Get the ith row of the matrix."""
+        """Get the ith row of the matrix.
+
+        Args:
+            id: The row index.
+
+        Returns:
+            The ith row of the matrix.
+        """
 
         if self.ndim > 2:
             raise Error(
@@ -2502,7 +2609,14 @@ struct NDArray[dtype: DType = DType.float64](
         return buffer
 
     fn col(self, id: Int) raises -> Self:
-        """Get the ith column of the matrix."""
+        """Get the ith column of the matrix.
+
+        Args:
+            id: The column index.
+
+        Returns:
+            The ith column of the matrix.
+        """
 
         if self.ndim > 2:
             raise Error(
@@ -2524,6 +2638,12 @@ struct NDArray[dtype: DType = DType.float64](
         Dot product of two matrix.
         Matrix A: M * N.
         Matrix B: N * L.
+
+        Args:
+            other: The other matrix.
+
+        Returns:
+            The dot product of the two matrices.
         """
 
         if (self.ndim != 2) or (other.ndim != 2):
@@ -2554,6 +2674,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn num_elements(self) -> Int:
         """
         Function to retreive size (compatability).
+
+        Returns:
+            The size of the array.
         """
         return self.size
 
@@ -2562,6 +2685,12 @@ struct NDArray[dtype: DType = DType.float64](
         Safely retrieve i-th item from the underlying buffer.
 
         `A.load(i)` differs from `A._buf.ptr[i]` due to boundary check.
+
+        Args:
+            index: Index of the item.
+
+        Returns:
+            The value at the index.
 
         Example:
         ```console
@@ -2574,7 +2703,7 @@ struct NDArray[dtype: DType = DType.float64](
         > # A is a 3x3 matrix, F-order (column-major)
         > A.load(3)  # Row 0, Col 1
         > A.item(3)  # Row 1, Col 0
-        ```
+        ```.
         """
 
         if index < 0:
@@ -2596,6 +2725,12 @@ struct NDArray[dtype: DType = DType.float64](
 
         To bypass boundary checks, use `self._buf.ptr.load` directly.
 
+        Args:
+            index: Index of the item.
+
+        Returns:
+            The SIMD element at the index.
+
         Raises:
             Index out of boundary.
         """
@@ -2615,6 +2750,12 @@ struct NDArray[dtype: DType = DType.float64](
         from the underlying buffer.
 
         To bypass boundary checks, use `self._buf.ptr.load` directly.
+
+        Args:
+            indices: Variadic indices.
+
+        Returns:
+            The SIMD element at the indices.
 
         Raises:
             Index out of boundary.
@@ -2647,6 +2788,10 @@ struct NDArray[dtype: DType = DType.float64](
 
         `A.store(i, a)` differs from `A._buf.ptr[i] = a` due to boundary check.
 
+        Args:
+            index: Index of the item.
+            val: Value to store.
+
         Raises:
             Index out of boundary.
 
@@ -2678,6 +2823,10 @@ struct NDArray[dtype: DType = DType.float64](
 
         To bypass boundary checks, use `self._buf.ptr.store` directly.
 
+        Args:
+            index: Index of the item.
+            val: Value to store.
+
         Raises:
             Index out of boundary.
         """
@@ -2699,6 +2848,10 @@ struct NDArray[dtype: DType = DType.float64](
         of the underlying buffer.
 
         To bypass boundary checks, use `self._buf.ptr.store` directly.
+
+        Args:
+            indices: Variadic indices.
+            val: Value to store.
 
         Raises:
             Index out of boundary.
@@ -2742,6 +2895,12 @@ struct NDArray[dtype: DType = DType.float64](
 
         If `axes` is not given, it is equal to flipping the axes.
 
+        Args:
+            axes: List of axes.
+
+        Returns:
+            Transposed array.
+
         Defined in `numojo.routines.manipulation.transpose`.
         """
         return numojo.routines.manipulation.transpose(self, axes)
@@ -2752,6 +2911,9 @@ struct NDArray[dtype: DType = DType.float64](
         If `axes` is not given, it is equal to flipping the axes.
         See docstring of `transpose`.
 
+        Returns:
+            Transposed array.
+
         Defined in `numojo.routines.manipulation.transpose`.
         """
         return numojo.routines.manipulation.transpose(self)
@@ -2759,6 +2921,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn all(self) raises -> Bool:
         """
         If all true return true.
+
+        Returns:
+            True if all elements are true, otherwise False.
         """
         # make this a compile time check when they become more readable
         if not (self.dtype is DType.bool or self.dtype.is_integral()):
@@ -2778,6 +2943,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn any(self) raises -> Bool:
         """
         True if any true.
+
+        Returns:
+            True if any element is true, otherwise False.
         """
         # make this a compile time check
         if not (self.dtype is DType.bool or self.dtype.is_integral()):
@@ -2796,6 +2964,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn argmax(self) raises -> Int:
         """
         Get location in pointer of max value.
+
+        Returns:
+            Index of the maximum value.
         """
         var result: Int = 0
         var max_val: SIMD[dtype, 1] = self.load[width=1](0)
@@ -2809,6 +2980,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn argmin(self) raises -> Int:
         """
         Get location in pointer of min value.
+
+        Returns:
+            Index of the minimum value.
         """
         var result: Int = 0
         var min_val: SIMD[dtype, 1] = self.load[width=1](0)
@@ -2834,6 +3008,12 @@ struct NDArray[dtype: DType = DType.float64](
     fn astype[target: DType](self) raises -> NDArray[target]:
         """
         Convert type of array.
+
+        Parameters:
+            target: Target data type.
+
+        Returns:
+            NDArray with the target data type.
         """
         return creation.astype[target](self)
 
@@ -2848,6 +3028,9 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Returns a copy of the array that owns the data.
         The returned array will be continuous in memory.
+
+        Returns:
+            A copy of the array.
         """
 
         if (self.strides == NDArrayStrides(shape=self.shape)) or (
@@ -2928,6 +3111,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn fill(mut self, val: Scalar[dtype]):
         """
         Fill all items of array with value.
+
+        Args:
+            val: Value to fill.
         """
 
         for i in range(self.size):
@@ -3165,6 +3351,12 @@ struct NDArray[dtype: DType = DType.float64](
     fn max(self, axis: Int = 0) raises -> Self:
         """
         Max on axis.
+
+        Args:
+            axis: Axis.
+
+        Returns:
+            Maximum value along the axis.
         """
         var ndim: Int = self.ndim
         var shape: List[Int] = List[Int]()
@@ -3206,6 +3398,12 @@ struct NDArray[dtype: DType = DType.float64](
     fn min(self, axis: Int = 0) raises -> Self:
         """
         Min on axis.
+
+        Args:
+            axis: Axis.
+
+        Returns:
+            Minimum value along the axis.
         """
         var ndim: Int = self.ndim
         var shape: List[Int] = List[Int]()
@@ -3301,6 +3499,12 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Return an iterator yielding the array elements according to the order.
 
+        Args:
+            order: Order of the array.
+
+        Returns:
+            An iterator yielding the array elements.
+
         ```console
         >>>var a = nm.random.rand[i8](2, 3, min=0, max=100)
         >>>print(a)
@@ -3310,7 +3514,7 @@ struct NDArray[dtype: DType = DType.float64](
         >>>for i in a.nditer():
         ...    print(i, end=" ")
         37 8 25 25 2 57
-        ```
+        ``.
         """
 
         return _NDIter[__origin_of(self), dtype](
@@ -3325,6 +3529,7 @@ struct NDArray[dtype: DType = DType.float64](
     fn prod(self: Self) raises -> Scalar[dtype]:
         """
         Product of all array elements.
+
         Returns:
             Scalar.
         """
@@ -3333,8 +3538,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn prod(self: Self, axis: Int) raises -> Self:
         """
         Product of array elements over a given axis.
+
         Args:
             axis: The axis along which the product is performed.
+
         Returns:
             An NDArray.
         """
@@ -3449,6 +3656,7 @@ struct NDArray[dtype: DType = DType.float64](
     fn sum(self: Self) raises -> Scalar[dtype]:
         """
         Sum of all array elements.
+
         Returns:
             Scalar.
         """
@@ -3457,8 +3665,10 @@ struct NDArray[dtype: DType = DType.float64](
     fn sum(self: Self, axis: Int) raises -> Self:
         """
         Sum of array elements over a given axis.
+
         Args:
             axis: The axis along which the sum is performed.
+
         Returns:
             An NDArray.
         """
@@ -3479,6 +3689,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn to_numpy(self) raises -> PythonObject:
         """
         Convert to a numpy array.
+
+        Returns:
+            A numpy array.
         """
         return to_numpy(self)
 
@@ -3503,6 +3716,9 @@ struct NDArray[dtype: DType = DType.float64](
             print(c)
             print(c.to_tensor())
         ```
+
+        Returns:
+            A tensor of the same dtype.
         """
 
         return to_tensor(self)
@@ -3529,6 +3745,9 @@ struct NDArray[dtype: DType = DType.float64](
         Returns a view of transposed array.
 
         It is unsafe!
+
+        Returns:
+            A view of transposed array.
         """
         return Self(
             shape=self.shape._flip(),
@@ -3540,6 +3759,9 @@ struct NDArray[dtype: DType = DType.float64](
     fn unsafe_ptr(self) -> UnsafePointer[Scalar[dtype]]:
         """
         Retreive pointer without taking ownership.
+
+        Returns:
+            Unsafe pointer to the data buffer.
         """
         return self._buf.ptr
 
@@ -3554,6 +3776,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         Args:
             ddof: Delta degree of freedom.
+
+        Returns:
+            The variance of the array.
         """
         return variance[returned_dtype](self, ddof=ddof)
 
@@ -3570,6 +3795,9 @@ struct NDArray[dtype: DType = DType.float64](
         Args:
             axis: The axis along which the mean is performed.
             ddof: Delta degree of freedom.
+
+        Returns:
+            The variance of the array along the axis.
         """
         return variance[returned_dtype](self, axis=axis, ddof=ddof)
 

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -220,9 +220,10 @@ struct NDArrayShape(Stringable, Writable):
         Construct NDArrayShape with number of dimensions.
         This method is useful when you want to create a shape with given ndim
         without knowing the shape values.
+        `ndim == 0` is allowed in this method for 0darray (numojo scalar).
 
         Raises:
-           Error: If the number of dimensions is not positive.
+           Error: If the number of dimensions is negative.
 
         Args:
             ndim: Number of dimensions.
@@ -230,14 +231,24 @@ struct NDArrayShape(Stringable, Writable):
                 If yes, the values will be set to 1.
                 If no, the values will be uninitialized.
         """
-        if ndim <= 0:
-            raise Error("Number of dimensions must be positive.")
+        if ndim < 0:
+            raise Error(
+                "Error in `numojo.NDArrayShape.__init__(out self, ndim:"
+                " Int, initialized: Bool,)`. \n"
+                "Number of dimensions must be non-negative."
+            )
 
-        self.ndim = ndim
-        self._buf = UnsafePointer[Int]().alloc(ndim)
-        if initialized:
-            for i in range(ndim):
-                (self._buf + i).init_pointee_copy(1)
+        if ndim == 0:
+            # This is a 0darray (numojo scalar)
+            self.ndim = ndim
+            self._buf = UnsafePointer[Int]()
+
+        else:
+            self.ndim = ndim
+            self._buf = UnsafePointer[Int]().alloc(ndim)
+            if initialized:
+                for i in range(ndim):
+                    (self._buf + i).init_pointee_copy(1)
 
     @always_inline("nodebug")
     fn __copyinit__(out self, other: Self):

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -204,9 +204,10 @@ struct NDArrayStrides(Stringable):
         Construct NDArrayStrides with number of dimensions.
         This method is useful when you want to create a strides with given ndim
         without knowing the strides values.
+        `ndim == 0` is allowed in this method for 0darray (numojo scalar).
 
         Raises:
-           Error: If the number of dimensions is not positive.
+           Error: If the number of dimensions is negative.
 
         Args:
             ndim: Number of dimensions.
@@ -215,13 +216,23 @@ struct NDArrayStrides(Stringable):
                 If no, the values will be uninitialized.
         """
         if ndim <= 0:
-            raise Error("Number of dimensions must be positive.")
+            raise Error(
+                "Error in `numojo.NDArrayStrides.__init__(out self, ndim:"
+                " Int, initialized: Bool,)`. \n"
+                "Number of dimensions must be non-negative."
+            )
 
-        self.ndim = ndim
-        self._buf = UnsafePointer[Int]().alloc(ndim)
-        if initialized:
-            for i in range(ndim):
-                (self._buf + i).init_pointee_copy(0)
+        if ndim == 0:
+            # This is a 0darray (numojo scalar)
+            self.ndim = ndim
+            self._buf = UnsafePointer[Int]()
+
+        else:
+            self.ndim = ndim
+            self._buf = UnsafePointer[Int]().alloc(ndim)
+            if initialized:
+                for i in range(ndim):
+                    (self._buf + i).init_pointee_copy(0)
 
     @always_inline("nodebug")
     fn __copyinit__(out self, other: Self):

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -215,7 +215,7 @@ struct NDArrayStrides(Stringable):
                 If yes, the values will be set to 0.
                 If no, the values will be uninitialized.
         """
-        if ndim <= 0:
+        if ndim < 0:
             raise Error(
                 "Error in `numojo.NDArrayStrides.__init__(out self, ndim:"
                 " Int, initialized: Bool,)`. \n"

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2271,9 +2271,9 @@ fn _0darray[
     """
     Initialize an special 0darray (numojo scalar).
     The ndim is 0.
-    The shape is unitialized.
-    The strides is unitialized.
-    The size is 1 (for internal use).
+    The shape is unitialized (0-element shape).
+    The strides is unitialized (0-element strides).
+    The size is 1 (`=0!`).
     """
 
     var b = NDArray[dtype](

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -1,13 +1,12 @@
+# ===----------------------------------------------------------------------=== #
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
 """
 Array creation routine.
-"""
-# ===----------------------------------------------------------------------=== #
-# ARRAY CREATION ROUTINES
-# Last updated: 2024-09-08
-# ===----------------------------------------------------------------------=== #
 
-
-"""
 # TODO (In order of priority)
 1) Implement axis argument for the NDArray creation functions
 2) Separate `array(object)` and `NDArray.__init__(shape)`.
@@ -34,6 +33,7 @@ function. So it is easy for modification.
 from algorithm import parallelize, vectorize
 from algorithm import parallelize, vectorize
 from builtin.math import pow
+from collections import Dict
 from collections.optional import Optional
 from memory import UnsafePointer, memset_zero, memset, memcpy
 from python import PythonObject
@@ -42,7 +42,7 @@ from tensor import Tensor, TensorShape
 
 from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import NDArrayShape
-from numojo.core.utility import _get_offset
+from numojo.core.utility import _get_offset, _update_flags
 from numojo.core.own_data import OwnData
 
 
@@ -2259,3 +2259,31 @@ fn array[
     """
 
     return from_tensor(data)
+
+
+# ===----------------------------------------------------------------------=== #
+# Internal functions
+# ===----------------------------------------------------------------------=== #
+# for creating a 0darray (only for internal use)
+fn _0darray[
+    dtype: DType
+](val: Scalar[dtype],) raises -> NDArray[dtype]:
+    """
+    Initialize an special 0darray (numojo scalar).
+    The ndim is 0.
+    The shape is unitialized.
+    The strides is unitialized.
+    The size is 1 (for internal use).
+    """
+
+    var b = NDArray[dtype](
+        shape=NDArrayShape(ndim=0, initialized=False),
+        strides=NDArrayStrides(ndim=0, initialized=False),
+        ndim=0,
+        size=1,
+        flags=Dict[String, Bool](),
+    )
+    b._buf = OwnData[dtype](1)
+    b._buf.ptr.init_pointee_copy(val)
+    b.flags["OWNDATA"] = True
+    return b

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -6,19 +6,19 @@ Implements arithmetic operations functions
 # ===----------------------------------------------------------------------=== #
 
 
+from algorithm import parallelize, Static2DTileUnitFunc as Tile2DFunc
 import math
-from algorithm import parallelize
-from algorithm import Static2DTileUnitFunc as Tile2DFunc
 from utils import Variant
 
 import numojo.core._math_funcs as _mf
+from numojo.core.traits.backend import Backend
 from numojo.core.ndarray import NDArray
 from numojo.core.datatypes import TypeCoercion
 
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform addition on two arrays.
@@ -44,7 +44,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -59,7 +59,7 @@ fn add[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -77,7 +77,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform addition on between an array and a scalar.
@@ -100,7 +100,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -115,7 +115,7 @@ fn add[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -133,7 +133,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform addition on between an array and a scalar.
@@ -154,7 +154,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -166,7 +166,7 @@ fn add[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -184,7 +184,7 @@ fn add[
 
 fn add[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](owned *values: Variant[NDArray[dtype], Scalar[dtype]]) raises -> NDArray[
     dtype
 ]:
@@ -222,7 +222,7 @@ fn add[
 
 
 fn sub[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform subtraction on two arrays.
@@ -248,7 +248,7 @@ fn sub[
 
 fn sub[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -263,7 +263,7 @@ fn sub[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -281,7 +281,7 @@ fn sub[
 
 fn sub[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform subtraction on between an array and a scalar.
@@ -304,7 +304,7 @@ fn sub[
 
 fn sub[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -316,7 +316,7 @@ fn sub[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -334,7 +334,7 @@ fn sub[
 
 fn sub[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform subtraction on between an array and a scalar.
@@ -355,7 +355,7 @@ fn sub[
 
 fn sub[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -367,7 +367,7 @@ fn sub[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -417,7 +417,7 @@ fn diff[
 
 
 fn mod[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise modulo of array1 and array2.
@@ -443,7 +443,7 @@ fn mod[
 
 fn mod[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform subtraction on between an array and a scalar.
@@ -466,7 +466,7 @@ fn mod[
 
 fn mod[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform subtraction on between an array and a scalar.
@@ -486,7 +486,7 @@ fn mod[
 
 
 fn mul[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise product of array1 and array2.
@@ -512,7 +512,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -524,7 +524,7 @@ fn mul[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -542,7 +542,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform multiplication on between an array and a scalar.
@@ -565,7 +565,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -577,7 +577,7 @@ fn mul[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -595,7 +595,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform multiplication on between an array and a scalar.
@@ -616,7 +616,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -628,7 +628,7 @@ fn mul[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -646,7 +646,7 @@ fn mul[
 
 fn mul[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](owned *values: Variant[NDArray[dtype], Scalar[dtype]]) raises -> NDArray[
     dtype
 ]:
@@ -684,10 +684,10 @@ fn mul[
 
 
 fn div[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Element-wise quotent of array1 and array2.
+    Element-wise quotient of array1 and array2.
 
     Constraints:
         Both arrays must have the same shapes.
@@ -710,7 +710,7 @@ fn div[
 
 fn div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -722,7 +722,7 @@ fn div[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -740,7 +740,7 @@ fn div[
 
 fn div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform true division on between an array and a scalar.
@@ -763,7 +763,7 @@ fn div[
 
 fn div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -775,7 +775,7 @@ fn div[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -793,7 +793,7 @@ fn div[
 
 fn div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform true division on between an array and a scalar.
@@ -814,7 +814,7 @@ fn div[
 
 fn div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
     *,
     OtherDType: DType,
     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),
@@ -826,7 +826,7 @@ fn div[
 
     Parameters:
         dtype: The element type.
-        backend: Sets utility function origin, defualts to `Vectorized`.
+        backend: Sets utility function origin, defaults to `Vectorized`.
         OtherDType: The element type of the second array.
         ResultDType: The element type of the result array.
 
@@ -843,10 +843,10 @@ fn div[
 
 
 fn floor_div[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Element-wise quotent of array1 and array2.
+    Element-wise quotient of array1 and array2.
 
     Constraints:
         Both arrays must have the same shapes.
@@ -869,7 +869,7 @@ fn floor_div[
 
 fn floor_div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
     Perform true division on between an array and a scalar.
@@ -892,7 +892,7 @@ fn floor_div[
 
 fn floor_div[
     dtype: DType,
-    backend: _mf.Backend = _mf.Vectorized,
+    backend: Backend = _mf.Vectorized,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Perform true division on between an array and a scalar.
@@ -912,12 +912,12 @@ fn floor_div[
 
 
 fn fma[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](
     array1: NDArray[dtype], array2: NDArray[dtype], array3: NDArray[dtype]
 ) raises -> NDArray[dtype]:
     """
-    Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
+    Apply a SIMD level fuse multiply add function of three variables and one return to a NDArray.
 
     Constraints:
         Both arrays must have the same shape.
@@ -938,12 +938,12 @@ fn fma[
 
 
 fn fma[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](
     array1: NDArray[dtype], array2: NDArray[dtype], simd: SIMD[dtype, 1]
 ) raises -> NDArray[dtype]:
     """
-    Apply a SIMD level fuse multipy add function of three variables and one return to a NDArray.
+    Apply a SIMD level fuse multiply add function of three variables and one return to a NDArray.
 
     Constraints:
         Both arrays must have the same shape
@@ -964,7 +964,7 @@ fn fma[
 
 
 fn remainder[
-    dtype: DType, backend: _mf.Backend = _mf.Vectorized
+    dtype: DType, backend: Backend = _mf.Vectorized
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise remainders of NDArray.
@@ -989,7 +989,7 @@ fn remainder[
 
 
 # fn reciprocal[
-#     dtype: DType, backend: _mf.Backend = _mf.Vectorized
+#     dtype: DType, backend: Backend = _mf.Vectorized
 # ](NDArray: NDArray[dtype]) -> NDArray[dtype]:
 #     """
 #     Element-wise reciprocals of array1 and array2.


### PR DESCRIPTION
This PR aims to improve the behaviors of 0-dimensional array (numojo scalar). Note that `a.item(0)` or `a[Item(0)]` is always preferred because the behavior is more determined, but we also allow some ***basic*** operations on 0darray to make users' life easier.

0-dimensional array cannot be constructed by users but can be obtained by array indexing and slicing. Printing this variable gives the scalar and a note that it is an 0darray instead of a mojo scalar. It is similar to `numpy` in that `a[0]` returns a numpy scalar and `a.item(0)` returns a Python scalar. For example,
```
>>> var a = nm.random.arange[f16](0, 3, 0.12)
>>> print(a[1])
0.11999512  (0darray[f16])
>>> print(a.item(1))
0.11999512
>>> var c = nm.array[f16]("[[1,2], [3,4]]")
>>> print(c[1, 1])
4.0  (0darray[f16])
```

0-dimensional array can be unpacked to get the corresponding mojo scalar either by `[]` or by `item()`. For example,
```
>>> var a = nm.random.arange[f16](0, 3, 0.12)
>>> var b = a[1]
>>> print(b)
0.11999512  (0darray[f16])
>>> print(b[])  # Unpack using []
0.11999512
>>> print(b.item())  # Unpack using item()
0.11999512
```

0-dimensional array can be used in arithmetic operations, just like a scalar.
```
>>> var a = nm.random.arange[f16](0, 3, 0.12)
>>> var b = a[1]
>>> var c = nm.array[f16]("[[1,2], [3,4]]")
>>> var d = c[1, 1]
>>> print(b - d)  # Arithmetic operations between two 0darrays
-3.8808594  (0darray[f16])
>>> print(b[] - d[])  # Arithmetic operations after unpacking
-3.8808594
>>> print(b < d)  # Comparison between 0darray and 0darray
True  (0darray[boolean])
>>>print(b == d[])  # Comparison between 0darray and unpacked 0darray
False  (0darray[boolean])
```



