### PR TITLE
[routines] Re-write `argmax` and `argmin` to returns indices along the given axis

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -24,20 +24,21 @@ p = "clear && magic run package"
 format = "magic run mojo format ./"
 
 # test whether tests pass on the built package
-test = "magic run package && magic run mojo test tests -I ./tests/"
+test = "magic run package && magic run mojo test tests -I tests/ && rm tests/numojo.mojopkg"
 t = "clear && magic run test"
 
 # run individual tests to avoid overheat
-test_core = "magic run mojo test tests/core -I ./ -I ./tests/"
-test_creation = "magic run mojo test tests/routines/test_creation.mojo -I ./ -I ./tests/"
-test_functional = "magic run mojo test tests/routines/test_functional.mojo -I ./ -I ./tests/"
-test_indexing = "magic run mojo test tests/routines/test_indexing.mojo -I ./ -I ./tests/"
-test_linalg = "magic run mojo test tests/routines/test_linalg.mojo -I ./ -I ./tests/"
-test_manipulation = "magic run mojo test tests/routines/test_manipulation.mojo -I ./ -I ./tests/"
-test_math = "magic run mojo test tests/routines/test_math.mojo -I ./ -I ./tests/"
-test_random = "magic run mojo test tests/routines/test_random.mojo -I ./ -I ./tests/"
-test_statistics = "magic run mojo test tests/routines/test_statistics.mojo -I ./ -I ./tests/"
-test_sorting = "magic run mojo test tests/routines/test_sorting.mojo -I ./ -I ./tests/"
+test_core = "magic run package && magic run mojo test tests/core -I tests/ && rm tests/numojo.mojopkg"
+test_creation = "magic run package && magic run mojo test tests/routines/test_creation.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_functional = "magic run package && magic run mojo test tests/routines/test_functional.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_indexing = "magic run package && magic run mojo test tests/routines/test_indexing.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_linalg = "magic run package && magic run mojo test tests/routines/test_linalg.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_manipulation = "magic run package && magic run mojo test tests/routines/test_manipulation.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_math = "magic run package && magic run mojo test tests/routines/test_math.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_random = "magic run package && magic run mojo test tests/routines/test_random.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_statistics = "magic run package && magic run mojo test tests/routines/test_statistics.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_sorting = "magic run package && magic run mojo test tests/routines/test_sorting.mojo -I tests/ && rm tests/numojo.mojopkg"
+test_searching = "magic run package && magic run mojo test tests/routines/test_searching.mojo -I tests/ && rm tests/numojo.mojopkg"
 
 # run all final checks before a commit
 final = "magic run format && magic run test"

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -88,6 +88,7 @@ from numojo.routines.io.formatting import (
 import numojo.routines.logic.comparison as comparison
 import numojo.routines.math.arithmetic as arithmetic
 import numojo.routines.math.rounding as rounding
+import numojo.routines.searching as searching
 
 
 struct NDArray[dtype: DType = DType.float64](
@@ -3630,42 +3631,36 @@ struct NDArray[dtype: DType = DType.float64](
         vectorize[vectorized_any, self.width](self.size)
         return result
 
-    fn argmax(self) raises -> Int:
+    fn argmax(self) raises -> Scalar[DType.index]:
+        """Returns the indices of the maximum values along an axis.
+        When no axis is specified, the array is flattened.
+        See `numojo.argmax()` for more details.
         """
-        Get location in pointer of max value.
+        return searching.argmax(self)
 
-        Returns:
-            Index of the maximum value.
+    fn argmax(self, axis: Int) raises -> NDArray[DType.index]:
+        """Returns the indices of the maximum values along an axis.
+        See `numojo.argmax()` for more details.
         """
-        var result: Int = 0
-        var max_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.size):
-            var temp: SIMD[dtype, 1] = self.load[width=1](i)
-            if temp > max_val:
-                max_val = temp
-                result = i
-        return result
+        return searching.argmax(self, axis=axis)
 
-    fn argmin(self) raises -> Int:
+    fn argmin(self) raises -> Scalar[DType.index]:
+        """Returns the indices of the minimum values along an axis.
+        When no axis is specified, the array is flattened.
+        See `numojo.argmin()` for more details.
         """
-        Get location in pointer of min value.
+        return searching.argmin(self)
 
-        Returns:
-            Index of the minimum value.
+    fn argmin(self, axis: Int) raises -> NDArray[DType.index]:
+        """Returns the indices of the minimum values along an axis.
+        See `numojo.argmin()` for more details.
         """
-        var result: Int = 0
-        var min_val: SIMD[dtype, 1] = self.load[width=1](0)
-        for i in range(1, self.size):
-            var temp: SIMD[dtype, 1] = self.load[width=1](i)
-            if temp < min_val:
-                min_val = temp
-                result = i
-        return result
+        return searching.argmin(self, axis=axis)
 
     fn argsort(self) raises -> NDArray[DType.index]:
         """
         Sort the NDArray and return the sorted indices.
-        See `numojo.argsort()`.
+        See `numojo.argsort()` for more details.
 
         Returns:
             The indices of the sorted NDArray.
@@ -3676,7 +3671,7 @@ struct NDArray[dtype: DType = DType.float64](
     fn argsort(self, axis: Int) raises -> NDArray[DType.index]:
         """
         Sort the NDArray and return the sorted indices.
-        See `numojo.argsort()`.
+        See `numojo.argsort()` for more details.
 
         Returns:
             The indices of the sorted NDArray.

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -131,7 +131,7 @@ fn max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
         normalized_axis += a.ndim
     if (normalized_axis < 0) or (normalized_axis >= a.ndim):
         raise Error(
-            String("Error in `mean`: Axis {} not in bound [-{}, {})").format(
+            String("Error in `max`: Axis {} not in bound [-{}, {})").format(
                 axis, a.ndim, a.ndim
             )
         )
@@ -243,7 +243,7 @@ fn min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
         normalized_axis += a.ndim
     if (normalized_axis < 0) or (normalized_axis >= a.ndim):
         raise Error(
-            String("Error in `mean`: Axis {} not in bound [-{}, {})").format(
+            String("Error in `min`: Axis {} not in bound [-{}, {})").format(
                 axis, a.ndim, a.ndim
             )
         )

--- a/tests/routines/test_searching.mojo
+++ b/tests/routines/test_searching.mojo
@@ -1,0 +1,221 @@
+from numojo.prelude import *
+from python import Python, PythonObject
+from utils_for_test import check, check_is_close, check_values_close
+
+
+fn test_argmax() raises:
+    var np = Python.import_module("numpy")
+
+    # Test 1D array
+    var a1d = nm.array[nm.f32]("[3.4, 1.2, 5.7, 0.9, 2.3]")
+    var a1d_np = a1d.to_numpy()
+
+    check_values_close(
+        nm.argmax(a1d),
+        np.argmax(a1d_np),
+        "`argmax` with 1D array is broken",
+    )
+
+    # Test 2D array without specifying axis (flattened)
+    var a2d = nm.array[nm.f32](
+        "[[3.4, 1.2, 5.7], [0.9, 2.3, 4.1], [7.6, 0.5, 2.8]]"
+    )
+    var a2d_np = a2d.to_numpy()
+
+    check_values_close(
+        nm.argmax(a2d),
+        np.argmax(a2d_np),
+        "`argmax` with 2D array (flattened) is broken",
+    )
+
+    # Test 2D array with axis=0
+    check(
+        nm.argmax(a2d, axis=0),
+        np.argmax(a2d_np, axis=0),
+        "`argmax` with 2D array on axis=0 is broken",
+    )
+
+    # Test 2D array with axis=1
+    check(
+        nm.argmax(a2d, axis=1),
+        np.argmax(a2d_np, axis=1),
+        "`argmax` with 2D array on axis=1 is broken",
+    )
+
+    # Test 2D array with negative axis
+    check(
+        nm.argmax(a2d, axis=-1),
+        np.argmax(a2d_np, axis=-1),
+        "`argmax` with 2D array on negative axis is broken",
+    )
+
+    # Test 3D array
+    var a3d = nm.random.randint(2, 3, 4, low=0, high=10)
+    var a3d_np = a3d.to_numpy()
+
+    check_values_close(
+        nm.argmax(a3d),
+        np.argmax(a3d_np),
+        "`argmax` with 3D array (flattened) is broken",
+    )
+
+    check(
+        nm.argmax(a3d, axis=0),
+        np.argmax(a3d_np, axis=0),
+        "`argmax` with 3D array on axis=0 is broken",
+    )
+
+    check(
+        nm.argmax(a3d, axis=1),
+        np.argmax(a3d_np, axis=1),
+        "`argmax` with 3D array on axis=1 is broken",
+    )
+
+    check(
+        nm.argmax(a3d, axis=2),
+        np.argmax(a3d_np, axis=2),
+        "`argmax` with 3D array on axis=2 is broken",
+    )
+
+    # Test with F-order array
+    var a3d_f = nm.random.randint(2, 3, 4, low=0, high=10).reshape(
+        Shape(2, 3, 4), order="F"
+    )
+    var a3d_f_np = a3d_f.to_numpy()
+
+    for i in range(3):
+        check(
+            nm.argmax(a3d_f, axis=i),
+            np.argmax(a3d_f_np, axis=i),
+            "`argmax` with F-order 3D array on axis={} is broken".format(i),
+        )
+
+
+fn test_argmin() raises:
+    var np = Python.import_module("numpy")
+
+    # Test 1D array
+    var a1d = nm.array[nm.f32]("[3.4, 1.2, 5.7, 0.9, 2.3]")
+    var a1d_np = a1d.to_numpy()
+
+    check_values_close(
+        nm.argmin(a1d),
+        np.argmin(a1d_np),
+        "`argmin` with 1D array is broken",
+    )
+
+    # Test 2D array without specifying axis (flattened)
+    var a2d = nm.array[nm.f32](
+        "[[3.4, 1.2, 5.7], [0.9, 2.3, 4.1], [7.6, 0.5, 2.8]]"
+    )
+    var a2d_np = a2d.to_numpy()
+
+    check_values_close(
+        nm.argmin(a2d),
+        np.argmin(a2d_np),
+        "`argmin` with 2D array (flattened) is broken",
+    )
+
+    # Test 2D array with axis=0
+    check(
+        nm.argmin(a2d, axis=0),
+        np.argmin(a2d_np, axis=0),
+        "`argmin` with 2D array on axis=0 is broken",
+    )
+
+    # Test 2D array with axis=1
+    check(
+        nm.argmin(a2d, axis=1),
+        np.argmin(a2d_np, axis=1),
+        "`argmin` with 2D array on axis=1 is broken",
+    )
+
+    # Test 2D array with negative axis
+    check(
+        nm.argmin(a2d, axis=-1),
+        np.argmin(a2d_np, axis=-1),
+        "`argmin` with 2D array on negative axis is broken",
+    )
+
+    # Test 3D array
+    var a3d = nm.random.randint(2, 3, 4, low=0, high=10)
+    var a3d_np = a3d.to_numpy()
+
+    check_values_close(
+        nm.argmin(a3d),
+        np.argmin(a3d_np),
+        "`argmin` with 3D array (flattened) is broken",
+    )
+
+    check(
+        nm.argmin(a3d, axis=0),
+        np.argmin(a3d_np, axis=0),
+        "`argmin` with 3D array on axis=0 is broken",
+    )
+
+    check(
+        nm.argmin(a3d, axis=1),
+        np.argmin(a3d_np, axis=1),
+        "`argmin` with 3D array on axis=1 is broken",
+    )
+
+    check(
+        nm.argmin(a3d, axis=2),
+        np.argmin(a3d_np, axis=2),
+        "`argmin` with 3D array on axis=2 is broken",
+    )
+
+    # Test with F-order array
+    var a3d_f = nm.random.randint(2, 3, 4, low=0, high=10).reshape(
+        Shape(2, 3, 4), order="F"
+    )
+    var a3d_f_np = a3d_f.to_numpy()
+
+    for i in range(3):
+        check(
+            nm.argmin(a3d_f, axis=i),
+            np.argmin(a3d_f_np, axis=i),
+            "`argmin` with F-order 3D array on axis={} is broken".format(i),
+        )
+
+
+fn test_take_along_axis_with_argmax_argmin() raises:
+    var np = Python.import_module("numpy")
+
+    # Test with argmax to get maximum values
+    var a2d = nm.random.randint(5, 4, low=0, high=10)
+    var a2d_np = a2d.to_numpy()
+
+    # Get indices of maximum values along axis=1
+    var max_indices = nm.argmax(a2d, axis=1)
+    var max_indices_np = np.argmax(a2d_np, axis=1)
+
+    # Reshape indices for take_along_axis
+    var reshaped_indices = max_indices.reshape(Shape(max_indices.shape[0], 1))
+    var reshaped_indices_np = max_indices_np.reshape(max_indices_np.shape[0], 1)
+
+    # Get maximum values using take_along_axis
+    check(
+        nm.indexing.take_along_axis(a2d, reshaped_indices, axis=1),
+        np.take_along_axis(a2d_np, reshaped_indices_np, axis=1),
+        "`take_along_axis` with argmax is broken",
+    )
+
+    # Test with argmin to get minimum values
+    var min_indices = nm.argmin(a2d, axis=1)
+    var min_indices_np = np.argmin(a2d_np, axis=1)
+
+    # Reshape indices for take_along_axis
+    var reshaped_min_indices = min_indices.reshape(
+        Shape(min_indices.shape[0], 1)
+    )
+    var reshaped_min_indices_np = min_indices_np.reshape(
+        min_indices_np.shape[0], 1
+    )
+
+    # Get minimum values using take_along_axis
+    check(
+        nm.indexing.take_along_axis(a2d, reshaped_min_indices, axis=1),
+        np.take_along_axis(a2d_np, reshaped_min_indices_np, axis=1),
+        "`take_along_axis` with argmin is broken",
+    )

--- a/tests/utils_for_test.mojo
+++ b/tests/utils_for_test.mojo
@@ -4,7 +4,7 @@ import numojo as nm
 
 
 fn check[
-    dtype: DType
+    dtype: DType, //
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)


### PR DESCRIPTION
This pull request focuses on enhancing the functionality of the `NDArray` class and improving the `argmax` and `argmin` methods. Additionally, new tests have been added to ensure the correctness of these methods.

Improvements to `argmax` and `argmin` methods:

* `numojo/routines/searching.mojo`: Introduced new `argmax` and `argmin` functions that handle both 1D and multi-dimensional arrays. These functions now support axis-based operations and include detailed documentation and examples.
* `numojo/routines/functional.mojo`: Added overloads of `apply_along_axis` to support the new `argmax` and `argmin` functions, ensuring they reduce the dimension of the input array appropriately.

Enhancements to `NDArray` class:

* `numojo/core/ndarray.mojo`: The `argmax` and `argmin` methods have been updated to use the new `searching.argmax` and `searching.argmin` functions. These methods now return indices of the maximum and minimum values along an axis, with improved documentation.

Bug fixes:

* `numojo/routines/math/extrema.mojo`: Corrected error messages in the `max` and `min` functions to accurately reflect the function names.

New tests:

* `tests/routines/test_searching.mojo`: Added comprehensive tests for the `argmax` and `argmin` functions, including tests for 1D, 2D, and 3D arrays, as well as tests for negative axes and Fortran-order arrays. Also included tests for `take_along_axis` with `argmax` and `argmin`.