### PR TITLE
[ndarray] Add `NDAxisIter` struct and `iter_by_axis` method that iterate array by any axis

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4100,8 +4100,15 @@ struct _NDAxisIter[
     dtype: DType,
     forward: Bool = True,
 ]():
+    # TODO:
+    # 1. Use `length` (`index`) instead of `size` (`offset`) for the
+    # length (counter) of the iterator.
+    # 2. Return a view instead of copy if possible (when Bufferable is supported).
+    # 3. Add an argument in `__init__()` to specify the starting offset or index.
     """
     An iterator yielding 1-d array by axis.
+    The yielded array is garanteed to be contiguous on memory,
+    and it is a view of the original array if possible.
 
     It can be used when a function reduces the dimension of the array by axis.
 

--- a/tests/core/test_array_methods.mojo
+++ b/tests/core/test_array_methods.mojo
@@ -1,5 +1,4 @@
-import numojo as nm
-from numojo import *
+from numojo.prelude import *
 from testing.testing import assert_true, assert_almost_equal, assert_equal
 from utils_for_test import check, check_is_close
 
@@ -57,4 +56,27 @@ def test_constructors():
     assert_true(
         arr5.shape[2] == 5,
         "NDArray constructor with NDArrayShape: shape element 2",
+    )
+
+
+def test_iterator():
+    var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
+    var a_iter = nm.core.ndarray._NDAxisIter[
+        origin = __origin_of(a), dtype=i8, forward=False
+    ](
+        ptr=a._buf.ptr,
+        axis=0,
+        length=a.size,
+        ndim=a.ndim,
+        shape=a.shape,
+        strides=a.strides,
+    )
+    var b = a_iter.__next__() == nm.array[i8]("[11, 23]")
+    assert_true(
+        b.item(0) == True,
+        "`_NDAxisIter` breaks",
+    )
+    assert_true(
+        b.item(1) == True,
+        "`_NDAxisIter` breaks",
     )

--- a/tests/core/test_array_methods.mojo
+++ b/tests/core/test_array_methods.mojo
@@ -61,16 +61,7 @@ def test_constructors():
 
 def test_iterator():
     var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
-    var a_iter = nm.core.ndarray._NDAxisIter[
-        origin = __origin_of(a), dtype=i8, forward=False
-    ](
-        ptr=a._buf.ptr,
-        axis=0,
-        length=a.size,
-        ndim=a.ndim,
-        shape=a.shape,
-        strides=a.strides,
-    )
+    var a_iter = a.iter_by_axis[forward=False](axis=0)
     var b = a_iter.__next__() == nm.array[i8]("[11, 23]")
     assert_true(
         b.item(0) == True,


### PR DESCRIPTION
Adds `NDAxisIter` struct and `iter_by_axis` method that iterate array by any axis. In each iteration, the iterator yields a 1-d array by specified axis. It is useful when we want to write a universal function to reduce the array by certain axis.

Example:
```mojo
from numojo.prelude import *
var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
print(a)
for i in a.iter_by_axis(axis=0):
    print(String(i))
```

This prints:

```console
[[[ 0  1  2  3]
    [ 4  5  6  7]
    [ 8  9 10 11]]
    [[12 13 14 15]
    [16 17 18 19]
    [20 21 22 23]]]
3D-array  Shape(2,3,4)  Strides(12,4,1)  DType: i8  C-cont: True  F-cont: False  own data: True
[ 0 12]
[ 1 13]
[ 2 14]
[ 3 15]
[ 4 16]
[ 5 17]
[ 6 18]
[ 7 19]
[ 8 20]
[ 9 21]
[10 22]
[11 23]
```

Another example:

```mojo
from numojo.prelude import *
var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
print(a)
for i in a.iter_by_axis(axis=2):
    print(String(i))
```

This prints:

```console
[[[ 0  1  2  3]
    [ 4  5  6  7]
    [ 8  9 10 11]]
    [[12 13 14 15]
    [16 17 18 19]
    [20 21 22 23]]]
3D-array  Shape(2,3,4)  Strides(12,4,1)  DType: i8  C-cont: True  F-cont: False  own data: True
[0 1 2 3]
[4 5 6 7]
[ 8  9 10 11]
[12 13 14 15]
[16 17 18 19]
[20 21 22 23]
```.