### PR TITLE
[core][flags] Add `Flags` type for storing information on memory layout

### DIFF
--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -16,6 +16,7 @@ from utils import Variant
 
 from numojo.core.complex.complex_simd import ComplexSIMD
 from numojo.core.datatypes import TypeCoercion, _concise_dtype_str
+from numojo.core.flags import Flags
 from numojo.core.item import Item
 from numojo.core.ndshape import NDArrayShape
 from numojo.core.ndstrides import NDArrayStrides
@@ -78,7 +79,7 @@ struct ComplexNDArray[
     """Size of ComplexNDArray."""
     var strides: NDArrayStrides
     """Contains offset, strides."""
-    var flags: Dict[String, Bool]
+    var flags: Flags
     "Information about the memory layout of the array."
 
     """LIFETIME METHODS"""

--- a/numojo/core/flags.mojo
+++ b/numojo/core/flags.mojo
@@ -1,0 +1,175 @@
+# ===----------------------------------------------------------------------=== #
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+"""
+Implements Flags type.
+"""
+
+from numojo.core.ndshape import NDArrayShape
+from numojo.core.ndstrides import NDArrayStrides
+
+
+@register_passable
+struct Flags:
+    """
+    Information about the memory layout of the array.
+    The Flags object can be accessed dictionary-like.
+    or by using lowercased attribute names.
+    Short names are available for convenience when using dictionary-like access.
+    """
+
+    # attributes
+    var C_CONTIGUOUS: Bool
+    """C_CONTIGUOUS (C): The data is in a C-style contiguous segment."""
+    var F_CONTIGUOUS: Bool
+    """F_CONTIGUOUS (F): The data is in a Fortran-style contiguous segment."""
+    var OWNDATA: Bool
+    """OWNDATA (O): The array owns the underlying data buffer."""
+    var WRITEABLE: Bool
+    """
+    The data area can be written to.
+    If it is False, the data is read-only and be blocked from writing.
+    The WRITEABLE field of a view or slice is inherited from the array where
+    it is derived. If the parent object is not writeable, the child object is 
+    also not writeable. If the parent object is writeable, the child object may 
+    be not writeable.
+    """
+
+    # === ---------------------------------------------------------------- === #
+    # Life cycle dunder methods
+    # === ---------------------------------------------------------------- === #
+
+    fn __init__(
+        out self,
+        c_contiguous: Bool,
+        f_contiguous: Bool,
+        owndata: Bool,
+        writeable: Bool,
+    ):
+        """
+        Initializes the Flags object with provided information.
+
+        Args:
+            c_contiguous: The data is in a C-style contiguous segment.
+            f_contiguous: The data is in a Fortran-style contiguous segment.
+            owndata: The array owns the underlying data buffer.
+            writeable: The data area can be written to.
+                If owndata is False, writeable is forced to be False.
+        """
+
+        self.C_CONTIGUOUS = c_contiguous
+        self.F_CONTIGUOUS = f_contiguous
+        self.OWNDATA = owndata
+        self.WRITEABLE = writeable and owndata
+
+    fn __init__(
+        out self,
+        shape: NDArrayShape,
+        strides: NDArrayStrides,
+        owndata: Bool,
+        writeable: Bool,
+    ) raises:
+        """
+        Initializes the Flags object according the shape and strides information.
+
+        Args:
+            shape: The shape of the array.
+            strides: The strides of the array.
+            owndata: The array owns the underlying data buffer.
+            writeable: The data area can be written to.
+                If owndata is False, writeable is forced to be False.
+        """
+
+        self.C_CONTIGUOUS = (
+            True if (strides[-1] == 1) or (shape[-1] == 1) else False
+        )
+        self.F_CONTIGUOUS = (
+            True if (strides[0] == 1) or (shape[0] == 1) else False
+        )
+        self.OWNDATA = owndata
+        self.WRITEABLE = writeable and owndata
+
+    fn __init__(
+        out self,
+        shape: Tuple[Int, Int],
+        strides: Tuple[Int, Int],
+        owndata: Bool,
+        writeable: Bool,
+    ):
+        """
+        Initializes the Flags object according the shape and strides information.
+
+        Args:
+            shape: The shape of the array.
+            strides: The strides of the array.
+            owndata: The array owns the underlying data buffer.
+            writeable: The data area can be written to.
+                If owndata is False, writeable is forced to be False.
+        """
+
+        self.C_CONTIGUOUS = (
+            True if (strides[1] == 1) or (shape[1] == 1) else False
+        )
+        self.F_CONTIGUOUS = (
+            True if (strides[0] == 1) or (shape[0] == 1) else False
+        )
+        self.OWNDATA = owndata
+        self.WRITEABLE = writeable and owndata
+
+    fn __copyinit__(out self, other: Self):
+        """
+        Initializes the Flags object by copying the information from
+        another Flags object.
+
+        Args:
+            other: The Flags object to copy information from.
+        """
+
+        self.C_CONTIGUOUS = other.C_CONTIGUOUS
+        self.F_CONTIGUOUS = other.F_CONTIGUOUS
+        self.OWNDATA = other.OWNDATA
+        self.WRITEABLE = other.WRITEABLE
+
+    # === ---------------------------------------------------------------- === #
+    # Get and set dunder methods
+    # === ---------------------------------------------------------------- === #
+
+    fn __getitem__(self, key: String) raises -> Bool:
+        """
+        Get the value of the fields with the given key.
+        The Flags object can be accessed dictionary-like.
+        Short names are available for convenience.
+
+        Args:
+            key: The key of the field to get.
+
+        Returns:
+            The value of the field with the given key.
+        """
+        if (
+            (key != "C_CONTIGUOUS")
+            and (key != "C")
+            and (key != "F_CONTIGUOUS")
+            and (key != "F")
+            and (key != "OWNDATA")
+            and (key != "O")
+            and (key != "WRITEABLE")
+            and (key != "W")
+        ):
+            raise Error(
+                String(
+                    "\nError in `Flags.__getitem__()`: "
+                    "Invalid field name or short name: {}".format(key)
+                )
+            )
+        if (key == "C_CONTIGUOUS") or (key == "C"):
+            return self.C_CONTIGUOUS
+        elif (key == "F_CONTIGUOUS") or (key == "F"):
+            return self.F_CONTIGUOUS
+        elif (key == "OWNDATA") or (key == "O"):
+            return self.OWNDATA
+        else:  # (key == "WRITEABLE") or (key == "W")
+            return self.WRITEABLE

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -63,7 +63,10 @@ struct NDArrayShape(Stringable, Writable):
             shape: Variable number of integers representing the shape dimensions.
         """
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
@@ -86,7 +89,10 @@ struct NDArrayShape(Stringable, Writable):
             size: The total number of elements in the array.
         """
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
@@ -109,7 +115,10 @@ struct NDArrayShape(Stringable, Writable):
             shape: A list of integers representing the shape dimensions.
         """
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
@@ -133,7 +142,10 @@ struct NDArrayShape(Stringable, Writable):
         """
 
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
 
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -158,7 +170,10 @@ struct NDArrayShape(Stringable, Writable):
         """
 
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
 
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -183,7 +198,10 @@ struct NDArrayShape(Stringable, Writable):
         """
 
         if len(shape) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(len(shape))
+            )
 
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -317,7 +335,7 @@ struct NDArrayShape(Stringable, Writable):
         if val <= 0:
             raise Error(String("Value to be set is not positive."))
 
