### PR TITLE
[sorting][core] Refine `argsort`, `sort`, `ravel`, and `_NDAxisIter`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,8 @@ magic.lock
 mojo
 numojo.mojopkg
 bench.mojo
-test_ndarray.ipynb
-test.mojo
+test*.mojo
+test*.ipynb
 tempCodeRunnerFile.mojo
 
 # Auto docs

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -34,6 +34,7 @@ test_linalg = "magic run mojo test tests/routines/test_linalg.mojo -I ./ -I ./te
 test_manipulation = "magic run mojo test tests/routines/test_manipulation.mojo -I ./ -I ./tests/"
 test_random = "magic run mojo test tests/routines/test_random.mojo -I ./ -I ./tests/"
 test_statistics = "magic run mojo test tests/routines/test_statistics.mojo -I ./ -I ./tests/"
+test_sorting = "magic run mojo test tests/routines/test_sorting.mojo -I ./ -I ./tests/"
 
 # run all final checks before a commit
 final = "magic run test && magic run format && magic run package"

--- a/numojo/core/flags.mojo
+++ b/numojo/core/flags.mojo
@@ -37,6 +37,8 @@ struct Flags:
     also not writeable. If the parent object is writeable, the child object may 
     be not writeable.
     """
+    var FORC: Bool
+    """F_CONTIGUOUS or C_CONTIGUOUS."""
 
     # === ---------------------------------------------------------------- === #
     # Life cycle dunder methods
@@ -64,6 +66,7 @@ struct Flags:
         self.F_CONTIGUOUS = f_contiguous
         self.OWNDATA = owndata
         self.WRITEABLE = writeable and owndata
+        self.FORC = f_contiguous or c_contiguous
 
     fn __init__(
         out self,
@@ -91,6 +94,7 @@ struct Flags:
         )
         self.OWNDATA = owndata
         self.WRITEABLE = writeable and owndata
+        self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
     fn __init__(
         out self,
@@ -118,6 +122,7 @@ struct Flags:
         )
         self.OWNDATA = owndata
         self.WRITEABLE = writeable and owndata
+        self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
     fn __copyinit__(out self, other: Self):
         """
@@ -132,6 +137,7 @@ struct Flags:
         self.F_CONTIGUOUS = other.F_CONTIGUOUS
         self.OWNDATA = other.OWNDATA
         self.WRITEABLE = other.WRITEABLE
+        self.FORC = other.FORC
 
     # === ---------------------------------------------------------------- === #
     # Get and set dunder methods
@@ -158,6 +164,7 @@ struct Flags:
             and (key != "O")
             and (key != "WRITEABLE")
             and (key != "W")
