### PR TITLE
Add support for column-major (F-contiguous) memory layout for improved Matrix decomposition performance

### DIFF
--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -17,7 +17,7 @@ from numojo.core.flags import Flags
 from numojo.core.ndarray import NDArray
 from numojo.core.own_data import OwnData
 from numojo.core.utility import _get_offset
-from numojo.routines.manipulation import broadcast_to
+from numojo.routines.manipulation import broadcast_to, reorder_layout
 
 # ===----------------------------------------------------------------------===#
 # Matrix struct
@@ -113,16 +113,21 @@ struct Matrix[dtype: DType = DType.float64](
     fn __init__(
         mut self,
         shape: Tuple[Int, Int],
+        c_contigous: Bool = True,
     ):
         """
-        Construct a matrix without initializing data.
+        Create a new matrix of the given shape,without initializing data.
 
         Args:
-            shape: List of shape.
+            shape: Tuple representing (rows, columns).
+            c_contigous: If True, use row-major(C-style) memory layout. Otherwise use column-major(Fortran-style) layout.
         """
 
         self.shape = (shape[0], shape[1])
-        self.strides = (shape[1], 1)
+        if c_contigous:
+            self.strides = (shape[1], 1)
+        else:
+            self.strides = (1, shape[0])
         self.size = shape[0] * shape[1]
         self._buf = OwnData[dtype](size=self.size)
         self.flags = Flags(
@@ -1171,6 +1176,12 @@ struct Matrix[dtype: DType = DType.float64](
         """
         return transpose(self)
 
+    fn reorder_layout(self) -> Self:
+        """
+        reorder_layout matrix.
+        """
+        return reorder_layout(self)
+
     fn T(self) -> Self:
         return transpose(self)
 
@@ -1221,6 +1232,10 @@ struct Matrix[dtype: DType = DType.float64](
         try:
             var np = Python.import_module("numpy")
 
+            var np_arr_dim = PythonObject([])
+            np_arr_dim.append(self.shape[0])
+            np_arr_dim.append(self.shape[1])
+
             np.set_printoptions(4)
 
             # Implement a dictionary for this later
@@ -1251,7 +1266,8 @@ struct Matrix[dtype: DType = DType.float64](
             elif dtype == DType.index:
                 np_dtype = np.int64
 
-            numpyarray = np.empty(self.shape, dtype=np_dtype)
+            var order = "C" if self.flags.C_CONTIGUOUS else "F"
+            numpyarray = np.empty(np_arr_dim, dtype=np_dtype, order=order)
             var pointer_d = numpyarray.__array_interface__["data"][
                 0
             ].unsafe_get_as_pointer[dtype]()
@@ -1270,7 +1286,11 @@ struct Matrix[dtype: DType = DType.float64](
     @staticmethod
     fn full[
         dtype: DType = DType.float64
-    ](shape: Tuple[Int, Int], fill_value: Scalar[dtype] = 0) -> Matrix[dtype]:
+    ](
+        shape: Tuple[Int, Int],
+        fill_value: Scalar[dtype] = 0,
+        c_contigous: Bool = True,
+    ) -> Matrix[dtype]:
         """Return a matrix with given shape and filled value.
 
         Example:
@@ -1280,7 +1300,7 @@ struct Matrix[dtype: DType = DType.float64](
         ```
         """
 
-        var matrix = Matrix[dtype](shape)
+        var matrix = Matrix[dtype](shape, c_contigous)
         for i in range(shape[0] * shape[1]):
             matrix._buf.ptr.store(i, fill_value)
 
@@ -1289,7 +1309,7 @@ struct Matrix[dtype: DType = DType.float64](
     @staticmethod
     fn zeros[
         dtype: DType = DType.float64
-    ](shape: Tuple[Int, Int]) -> Matrix[dtype]:
+    ](shape: Tuple[Int, Int], c_contigous: Bool = True) -> Matrix[dtype]:
         """Return a matrix with given shape and filled with zeros.
 
         Example:
@@ -1299,14 +1319,14 @@ struct Matrix[dtype: DType = DType.float64](
         ```
         """
 
-        var M = Matrix[dtype](shape)
+        var M = Matrix[dtype](shape, c_contigous)
         memset_zero(M._buf.ptr, M.size)
         return M^
 
     @staticmethod
     fn ones[
         dtype: DType = DType.float64
-    ](shape: Tuple[Int, Int]) -> Matrix[dtype]:
+    ](shape: Tuple[Int, Int], c_contigous: Bool = True) -> Matrix[dtype]:
         """Return a matrix with given shape and filled with ones.
 
         Example:
@@ -1319,8 +1339,10 @@ struct Matrix[dtype: DType = DType.float64](
         return Matrix.full[dtype](shape=shape, fill_value=1)
 
     @staticmethod
-    fn identity[dtype: DType = DType.float64](len: Int) -> Matrix[dtype]:
-        """Return a matrix with given shape and filled value.
+    fn identity[
+        dtype: DType = DType.float64
+    ](len: Int, c_contigous: Bool = True) -> Matrix[dtype]:
+        """Return an identity matrix with given size.
 
         Example:
         ```mojo
@@ -1328,16 +1350,17 @@ struct Matrix[dtype: DType = DType.float64](
         var A = Matrix.identity(12)
         ```
         """
-
-        var matrix = Matrix.zeros[dtype]((len, len))
+        var matrix = Matrix.zeros[dtype]((len, len), c_contigous)
         for i in range(len):
-            matrix._buf.ptr.store(i * matrix.strides[0] + i, 1)
+            matrix._buf.ptr.store(
+                i * matrix.strides[0] + i * matrix.strides[1], 1
+            )
         return matrix^
 
     @staticmethod
     fn rand[
         dtype: DType = DType.float64
-    ](shape: Tuple[Int, Int]) -> Matrix[dtype]:
+    ](shape: Tuple[Int, Int], c_contigous: Bool = True) -> Matrix[dtype]:
         """Return a matrix with random values uniformed distributed between 0 and 1.
 
         Example:
@@ -1352,7 +1375,7 @@ struct Matrix[dtype: DType = DType.float64](
         Args:
             shape: The shape of the Matrix.
         """
-        var result = Matrix[dtype](shape)
+        var result = Matrix[dtype](shape, c_contigous)
         for i in range(result.size):
             result._buf.ptr.store(i, random_float64(0, 1).cast[dtype]())
         return result^
@@ -1361,7 +1384,9 @@ struct Matrix[dtype: DType = DType.float64](
     fn fromlist[
         dtype: DType
     ](
-        object: List[Scalar[dtype]], shape: Tuple[Int, Int] = (0, 0)
+        object: List[Scalar[dtype]],
+        shape: Tuple[Int, Int] = (0, 0),
+        c_contigous: Bool = True,
     ) raises -> Matrix[dtype]:
         """Create a matrix from a 1-dimensional list into given shape.
 
@@ -1385,14 +1410,16 @@ struct Matrix[dtype: DType = DType.float64](
                 "The input has {} elements, but the target has the shape {}x{}"
             ).format(len(object), shape[0], shape[1])
             raise Error(message)
-        var M = Matrix[dtype](shape=shape)
+        var M = Matrix[dtype](shape=shape, c_contigous=c_contigous)
         memcpy(M._buf.ptr, object.data, M.size)
         return M^
 
     @staticmethod
     fn fromstring[
         dtype: DType = DType.float64
-    ](text: String, shape: Tuple[Int, Int] = (0, 0)) raises -> Matrix[dtype]:
+    ](
+        text: String, shape: Tuple[Int, Int] = (0, 0), c_contigous: Bool = True
+    ) raises -> Matrix[dtype]:
         """Matrix initialization from string representation of an matrix.
 
         Comma, right brackets, and whitespace are treated as seperators of numbers.

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -295,6 +295,39 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return B^
 
 
+fn reorder_layout[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+    """
+    Create a new Matrix with the opposite layout from A:
+    if A is C-contiguous, then create a new F-contiguous matrix of the same shape.
+    If A is F-contiguous, create a new C-contiguous matrix.
+
+    Copy data into the new layout.
+    """
+
+    var rows = A.shape[0]
+    var cols = A.shape[1]
+
+    var want_c: Bool
+
+    try:
+        want_c = not A.flags["C_CONTIGUOUS"]
+    except Error:
+        return A
+
+    var B = Matrix[dtype](Tuple(rows, cols), c_contigous=want_c)
+
+    if want_c:
+        for i in range(rows):
+            for j in range(cols):
+                B._buf.ptr[i * cols + j] = A._buf.ptr[i + j * rows]
+    else:
+        for j in range(cols):
+            for i in range(rows):
+                B._buf.ptr[j * rows + i] = A._buf.ptr[i * cols + j]
+
+    return B^
+
+
 # ===----------------------------------------------------------------------=== #
 # Changing number of dimensions
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION

**Summary**  
This PR introduces a makes matrix memory layouts configurable. In addition to the default row-major (C-contiguous) layout, one can now use column-major (F-contiguous) layout. This enhancement is especially beneficial for routines such as QR decomposition. By aligning the data layout with the typical access patterns of many algorithms, we can achieve better performance when using SIMD.

Other Matrix libraries like [Eigen](https://eigen.tuxfamily.org/dox/group__TopicStorageOrders.html) allow compile-time selection of row-major or column-major storage through template parameters:

While Eigen handles this at compile time, the current approach does not use a parameter. 

### Changes  

1. **Added a `c_contigous` Bool Argument**  
   - Modifies the `Matrix` constructor and static creation methods (`zeros`, `ones`, `full`, `rand`, etc.) to accept an optional `c_contigous` boolean.  
   - When `c_contigous` is `True`, the matrix uses row-major (C-style). When `False`, it uses column-major (F-style).

2. **Introduced `reorder_layout`**  
   - A new function that creates a matrix with the opposite layout (C ↔ F) and copies data over.  
   - Intended for use in algorithms that need to switch layout after an operation or to prepare the matrix for certain column-based operations.

3. **Extended `Matrix.to_numpy`**  
   - Respects the matrix’s memory layout. If `C_CONTIGUOUS` is set, data is written in row-major; if `F_CONTIGUOUS` is set, data is written in column-major.


### Future Work  

- **Compile-Time Parameter**:  Adapting Matrix class to take a similar approach to Eigen.
- **Adapt Decomposition Routines**: I have already implemented a QR decomposition making use of the `F_CONTIGUOUS` memory layout. I will make a follow-up PR.
