### PR TITLE
[core][print] Significantly increase the speed of printing arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,8 @@ magic.lock
 mojo
 numojo.mojopkg
 bench.mojo
-test_ndarray.ipynb
-test.mojo
+test*.mojo
+test*.ipynb
 tempCodeRunnerFile.mojo
 
 # Auto docs

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -44,18 +44,36 @@ alias printoptions = PrintOptions
 @value
 struct PrintOptions:
     var precision: Int
+    """
+    The number of decimal places to include in the formatted string.
+    Defaults to 4.
+    """
     var suppress_small: Bool
     var separator: String
+    """
+    The separator between elements in the array. Defaults to a space.
+    """
     var padding: String
+    """
+    The padding symbol between the elements at the edge and the brackets.
+    Defaults to an empty string.
+    """
     var threshold: Int
     var line_width: Int
     var edge_items: Int
+    """
+    The number of items to display at the beginning and end of a dimension.
+    Defaults to 3.
+    """
     var sign: Bool
     var float_format: String
     var complex_format: String
     var nan_string: String
     var inf_string: String
     var formatted_width: Int
+    """
+    The width of the formatted string per element of array.
+    """
     var exponent_threshold: Int
     var suppress_scientific: Bool
 


### PR DESCRIPTION
This PR changes the approach in determining the min and max values of the printable regions of an array. This significantly improves the speed of printing arrays.

This improvement is particularly significant when we encounter very large arrays. The speed increase can be x100000. See the following comparison on a (10000, 1000) array.

```console
# before the change
2D-array  Shape(10000,1000)  Strides(1000,1)  DType: f64  C-cont: True  F-cont: False  own data: True
Time to print array: 19.190531999978703

# after the change
2D-array  Shape(10000,1000)  Strides(1000,1)  DType: f64  C-cont: True  F-cont: False  own data: True
Time to print array: 0.0001010000123642385
```