### PR TITLE
[core] Improve `NDIter` to allow arbitrary axis to travel

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,7 @@ Available functions and objects by topics (also see imports within `__init__` fi
 - Array manipulation routines (`numojo.routines.manipulation`)
 - Bit-wise operations (`numojo.routines.bitwise`)
 - Constants (`numojo.routines.constants`)
+- Indexing routines (`numojo.routines.indexing`)
 - Input and output (`numojo.routines.io`)
 - Text files (`numojo.routines.files`)
 - Text formatting options (`numojo.routines.formatting`)
@@ -20,7 +21,13 @@ Available functions and objects by topics (also see imports within `__init__` fi
 - Array contents (`numojo.routines.contents`)
 - Truth value testing (`numojo.routines.truth`)
 - Mathematical functions (`numojo.routines.math`)
-  - Extrema: maxT, minT
+  - Sums (`numojo.routines.sums`)
+    - `sum()`
+  - Products (`numojo.routines.products`)
+    - `prod()`
+  - Differences (`numojo.routines.differences`)
+  - Extrema (`numojo.routines.math.extrema`)
+    - `max()`, `min()`
   - Trigonometry: acos, asin, atan, cos, sin, tan, atan2, hypot
   - Hyperbolic: acosh, asinh, atanh, cosh, sinh, tanh
   - Floating: copysign
@@ -35,17 +42,14 @@ Available functions and objects by topics (also see imports within `__init__` fi
 - Indexing (`numojo.routines.indexing`)
 - Miscellaneous (`numojo.routines.misc`)
 - Rounding (`numojo.routines.rounding`)
-- Sums, products, differences (`numojo.routines.sums`, `numojo.routines.products`, `numojo.routines.differences`)
-  - sum, prod
 - Trigonometric functions (`numojo.routines.trig`)
 - Random sampling (`numojo.routines.random`)
 - Sorting, searching, and counting (`numojo.routines.sorting`, `numojo.routines.searching`)
 - Statistics (`numojo.routines.statistics`)
-  - mean, mode, median
-  - variance
-- Averages and variances (`numojo.routines.averages`)
+  - Averages and variances (`numojo.routines.averages`)
+    - `mean()`, `mode()`, `median()`
+    - `variance()`, `std()`
 
 To-be-implemented functions and objects by topics:
 
 - Mathematical functions: abs, floor, ceil, trunc, round, roundeven, round_half_down, round_half_up, reciprocal, nextafter, remainder
-- Statistical functions: pvariance, pstdev, std

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -71,9 +71,11 @@ struct Item(CollectionElement):
     ) raises:
         """
         Construct Item with number of dimensions.
-
         This method is useful when you want to create a Item with given ndim
         without knowing the Item values.
+
+        Raise
+            Error: If the number of dimensions is negative.
 
         Args:
             ndim: Number of dimensions.
@@ -83,6 +85,7 @@ struct Item(CollectionElement):
         """
         if ndim < 0:
             raise Error("Number of dimensions must be non-negative.")
+
         self.ndim = ndim
         self._buf = UnsafePointer[Int]().alloc(ndim)
         if initialized:
@@ -115,7 +118,7 @@ struct Item(CollectionElement):
 
     @always_inline("nodebug")
     fn __getitem__[T: Indexer](self, idx: T) raises -> Int:
-        """Get the value at the specified index.
+        """Gets the value at the specified index.
 
         Parameter:
             T: Type of values. It can be converted to `Int` with `Int()`.

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -205,6 +205,34 @@ struct Item(CollectionElement):
             + String(self.ndim)
         )
 
+    # ===-------------------------------------------------------------------===#
+    # Other methods
+    # ===-------------------------------------------------------------------===#
+
+    fn offset(self, strides: NDArrayStrides) -> Int:
+        """Calculates the offset of the item according to strides.
+
+        Args:
+            strides: The strides of the array.
+
+        Returns:
+            The offset of the item.
+
+        Example:
+
+        ```mojo
+        >>> from numojo.prelude import *
+        >>> var item = Item(1, 2, 3)
+        >>> var strides = nm.Strides(4, 3, 2)
+        >>> print(item.offset(strides))
+        16
+        ```.
+        """
+        var offset: Int = 0
+        for i in range(self.ndim):
+            offset += self._buf[i] * strides._buf[i]
+        return offset
+
 
 @value
 struct _ItemIter[

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -108,6 +108,18 @@ struct Item(CollectionElement):
         Args:
             idx: The i-th item of the array.
             shape: The strides of the array.
+
+        Examples:
+
+        The following example demonstrates how to get the indices (coordinates)
+        of the 123-th item of a 3D array with shape (20, 30, 40).
+
+        ```console
+        >>> from numojo.prelude import *
+        >>> var item = Item(123, Shape(20, 30, 40))
+        >>> print(item)
+        Item at index: (0,3,3)  Length: 3
+        ```
         """
 
         if (idx < 0) or (idx >= shape.size_of_array()):

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -210,7 +210,8 @@ struct Item(CollectionElement):
     # ===-------------------------------------------------------------------===#
 
     fn offset(self, strides: NDArrayStrides) -> Int:
-        """Calculates the offset of the item according to strides.
+        """
+        Calculates the offset of the item according to strides.
 
         Args:
             strides: The strides of the array.
@@ -218,16 +219,17 @@ struct Item(CollectionElement):
         Returns:
             The offset of the item.
 
-        Example:
+        Examples:
 
         ```mojo
-        >>> from numojo.prelude import *
-        >>> var item = Item(1, 2, 3)
-        >>> var strides = nm.Strides(4, 3, 2)
-        >>> print(item.offset(strides))
-        16
-        ```.
+        from numojo.prelude import *
+        var item = Item(1, 2, 3)
+        var strides = nm.Strides(4, 3, 2)
+        print(item.offset(strides))
+        # This prints `16`.
+        ```
         """
+
         var offset: Int = 0
         for i in range(self.ndim):
             offset += self._buf[i] * strides._buf[i]

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -121,7 +121,7 @@ struct Item(CollectionElement):
         self.ndim = shape.ndim
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
 
-        var strides = NDArrayStrides(shape)
+        var strides = NDArrayStrides(shape, order="C")
         var remainder = idx
 
         for i in range(self.ndim):

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -18,6 +18,10 @@ alias item = Item
 
 @register_passable
 struct Item(CollectionElement):
+    """
+    Specifies the indices of an item of an array.
+    """
+
     var _buf: UnsafePointer[Int]
     var ndim: Int
 
@@ -231,6 +235,7 @@ struct Item(CollectionElement):
         print(item.offset(strides))
         # This prints `16`.
         ```
+        .
         """
 
         var offset: Int = 0

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4271,8 +4271,8 @@ struct NDArray[dtype: DType = DType.float64](
         if order not in List[String]("C", "F"):
             raise Error(
                 String(
-                    "\nError in `nditer()`: Invalid order: '{}'. The order"
-                    " should be 'C' or 'F'."
+                    "\nError in `nditer()`: Invalid order: '{}'. "
+                    "The order should be 'C' or 'F'."
                 ).format(order)
             )
 
@@ -5271,11 +5271,19 @@ struct _NDIter[
 
         if self.order == "C":
             for i in range(self.ndim):
-                indices._buf[i] = remainder // self.strides_compatible._buf[i]
-                remainder %= self.strides_compatible._buf[i]
+                if i != self.axis:
+                    (indices._buf + i).init_pointee_copy(
+                        remainder // self.strides_compatible._buf[i]
+                    )
+                    remainder %= self.strides_compatible._buf[i]
+            (indices._buf + self.axis).init_pointee_copy(remainder)
         else:
             for i in range(self.ndim - 1, -1, -1):
-                indices._buf[i] = remainder // self.strides_compatible._buf[i]
-                remainder %= self.strides_compatible._buf[i]
+                if i != self.axis:
+                    (indices._buf + i).init_pointee_copy(
+                        remainder // self.strides_compatible._buf[i]
+                    )
+                    remainder %= self.strides_compatible._buf[i]
+            (indices._buf + self.axis).init_pointee_copy(remainder)
 
         return self.ptr[_get_offset(indices, self.strides)]

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -10,16 +10,17 @@ Implements basic object methods for working with N-Dimensional Array.
 # ===----------------------------------------------------------------------===#
 # SECTIONS OF THE FILE:
 #
-# NDArray
+# `NDArray` type
 # 1. Life cycle methods.
 # 2. Indexing and slicing (get and set dunders and relevant methods).
 # 3. Operator dunders.
 # 4. IO, trait, and iterator dunders.
 # 5. Other methods (Sorted alphabetically).
 #
-# _NDArrayIter
-# _NDAxisIter
-# _NDIter
+# Iterators of `NDArray`:
+# 1. `_NDArrayIter` type
+# 2. `_NDAxisIter` type
+# 3. `_NDIter` type
 #
 # ===----------------------------------------------------------------------===#
 # FORMAT FOR DOCSTRING
@@ -4268,11 +4269,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         return _NDIter[__origin_of(self), dtype](
-            ptr=self._buf.ptr,
-            length=self.size,
-            ndim=self.ndim,
-            strides=self.strides,
-            shape=self.shape,
+            a=self,
             order=order,
         )
 
@@ -5159,6 +5156,7 @@ struct _NDIter[
 ]():
     """
     An iterator yielding the array elements according to the order.
+    It can be constructed by `NDArray.nditer()` method.
     """
 
     var ptr: UnsafePointer[Scalar[dtype]]
@@ -5172,22 +5170,18 @@ struct _NDIter[
 
     fn __init__(
         out self,
-        ptr: UnsafePointer[Scalar[dtype]],
-        length: Int,
-        ndim: Int,
-        shape: NDArrayShape,
-        strides: NDArrayStrides,
+        a: NDArray[dtype],
         order: String,
     ) raises:
-        self.length = length
-        self.ptr = ptr
-        self.ndim = ndim
-        self.shape = shape
-        self.strides = strides
+        self.length = a.size
+        self.ptr = a._buf.ptr
+        self.ndim = a.ndim
+        self.shape = a.shape
+        self.strides = a.strides
         if order == "C":
-            self.strides_of_shape = NDArrayStrides(shape, order="C")
+            self.strides_of_shape = NDArrayStrides(self.shape, order="C")
         else:
-            self.strides_of_shape = NDArrayStrides(shape, order="F")
+            self.strides_of_shape = NDArrayStrides(self.shape, order="F")
         self.order = order
         self.index = 0
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -23,17 +23,18 @@ Implements basic object methods for working with N-Dimensional Array.
 # 3. `_NDIter` type
 #
 # ===----------------------------------------------------------------------===#
-# FORMAT FOR DOCSTRING
-# 1) DESCRIPTION
-# 2) PARAMETERS
-# 3) ARGS
-# 4) RETURNS
-# 5) RAISES
+# FORMAT FOR DOCSTRING (See "Mojo docstring style guide" for more information)
+# 1. Description *
+# 2. Parameters *
+# 3. Args *
+# 4. Constraints *
+# 4) Returns *
+# 5) Raises *
 # 6) SEE ALSO
 # 7) NOTES
 # 8) REFERENCES
-# 9) EXAMPLES
-# ===----------------------------------------------------------------------===#
+# 9) Examples *
+# (Items marked with * are flavored in "Mojo docstring style guide")
 #
 # ===----------------------------------------------------------------------===#
 # TODO: Consider whether we should add vectorization for _get_offset.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -5246,3 +5246,36 @@ struct _NDIter[
             (indices._buf + self.axis).init_pointee_copy(remainder)
 
         return self.ptr[_get_offset(indices, self.strides)]
+
+    fn ith(self, index: Int) raises -> Scalar[dtype]:
+        """
+        Gets the i-th element of the iterator.
+
+        Args:
+            index: The index of the item. It must be non-negative.
+
+        Returns:
+            The i-th element of the iterator.
+        """
+
+        if (index >= self.length) or (index < 0):
+            raise Error(
+                String(
+                    "\nError in `NDIter.ith()`: "
+                    "Index ({}) must be in the range of [0, {})"
+                ).format(index, self.length)
+            )
+
+        var remainder = index
+        var indices = Item(ndim=self.ndim, initialized=False)
+
+        if self.order == "C":
+            for i in range(self.ndim):
+                indices._buf[i] = remainder // self.strides_compatible._buf[i]
+                remainder %= self.strides_compatible._buf[i]
+        else:
+            for i in range(self.ndim - 1, -1, -1):
+                indices._buf[i] = remainder // self.strides_compatible._buf[i]
+                remainder %= self.strides_compatible._buf[i]
+
+        return self.ptr[_get_offset(indices, self.strides)]

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1397,7 +1397,6 @@ struct NDArray[dtype: DType = DType.float64](
             indices: Indices to set the value.
             val: Value to set.
 
-
         Notes:
             This function is unsafe and for internal use only.
 

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -438,18 +438,6 @@ struct NDArrayShape(Stringable, Writable):
         memcpy(res._buf, self._buf, self.ndim)
         return res
 
-    fn size_of_array(self) -> Int:
-        """
-        Returns the total number of elements in the array.
-
-        Returns:
-          The total number of elements in the corresponding array.
-        """
-        var size = 1
-        for i in range(self.ndim):
-            size *= self._buf[i]
-        return size
-
     fn join(self, *shapes: Self) raises -> Self:
         """
         Join multiple shapes into a single shape.
@@ -477,6 +465,18 @@ struct NDArrayShape(Stringable, Writable):
 
         return new_shape
 
+    fn size_of_array(self) -> Int:
+        """
+        Returns the total number of elements in the array.
+
+        Returns:
+          The total number of elements in the corresponding array.
+        """
+        var size = 1
+        for i in range(self.ndim):
+            size *= self._buf[i]
+        return size
+
     fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
         """
         Returns a new shape with the given axes swapped.
@@ -488,11 +488,10 @@ struct NDArrayShape(Stringable, Writable):
         Returns:
             A new shape with the given axes swapped.
         """
-        var shape = NDArrayShape(self)
-        var temp = shape[axis1]
-        shape[axis1] = shape[axis2]
-        shape[axis2] = temp
-        return shape
+        var res = self
+        res[axis1] = self[axis2]
+        res[axis2] = self[axis1]
+        return res
 
     # ===-------------------------------------------------------------------===#
     # Other private methods

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -428,6 +428,16 @@ struct NDArrayShape(Stringable, Writable):
     # Other methods
     # ===-------------------------------------------------------------------===#
 
+    @always_inline("nodebug")
+    fn copy(read self) raises -> Self:
+        """
+        Returns a deep copy of the shape.
+        """
+
+        var res = Self(ndim=self.ndim, initialized=False)
+        memcpy(res._buf, self._buf, self.ndim)
+        return res
+
     fn size_of_array(self) -> Int:
         """
         Returns the total number of elements in the array.
@@ -466,6 +476,23 @@ struct NDArrayShape(Stringable, Writable):
                 index += 1
 
         return new_shape
+
+    fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
+        """
+        Returns a new shape with the given axes swapped.
+
+        Args:
+            axis1: The first axis to swap.
+            axis2: The second axis to swap.
+
+        Returns:
+            A new shape with the given axes swapped.
+        """
+        var shape = NDArrayShape(self)
+        var temp = shape[axis1]
+        shape[axis1] = shape[axis2]
+        shape[axis2] = temp
+        return shape
 
     # ===-------------------------------------------------------------------===#
     # Other private methods

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -411,6 +411,22 @@ struct NDArrayStrides(Stringable):
         memcpy(res._buf, self._buf, self.ndim)
         return res
 
+    fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
+        """
+        Returns a new strides with the given axes swapped.
+
+        Args:
+            axis1: The first axis to swap.
+            axis2: The second axis to swap.
+
+        Returns:
+            A new strides with the given axes swapped.
+        """
+        var res = self
+        res[axis1] = self[axis2]
+        res[axis2] = self[axis1]
+        return res
+
     # ===-------------------------------------------------------------------===#
     # Other private methods
     # ===-------------------------------------------------------------------===#

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -398,6 +398,20 @@ struct NDArrayStrides(Stringable):
         return False
 
     # ===-------------------------------------------------------------------===#
+    # Other methods
+    # ===-------------------------------------------------------------------===#
+
+    @always_inline("nodebug")
+    fn copy(read self) raises -> Self:
+        """
+        Returns a deep copy of the strides.
+        """
+
+        var res = Self(ndim=self.ndim, initialized=False)
+        memcpy(res._buf, self._buf, self.ndim)
+        return res
+
+    # ===-------------------------------------------------------------------===#
     # Other private methods
     # ===-------------------------------------------------------------------===#
 

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -436,6 +436,9 @@ struct NDArrayStrides(Stringable):
         Returns a new strides by flipping the items.
         ***UNSAFE!*** No boundary check!
 
+        Returns:
+            A new strides with the items flipped.
+
         Example:
         ```mojo
         import numojo as nm
@@ -463,9 +466,6 @@ struct NDArrayStrides(Stringable):
         print(A.strides._move_axis_to_end(0))  # Stride: [4, 1, 12]
         print(A.strides._move_axis_to_end(1))  # Stride: [12, 1, 4]
         ```
-
-        Returns:
-            A new strides with the items flipped.
         """
 
         if axis < 0:

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -5,6 +5,7 @@ Implements routines by topic:
 - Array manipulation routines (manipulation.mojo)
 - Bit-wise operations (bitwise.mojo)
 - Constants (constants.mojo)
+- Indexing routines (indexing.mojo)
 - Input and output (io/)
     - Text files (files.mojo)
     - Text formatting options (formatting.mojo)

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -273,3 +273,27 @@ fn apply_along_axis[
         parallelize[parallelized_func](a.size // a.shape[axis])
 
     return res^
+
+
+# ===----------------------------------------------------------------------=== #
+# `vectorize`
+#
+# This section are OVERLOADS for the function `vectorize` that
+# applies a function to scalars to arrays.
+# It execute `func(a: Scalar, b: Scalar, *args, **kwargs)` where
+# `func` operates on scalars.
+# ===----------------------------------------------------------------------=== #
+
+"""
+If a and b have the same shape and strides, the function will be applied
+element-wise to the two arrays.
+
+Else if a and b have the same shape and the strides are both 1 for axis -1 or 0
+(C or F contiguous is not sufficient due to broadcasted views),
+the function with be applied by axis -1 or axis 0.
+
+Else, conduct item-wise calculation.
+
+If a and b have different shape (including when b is scalar), 
+conduct a broadcasting.
+"""

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -1,5 +1,16 @@
+# ===----------------------------------------------------------------------=== #
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
 """
-Indexing routines.
+Implement indexing routines.
+
+- Generating index arrays
+- Indexing-like operations
+- Inserting data into arrays
+- Iterating over arrays
 """
 
 from memory import memcpy

--- a/tests/core/test_array_methods.mojo
+++ b/tests/core/test_array_methods.mojo
@@ -2,7 +2,7 @@ from python import Python
 
 from numojo.prelude import *
 from testing.testing import assert_true, assert_almost_equal, assert_equal
-from utils_for_test import check, check_is_close
+from utils_for_test import check, check_is_close, check_values_close
 
 
 def test_constructors():
@@ -63,9 +63,14 @@ def test_constructors():
 
 def test_iterator():
     var py = Python.import_module("builtins")
+    var np = Python.import_module("numpy")
 
     var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
     var anp = a.to_numpy()
+    var f = nm.arange[i8](24).reshape(Shape(2, 3, 4), order="F")
+    var fnp = f.to_numpy()
+
+    # NDAxisIter
     var a_iter_along_axis = a.iter_along_axis[forward=False](axis=0)
     var b = a_iter_along_axis.__next__() == nm.array[i8]("[11, 23]")
     assert_true(
@@ -77,6 +82,7 @@ def test_iterator():
         "`_NDAxisIter` breaks",
     )
 
+    # NDArrayIter
     var a_iter_over_dimension = a.__iter__()
     var anp_iter_over_dimension = anp.__iter__()
     for i in range(a.shape[0]):
@@ -93,4 +99,42 @@ def test_iterator():
             a_iter_over_dimension_reversed.__next__(),
             anp_iter_over_dimension_reversed.__next__(),
             "`_NDArrayIter` or `__reversed__()` breaks",
+        )
+
+    # NDIter of C-order array
+    var a_nditer = a.nditer()
+    var anp_nditer = np.nditer(anp)
+    for i in range(a.size):
+        check_values_close(
+            a_nditer.__next__(),
+            anp_nditer.__next__(),
+            "`_NDIter` or `nditer()` of C array by order C breaks",
+        )
+
+    var a_nditer_f = a.nditer(order="F")
+    var anp_nditer_f = np.nditer(anp, order="F")
+    for i in range(a.size):
+        check_values_close(
+            a_nditer_f.__next__(),
+            anp_nditer_f.__next__(),
+            "`_NDIter` or `nditer()` of C array by order F breaks",
+        )
+
+    # NDIter of F-order array
+    var f_nditer = f.nditer()
+    var fnp_nditer = np.nditer(fnp)
+    for i in range(f.size):
+        check_values_close(
+            f_nditer.__next__(),
+            fnp_nditer.__next__(),
+            "`_NDIter` or `nditer()` of F array by order C breaks",
+        )
+
+    var f_nditer_f = f.nditer(order="F")
+    var fnp_nditer_f = np.nditer(fnp, order="F")
+    for i in range(f.size):
+        check_values_close(
+            f_nditer_f.__next__(),
+            fnp_nditer_f.__next__(),
+            "`_NDIter` or `nditer()` of F array by order F breaks",
         )

--- a/tests/core/test_array_methods.mojo
+++ b/tests/core/test_array_methods.mojo
@@ -111,6 +111,16 @@ def test_iterator():
             "`_NDIter` or `nditer()` of C array by order C breaks",
         )
 
+    # NDIter of C-order array
+    a_nditer = a.nditer()
+    anp_nditer = np.nditer(anp)
+    for i in range(a.size):
+        check_values_close(
+            a_nditer.ith(i),
+            anp_nditer.__next__(),
+            "`_NDIter.ith()` of C array by order C breaks",
+        )
+
     var a_nditer_f = a.nditer(order="F")
     var anp_nditer_f = np.nditer(anp, order="F")
     for i in range(a.size):


### PR DESCRIPTION
- Improve `_NDIter` to allow arbitrary axis to travel.
- Add method `ith()` to get the i-th item of the iterator.
- Add `swapaxes()` for shape and strides.
- Add `offset()` for `Item` type to get offset.
- Constructor for `Item` from index and shape.
- Add tests for C or F array with `nditer` from C or F orders.