+            and (key != "FORC")
         ):
             raise Error(
                 String(
@@ -171,5 +178,7 @@ struct Flags:
             return self.F_CONTIGUOUS
         elif (key == "OWNDATA") or (key == "O"):
             return self.OWNDATA
-        else:  # (key == "WRITEABLE") or (key == "W")
+        elif (key == "WRITEABLE") or (key == "W"):
             return self.WRITEABLE
+        else:
+            return self.FORC

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3335,7 +3335,9 @@ struct NDArray[dtype: DType = DType.float64](
 
     fn iter_by_axis[
         forward: Bool = True
-    ](self, axis: Int) raises -> _NDAxisIter[__origin_of(self), dtype, forward]:
+    ](self, axis: Int, order: String = "C") raises -> _NDAxisIter[
+        __origin_of(self), dtype, forward
+    ]:
         """
         Returns an iterator yielding 1-d array by axis.
 
@@ -3344,7 +3346,8 @@ struct NDArray[dtype: DType = DType.float64](
                 If False, iterate from the end to the beginning.
 
         Args:
-            axis: Axis by which the iteration is performed.
+            axis: The axis by which the iteration is performed.
+            order: The order to traverse the array.
 
         Returns:
             An iterator yielding 1-d array by axis.
@@ -3425,6 +3428,7 @@ struct NDArray[dtype: DType = DType.float64](
         return _NDAxisIter[__origin_of(self), dtype, forward](
             ptr=self._buf.ptr,
             axis=normalized_axis,
+            order=order,
             size=self.size,
             ndim=self.ndim,
             shape=self.shape,
@@ -4205,6 +4209,7 @@ struct _NDAxisIter[
 
     var ptr: UnsafePointer[Scalar[dtype]]
     var axis: Int
+    var order: String
     var length: Int
     var size: Int
     var ndim: Int
@@ -4222,6 +4227,7 @@ struct _NDAxisIter[
         out self,
         ptr: UnsafePointer[Scalar[dtype]],
         axis: Int,
+        order: String,
         size: Int,
         ndim: Int,
         shape: NDArrayShape,
@@ -4233,6 +4239,7 @@ struct _NDAxisIter[
         Args:
             ptr: Pointer to the data buffer.
             axis: Axis.
+            order: Order to traverse the array.
             size: Size of the axis.
             ndim: Number of dimensions.
             shape: Shape of the array.
@@ -4244,19 +4251,27 @@ struct _NDAxisIter[
         self.size_of_res = shape[axis]
         self.ptr = ptr
         self.axis = axis
+        self.order = order
         self.length = size // self.size_of_res
         self.size = size
         self.ndim = ndim
         self.shape = shape
         self.strides = strides
         self.strides_by_axis = NDArrayStrides(ndim=self.ndim, initialized=False)
-        var temp = 1
-        (self.strides_by_axis._buf + axis).init_pointee_copy(temp)
-        temp *= shape[axis]
-        for i in range(self.ndim - 1, -1, -1):
-            if i != axis:
-                (self.strides_by_axis._buf + i).init_pointee_copy(temp)
-                temp *= shape[i]
+        (self.strides_by_axis._buf + axis).init_pointee_copy(1)
+        temp = shape[axis]
+        if order == "C":
+            for i in range(self.ndim - 1, -1, -1):
+                if i != axis:
+                    (self.strides_by_axis._buf + i).init_pointee_copy(temp)
+                    temp *= shape[i]
+        else:
+            for i in range(self.ndim):
+                if i != axis:
+                    (self.strides_by_axis._buf + i).init_pointee_copy(temp)
+                    temp *= shape[i]
+
+        # Status of the iterator
         self.index = 0 if forward else self.length - 1
 
     fn __has_next__(self) -> Bool:
@@ -4288,10 +4303,19 @@ struct _NDAxisIter[
 
         var remainder = current_index * self.size_of_res
         var item = Item(ndim=self.ndim, initialized=True)
-        for i in range(self.axis):
-            item[i], remainder = divmod(remainder, self.strides_by_axis[i])
-        for i in range(self.axis + 1, self.ndim):
-            item[i], remainder = divmod(remainder, self.strides_by_axis[i])
+
+        if self.order == "C":
+            for i in range(self.ndim):
+                if i != self.axis:
+                    item[i], remainder = divmod(
+                        remainder, self.strides_by_axis[i]
+                    )
+        else:
+            for i in range(self.ndim - 1, -1, -1):
+                if i != self.axis:
+                    item[i], remainder = divmod(
+                        remainder, self.strides_by_axis[i]
+                    )
 
         if (self.axis == self.ndim - 1) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
@@ -4334,10 +4358,19 @@ struct _NDAxisIter[
 
         var remainder = index * self.size_of_res
         var item = Item(ndim=self.ndim, initialized=True)
-        for i in range(self.axis):
-            item[i], remainder = divmod(remainder, self.strides_by_axis[i])
-        for i in range(self.axis + 1, self.ndim):
-            item[i], remainder = divmod(remainder, self.strides_by_axis[i])
+
+        if self.order == "C":
+            for i in range(self.ndim):
+                if i != self.axis:
+                    item[i], remainder = divmod(
+                        remainder, self.strides_by_axis[i]
+                    )
+        else:
+            for i in range(self.ndim - 1, -1, -1):
+                if i != self.axis:
+                    item[i], remainder = divmod(
+                        remainder, self.strides_by_axis[i]
+                    )
 
         if ((self.axis == self.ndim - 1) or (self.axis == 0)) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4390,20 +4390,19 @@ struct _NDAxisIter[
 
         return elements
 
-    fn ith_with_indices(
+    fn ith_with_offsets(
         self, index: Int
     ) raises -> Tuple[NDArray[DType.index], NDArray[dtype]]:
         """
-        Gets the i-th 1-d array of the iterator and its indices
-        (C-order coordinates).
+        Gets the i-th 1-d array of the iterator and the offsets of its elements.
 
         Args:
             index: The index of the item. It must be non-negative.
 
         Returns:
-            Coordinates and elements of the i-th 1-d array of the iterator.
+            Offsets and elements of the i-th 1-d array of the iterator.
         """
-        var indices = NDArray[DType.index](Shape(self.size_of_res))
+        var offsets = NDArray[DType.index](Shape(self.size_of_res))
         var elements = NDArray[dtype](Shape(self.size_of_res))
 
         if (index >= self.length) or (index < 0):
@@ -4423,7 +4422,7 @@ struct _NDAxisIter[
 
         var new_strides = NDArrayStrides(self.shape, order="C")
         for j in range(self.size_of_res):
-            (indices._buf.ptr + j).init_pointee_copy(
+            (offsets._buf.ptr + j).init_pointee_copy(
                 _get_offset(item, new_strides)
             )
             (elements._buf.ptr + j).init_pointee_copy(
@@ -4431,7 +4430,7 @@ struct _NDAxisIter[
             )
             item[self.axis] += 1
 
-        return Tuple(indices, elements)
+        return Tuple(offsets, elements)
 
 
 @value

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -461,7 +461,7 @@ fn apply_func_on_array_without_dim_reduction[
                 # The elements of the input array in each iteration
                 var elements: NDArray[dtype]
                 # The array after applied the function
-                indices, elements = iterator.ith_with_indices(i)
+                indices, elements = iterator.ith_with_offsets(i)
 
                 var res_along_axis: NDArray[dtype] = func[dtype](elements)
 
@@ -536,7 +536,7 @@ fn apply_func_on_array_without_dim_reduction[
                 # The elements of the input array in each iteration
                 var elements: NDArray[dtype]
                 # The array after applied the function
-                indices, elements = iterator.ith_with_indices(i)
+                indices, elements = iterator.ith_with_offsets(i)
 
                 var res_along_axis: NDArray[DType.index] = func[dtype](elements)
 

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -222,6 +222,19 @@ fn randint[
 
 fn randint[
     dtype: DType = DType.int64
+](*shape: Int, low: Int, high: Int) raises -> NDArray[dtype]:
+    """
+    Overloads the function `randint(shape: NDArrayShape, low, high)`.
+    Return an array of random integers from low (inclusive) to high (exclusive).
+    Note that it is different from the built-in `random.randint()` function
+    which returns integer in range low (inclusive) to high (inclusive).
+    """
+
+    return randint[dtype](NDArrayShape(shape), low=low, high=high)
+
+
+fn randint[
+    dtype: DType = DType.int64
 ](shape: NDArrayShape, high: Int) raises -> NDArray[dtype]:
     """
     Return an array of random integers from 0 (inclusive) to high (exclusive).
@@ -255,6 +268,17 @@ fn randint[
     )
 
     return result^
+
+
+fn randint[
+    dtype: DType = DType.int64
+](*shape: Int, high: Int) raises -> NDArray[dtype]:
+    """
+    Overloads the function `randint(shape: NDArrayShape, high)`.
+    Return an array of random integers from 0 (inclusive) to high (exclusive).
+    """
+
+    return randint[dtype](NDArrayShape(shape), high=high)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -39,7 +39,6 @@ fn sort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Sort NDArray using quick sort method.
     It is not guaranteed to be unstable.
-
     When no axis is given, the array is flattened before sorting.
 
     Parameters:
@@ -49,10 +48,7 @@ fn sort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
         a: NDArray.
     """
 
-    if a.ndim == 1:
-        return quick_sort_1d(a)
-    else:
-        return quick_sort_1d(ravel(a))
+    return quick_sort_1d(a)
 
 
 fn sort[
@@ -61,7 +57,6 @@ fn sort[
     """
     Sort NDArray along the given axis using quick sort method.
     It is not guaranteed to be unstable.
-
     When no axis is given, the array is flattened before sorting.
 
     Parameters:
@@ -118,45 +113,50 @@ fn sort[
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn argsort[
-    dtype: DType
-](owned A: NDArray[dtype]) raises -> NDArray[DType.index]:
+fn argsort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[DType.index]:
     """
     Returns the indices that would sort an array.
     It is not guaranteed to be unstable.
-
     When no axis is given, the array is flattened before sorting.
 
     Parameters:
         dtype: The input element type.
 
     Args:
-        A: NDArray.
+        a: NDArray.
 
     Returns:
         Indices that would sort an array.
     """
 
-    A = ravel(A)
-    var I = NDArray[DType.index](A.shape)
-    _sort_inplace(A, I, axis=0)
-    return I^
+    if a.ndim == 1:
+        res = a
+    else:
+        res = ravel(a)
+
+    var indices = arange[DType.index](res.size)
+
+    _sort_inplace(res, indices)
+
+    return indices^
 
 
 fn argsort[
     dtype: DType
-](owned A: NDArray[dtype], owned axis: Int) raises -> NDArray[DType.index]:
+](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.index]:
     """
     Returns the indices that would sort an array.
     It is not guaranteed to be unstable.
-
     When no axis is given, the array is flattened before sorting.
+
+    Raises:
+        Error: If the axis is out of bound.
 
     Parameters:
         dtype: The input element type.
 
     Args:
-        A: NDArray to sort.
+        a: NDArray to sort.
         axis: The axis along which the array is sorted.
 
     Returns:
@@ -164,9 +164,19 @@ fn argsort[
 
     """
 
-    var I = NDArray[DType.index](A.shape)
-    _sort_inplace(A, I, axis)
-    return I^
+    var normalized_axis = axis
+    if normalized_axis < 0:
+        normalized_axis += a.ndim
+    if (normalized_axis >= a.ndim) or (normalized_axis < 0):
+        raise Error(
+            String("Error in `mean`: Axis {} not in bound [-{}, {})").format(
+                axis, a.ndim, a.ndim
+            )
+        )
+
+    return utility.apply_func_on_array_without_dim_reduction[
+        func=argsort_quick_sort_1d
+    ](a, axis=normalized_axis)
 
 
 fn argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.index]:
@@ -306,11 +316,9 @@ fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 
 fn quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     """
-    Sort 1-d array using quick sort method.
+    Sort array using quick sort method.
+    Regardless of the shape of input, it is treated as a 1-d array.
     It is not guaranteed to be unstable.
-
-    Raises:
-        Error: If the input array is not 1-d.
 
     Parameters:
         dtype: The input element type.
@@ -318,17 +326,84 @@ fn quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     Args:
         a: An 1-d array.
     """
+    var res: NDArray[dtype]
+    if a.ndim == 1:
+        res = a
+    else:
+        res = ravel(a)
 
-    if a.ndim != 1:
-        raise Error(
-            String(
-                "\nError in `sort_1d`: Input array must be 1-d, but got {}-d"
-            ).format(a.ndim)
-        )
-    res = a
-    var _I = NDArray[DType.index](a.shape)
-    _sort_inplace(res, _I, axis=0)
+    _sort_inplace(res)
+
     return res^
+
+
+fn argsort_quick_sort_1d[
+    dtype: DType
+](a: NDArray[dtype]) raises -> NDArray[DType.index]:
+    """
+    Returns the indices that would sort the buffer of an array.
+    Regardless of the shape of input, it is treated as a 1-d array.
+    It is not guaranteed to be unstable.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        a: NDArray.
+
+    Returns:
+        Indices that would sort an array.
+    """
+
+    var res = a
+    var indices = arange[DType.index](res.size)
+    _sort_inplace(res, indices)
+    return indices^
+
+
+fn _partition_in_range(
+    mut A: NDArray,
+    left: Int,
+    right: Int,
+    pivot_index: Int,
+) raises -> Int:
+    """
+    Do in-place partition for array buffer within given range.
+    Auxiliary function for `sort`, `argsort`, and `partition`.
+
+    Args:
+        A: NDArray.
+        left: Left index of the partition.
+        right: Right index of the partition.
+        pivot_index: Input pivot index
+
+    Returns:
+        New pivot index.
+    """
+
+    var pivot_value = A._buf.ptr[pivot_index]
+
+    A._buf.ptr[pivot_index], A._buf.ptr[right] = (
+        A._buf.ptr[right],
+        A._buf.ptr[pivot_index],
+    )
+
+    var store_index = left
+
+    for i in range(left, right):
+        if A._buf.ptr[i] < pivot_value:
+            A._buf.ptr[store_index], A._buf.ptr[i] = (
+                A._buf.ptr[i],
+                A._buf.ptr[store_index],
+            )
+            store_index = store_index + 1
+
+    A._buf.ptr[store_index], A._buf.ptr[right] = (
+        A._buf.ptr[right],
+        A._buf.ptr[store_index],
+    )
+
+    return store_index
 
 
 fn _partition_in_range(
@@ -340,6 +415,7 @@ fn _partition_in_range(
 ) raises -> Int:
     """
     Do in-place partition for array buffer within given range.
+    The indices are also sorted.
     Auxiliary function for `sort`, `argsort`, and `partition`.
 
     Args:
@@ -352,9 +428,6 @@ fn _partition_in_range(
     Returns:
         New pivot index.
     """
-
-    # (Unsafe) Boundary checks are not done for sake of speed:
-    # if (left >= A.size) or (right >= A.size) or (pivot_index >= A.size):
 
     var pivot_value = A._buf.ptr[pivot_index]
 
@@ -456,9 +529,28 @@ fn _sort_partition(
     return store_index
 
 
+fn _sort_in_range(mut A: NDArray, left: Int, right: Int) raises:
+    """
+    Sort in-place of the data buffer (quick-sort) within give range.
+    It is not guaranteed to be stable.
+
+    Args:
+        A: NDArray.
+        left: Left index of the partition.
+        right: Right index of the partition.
+    """
+
+    if right > left:
+        var pivot_index = left + (right - left) // 2
+        var pivot_new_index = _partition_in_range(A, left, right, pivot_index)
+        _sort_in_range(A, left, pivot_new_index - 1)
+        _sort_in_range(A, pivot_new_index + 1, right)
+
+
 fn _sort_in_range(mut A: NDArray, mut I: NDArray, left: Int, right: Int) raises:
     """
     Sort in-place of the data buffer (quick-sort) within give range.
+    The indices are also sorted.
     It is not guaranteed to be stable.
 
     Args:
@@ -481,6 +573,7 @@ fn _sort_inplace(mut A: Matrix, mut I: Matrix, left: Int, right: Int) raises:
     """
     Sort in-place of the data buffer (quick-sort).
     It is not guaranteed to be stable.
+    The data buffer must be contiguous.
 
     Args:
         A: A Matrix.
@@ -494,6 +587,73 @@ fn _sort_inplace(mut A: Matrix, mut I: Matrix, left: Int, right: Int) raises:
         var pivot_new_index = _sort_partition(A, I, left, right, pivot_index)
         _sort_inplace(A, I, left, pivot_new_index - 1)
         _sort_inplace(A, I, pivot_new_index + 1, right)
+
+
+fn _sort_inplace[dtype: DType](mut A: NDArray[dtype]) raises:
+    """
+    Sort in-place array's buffer using quick sort method.
+    It is not guaranteed to be unstable.
+    The data buffer must be contiguous.
+
+    Raises:
+        Error: If the array is not contiguous.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        A: NDArray to sort.
+    """
+
+    if not A.flags.FORC:
+        raise Error(
+            String(
+                "\nError in `_sort_inplace`:"
+                "The array must be contiguous to perform in-place sorting."
+            )
+        )
+
+    _sort_in_range(
+        A,
+        left=0,
+        right=A.size - 1,
+    )
+
+
+fn _sort_inplace[
+    dtype: DType
+](mut A: NDArray[dtype], mut I: NDArray[DType.index]) raises:
+    """
+    Sort in-place array's buffer using quick sort method.
+    The indices are also sorted.
+    It is not guaranteed to be unstable.
+    The data buffer must be contiguous.
+
+    Raises:
+        Error: If the array is not contiguous.
+
+    Parameters:
+        dtype: The input element type.
+
+    Args:
+        A: NDArray to sort.
+        I: NDArray that stores the indices.
+    """
+
+    if not A.flags.FORC:
+        raise Error(
+            String(
+                "\nError in `_sort_inplace`:"
+                "The array must be contiguous to perform in-place sorting."
+            )
+        )
+
+    _sort_in_range(
+        A,
+        I,
+        left=0,
+        right=A.size - 1,
+    )
 
 
 fn _sort_inplace[

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -78,6 +78,9 @@ fn sort[
             )
         )
 
+    if (a.ndim == 1) and (normalized_axis == 0):
+        return quick_sort_1d(a)
+
     return utility.apply_func_on_array_without_dim_reduction[
         func=quick_sort_1d
     ](a, axis=normalized_axis)
@@ -174,6 +177,9 @@ fn argsort[
             )
         )
 
+    if (a.ndim == 1) and (normalized_axis == 0):
+        return argsort_quick_sort_1d(a)
+
     return utility.apply_func_on_array_without_dim_reduction[
         func=argsort_quick_sort_1d
     ](a, axis=normalized_axis)
@@ -223,6 +229,17 @@ fn argsort[
 ###############
 # Binary sort #
 ###############
+
+
+fn binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
+    var res = a
+    for end in range(res.size, 1, -1):
+        for i in range(1, end):
+            if res._buf.ptr[i - 1] > res._buf.ptr[i]:
+                var temp = res._buf.ptr[i - 1]
+                res._buf.ptr[i - 1] = res._buf.ptr[i]
+                res._buf.ptr[i] = temp
+    return res
 
 
 fn binary_sort[

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -30,10 +30,8 @@ fn mean_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
-    Calculate the arithmetic average of all items in the 1-d array.
-
-    Raises:
-        Error: If the array is not 1-d.
+    Calculate the arithmetic average of all items in an array.
+    Regardless of the shape of input, it is treated as a 1-d array.
 
     Parameters:
         dtype: The element type.
@@ -45,12 +43,6 @@ fn mean_1d[
     Returns:
         A scalar defaulting to float64.
     """
-    if a.ndim != 1:
-        raise Error(
-            String(
-                "\nError in `sort_1d`: Input array must be 1-d, but got {}-d"
-            ).format(a.ndim)
-        )
 
     return sum(a).cast[returned_dtype]() / a.size
 
@@ -70,9 +62,8 @@ fn mean[
 
     Returns:
         A scalar defaulting to float64.
-
     """
-    return sum(a).cast[returned_dtype]() / a.size
+    return mean_1d[returned_dtype](a)
 
 
 fn mean[
@@ -158,7 +149,8 @@ fn median_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
-    Median value of all items of a 1-d array.
+    Median value of all items an array.
+    Regardless of the shape of input, it is treated as a 1-d array.
 
     Parameters:
          dtype: The element type.
@@ -170,13 +162,6 @@ fn median_1d[
     Returns:
         The median of all of the member values of array as a SIMD Value of `dtype`.
     """
-
-    if a.ndim != 1:
-        raise Error(
-            String(
-                "\nError in `sort_1d`: Input array must be 1-d, but got {}-d"
-            ).format(a.ndim)
-        )
 
     var sorted_array = sort(a)
 
@@ -205,7 +190,7 @@ fn median[
         The median of all of the member values of array as a SIMD Value of `dtype`.
     """
 
-    return median_1d[returned_dtype](ravel(a))
+    return median_1d[returned_dtype](a)
 
 
 fn median[
@@ -240,10 +225,9 @@ fn median[
 
 
 fn mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
-    """Mode of all items of a 1d array.
-
-    Raises:
-        Error: If the array is not 1-d.
+    """
+    Returns mode of all items of an array.
+    Regardless of the shape of input, it is treated as a 1-d array.
 
     Parameters:
         dtype: The element type.
@@ -254,13 +238,6 @@ fn mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     Returns:
         The mode of all of the member values of array as a SIMD Value of `dtype`.
     """
-
-    if a.ndim != 1:
-        raise Error(
-            String(
-                "\nError in `sort_1d`: Input array must be 1-d, but got {}-d"
-            ).format(a.ndim)
-        )
 
     var sorted_array: NDArray[dtype] = sort(a)
     var max_count = 0

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -25,23 +25,60 @@ fn test_arr_manipulation() raises:
             String("`flip` by `axis` {} fails.").format(i),
         )
 
-    # Test reshape and ravel
+
+def test_ravel_reshape():
+    var np = Python.import_module("numpy")
+    var c = nm.fromstring[i8](
+        "[[[1,2,3,4][5,6,7,8]][[9,10,11,12][13,14,15,16]]]", order="C"
+    )
+    var cnp = c.to_numpy()
+    var f = nm.fromstring[i8](
+        "[[[1,2,3,4][5,6,7,8]][[9,10,11,12][13,14,15,16]]]", order="F"
+    )
+    var fnp = f.to_numpy()
+
+    # Test ravel
     check_is_close(
-        nm.reshape(B, Shape(4, 3, 2), "C"),
-        np.reshape(Bnp, (4, 3, 2), "C"),
-        "`reshape` by C is broken",
+        nm.ravel(c, order="C"),
+        np.ravel(cnp, order="C"),
+        "`ravel` C-order array by C order is broken.",
     )
     check_is_close(
-        nm.reshape(B, Shape(4, 3, 2), "F"),
-        np.reshape(Bnp, (4, 3, 2), "F"),
-        "`reshape` by F is broken",
+        nm.ravel(c, order="F"),
+        np.ravel(cnp, order="F"),
+        "`ravel` C-order array by F order is broken.",
+    )
+    check_is_close(
+        nm.ravel(f, order="C"),
+        np.ravel(fnp, order="C"),
+        "`ravel` F-order array by C order is broken.",
+    )
+    check_is_close(
+        nm.ravel(f, order="F"),
+        np.ravel(fnp, order="F"),
+        "`ravel` F-order array by F order is broken.",
     )
 
+    # Test reshape
     check_is_close(
-        nm.ravel(B, "C"), np.ravel(Bnp, "C"), "`ravel` by C is broken"
+        nm.reshape(c, Shape(4, 2, 2), "C"),
+        np.reshape(cnp, (4, 2, 2), "C"),
+        "`reshape` C by C is broken",
     )
     check_is_close(
-        nm.ravel(B, "F"), np.ravel(Bnp, "F"), "`ravel` by F is broken"
+        nm.reshape(c, Shape(4, 2, 2), "F"),
+        np.reshape(cnp, (4, 2, 2), "F"),
+        "`reshape` C by F is broken",
+    )
+    check_is_close(
+        nm.reshape(f, Shape(4, 2, 2), "C"),
+        np.reshape(fnp, (4, 2, 2), "C"),
+        "`reshape` F by C is broken",
+    )
+    check_is_close(
+        nm.reshape(f, Shape(4, 2, 2), "F"),
+        np.reshape(fnp, (4, 2, 2), "F"),
+        "`reshape` F by F is broken",
     )
 
 

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -9,6 +9,7 @@ fn test_sorting() raises:
     var B = nm.random.randn(2, 3)
     var C = nm.random.randn(2, 3, 4)
     var S = nm.random.randn(3, 3, 3, 3, 3, 3)  # 6d array
+    var Sf = S.reshape(S.shape, order="F")  # 6d array F order
 
     # Sort
     check(
@@ -59,9 +60,25 @@ fn test_sorting() raises:
             np.argsort(C.to_numpy(), axis=i),
             String("`argsort` 3d by axis {} is broken").format(i),
         )
+    check(
+        nm.argsort(S),
+        np.argsort(S.to_numpy(), axis=None),
+        String("`argsort` 6d by axis None is broken"),
+    )
     for i in range(6):
         check(
             nm.argsort(S, axis=i),
             np.argsort(S.to_numpy(), axis=i),
             String("`argsort` 6d by axis {} is broken").format(i),
+        )
+    check(
+        nm.argsort(Sf),
+        np.argsort(Sf.to_numpy(), axis=None),
+        String("`argsort` 6d F-order array by axis None is broken"),
+    )
+    for i in range(6):
+        check(
+            nm.argsort(Sf, axis=i),
+            np.argsort(Sf.to_numpy(), axis=i),
+            String("`argsort` 6d F-order by axis {} is broken").format(i),
         )


### PR DESCRIPTION
## Changes

1. Refine `argsort` function by applying the universal function. Improve the speed significantly (see below). Also, it fixes the problem that `argsort` does not work for F-order array.
2. Improve the speed of `sort` for 1d-array by adding partition functions which do not construct the indices array.
3. Update `_NDAxisIter` to allow order argument.
4. Re-write `ravel` function by means of `_NDAxisIter`, so that it will not break for F-order arrays.
5. Add many tests for the functions, to allow C or F operations both C and F arrays (4 different scenarios).
6. Add `FORC` attribute for the `Flags` type.

## Comparison

`argsort` numojo vs numpy:
```console
100000000 1-d array.
numojo 8.672953000001144
numpy 11.353579999995418

10_000 * 10_000 2-d array sorted by axis 0.
numojo 1.9524170000222512
numpy 4.66693300002953

10_000 * 10_000 2-d array sorted by axis 1.
numojo 0.5791429999517277
numpy 4.1895380000351
```