### PR TITLE
[Matrix][routines] Add Column-Major Memory Layout Support Across All Matrix Routines

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -53,3 +53,4 @@ jobs:
         run: |
           magic install
           magic run mojo test tests -I .
+          magic run mojo test tests/core/test_matrix.mojo -I . -D F_CONTIGUOUS

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -1221,7 +1221,7 @@ struct Matrix[dtype: DType = DType.float64](
 
     fn reorder_layout(self) -> Self:
         """
-        reorder_layout matrix.
+        Reorder_layout matrix.
         """
         return reorder_layout(self)
 
@@ -1417,6 +1417,7 @@ struct Matrix[dtype: DType = DType.float64](
 
         Args:
             shape: The shape of the Matrix.
+            order: The order of the Matrix. "C" or "F".
         """
         var result = Matrix[dtype](shape, order)
         for i in range(result.size):
@@ -1491,6 +1492,7 @@ struct Matrix[dtype: DType = DType.float64](
         Args:
             text: String representation of a matrix.
             shape: Shape of the matrix.
+            order: Order of the matrix. "C" or "F".
         """
 
         var data = List[Scalar[dtype]]()

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -220,8 +220,8 @@ fn lu_decomposition[
     var n = A.shape[0]
 
     # Initiate upper and lower triangular matrices
-    var U = Matrix.full[dtype](shape=(n, n))
-    var L = Matrix.full[dtype](shape=(n, n))
+    var U = Matrix.full[dtype](shape=(n, n), order=A.order())
+    var L = Matrix.full[dtype](shape=(n, n), order=A.order())
 
     # Fill in L and U
     for i in range(0, n):
@@ -305,6 +305,8 @@ fn partial_pivoting[
     """
     var n = A.shape[0]
     var P = Matrix.identity[dtype](n)
+    if A.flags.F_CONTIGUOUS:
+        A = A.reorder_layout()
     var s: Int = 0  # Number of exchanges, for determinant
     for col in range(n):
         var max_p = abs(A[col, col])
@@ -318,6 +320,9 @@ fn partial_pivoting[
 
         if max_p_row != col:
             s = s + 1
+    if A.flags.F_CONTIGUOUS:
+        A = A.reorder_layout()
+        P = P.reorder_layout()
 
     return Tuple(A^, P^, s)
 

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -381,25 +381,67 @@ fn matmul[
             )
         )
 
-    var C: Matrix[dtype] = Matrix.zeros[dtype](shape=(A.shape[0], B.shape[1]))
+    var C: Matrix[dtype]
 
-    @parameter
-    fn calculate_CC(m: Int):
-        for k in range(A.shape[1]):
+    if A.flags.C_CONTIGUOUS and B.flags.C_CONTIGUOUS:
+        C = Matrix.zeros[dtype](shape=(A.shape[0], B.shape[1]), order=B.order())
 
-            @parameter
-            fn dot[simd_width: Int](n: Int):
-                C._store[simd_width](
-                    m,
-                    n,
-                    C._load[simd_width](m, n)
-                    + A._load(m, k) * B._load[simd_width](k, n),
-                )
+        @parameter
+        fn calculate_CC(m: Int):
+            for k in range(A.shape[1]):
 
-            vectorize[dot, width](B.shape[1])
+                @parameter
+                fn dot[simd_width: Int](n: Int):
+                    C._store[simd_width](
+                        m,
+                        n,
+                        C._load[simd_width](m, n)
+                        + A._load(m, k) * B._load[simd_width](k, n),
+                    )
 
-    parallelize[calculate_CC](A.shape[0], A.shape[0])
+                vectorize[dot, width](B.shape[1])
 
+        parallelize[calculate_CC](A.shape[0], A.shape[0])
+    elif A.flags.F_CONTIGUOUS and B.flags.F_CONTIGUOUS:
+        C = Matrix.zeros[dtype](shape=(A.shape[0], B.shape[1]), order=B.order())
+
+        @parameter
+        fn calculate_FF(n: Int):
+            for k in range(A.shape[1]):
+
+                @parameter
+                fn dot_F[simd_width: Int](m: Int):
+                    C._store[simd_width](
+                        m,
+                        n,
+                        C._load[simd_width](m, n)
+                        + A._load[simd_width](m, k) * B._load(k, n),
+                    )
+
+                vectorize[dot_F, width](A.shape[0])
+
+        parallelize[calculate_FF](B.shape[1], B.shape[1])
+    elif A.flags.C_CONTIGUOUS and B.flags.F_CONTIGUOUS:
+        C = Matrix.zeros[dtype](shape=(A.shape[0], B.shape[1]), order=B.order())
+
+        @parameter
+        fn calculate_CF(m: Int):
+            for n in range(B.shape[1]):
+                var sum: Scalar[dtype] = 0.0
+
+                @parameter
+                fn dot_product[simd_width: Int](k: Int):
+                    sum += (
+                        A._load[simd_width](m, k) * B._load[simd_width](k, n)
+                    ).reduce_add()
+
+                vectorize[dot_product, width](A.shape[1])
+                C._store(m, n, sum)
+
+        parallelize[calculate_CF](A.shape[0], A.shape[0])
+
+    else:
+        C = matmul(A.reorder_layout(), B)
     var _A = A
     var _B = B
 

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -123,8 +123,11 @@ fn inv[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
         raise Error(
             String("{}x{} matrix is not square.").format(A.shape[0], A.shape[1])
         )
+    var order = "F"
+    if A.flags.C_CONTIGUOUS:
+        order = "C"
 
-    var I = Matrix.identity[dtype](A.shape[0])
+    var I = Matrix.identity[dtype](A.shape[0], order=order)
     var B = solve(A, I)
 
     return B^
@@ -364,16 +367,20 @@ fn solve[
     """
     Solve `AX = Y` using LUP decomposition.
     """
+    if A.flags.C_CONTIGUOUS != Y.flags.C_CONTIGUOUS:
+        raise Error("Input matrices A and Y must have the same memory layout")
+
     var U: Matrix[dtype]
     var L: Matrix[dtype]
+
     A_pivoted, P, _ = partial_pivoting(A)
     L, U = lu_decomposition[dtype](A_pivoted)
 
     var m = A.shape[0]
     var n = Y.shape[1]
 
-    var Z = Matrix.full[dtype]((m, n))
-    var X = Matrix.full[dtype]((m, n))
+    var Z = Matrix.full[dtype]((m, n), order=A.order())
+    var X = Matrix.full[dtype]((m, n), order=A.order())
 
     var PY = P @ Y
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -283,8 +283,11 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Transpose of matrix.
     """
+    var order = "F"
+    if A.flags.C_CONTIGUOUS:
+        order = "C"
 
-    var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]), order=A.order())
+    var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]), order=order)
 
     if A.shape[0] == 1 or A.shape[1] == 1:
         memcpy(B._buf.ptr, A._buf.ptr, A.size)
