### PR TITLE
[routines] Optimized QR Decomposition with SIMD and Column-Major Layout

### DIFF
--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -227,6 +227,90 @@ def test_qr_decomposition():
     assert_true(np.allclose(A_test.to_numpy(), A.to_numpy(), atol=1e-14))
 
 
+def test_qr_decomposition_asym_reduced():
+    var np = Python.import_module("numpy")
+    var A = Matrix.rand[f64]((12, 5))
+    Q, R = nm.linalg.qr(A, mode="reduced")
+
+    assert_true(
+        Q.shape[0] == 12 and Q.shape[1] == 5,
+        "Q has unexpected shape for reduced.",
+    )
+    assert_true(
+        R.shape[0] == 5 and R.shape[1] == 5,
+        "R has unexpected shape for reduced.",
+    )
+
+    var id = Q.transpose() @ Q
+    assert_true(
+        np.allclose(id.to_numpy(), np.eye(Q.shape[1]), atol=1e-14),
+        "Q not orthonormal for reduced.",
+    )
+    assert_true(
+        np.allclose(R.to_numpy(), np.triu(R.to_numpy()), atol=1e-14),
+        "R not upper triangular for reduced.",
+    )
+
+    var A_test = Q @ R
+    assert_true(np.allclose(A_test.to_numpy(), A.to_numpy(), atol=1e-14))
+
+
+def test_qr_decomposition_asym_complete():
+    var np = Python.import_module("numpy")
+    var A = Matrix.rand[f64]((12, 5))
+    Q, R = nm.linalg.qr(A, mode="complete")
+
+    assert_true(
+        Q.shape[0] == 12 and Q.shape[1] == 12,
+        "Q has unexpected shape for complete.",
+    )
+    assert_true(
+        R.shape[0] == 12 and R.shape[1] == 5,
+        "R has unexpected shape for complete.",
+    )
+
+    var id = Q.transpose() @ Q
+    assert_true(
+        np.allclose(id.to_numpy(), np.eye(Q.shape[0]), atol=1e-14),
+        "Q not orthonormal for complete.",
+    )
+    assert_true(
+        np.allclose(R.to_numpy(), np.triu(R.to_numpy()), atol=1e-14),
+        "R not upper triangular for complete.",
+    )
+
+    var A_test = Q @ R
+    assert_true(np.allclose(A_test.to_numpy(), A.to_numpy(), atol=1e-14))
+
+
+def test_qr_decomposition_asym_complete2():
+    var np = Python.import_module("numpy")
+    var A = Matrix.rand[f64]((5, 12))
+    Q, R = nm.linalg.qr(A, mode="complete")
+
+    assert_true(
+        Q.shape[0] == 5 and Q.shape[1] == 5,
+        "Q has unexpected shape for complete.",
+    )
+    assert_true(
+        R.shape[0] == 5 and R.shape[1] == 12,
+        "R has unexpected shape for complete.",
+    )
+
+    var id = Q.transpose() @ Q
+    assert_true(
+        np.allclose(id.to_numpy(), np.eye(Q.shape[0]), atol=1e-14),
+        "Q not orthonormal for complete.",
+    )
+    assert_true(
+        np.allclose(R.to_numpy(), np.triu(R.to_numpy()), atol=1e-14),
+        "R not upper triangular for complete.",
+    )
+
+    var A_test = Q @ R
+    assert_true(np.allclose(A_test.to_numpy(), A.to_numpy(), atol=1e-14))
+
+
 # ===-----------------------------------------------------------------------===#
 # Mathematics
 # ===-----------------------------------------------------------------------===#


### PR DESCRIPTION
This PR optimizes the QR decomposition utilizing configurable memory layouts and SIMD. When the input matrix is detected to be in row-major (C) layout, it is reordered to column-major (F) layout before performing Householder transformations. After factorization, the final Q and R are reordered to the original layout of the input Matrix, preserving consistency for downstream operations.  For an input matrix with column-major (F) layout, no reordering is needed.

**Changes**  

1. **Vectorized Householder Transformations**  
   Updated algorithm leverages SIMD with calls to `vectorize` for computing and applying Householder reflections.  

2. **Reduced and Complete Modes**  
   Adds support for both “reduced” and “complete” modes, similar to NumPy’s QR.  For an input Matrix A with shape (m,n):
     - “reduced”: Q has `shape(m, min(m,n))` and R has `shape(min(m,n), n)`.  
     - “complete”: Q has `shape(m, m)` and R has `shape(m, n)`.  
3. **Additional tests**  
Beyond the existing  test with `shape(20,20)` and default parameters, new tests now verify the QR decomposition for non-square matrices (`shape(12,5)` and `shape(5,12)`) in both reduced and complete modes.

