### PR TITLE
[mojo] Update the code to accommodate to Mojo v25.1

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -10,7 +10,7 @@ authors = [
     "sandstromviktor <>",
     "durnwalder <>"
 ]
-channels = ["https://conda.modular.com/max-nightly", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
 platforms = ["osx-arm64", "linux-64"]
 license = "Apache-2.0"
 readme = "README.MD"
@@ -46,7 +46,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && magic run final && magic run doc_pages"
 
 [dependencies]
-max = "~=25.1"
+max = "=25.1"
 python = ">=3.11"
 numpy = ">=1.19"
 scipy = ">=1.14"

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -46,8 +46,8 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && magic run final && magic run doc_pages"
 
 [dependencies]
-max = "==24.6.0"
-python = ">=3.9,<3.13"
-numpy = ">=1.19,<2.2"
-scipy = ">=1.14,<1.15"
-mdutils = ">=1.6.0"
+max = "~=25.1"
+python = ">=3.11"
+numpy = ">=1.19"
+scipy = ">=1.14"
+mdutils = ">=1.6"

--- a/numojo/core/complex/complex_dtype.mojo
+++ b/numojo/core/complex/complex_dtype.mojo
@@ -113,14 +113,14 @@ struct CDType(
     - fn: finite (no inf or -inf encodings)
     - uz: unsigned zero (no -0 encoding)
     """
-    alias float8_e4m3fn = CDType(
+    alias float8_e4m3 = CDType(
         __mlir_attr.`#kgen.dtype.constant<f8e4m3> : !kgen.dtype`,
         __mlir_attr.`#kgen.dtype.constant<f8e4m3> : !kgen.dtype`,
     )
     """Represents a FP8E4M3 floating point format from the [OFP8
     standard](https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1).
 
-    This type is named `float8_e4m3fnfn` (the "fn" stands for "finite") in some
+    This type is named `float8_e4m3fn` (the "fn" stands for "finite") in some
     frameworks, as it does not encode -inf or inf.
 
     The 8 bits are encoded as `seeeemmm`:
@@ -236,8 +236,8 @@ struct CDType(
             return CDType.float8_e5m2
         if dtype == DType.float8_e5m2fnuz:
             return CDType.float8_e5m2fnuz
-        if dtype == DType.float8_e4m3fn:
-            return CDType.float8_e4m3fn
+        if dtype == DType.float8_e4m3:
+            return CDType.float8_e4m3
         if dtype == DType.float8_e4m3fnuz:
             return CDType.float8_e4m3fnuz
         if dtype == DType.bfloat16:
@@ -287,8 +287,8 @@ struct CDType(
             return CDType.float8_e5m2
         if dtype == DType.float8_e5m2fnuz:
             return CDType.float8_e5m2fnuz
-        if dtype == DType.float8_e4m3fn:
-            return CDType.float8_e4m3fn
+        if dtype == DType.float8_e4m3:
+            return CDType.float8_e4m3
         if dtype == DType.float8_e4m3fnuz:
             return CDType.float8_e4m3fnuz
         if dtype == DType.bfloat16:
@@ -339,8 +339,8 @@ struct CDType(
             return CDType.float8_e5m2
         elif str == String("float8_e5m2fnuz"):
             return CDType.float8_e5m2fnuz
-        elif str == String("float8_e4m3fn"):
-            return CDType.float8_e4m3fn
+        elif str == String("float8_e4m3"):
+            return CDType.float8_e4m3
         elif str == String("float8_e4m3fnuz"):
             return CDType.float8_e4m3fnuz
         elif str == String("bfloat16"):
@@ -392,8 +392,8 @@ struct CDType(
             return DType.float8_e5m2
         if other == CDType.float8_e5m2fnuz:
             return DType.float8_e5m2fnuz
-        if other == CDType.float8_e4m3fn:
-            return DType.float8_e4m3fn
+        if other == CDType.float8_e4m3:
+            return DType.float8_e4m3
         if other == CDType.float8_e4m3fnuz:
             return DType.float8_e4m3fnuz
         if other == CDType.bfloat16:
@@ -457,8 +457,8 @@ struct CDType(
             return writer.write("cfloat8_e5m2")
         if self == CDType.float8_e5m2fnuz:
             return writer.write("cfloat8_e5m2fnuz")
-        if self == CDType.float8_e4m3fn:
-            return writer.write("cfloat8_e4m3fn")
+        if self == CDType.float8_e4m3:
+            return writer.write("cfloat8_e4m3")
         if self == CDType.float8_e4m3fnuz:
             return writer.write("cfloat8_e4m3fnuz")
         if self == CDType.bfloat16:
@@ -662,7 +662,7 @@ struct CDType(
     @always_inline("nodebug")
     fn is_float8(self) -> Bool:
         """Returns True if the type is a 8bit-precision floating point type,
-        e.g. float8_e5m2, float8_e5m2fnuz, float8_e4m3fn and float8_e4m3fnuz.
+        e.g. float8_e5m2, float8_e5m2fnuz, float8_e4m3 and float8_e4m3fnuz.
 
         Returns:
             True if the type is a 8bit-precision float, false otherwise.
@@ -670,7 +670,7 @@ struct CDType(
 
         return self in (
             CDType.float8_e5m2,
-            CDType.float8_e4m3fn,
+            CDType.float8_e4m3,
             CDType.float8_e5m2fnuz,
             CDType.float8_e4m3fnuz,
         )
@@ -731,8 +731,8 @@ struct CDType(
             return 2 * sizeof[DType.float8_e5m2]()
         if self == CDType.float8_e5m2fnuz:
             return 2 * sizeof[DType.float8_e5m2fnuz]()
-        if self == CDType.float8_e4m3fn:
-            return 2 * sizeof[DType.float8_e4m3fn]()
+        if self == CDType.float8_e4m3:
+            return 2 * sizeof[DType.float8_e4m3]()
         if self == CDType.float8_e4m3fnuz:
             return 2 * sizeof[DType.float8_e4m3fnuz]()
         if self == CDType.bfloat16:

--- a/numojo/core/complex/complex_dtype.mojo
+++ b/numojo/core/complex/complex_dtype.mojo
@@ -81,7 +81,7 @@ struct CDType(
         __mlir_attr.`#kgen.dtype.constant<ui64> : !kgen.dtype`,
     )
     """Represents an unsigned integer type whose bitwidth is 64."""
-    alias float8e5m2 = CDType(
+    alias float8_e5m2 = CDType(
         __mlir_attr.`#kgen.dtype.constant<f8e5m2> : !kgen.dtype`,
         __mlir_attr.`#kgen.dtype.constant<f8e5m2> : !kgen.dtype`,
     )
@@ -98,7 +98,7 @@ struct CDType(
     - -inf: 11111100
     - -0: 10000000
     """
-    alias float8e5m2fnuz = CDType(
+    alias float8_e5m2fnuz = CDType(
         __mlir_attr.`#kgen.dtype.constant<f8e5m2fnuz> : !kgen.dtype`,
         __mlir_attr.`#kgen.dtype.constant<f8e5m2fnuz> : !kgen.dtype`,
     )
@@ -113,14 +113,14 @@ struct CDType(
     - fn: finite (no inf or -inf encodings)
     - uz: unsigned zero (no -0 encoding)
     """
-    alias float8e4m3 = CDType(
+    alias float8_e4m3fn = CDType(
         __mlir_attr.`#kgen.dtype.constant<f8e4m3> : !kgen.dtype`,
         __mlir_attr.`#kgen.dtype.constant<f8e4m3> : !kgen.dtype`,
     )
     """Represents a FP8E4M3 floating point format from the [OFP8
     standard](https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-12-01-pdf-1).
 
-    This type is named `float8_e4m3fn` (the "fn" stands for "finite") in some
+    This type is named `float8_e4m3fnfn` (the "fn" stands for "finite") in some
     frameworks, as it does not encode -inf or inf.
 
     The 8 bits are encoded as `seeeemmm`:
@@ -132,7 +132,7 @@ struct CDType(
     - -0: 10000000
     - fn: finite (no inf or -inf encodings)
     """
-    alias float8e4m3fnuz = CDType(
+    alias float8_e4m3fnuz = CDType(
         __mlir_attr.`#kgen.dtype.constant<f8e4m3fnuz> : !kgen.dtype`,
         __mlir_attr.`#kgen.dtype.constant<f8e4m3fnuz> : !kgen.dtype`,
     )
@@ -232,14 +232,14 @@ struct CDType(
             return CDType.uint64
         if dtype == DType.index:
             return CDType.index
-        if dtype == DType.float8e5m2:
-            return CDType.float8e5m2
-        if dtype == DType.float8e5m2fnuz:
-            return CDType.float8e5m2fnuz
-        if dtype == DType.float8e4m3:
-            return CDType.float8e4m3
-        if dtype == DType.float8e4m3fnuz:
-            return CDType.float8e4m3fnuz
+        if dtype == DType.float8_e5m2:
+            return CDType.float8_e5m2
+        if dtype == DType.float8_e5m2fnuz:
+            return CDType.float8_e5m2fnuz
+        if dtype == DType.float8_e4m3fn:
+            return CDType.float8_e4m3fn
+        if dtype == DType.float8_e4m3fnuz:
+            return CDType.float8_e4m3fnuz
         if dtype == DType.bfloat16:
             return CDType.bfloat16
         if dtype == DType.float16:
@@ -283,14 +283,14 @@ struct CDType(
             return CDType.uint64
         if dtype == DType.index:
             return CDType.index
-        if dtype == DType.float8e5m2:
-            return CDType.float8e5m2
-        if dtype == DType.float8e5m2fnuz:
-            return CDType.float8e5m2fnuz
-        if dtype == DType.float8e4m3:
-            return CDType.float8e4m3
-        if dtype == DType.float8e4m3fnuz:
-            return CDType.float8e4m3fnuz
+        if dtype == DType.float8_e5m2:
+            return CDType.float8_e5m2
+        if dtype == DType.float8_e5m2fnuz:
+            return CDType.float8_e5m2fnuz
+        if dtype == DType.float8_e4m3fn:
+            return CDType.float8_e4m3fn
+        if dtype == DType.float8_e4m3fnuz:
+            return CDType.float8_e4m3fnuz
         if dtype == DType.bfloat16:
             return CDType.bfloat16
         if dtype == DType.float16:
@@ -335,14 +335,14 @@ struct CDType(
             return CDType.uint64
         elif str == String("index"):
             return CDType.index
-        elif str == String("float8e5m2"):
-            return CDType.float8e5m2
-        elif str == String("float8e5m2fnuz"):
-            return CDType.float8e5m2fnuz
-        elif str == String("float8e4m3"):
-            return CDType.float8e4m3
-        elif str == String("float8e4m3fnuz"):
-            return CDType.float8e4m3fnuz
+        elif str == String("float8_e5m2"):
+            return CDType.float8_e5m2
+        elif str == String("float8_e5m2fnuz"):
+            return CDType.float8_e5m2fnuz
+        elif str == String("float8_e4m3fn"):
+            return CDType.float8_e4m3fn
+        elif str == String("float8_e4m3fnuz"):
+            return CDType.float8_e4m3fnuz
         elif str == String("bfloat16"):
             return CDType.bfloat16
         elif str == String("float16"):
@@ -388,14 +388,14 @@ struct CDType(
             return DType.uint64
         if other == CDType.index:
             return DType.index
-        if other == CDType.float8e5m2:
-            return DType.float8e5m2
-        if other == CDType.float8e5m2fnuz:
-            return DType.float8e5m2fnuz
-        if other == CDType.float8e4m3:
-            return DType.float8e4m3
-        if other == CDType.float8e4m3fnuz:
-            return DType.float8e4m3fnuz
+        if other == CDType.float8_e5m2:
+            return DType.float8_e5m2
+        if other == CDType.float8_e5m2fnuz:
+            return DType.float8_e5m2fnuz
+        if other == CDType.float8_e4m3fn:
+            return DType.float8_e4m3fn
+        if other == CDType.float8_e4m3fnuz:
+            return DType.float8_e4m3fnuz
         if other == CDType.bfloat16:
             return DType.bfloat16
         if other == CDType.float16:
@@ -453,14 +453,14 @@ struct CDType(
             return writer.write("cuint64")
         if self == CDType.index:
             return writer.write("cindex")
-        if self == CDType.float8e5m2:
-            return writer.write("cfloat8e5m2")
-        if self == CDType.float8e5m2fnuz:
-            return writer.write("cfloat8e5m2fnuz")
-        if self == CDType.float8e4m3:
-            return writer.write("cfloat8e4m3")
-        if self == CDType.float8e4m3fnuz:
-            return writer.write("cfloat8e4m3fnuz")
+        if self == CDType.float8_e5m2:
+            return writer.write("cfloat8_e5m2")
+        if self == CDType.float8_e5m2fnuz:
+            return writer.write("cfloat8_e5m2fnuz")
+        if self == CDType.float8_e4m3fn:
+            return writer.write("cfloat8_e4m3fn")
+        if self == CDType.float8_e4m3fnuz:
+            return writer.write("cfloat8_e4m3fnuz")
         if self == CDType.bfloat16:
             return writer.write("cbfloat16")
         if self == CDType.float16:
@@ -662,17 +662,17 @@ struct CDType(
     @always_inline("nodebug")
     fn is_float8(self) -> Bool:
         """Returns True if the type is a 8bit-precision floating point type,
-        e.g. float8e5m2, float8e5m2fnuz, float8e4m3 and float8e4m3fnuz.
+        e.g. float8_e5m2, float8_e5m2fnuz, float8_e4m3fn and float8_e4m3fnuz.
 
         Returns:
             True if the type is a 8bit-precision float, false otherwise.
         """
 
         return self in (
-            CDType.float8e5m2,
-            CDType.float8e4m3,
-            CDType.float8e5m2fnuz,
-            CDType.float8e4m3fnuz,
+            CDType.float8_e5m2,
+            CDType.float8_e4m3fn,
+            CDType.float8_e5m2fnuz,
+            CDType.float8_e4m3fnuz,
         )
 
     @always_inline("nodebug")
@@ -706,7 +706,7 @@ struct CDType(
         """
 
         if self._is_non_index_integral():
-            return int(
+            return Int(
                 UInt8(
                     __mlir_op.`pop.shl`(
                         UInt8(1).value,
@@ -727,14 +727,14 @@ struct CDType(
             return 2 * sizeof[DType.bool]()
         if self == CDType.index:
             return 2 * sizeof[DType.index]()
-        if self == CDType.float8e5m2:
-            return 2 * sizeof[DType.float8e5m2]()
-        if self == CDType.float8e5m2fnuz:
-            return 2 * sizeof[DType.float8e5m2fnuz]()
-        if self == CDType.float8e4m3:
-            return 2 * sizeof[DType.float8e4m3]()
-        if self == CDType.float8e4m3fnuz:
-            return 2 * sizeof[DType.float8e4m3fnuz]()
+        if self == CDType.float8_e5m2:
+            return 2 * sizeof[DType.float8_e5m2]()
+        if self == CDType.float8_e5m2fnuz:
+            return 2 * sizeof[DType.float8_e5m2fnuz]()
+        if self == CDType.float8_e4m3fn:
+            return 2 * sizeof[DType.float8_e4m3fn]()
+        if self == CDType.float8_e4m3fnuz:
+            return 2 * sizeof[DType.float8_e4m3fnuz]()
         if self == CDType.bfloat16:
             return 2 * sizeof[DType.bfloat16]()
         if self == CDType.float16:

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -115,8 +115,8 @@ struct ComplexNDArray[
         var A = nm.ComplexNDArray[cf32](Shape(2,3,4))
         ```
         """
-        self._re.__init__(shape, order)
-        self._im.__init__(shape, order)
+        self._re = NDArray[dtype](shape, order)
+        self._im = NDArray[dtype](shape, order)
         self.ndim = self._re.ndim
         self.shape = self._re.shape
         self.size = self._re.size
@@ -136,8 +136,8 @@ struct ComplexNDArray[
             shape: List of shape.
             order: Memory order C or F.
         """
-        self._re.__init__(shape, order)
-        self._im.__init__(shape, order)
+        self._re = NDArray[dtype](shape, order)
+        self._im = NDArray[dtype](shape, order)
         self.ndim = self._re.ndim
         self.shape = self._re.shape
         self.size = self._re.size
@@ -157,8 +157,8 @@ struct ComplexNDArray[
             shape: Variadic List of shape.
             order: Memory order C or F.
         """
-        self._re.__init__(shape, order)
-        self._im.__init__(shape, order)
+        self._re = NDArray[dtype](shape, order)
+        self._im = NDArray[dtype](shape, order)
         self.ndim = self._re.ndim
         self.shape = self._re.shape
         self.size = self._re.size
@@ -174,8 +174,8 @@ struct ComplexNDArray[
         """
         Extremely specific ComplexNDArray initializer.
         """
-        self._re.__init__(shape, offset, strides)
-        self._im.__init__(shape, offset, strides)
+        self._re = NDArray[dtype](shape, offset, strides)
+        self._im = NDArray[dtype](shape, offset, strides)
         self.ndim = self._re.ndim
         self.shape = self._re.shape
         self.size = self._re.size
@@ -193,8 +193,8 @@ struct ComplexNDArray[
         """
         Extremely specific ComplexNDArray initializer.
         """
-        self._re.__init__(shape, buffer_re, offset, strides)
-        self._im.__init__(shape, buffer_im, offset, strides)
+        self._re = NDArray(shape, buffer_re, offset, strides)
+        self._im = NDArray(shape, buffer_re, offset, strides)
         self.ndim = self._re.ndim
         self.shape = self._re.shape
         self.size = self._re.size
@@ -206,8 +206,8 @@ struct ComplexNDArray[
         """
         Copy other into self.
         """
-        self._re.__copyinit__(other._re)
-        self._im.__copyinit__(other._im)
+        self._re = other._re
+        self._im = other._im
         self.ndim = other.ndim
         self.shape = other.shape
         self.size = other.size
@@ -219,8 +219,8 @@ struct ComplexNDArray[
         """
         Move other into self.
         """
-        self._re.__moveinit__(existing._re)
-        self._im.__moveinit__(existing._im)
+        self._re = existing._re^
+        self._im = existing._im^
         self.ndim = existing.ndim
         self.shape = existing.shape
         self.size = existing.size
@@ -570,10 +570,10 @@ struct ComplexNDArray[
 
         for i in range(len(index)):
             self._re.store(
-                int(index.load(i)), rebind[Scalar[dtype]](val._re.load(i))
+                Int(index.load(i)), rebind[Scalar[dtype]](val._re.load(i))
             )
             self._im.store(
-                int(index.load(i)), rebind[Scalar[dtype]](val._im.load(i))
+                Int(index.load(i)), rebind[Scalar[dtype]](val._im.load(i))
             )
 
     fn __setitem__(
@@ -923,7 +923,7 @@ struct ComplexNDArray[
         ndshape[0] = len(index)
         ndsize = 1
         for i in range(ndshape.ndim):
-            ndsize *= int(ndshape._buf[i])
+            ndsize *= Int(ndshape._buf[i])
         var result = ComplexNDArray[cdtype, dtype=dtype](ndshape)
         var size_per_item = ndsize // len(index)
 
@@ -931,10 +931,10 @@ struct ComplexNDArray[
         for i in range(len(index)):
             for j in range(size_per_item):
                 result._re._buf.ptr.store(
-                    i * size_per_item + j, self[int(index[i])].item(j).re
+                    i * size_per_item + j, self[Int(index[i])].item(j).re
                 )
                 result._im._buf.ptr.store(
-                    i * size_per_item + j, self[int(index[i])].item(j).im
+                    i * size_per_item + j, self[Int(index[i])].item(j).im
                 )
 
         return result
@@ -948,7 +948,7 @@ struct ComplexNDArray[
 
         var new_index = List[Int]()
         for i in index:
-            new_index.append(int(i.item(0)))
+            new_index.append(Int(i.item(0)))
 
         return self[new_index]
 
@@ -1427,13 +1427,13 @@ struct ComplexNDArray[
     # ===-------------------------------------------------------------------===#
     fn __str__(self) -> String:
         """
-        Enables str(array).
+        Enables String(array).
         """
         var res: String
         try:
             res = self._array_to_string(0, 0, GLOBAL_PRINT_OPTIONS)
         except e:
-            res = String("Cannot convert array to string") + str(e)
+            res = String("Cannot convert array to string") + String(e)
 
         return res
 
@@ -1442,22 +1442,22 @@ struct ComplexNDArray[
             writer.write(
                 self._array_to_string(0, 0, GLOBAL_PRINT_OPTIONS)
                 + "\n"
-                + str(self.ndim)
+                + String(self.ndim)
                 + "D-array  Shape"
-                + str(self.shape)
+                + String(self.shape)
                 + "  Strides"
-                + str(self.strides)
+                + String(self.strides)
                 + "  DType: "
                 + _concise_dtype_str(self.dtype)
                 + "  C-cont: "
-                + str(self.flags["C_CONTIGUOUS"])
+                + String(self.flags["C_CONTIGUOUS"])
                 + "  F-cont: "
-                + str(self.flags["F_CONTIGUOUS"])
+                + String(self.flags["F_CONTIGUOUS"])
                 + "  own data: "
-                + str(self.flags["OWNDATA"])
+                + String(self.flags["OWNDATA"])
             )
         except e:
-            writer.write("Cannot convert array to string" + str(e))
+            writer.write("Cannot convert array to string" + String(e))
 
     fn __repr__(self) -> String:
         """
@@ -1474,22 +1474,24 @@ struct ComplexNDArray[
         ```.
         """
         try:
-            var result: String = str("ComplexNDArray[CDType.") + str(
+            var result: String = String("ComplexNDArray[CDType.") + String(
                 self.cdtype
-            ) + str("](List[ComplexSIMD[CDType.c") + str(self._re.dtype) + str(
+            ) + String("](List[ComplexSIMD[CDType.c") + String(
+                self._re.dtype
+            ) + String(
                 "]]("
             )
             if self._re.size > 6:
                 for i in range(6):
-                    result = result + str(self.item(i)) + str(",")
+                    result = result + String(self.item(i)) + String(",")
                 result = result + " ... "
             else:
                 for i in range(self._re.size):
-                    result = result + str(self.item(i)) + str(",")
-            result = result + str("), shape=List[Int](")
+                    result = result + String(self.item(i)) + String(",")
+            result = result + String("), shape=List[Int](")
             for i in range(self._re.shape.ndim):
-                result = result + str(self._re.shape._buf[i]) + ","
-            result = result + str("))")
+                result = result + String(self._re.shape._buf[i]) + ","
+            result = result + String("))")
             return result
         except e:
             print("Cannot convert array to string", e)
@@ -1514,7 +1516,7 @@ struct ComplexNDArray[
         var edge_items = print_options.edge_items
 
         if self.ndim == 0:
-            return str(self.item(0))
+            return String(self.item(0))
         if dimension == self.ndim - 1:
             var result: String = String("[") + padding
             var number_of_items = self.shape[dimension]
@@ -1550,7 +1552,7 @@ struct ComplexNDArray[
             result = result + "]"
             return result
         else:
-            var result: String = str("[")
+            var result: String = String("[")
             var number_of_items = self.shape[dimension]
             if number_of_items <= edge_items:  # Print all items
                 for i in range(number_of_items):
@@ -1563,7 +1565,7 @@ struct ComplexNDArray[
                     if i > 0:
                         result = (
                             result
-                            + str(" ") * (dimension + 1)
+                            + String(" ") * (dimension + 1)
                             + self._array_to_string(
                                 dimension + 1,
                                 offset + i * self.strides[dimension].__int__(),
@@ -1583,7 +1585,7 @@ struct ComplexNDArray[
                     if i > 0:
                         result = (
                             result
-                            + str(" ") * (dimension + 1)
+                            + String(" ") * (dimension + 1)
                             + self._array_to_string(
                                 dimension + 1,
                                 offset + i * self.strides[dimension].__int__(),
@@ -1596,7 +1598,7 @@ struct ComplexNDArray[
                 for i in range(number_of_items - edge_items, number_of_items):
                     result = (
                         result
-                        + str(" ") * (dimension + 1)
+                        + String(" ") * (dimension + 1)
                         + self._array_to_string(
                             dimension + 1,
                             offset + i * self.strides[dimension].__int__(),
@@ -1609,7 +1611,7 @@ struct ComplexNDArray[
             return result
 
     fn __len__(self) -> Int:
-        return int(self._re.size)
+        return Int(self._re.size)
 
     fn load[
         width: Int = 1

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -260,7 +260,7 @@ struct ComplexSIMD[
         Returns:
             String: The string representation of the ComplexSIMD instance.
         """
-        return "ComplexSIMD[{}]({}, {})".format(str(dtype), self.re, self.im)
+        return "ComplexSIMD[{}]({}, {})".format(String(dtype), self.re, self.im)
 
     fn __getitem__(self, idx: Int) raises -> SIMD[dtype, size]:
         """

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -26,7 +26,7 @@ struct Item(CollectionElement):
         """Construct the tuple.
 
         Parameter:
-            T: Type of values. It can be converted to `Int` with `index()`.
+            T: Type of values. It can be converted to `Int` with `Int()`.
 
         Args:
             args: Initial values.
@@ -34,14 +34,14 @@ struct Item(CollectionElement):
         self._buf = UnsafePointer[Int]().alloc(args.__len__())
         self.ndim = args.__len__()
         for i in range(args.__len__()):
-            self._buf[i] = index(args[i])
+            self._buf[i] = Int(args[i])
 
     @always_inline("nodebug")
     fn __init__[T: IndexerCollectionElement](out self, args: List[T]) raises:
         """Construct the tuple.
 
         Parameter:
-            T: Type of values. It can be converted to `Int` with `index()`.
+            T: Type of values. It can be converted to `Int` with `Int()`.
 
         Args:
             args: Initial values.
@@ -49,7 +49,7 @@ struct Item(CollectionElement):
         self.ndim = len(args)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
-            (self._buf + i).init_pointee_copy(index(args[i]))
+            (self._buf + i).init_pointee_copy(Int(args[i]))
 
     @always_inline("nodebug")
     fn __init__(out self, args: VariadicList[Int]) raises:
@@ -61,7 +61,7 @@ struct Item(CollectionElement):
         self.ndim = len(args)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
-            (self._buf + i).init_pointee_copy(index(args[i]))
+            (self._buf + i).init_pointee_copy(Int(args[i]))
 
     @always_inline("nodebug")
     fn __init__(
@@ -118,7 +118,7 @@ struct Item(CollectionElement):
         """Get the value at the specified index.
 
         Parameter:
-            T: Type of values. It can be converted to `Int` with `index()`.
+            T: Type of values. It can be converted to `Int` with `Int()`.
 
         Args:
             idx: The index of the value to get.
@@ -127,16 +127,16 @@ struct Item(CollectionElement):
             The value at the specified index.
         """
 
-        var normalized_idx: Int = index(idx)
+        var normalized_idx: Int = Int(idx)
         if normalized_idx < 0:
-            normalized_idx = idx + self.ndim
+            normalized_idx = Int(idx) + self.ndim
 
         if normalized_idx < 0 or normalized_idx >= self.ndim:
             raise Error(
                 String(
                     "Error in `numojo.Item.__getitem__()`: \n"
                     "Index ({}) out of range [{}, {})\n"
-                ).format(index(idx), -self.ndim, self.ndim - 1)
+                ).format(Int(idx), -self.ndim, self.ndim - 1)
             )
 
         return self._buf[normalized_idx]
@@ -146,27 +146,27 @@ struct Item(CollectionElement):
         """Set the value at the specified index.
 
         Parameter:
-            T: Type of values. It can be converted to `Int` with `index()`.
-            U: Type of values. It can be converted to `Int` with `index()`.
+            T: Type of values. It can be converted to `Int` with `Int()`.
+            U: Type of values. It can be converted to `Int` with `Int()`.
 
         Args:
             idx: The index of the value to set.
             val: The value to set.
         """
 
-        var normalized_idx: Int = index(idx)
+        var normalized_idx: Int = Int(idx)
         if normalized_idx < 0:
-            normalized_idx = idx + self.ndim
+            normalized_idx = Int(idx) + self.ndim
 
         if normalized_idx < 0 or normalized_idx >= self.ndim:
             raise Error(
                 String(
                     "Error in `numojo.Item.__getitem__()`: \n"
                     "Index ({}) out of range [{}, {})\n"
-                ).format(index(idx), -self.ndim, self.ndim - 1)
+                ).format(Int(idx), -self.ndim, self.ndim - 1)
             )
 
-        self._buf[normalized_idx] = index(val)
+        self._buf[normalized_idx] = Int(val)
 
     fn __iter__(self) raises -> _ItemIter:
         """Iterate over elements of the NDArray, returning copied value.
@@ -184,13 +184,13 @@ struct Item(CollectionElement):
         )
 
     fn __repr__(self) -> String:
-        var result: String = "numojo.Item" + str(self)
+        var result: String = "numojo.Item" + String(self)
         return result
 
     fn __str__(self) -> String:
         var result: String = "("
         for i in range(self.ndim):
-            result += str(self._buf[i])
+            result += String(self._buf[i])
             if i < self.ndim - 1:
                 result += ","
         result += ")"
@@ -198,7 +198,11 @@ struct Item(CollectionElement):
 
     fn write_to[W: Writer](self, mut writer: W):
         writer.write(
-            "Item at index: " + str(self) + "  " + "Length: " + str(self.ndim)
+            "Item at index: "
+            + String(self)
+            + "  "
+            + "Length: "
+            + String(self.ndim)
         )
 
 

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -478,26 +478,26 @@ struct Matrix[dtype: DType = DType.float64](
 
     fn write_to[W: Writer](self, mut writer: W):
         fn print_row(self: Self, i: Int, sep: String) raises -> String:
-            var result: String = str("[")
+            var result: String = String("[")
             var number_of_sep: Int = 1
             if self.shape[1] <= 6:
                 for j in range(self.shape[1]):
                     if j == self.shape[1] - 1:
                         number_of_sep = 0
-                    result += str(self[i, j]) + sep * number_of_sep
+                    result += String(self[i, j]) + sep * number_of_sep
             else:
                 for j in range(3):
-                    result += str(self[i, j]) + sep
-                result += str("...") + sep
+                    result += String(self[i, j]) + sep
+                result += String("...") + sep
                 for j in range(self.shape[1] - 3, self.shape[1]):
                     if j == self.shape[1] - 1:
                         number_of_sep = 0
-                    result += str(self[i, j]) + sep * number_of_sep
-            result += str("]")
+                    result += String(self[i, j]) + sep * number_of_sep
+            result += String("]")
             return result
 
-        var sep: String = str("\t")
-        var newline: String = str("\n ")
+        var sep: String = String("\t")
+        var newline: String = String("\n ")
         var number_of_newline: Int = 1
         var result: String = "["
 
@@ -512,32 +512,32 @@ struct Matrix[dtype: DType = DType.float64](
             else:
                 for i in range(3):
                     result += print_row(self, i, sep) + newline
-                result += str("...") + newline
+                result += String("...") + newline
                 for i in range(self.shape[0] - 3, self.shape[0]):
                     if i == self.shape[0] - 1:
                         number_of_newline = 0
                     result += (
                         print_row(self, i, sep) + newline * number_of_newline
                     )
-            result += str("]")
+            result += String("]")
             writer.write(
                 result
                 + "\nDType: "
-                + str(self.dtype)
+                + String(self.dtype)
                 + "  Shape: "
-                + str(self.shape[0])
+                + String(self.shape[0])
                 + "x"
-                + str(self.shape[1])
+                + String(self.shape[1])
                 + "  Strides: "
-                + str(self.strides[0])
+                + String(self.strides[0])
                 + ","
-                + str(self.strides[1])
+                + String(self.strides[1])
                 + "  C: "
-                + str(self.flags["C_CONTIGUOUS"])
+                + String(self.flags["C_CONTIGUOUS"])
                 + "  F: "
-                + str(self.flags["F_CONTIGUOUS"])
+                + String(self.flags["F_CONTIGUOUS"])
                 + "  Own: "
-                + str(self.flags["OWNDATA"])
+                + String(self.flags["OWNDATA"])
             )
         except e:
             print("Cannot transfer matrix to string!", e)
@@ -1428,16 +1428,20 @@ struct Matrix[dtype: DType = DType.float64](
 
         for i in range(len(bytes)):
             var b = bytes[i]
-            if isdigit(b) or (chr(int(b)) == ".") or (chr(int(b)) == "-"):
-                number_as_str = number_as_str + chr(int(b))
+            if (
+                chr(Int(b)).isdigit()
+                or (chr(Int(b)) == ".")
+                or (chr(Int(b)) == "-")
+            ):
+                number_as_str = number_as_str + chr(Int(b))
                 if i == len(bytes) - 1:  # Last byte
                     var number = atof(number_as_str).cast[dtype]()
                     data.append(number)  # Add the number to the data buffer
                     number_as_str = ""  # Clean the number cache
             if (
-                (chr(int(b)) == ",")
-                or (chr(int(b)) == "]")
-                or (chr(int(b)) == " ")
+                (chr(Int(b)) == ",")
+                or (chr(Int(b)) == "]")
+                or (chr(Int(b)) == " ")
             ):
                 if number_as_str != "":
                     var number = atof(number_as_str).cast[dtype]()

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -710,7 +710,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         for i in range(len(index)):
-            self.store(int(index.load(i)), rebind[Scalar[dtype]](val.load(i)))
+            self.store(Int(index.load(i)), rebind[Scalar[dtype]](val.load(i)))
 
     fn __setitem__(
         mut self, mask: NDArray[DType.bool], val: NDArray[dtype]
@@ -1501,13 +1501,13 @@ struct NDArray[dtype: DType = DType.float64](
         Example:
         ```console
         > var A = NDArray[dtype](6, random=True)
-        > print(int(A))
+        > print(Int(A))
 
         Unhandled exception caught during execution: Only 0-D arrays or length-1 arrays can be converted to scalars
         mojo: error: execution exited with a non-zero result: 1
 
         > var B = NDArray[dtype](1, 1, random=True)
-        > print(int(B))
+        > print(Int(B))
         14
         ```
 
@@ -1516,7 +1516,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         """
         if (self.size == 1) or (self.ndim == 0):
-            return int(self._buf.ptr[])
+            return Int(self._buf.ptr[])
         else:
             raise Error(
                 "Error in `numojo.NDArray.__int__(self)`: \n"
@@ -1538,7 +1538,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         """
         if (self.size == 1) or (self.ndim == 0):
-            return float(self._buf.ptr[])
+            return Float64(self._buf.ptr[])
         else:
             raise Error(
                 "Error in `numojo.NDArray.__int__(self)`: \n"
@@ -2252,13 +2252,13 @@ struct NDArray[dtype: DType = DType.float64](
     # ===-------------------------------------------------------------------===#
     fn __str__(self) -> String:
         """
-        Enables str(array).
+        Enables String(array).
         """
         var res: String
         try:
             res = self._array_to_string(0, 0, GLOBAL_PRINT_OPTIONS)
         except e:
-            res = String("Cannot convert array to string.\n") + str(e)
+            res = String("Cannot convert array to string.\n") + String(e)
 
         return res
 
@@ -2266,7 +2266,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.ndim == 0:
             # For 0darray (numojo scalar), we can directly write the value
             writer.write(
-                str(self._buf.ptr[])
+                String(self._buf.ptr[])
                 + String("  (0darray[" + _concise_dtype_str(self.dtype) + "])")
             )
         else:
@@ -2274,22 +2274,22 @@ struct NDArray[dtype: DType = DType.float64](
                 writer.write(
                     self._array_to_string(0, 0, GLOBAL_PRINT_OPTIONS)
                     + "\n"
-                    + str(self.ndim)
+                    + String(self.ndim)
                     + "D-array  Shape"
-                    + str(self.shape)
+                    + String(self.shape)
                     + "  Strides"
-                    + str(self.strides)
+                    + String(self.strides)
                     + "  DType: "
                     + _concise_dtype_str(self.dtype)
                     + "  C-cont: "
-                    + str(self.flags.C_CONTIGUOUS)
+                    + String(self.flags.C_CONTIGUOUS)
                     + "  F-cont: "
-                    + str(self.flags.F_CONTIGUOUS)
+                    + String(self.flags.F_CONTIGUOUS)
                     + "  own data: "
-                    + str(self.flags.OWNDATA)
+                    + String(self.flags.OWNDATA)
                 )
             except e:
-                writer.write("Cannot convert array to string.\n" + str(e))
+                writer.write("Cannot convert array to string.\n" + String(e))
 
     fn __repr__(self) -> String:
         """
@@ -2316,14 +2316,14 @@ struct NDArray[dtype: DType = DType.float64](
 
         try:
             result = (
-                str("numojo.array[")
+                String("numojo.array[")
                 + _concise_dtype_str(self.dtype)
-                + str('](\n"""\n')
+                + String('](\n"""\n')
                 + self._array_to_string(0, 0, GLOBAL_PRINT_OPTIONS)
                 + '\n"""\n)'
             )
         except e:
-            result = "Cannot convert array to string.\n" + str(e)
+            result = "Cannot convert array to string.\n" + String(e)
 
         return result
 
@@ -2452,7 +2452,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.ndim == 0:
             # For 0darray (numojo scalar), return the scalar value.
-            return str(self._buf.ptr[0])
+            return String(self._buf.ptr[0])
 
         var seperator = print_options.separator
         var padding = print_options.padding
@@ -2499,18 +2499,18 @@ struct NDArray[dtype: DType = DType.float64](
                 min_value,
                 abs(val),
             )
-        number_of_digits = int(log10(float(max_value))) + 1
-        number_of_digits_small_values = abs(int(log10(float(min_value)))) + 1
+        number_of_digits = Int(log10(Float64(max_value))) + 1
+        number_of_digits_small_values = abs(Int(log10(Float64(min_value)))) + 1
 
         if dtype.is_floating_point():
             formatted_width = (
                 print_options.precision
                 + 1
                 + number_of_digits
-                + int(negative_sign)
+                + Int(negative_sign)
             )
         else:
-            formatted_width = number_of_digits + int(negative_sign)
+            formatted_width = number_of_digits + Int(negative_sign)
 
         # If the number is not too wide,
         # or digits after decimal point is not many
@@ -2557,7 +2557,7 @@ struct NDArray[dtype: DType = DType.float64](
             result = result + "]"
             return result
         else:
-            var result: String = str("[")
+            var result: String = String("[")
             var number_of_items = self.shape[dimension]
             if number_of_items <= edge_items * 2:  # Print all items
                 for i in range(number_of_items):
@@ -2570,7 +2570,7 @@ struct NDArray[dtype: DType = DType.float64](
                     if i > 0:
                         result = (
                             result
-                            + str(" ") * (dimension + 1)
+                            + String(" ") * (dimension + 1)
                             + self._array_to_string(
                                 dimension + 1,
                                 offset + i * self.strides[dimension].__int__(),
@@ -2590,7 +2590,7 @@ struct NDArray[dtype: DType = DType.float64](
                     if i > 0:
                         result = (
                             result
-                            + str(" ") * (dimension + 1)
+                            + String(" ") * (dimension + 1)
                             + self._array_to_string(
                                 dimension + 1,
                                 offset + i * self.strides[dimension].__int__(),
@@ -2603,7 +2603,7 @@ struct NDArray[dtype: DType = DType.float64](
                 for i in range(number_of_items - edge_items, number_of_items):
                     result = (
                         result
-                        + str(" ") * (dimension + 1)
+                        + String(" ") * (dimension + 1)
                         + self._array_to_string(
                             dimension + 1,
                             offset + i * self.strides[dimension].__int__(),

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -356,7 +356,7 @@ struct NDArrayShape(Stringable, Writable):
         Returns:
             String representation of the shape of the array.
         """
-        return "numojo.Shape" + str(self)
+        return "numojo.Shape" + String(self)
 
     @always_inline("nodebug")
     fn __str__(self) -> String:
@@ -368,14 +368,16 @@ struct NDArrayShape(Stringable, Writable):
         """
         var result: String = "("
         for i in range(self.ndim):
-            result += str(self._buf[i])
+            result += String(self._buf[i])
             if i < self.ndim - 1:
                 result += ","
         result += ")"
         return result
 
     fn write_to[W: Writer](self, mut writer: W):
-        writer.write("Shape: " + str(self) + "  " + "ndim: " + str(self.ndim))
+        writer.write(
+            "Shape: " + String(self) + "  " + "ndim: " + String(self.ndim)
+        )
 
     @always_inline("nodebug")
     fn __eq__(self, other: Self) -> Bool:

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -334,7 +334,7 @@ struct NDArrayStrides(Stringable):
         Returns:
             String representation of the strides of the array.
         """
-        return "numojo.Strides" + str(self)
+        return "numojo.Strides" + String(self)
 
     @always_inline("nodebug")
     fn __str__(self) -> String:
@@ -346,14 +346,16 @@ struct NDArrayStrides(Stringable):
         """
         var result: String = "("
         for i in range(self.ndim):
-            result += str(self._buf[i])
+            result += String(self._buf[i])
             if i < self.ndim - 1:
                 result += ","
         result = result + ")"
         return result
 
     fn write_to[W: Writer](self, mut writer: W):
-        writer.write("Strides: " + str(self) + "  " + "ndim: " + str(self.ndim))
+        writer.write(
+            "Strides: " + String(self) + "  " + "ndim: " + String(self.ndim)
+        )
 
     @always_inline("nodebug")
     fn __eq__(self, other: Self) -> Bool:

--- a/numojo/core/traits/indexer_collection_element.mojo
+++ b/numojo/core/traits/indexer_collection_element.mojo
@@ -1,4 +1,4 @@
-trait IndexerCollectionElement(Indexer, CollectionElement):
+trait IndexerCollectionElement(CollectionElement, Indexer):
     """The IndexerCollectionElement trait denotes a trait composition
     of the `Indexer` and `CollectionElement` traits.
 

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -91,7 +91,7 @@ fn arange[
     (Overload) When start is 0 and step is 1.
     """
 
-    var size = int(stop)
+    var size = Int(stop)
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(size))
     for i in range(size):
         (result._buf.ptr + i).init_pointee_copy(Scalar[dtype](i))
@@ -159,8 +159,8 @@ fn arange[
     (Overload) When start is 0 and step is 1.
     """
 
-    var size_re = int(stop.re)
-    var size_im = int(stop.im)
+    var size_re = Int(stop.re)
+    var size_im = Int(stop.im)
     if size_re != size_im:
         raise Error(
             "Number of real and imaginary parts are not equal {} != {}".format(
@@ -2031,22 +2031,26 @@ fn fromstring[
     var number_as_str: String = ""
     for i in range(len(bytes)):
         var b = bytes[i]
-        if chr(int(b)) == "[":
+        if chr(Int(b)) == "[":
             level += 1
             ndim = max(ndim, level)
             if len(shape) < ndim:
                 shape.append(0)
             shape[level - 1] = 0
 
-        if isdigit(b) or (chr(int(b)) == ".") or (chr(int(b)) == "-"):
-            number_as_str = number_as_str + chr(int(b))
-        if (chr(int(b)) == ",") or (chr(int(b)) == "]"):
+        if (
+            chr(Int(b)).isdigit()
+            or (chr(Int(b)) == ".")
+            or (chr(Int(b)) == "-")
+        ):
+            number_as_str = number_as_str + chr(Int(b))
+        if (chr(Int(b)) == ",") or (chr(Int(b)) == "]"):
             if number_as_str != "":
                 var number = atof(number_as_str).cast[dtype]()
                 data.append(number)  # Add the number to the data buffer
                 number_as_str = ""  # Clean the number cache
                 shape[-1] = shape[-1] + 1
-        if chr(int(b)) == "]":
+        if chr(Int(b)) == "]":
             level = level - 1
             if level < 0:
                 raise ("Unmatched left and right brackets!")
@@ -2214,16 +2218,16 @@ fn array[
         An Array of given data, shape and order.
     """
 
-    var len = int(len(data.shape))
+    var len = Int(len(data.shape))
     var shape: List[Int] = List[Int]()
     for i in range(len):
-        if int(data.shape[i]) == 1:
+        if Int(data.shape[i]) == 1:
             continue
-        shape.append(int(data.shape[i]))
+        shape.append(Int(data.shape[i]))
     A = NDArray[dtype](NDArrayShape(shape), order=order)
     for i in range(A.size):
         (A._buf.ptr + i).init_pointee_copy(
-            float(data.item(PythonObject(i))).cast[dtype]()
+            Float64(data.item(PythonObject(i))).cast[dtype]()
         )
     return A
 

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -20,11 +20,11 @@ fn loadtxt[
         var shape_offset_fin: Int = string.find("]")
         var ndim_offset_init: Int = string.find("[", start=shape_offset_fin)
         var ndim_offset_fin: Int = string.find("]", start=ndim_offset_init)
-        var ndim: Int = int(string[ndim_offset_init + 1 : ndim_offset_fin])
+        var ndim: Int = Int(string[ndim_offset_init + 1 : ndim_offset_fin])
         var ndshape: List[Int] = List[Int]()
         for i in range(shape_offset_init + 1, shape_offset_fin):
             if string[i].isdigit():
-                ndshape.append(int(string[i]))
+                ndshape.append(Int(string[i]))
         var data: List[Scalar[dtype]] = List[Scalar[dtype]]()
         for i in range(ndim_offset_fin + 2, len(string)):
             if string[i].isdigit():
@@ -38,7 +38,7 @@ fn savetxt[
 ](filename: String, array: NDArray[dtype], delimiter: String = ",") raises:
     var shape: String = "ndshape=["
     for i in range(array.ndim):
-        shape += str(array.shape[i])
+        shape += String(array.shape[i])
         if i != array.ndim - 1:
             shape = shape + ", "
     shape = shape + "]"
@@ -46,8 +46,8 @@ fn savetxt[
 
     with open(filename, "w") as file:
         file.write(shape + "\n")
-        file.write("ndim=[" + str(array.ndim) + "]\n")
+        file.write("ndim=[" + String(array.ndim) + "]\n")
         for i in range(array.size):
             if i % 10 == 0:
-                file.write(str("\n"))
-            file.write(str(array._buf.ptr[i]) + ",")
+                file.write(String("\n"))
+            file.write(String(array._buf.ptr[i]) + ",")

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -229,11 +229,11 @@ fn format_floating_scientific[
                 var result: String = " 0." + "0" * precision + "e+00"
                 return result.rjust(formatted_width)
 
-        var power: Int = int(mt.log10(abs(x)))
+        var power: Int = Int(mt.log10(abs(x)))
         if Scalar[dtype](0.0) < abs(x) < Scalar[dtype](1.0):
             power -= 1
         var mantissa: Scalar[dtype] = x / pow(10.0, power).cast[dtype]()
-        var mantissa_without_sign_string = str(abs(mantissa))
+        var mantissa_without_sign_string = String(abs(mantissa))
 
         var result: String
         if x < 0:
@@ -308,10 +308,10 @@ fn format_floating_precision[
     var scaling_factor = 10**precision
     var rounded_value = round(value * scaling_factor) / scaling_factor
 
-    var integer_part = int(rounded_value)
+    var integer_part = Int(rounded_value)
     var fractional_part = abs(rounded_value - integer_part)
 
-    var result = str(integer_part)
+    var result = String(integer_part)
     if Scalar[dtype](0) > rounded_value > Scalar[dtype](-1):
         result = "-" + result
 
@@ -319,8 +319,8 @@ fn format_floating_precision[
         result += "."
         for _ in range(precision):
             fractional_part *= 10
-            var digit = int(fractional_part)
-            result += str(digit)
+            var digit = Int(fractional_part)
+            result += String(digit)
             fractional_part -= digit
 
     if sign and value > 0:
@@ -393,7 +393,7 @@ fn format_value[
                 value, print_options.precision, sign
             ).rjust(formatted_width)
     else:
-        var formatted = str(value)
+        var formatted = String(value)
         if sign and value > 0:
             formatted = "+" + formatted
         return formatted.rjust(formatted_width)
@@ -458,8 +458,8 @@ fn format_value[
         if value.re == 0 and value.im == 0:
             im_str = "+" + im_str
     else:
-        re_str = str(value.re)
-        im_str = str(value.im)
+        re_str = String(value.re)
+        im_str = String(value.im)
         if sign:
             if value.re >= 0:
                 re_str = "+" + re_str

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -13,7 +13,7 @@ from numojo.routines.creation import zeros, eye, full
 fn compute_householder[
     dtype: DType
 ](
-    inout H: Matrix[dtype], inout R: Matrix[dtype], row: Int, column: Int
+    mut H: Matrix[dtype], mut R: Matrix[dtype], row: Int, column: Int
 ) raises -> None:
     var sqrt2: SIMD[dtype, 1] = 1.4142135623730951
     var rRows = R.shape[0]
@@ -54,9 +54,9 @@ fn compute_householder[
 fn compute_qr[
     dtype: DType
 ](
-    inout H: Matrix[dtype],
+    mut H: Matrix[dtype],
     work_index: Int,
-    inout A: Matrix[dtype],
+    mut A: Matrix[dtype],
     row_start: Int,
     column_start: Int,
 ) raises -> None:

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -239,8 +239,8 @@ fn cumsum[
 
     for i in range(0, A.size, A.shape[axis]):
         for j in range(A.shape[axis] - 1):
-            A._buf.ptr[int(I._buf.ptr[i + j + 1])] += A._buf.ptr[
-                int(I._buf.ptr[i + j])
+            A._buf.ptr[Int(I._buf.ptr[i + j + 1])] += A._buf.ptr[
+                Int(I._buf.ptr[i + j])
             ]
 
     return A^

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -445,8 +445,8 @@ fn _int_rand_func[
     builtin_random.randint[dtype](
         ptr=result._buf.ptr,
         size=result.size,
-        low=int(min),
-        high=int(max),
+        low=Int(min),
+        high=Int(max),
     )
 
 

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -332,11 +332,7 @@ def test_sorting():
         )
 
     check_matrices_close(
-        nm.argsort(A),
-        np.argsort(Anp, axis=None),
-        String("Argsort is broken")
-        + str(nm.argsort(A))
-        + str(np.argsort(Anp, axis=None)),
+        nm.argsort(A), np.argsort(Anp, axis=None), String("Argsort is broken")
     )
     for i in range(2):
         check_matrices_close(

--- a/tests/science/test_signal.mojo
+++ b/tests/science/test_signal.mojo
@@ -15,8 +15,4 @@ def test_convolve2d():
 
     res1 = nm.science.signal.convolve2d(in1, in2)
     res2 = sp.signal.convolve2d(npin1, npin2, mode="valid")
-    check(
-        res1,
-        res2,
-        "test_convolve2d failed #2\n" + str(res1) + "\n" + str(res2),
-    )
+    check(res1, res2, "test_convolve2d failed #2\n")

--- a/tests/utils_for_test.mojo
+++ b/tests/utils_for_test.mojo
@@ -14,7 +14,7 @@ fn check_with_dtype[
     dtype: DType
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
-    assert_true(str(array.dtype) == str(np_sol.dtype), "DType mismatch")
+    assert_true(String(array.dtype) == String(np_sol.dtype), "DType mismatch")
     assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)
 
 


### PR DESCRIPTION
Updates the code to accommodate to Mojo v25.1. The changes include but are not limited to:

Change constructors.
`str(` -> `String(`
`int(` -> `Int(`
`float(` -> `Float64(`

Change `index()` to `Int()`.
`index(T)` -> `Int(T)`

The function `isdigit()` becomes a method.
`isdigit(a)` -> `a.isdigit()`

Use explicit constructor for complex ndarray.
```mojo
self._re = NDArray[dtype](shape, order)
self._im = NDArray[dtype](shape, order)
```