-        self._buf[index] = val
+        self._buf[normalized_index] = val
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -42,7 +42,12 @@ struct NDArrayStrides(Stringable):
             strides: Strides of the array.
         """
         if len(strides) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(
+                    len(strides)
+                )
+            )
 
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -61,7 +66,12 @@ struct NDArrayStrides(Stringable):
             strides: Strides of the array.
         """
         if len(strides) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(
+                    len(strides)
+                )
+            )
 
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -80,7 +90,12 @@ struct NDArrayStrides(Stringable):
             strides: Strides of the array.
         """
         if len(strides) <= 0:
-            raise Error("Number of dimensions of array must be positive.")
+            raise Error(
+                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
+                " array must be positive. However, it is {}.".format(
+                    len(strides)
+                )
+            )
 
         self.ndim = len(strides)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -272,7 +287,7 @@ struct NDArrayStrides(Stringable):
                 )
             )
 
-        return self._buf[index]
+        return self._buf[normalized_index]
 
     @always_inline("nodebug")
     fn __setitem__(mut self, index: Int, val: Int) raises:
@@ -298,7 +313,7 @@ struct NDArrayStrides(Stringable):
                 )
             )
 
-        self._buf[index] = val
+        self._buf[normalized_index] = val
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -13,9 +13,10 @@ from python import Python, PythonObject
 from sys import simdwidthof
 from tensor import Tensor, TensorShape
 
-from .ndarray import NDArray
-from .ndshape import NDArrayShape
-from .ndstrides import NDArrayStrides
+from numojo.core.flags import Flags
+from numojo.core.ndarray import NDArray
+from numojo.core.ndshape import NDArrayShape
+from numojo.core.ndstrides import NDArrayStrides
 
 
 # FIXME: No long useful from 24.6:
@@ -146,7 +147,7 @@ fn _get_offset(indices: Tuple[Int, Int], strides: Tuple[Int, Int]) -> Int:
         strides: The strides of the indices.
 
     Returns:
-        Offset of continuous memory layout.
+        Offset of contiguous memory layout.
     """
     return indices[0] * strides[0] + indices[1] * strides[1]
 