@@ -428,17 +431,17 @@ fn broadcast_to[
     Unhandled exception caught during execution: Cannot broadcast shape 2x2 to shape 4x2!
     ```
     """
-    var new_order: String
+    var ord: String
     if override_order == "":
-        new_order = A.order()
+        ord = A.order()
     else:
-        new_order = override_order
+        ord = override_order
 
-    var B = Matrix[dtype](shape, order=new_order)
+    var B = Matrix[dtype](shape, order=ord)
     if (A.shape[0] == shape[0]) and (A.shape[1] == shape[1]):
         return A
     elif (A.shape[0] == 1) and (A.shape[1] == 1):
-        B = Matrix.full[dtype](shape, A[0, 0], order=new_order)
+        B = Matrix.full[dtype](shape, A[0, 0], order=ord)
     elif (A.shape[0] == 1) and (A.shape[1] == shape[1]):
         for i in range(shape[0]):
             memcpy(

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -284,7 +284,7 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Transpose of matrix.
     """
 
-    var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]))
+    var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]), order=A.order())
 
     if A.shape[0] == 1 or A.shape[1] == 1:
         memcpy(B._buf.ptr, A._buf.ptr, A.size)
@@ -395,7 +395,9 @@ fn broadcast_to[
 
 fn broadcast_to[
     dtype: DType
-](A: Matrix[dtype], shape: Tuple[Int, Int]) raises -> Matrix[dtype]:
+](
+    A: Matrix[dtype], shape: Tuple[Int, Int], override_order: String = ""
+) raises -> Matrix[dtype]:
     """
     Broadcasts the vector to the given shape.
 
@@ -426,12 +428,17 @@ fn broadcast_to[
     Unhandled exception caught during execution: Cannot broadcast shape 2x2 to shape 4x2!
     ```
     """
+    var new_order: String
+    if override_order == "":
+        new_order = A.order()
+    else:
+        new_order = override_order
 
-    var B = Matrix[dtype](shape)
+    var B = Matrix[dtype](shape, order=new_order)
     if (A.shape[0] == shape[0]) and (A.shape[1] == shape[1]):
-        B = A
+        return A
     elif (A.shape[0] == 1) and (A.shape[1] == 1):
-        B = Matrix.full[dtype](shape, A[0, 0])
+        B = Matrix.full[dtype](shape, A[0, 0], order=new_order)
     elif (A.shape[0] == 1) and (A.shape[1] == shape[1]):
         for i in range(shape[0]):
             memcpy(
@@ -453,13 +460,15 @@ fn broadcast_to[
 
 fn broadcast_to[
     dtype: DType
-](A: Scalar[dtype], shape: Tuple[Int, Int]) raises -> Matrix[dtype]:
+](A: Scalar[dtype], shape: Tuple[Int, Int], order: String) raises -> Matrix[
+    dtype
+]:
     """
     Broadcasts the scalar to the given shape.
     """
 
     var B = Matrix[dtype](shape)
-    B = Matrix.full[dtype](shape, A)
+    B = Matrix.full[dtype](shape, A, order=order)
     return B^
 
 

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -105,6 +105,11 @@ def test_arithmetic():
     check_matrices_close(A - B, Ap - Bp, "Sub is broken")
     check_matrices_close(A * B, Ap * Bp, "Mul is broken")
     check_matrices_close(A @ B, np.matmul(Ap, Bp), "Matmul is broken")
+    check_matrices_close(
+        A @ B.reorder_layout(),
+        np.matmul(Ap, Bp),
+        "Matmul is broken for mixed memory layouts",
+    )
     check_matrices_close(A + C, Ap + Cp, "Add (broadcast) is broken")
     check_matrices_close(A - C, Ap - Cp, "Sub (broadcast) is broken")
     check_matrices_close(A * C, Ap * Cp, "Mul (broadcast) is broken")

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -3,6 +3,9 @@ from numojo.prelude import *
 from numojo.core.matrix import Matrix
 from python import Python, PythonObject
 from testing.testing import assert_raises, assert_true
+from sys import is_defined
+
+alias order = "F" if is_defined["F_CONTIGUOUS"]() else "C"
 
 # ===-----------------------------------------------------------------------===#
 # Main functions
@@ -39,7 +42,7 @@ fn check_values_close[
 
 def test_manipulation():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((10, 10)) * 1000
+    var A = Matrix.rand[f64]((10, 10), order=order) * 1000
     var Anp = np.matrix(A.to_numpy())
     check_matrices_equal(
         A.astype[nm.i32](),
@@ -70,7 +73,7 @@ def test_manipulation():
 def test_full():
     var np = Python.import_module("numpy")
     check_matrices_equal(
-        Matrix.full[f64]((10, 10), 10),
+        Matrix.full[f64]((10, 10), 10, order=order),
         np.full((10, 10), 10, dtype=np.float64),
         "Full is broken",
     )
@@ -79,7 +82,7 @@ def test_full():
 def test_zeros():
     var np = Python.import_module("numpy")
     check_matrices_equal(
-        Matrix.zeros[f64](shape=(10, 10)),
+        Matrix.zeros[f64](shape=(10, 10), order=order),
         np.zeros((10, 10), dtype=np.float64),
         "Zeros is broken",
     )
@@ -92,9 +95,9 @@ def test_zeros():
 
 def test_arithmetic():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((10, 10))
-    var B = Matrix.rand[f64]((10, 10))
-    var C = Matrix.rand[f64]((10, 1))
+    var A = Matrix.rand[f64]((10, 10), order=order)
+    var B = Matrix.rand[f64]((10, 10), order=order)
+    var C = Matrix.rand[f64]((10, 1), order=order)
     var Ap = A.to_numpy()
     var Bp = B.to_numpy()
     var Cp = C.to_numpy()
@@ -116,8 +119,8 @@ def test_arithmetic():
 
 def test_logic():
     var np = Python.import_module("numpy")
-    var A = Matrix.ones((5, 1))
-    var B = Matrix.ones((5, 1))
+    var A = Matrix.ones((5, 1), order=order)
+    var B = Matrix.ones((5, 1), order=order)
     var L = Matrix.fromstring[i8](
         "[[0,0,0],[0,0,1],[1,1,1],[1,0,0]]", shape=(4, 3)
     )
@@ -156,12 +159,12 @@ def test_logic():
 
 def test_linalg():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((100, 100))
-    var B = Matrix.rand[f64]((100, 100))
+    var A = Matrix.rand[f64]((100, 100), order=order)
+    var B = Matrix.rand[f64]((100, 100), order=order)
     var E = Matrix.fromstring(
-        "[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]", shape=(4, 3)
+        "[[1,2,3],[4,5,6],[7,8,9],[10,11,12]]", shape=(4, 3), order=order
     )
-    var Y = Matrix.rand((100, 1))
+    var Y = Matrix.rand((100, 1), order=order)
     var Anp = A.to_numpy()
     var Bnp = B.to_numpy()
     var Ynp = Y.to_numpy()
@@ -209,7 +212,7 @@ def test_linalg():
 
 
 def test_qr_decomposition():
-    A = Matrix.rand[f64]((20, 20))
+    A = Matrix.rand[f64]((20, 20), order=order)
 
     var np = Python.import_module("numpy")
 
@@ -229,7 +232,7 @@ def test_qr_decomposition():
 
 def test_qr_decomposition_asym_reduced():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((12, 5))
+    var A = Matrix.rand[f64]((12, 5), order=order)
     Q, R = nm.linalg.qr(A, mode="reduced")
 
     assert_true(
@@ -257,7 +260,7 @@ def test_qr_decomposition_asym_reduced():
 
 def test_qr_decomposition_asym_complete():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((12, 5))
+    var A = Matrix.rand[f64]((12, 5), order=order)
     Q, R = nm.linalg.qr(A, mode="complete")
 
     assert_true(
@@ -285,7 +288,7 @@ def test_qr_decomposition_asym_complete():
 
 def test_qr_decomposition_asym_complete2():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((5, 12))
+    var A = Matrix.rand[f64]((5, 12), order=order)
     Q, R = nm.linalg.qr(A, mode="complete")
 
     assert_true(
@@ -318,7 +321,7 @@ def test_qr_decomposition_asym_complete2():
 
 def test_math():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((100, 100))
+    var A = Matrix.rand[f64]((100, 100), order=order)
     var Anp = np.matrix(A.to_numpy())
 
     assert_true(
@@ -370,7 +373,7 @@ def test_math():
 
 def test_trigonometric():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((100, 100))
+    var A = Matrix.rand[f64]((100, 100), order=order)
     var Anp = np.matrix(A.to_numpy())
     check_matrices_close(nm.sin(A), np.sin(Anp), "sin is broken")
     check_matrices_close(nm.cos(A), np.cos(Anp), "cos is broken")
@@ -385,7 +388,9 @@ def test_trigonometric():
 
 def test_hyperbolic():
     var np = Python.import_module("numpy")
-    var A = Matrix.fromstring("[[1,2,3],[4,5,6],[7,8,9]]", shape=(3, 3))
+    var A = Matrix.fromstring(
+        "[[1,2,3],[4,5,6],[7,8,9]]", shape=(3, 3), order=order
+    )
     var B = A / 10
     var Anp = np.matrix(A.to_numpy())
     var Bnp = np.matrix(B.to_numpy())
@@ -402,7 +407,7 @@ def test_hyperbolic():
 
 def test_sorting():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((10, 10))
+    var A = Matrix.rand[f64]((10, 10), order=order)
     var Anp = np.matrix(A.to_numpy())
 
     check_matrices_close(
@@ -428,7 +433,7 @@ def test_sorting():
 
 def test_searching():
     var np = Python.import_module("numpy")
-    var A = Matrix.rand[f64]((10, 10))
+    var A = Matrix.rand[f64]((10, 10), order=order)
     var Anp = np.matrix(A.to_numpy())
 
     check_values_close(


### PR DESCRIPTION
This PR enhances Matrix with support for both C-contiguous (row-major) and F-contiguous (column-major) memory layouts across all matrix routines. Default memory layout remains C-contiguous to keep API close to NumPy. Matrix tests are performed for both memory layouts.

- Add conditional compilation flag `F_CONTIGUOUS` to control matrix memory layout in tests
- Modify GitHub workflow to run test suite with both layouts:
  - Additional test run for matrix tests with [flag](https://docs.modular.com/mojo/cli/test/#-d-keyvalue) `-D F_CONTIGUOUS`
- Matmul handles all memory layout combinations with specialized implementations.  