@@ -395,7 +396,7 @@ fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
         elif dtype == DType.bool:
             np_dtype = np.bool_
 
-        var order = "C" if array.flags["C_CONTIGUOUS"] else "F"
+        var order = "C" if array.flags.C_CONTIGUOUS else "F"
         numpyarray = np.empty(np_arr_dim, dtype=np_dtype, order=order)
         var pointer_d = numpyarray.__array_interface__["data"][
             0
@@ -565,38 +566,3 @@ fn _list_of_flipped_range(n: Int) -> List[Int]:
     for i in range(n - 1, -1, -1):
         l.append(i)
     return l
-
-
-fn _update_flags(
-    mut flags: Dict[String, Bool],
-    shape: NDArrayShape,
-    strides: NDArrayStrides,
-    ndim: Int,
-) raises:
-    """
-    Update C_CONTIGUOUS and F_CONTIGUOUS of flags
-    according the shape and strides information.
-    """
-    flags["C_CONTIGUOUS"] = (
-        True if (strides[ndim - 1] == 1) or (shape[ndim - 1] == 1) else False
-    )
-    flags["F_CONTIGUOUS"] = (
-        True if (strides[0] == 1) or (shape[0] == 1) else False
-    )
-
-
-fn _update_flags(
-    mut flags: Dict[String, Bool],
-    shape: Tuple[Int, Int],
-    strides: Tuple[Int, Int],
-):
-    """
-    Update C_CONTIGUOUS and F_CONTIGUOUS of flags
-    according the shape and strides information.
-    """
-    flags["C_CONTIGUOUS"] = (
-        True if (strides[1] == 1) or (shape[1] == 1) else False
-    )
-    flags["F_CONTIGUOUS"] = (
-        True if (strides[0] == 1) or (shape[0] == 1) else False
-    )

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -40,9 +40,10 @@ from python import PythonObject
 from sys import simdwidthof
 from tensor import Tensor, TensorShape
 
+from numojo.core.flags import Flags
 from numojo.core.ndarray import NDArray
 from numojo.core.ndshape import NDArrayShape
-from numojo.core.utility import _get_offset, _update_flags
+from numojo.core.utility import _get_offset
 from numojo.core.own_data import OwnData
 
 
@@ -1886,7 +1887,7 @@ fn astype[
         A NDArray with the same shape and strides as `a`
         but with elements casted to `target`.
     """
-    var array_order = "C" if a.flags["C_CONTIGUOUS"] else "F"
+    var array_order = "C" if a.flags.C_CONTIGUOUS else "F"
     var res = NDArray[target](a.shape, order=array_order)
 
     @parameter
@@ -2281,9 +2282,11 @@ fn _0darray[
         strides=NDArrayStrides(ndim=0, initialized=False),
         ndim=0,
         size=1,
-        flags=Dict[String, Bool](),
+        flags=Flags(
+            c_contiguous=True, f_contiguous=True, owndata=True, writeable=False
+        ),
     )
     b._buf = OwnData[dtype](1)
     b._buf.ptr.init_pointee_copy(val)
-    b.flags["OWNDATA"] = True
+    b.flags.OWNDATA = True
     return b

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -103,7 +103,7 @@ fn reshape[
     if A.size != shape.size_of_array():
         raise Error("Cannot reshape: Number of elements do not match.")
 
-    var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+    var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
 
     if array_order != order:
         # Read in this order from the original array
@@ -130,7 +130,7 @@ fn ravel[
         A contiguous flattened array.
     """
 
-    var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+    var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
 
     if A.ndim == 1:
         return A
@@ -227,7 +227,7 @@ fn transpose[
     for i in range(A.ndim):
         new_strides._buf[i] = A.strides[axes[i]]
 
-    var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+    var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
     var I = NDArray[DType.index](Shape(A.size), order=array_order)
     var ptr = I._buf.ptr
     numojo.core.utility._traverse_buffer_according_to_shape_and_strides(
@@ -250,7 +250,7 @@ fn transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     if A.ndim == 1:
         return A
     if A.ndim == 2:
-        var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+        var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
         var B = NDArray[dtype](Shape(A.shape[1], A.shape[0]), order=array_order)
         if A.shape[0] == 1 or A.shape[1] == 1:
             memcpy(B._buf.ptr, A._buf.ptr, A.size)

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -258,9 +258,9 @@ fn _sort_inplace[
             )
         )
 
-    var array_order = "C" if A.flags["C_CONTIGUOUS"] else "F"
+    var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
     var continous_axis = A.ndim - 1 if array_order == "C" else A.ndim - 2
-    """Continuously stored axis. -1 if row-major, -2 if col-major."""
+    """Contiguously stored axis. -1 if row-major, -2 if col-major."""
 
     if axis == continous_axis:  # Last axis
         I = NDArray[DType.index](shape=A.shape)

--- a/tests/core/test_shape_strides_item.mojo
+++ b/tests/core/test_shape_strides_item.mojo
@@ -1,0 +1,31 @@
+from numojo.prelude import *
+from testing.testing import assert_true, assert_almost_equal, assert_equal
+from utils_for_test import check, check_is_close
+
+
+def test_shape():
+    var A = nm.NDArrayShape(2, 3, 4)
+    assert_true(
+        A[-1] == 4,
+        msg=String("`NDArrayShape.__getitem__()` fails: may overflow"),
+    )
+
+
+def test_strides():
+    var A = nm.NDArrayStrides(2, 3, 4)
+    assert_true(
+        A[-1] == 4,
+        msg=String("`NDArrayStrides.__getitem__()` fails: may overflow"),
+    )
+    assert_true(
+        A[-2] == 3,
+        msg=String("`NDArrayStrides.__getitem__()` fails: may overflow"),
+    )
+
+
+def test_item():
+    var A = nm.Item(2, 3, 4)
+    assert_true(
+        A[-1] == 4,
+        msg=String("`NDArrayStrides.__getitem__()` fails: may overflow"),
+    )


### PR DESCRIPTION
Adds the `Flags` type for storing information on memory layout. It replaces the current `Dict[String, Bool]` type. The Flags object can also be accessed dictionary-like. Short names are available for convenience. It is similar to `numpy.flags` object. Example:

```mojo
fn main() raises:
    var A = nm.random.rand(2, 3, 4)
    print(A.flags.C_CONTIGUOUS)
    print(A.flags["C_CONTIGUOUS"])
    print(A.flags["C"])
```

They all print `True`.