### PR TITLE
[mojo] Update the syntax to accommodate the changes in Mojo 25.3

### DIFF
--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "NuMojo"
-version = "0.6"
+version = "0.7.0"
 description = "NuMojo is a library for numerical computing written in Mojo 🔥"
 authors = [
     "Shivasankar <shivasankar.ka@gmail.com>",
@@ -10,7 +10,7 @@ authors = [
     "sandstromviktor <>",
     "durnwalder <>"
 ]
-channels = ["https://conda.modular.com/max", "https://repo.prefix.dev/modular-community", "conda-forge"]
+channels = ["conda-forge", "https://conda.modular.com/max", "https://repo.prefix.dev/modular-community"]
 platforms = ["osx-arm64", "linux-64"]
 license = "Apache-2.0"
 readme = "README.MD"
@@ -51,7 +51,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && magic run final && magic run doc_pages"
 
 [dependencies]
-max = "=25.2"
+max = "==25.3"
 python = ">=3.11"
-numpy = ">=1.19"
+numpy = ">=2.0"
 scipy = ">=1.14"

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -3,7 +3,7 @@ NuMojo is a library for numerical computing in Mojo 🔥
 similar to NumPy, SciPy in Python.
 """
 
-alias __version__ = "V0.5"
+alias __version__ = "V0.7.0"
 
 # ===----------------------------------------------------------------------=== #
 # Import core types

--- a/numojo/core/_array_funcs.mojo
+++ b/numojo/core/_array_funcs.mojo
@@ -1,12 +1,11 @@
+"""
+Implementing backend for array keeping it simple for now
+"""
 # from ..traits.NDArrayTraits import NDArrayBackend
 from algorithm.functional import parallelize, vectorize, num_physical_cores
 from sys import simdwidthof
 
 from numojo.core.ndarray import NDArray
-
-"""
-Implementing backend for array keeping it simple for now
-"""
 
 
 fn math_func_1_array_in_one_array_out[

--- a/numojo/core/_math_funcs.mojo
+++ b/numojo/core/_math_funcs.mojo
@@ -29,7 +29,7 @@ struct Vectorized(Backend):
     Uses defualt simdwidth.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[
@@ -445,7 +445,7 @@ struct VectorizedUnroll[unroll_factor: Int = 1](Backend):
     Uses defualt simdwidth.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[
@@ -791,7 +791,7 @@ struct Parallelized(Backend):
     No idea why, Not Reccomened for use at this Time.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[
@@ -1279,7 +1279,7 @@ struct VectorizedParallelized(Backend):
     No idea why, Not Reccomened for use at this Time.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[
@@ -2369,7 +2369,7 @@ struct Naive(Backend):
     Just loops for SIMD[Dtype, 1] equations
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[
@@ -2669,7 +2669,7 @@ struct VectorizedVerbose(Backend):
     Uses defualt simdwidth.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         pass
 
     fn math_func_fma[

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -97,7 +97,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
         dtype: Complex data type.
     """
 
-    """FIELDS"""
+    # FIELDS
     var _re: NDArray[Self.dtype]
     var _im: NDArray[Self.dtype]
 
@@ -286,7 +286,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
         self.flags = self._re.flags
 
     @always_inline("nodebug")
-    fn __copyinit__(mut self, other: Self):
+    fn __copyinit__(out self, other: Self):
         """
         Copy other into self.
         """
@@ -299,7 +299,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
         self.flags = other.flags
 
     @always_inline("nodebug")
-    fn __moveinit__(mut self, owned existing: Self):
+    fn __moveinit__(out self, owned existing: Self):
         """
         Move other into self.
         """
@@ -601,7 +601,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
         var nshape = List[Int]()
         var ncoefficients = List[Int]()
         var noffset = 0
-        var nnum_elements = 1
+        var nnum_elements: Int = 1
 
         for i in range(self.ndim):
             if spec[i] != 1:
@@ -612,7 +612,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
 
         if nshape.__len__() == 0:
             nshape.append(1)
-            nnum_elements = 1
+            # nnum_elements = 1
             ncoefficients.append(1)
 
         # Calculate strides based on memory layout: only C & F order are supported
@@ -1174,7 +1174,7 @@ struct ComplexNDArray[dtype: DType = DType.float64](
 
             var start: Int = 0
             var end: Int = self.shape[i]
-            var step: Int = 1
+            var step: Int
             if slice_list[i].start is not None:
                 start = slice_list[i].start.value()
                 if start < 0:
@@ -1625,7 +1625,9 @@ struct ComplexNDArray[dtype: DType = DType.float64](
             self._re, other.re
         ) and comparison.not_equal[dtype](self._im, other.im)
 
-    """ ARITHMETIC OPERATIONS """
+    # ===------------------------------------------------------------------=== #
+    # ARITHMETIC OPERATIONS
+    # ===------------------------------------------------------------------=== #
 
     fn __add__(self, other: ComplexSIMD[Self.dtype]) raises -> Self:
         """
@@ -2216,10 +2218,8 @@ struct ComplexNDArray[dtype: DType = DType.float64](
 
         if len(indices) != self.ndim:
             raise (
-                String(
-                    "Length of indices {} does not match ndim {}".format(
-                        len(indices), self.ndim
-                    )
+                String("Length of indices {} does not match ndim {}").format(
+                    len(indices), self.ndim
                 )
             )
 

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -10,7 +10,7 @@ struct ComplexSIMD[dtype: DType, width: Int = 1]():
     """
 
     # FIELDS
-    """The underlying data real and imaginary parts of the complex number."""
+    # The underlying data real and imaginary parts of the complex number.
     var re: SIMD[dtype, width]
     var im: SIMD[dtype, width]
 
@@ -249,7 +249,7 @@ struct ComplexSIMD[dtype: DType, width: Int = 1]():
             writer: The writer to write to.
         """
         try:
-            writer.write("({} + {} j)".format(self.re, self.im))
+            writer.write(String("({} + {} j)").format(self.re, self.im))
         except e:
             writer.write("Cannot convert ComplexSIMD to string")
 
@@ -260,7 +260,7 @@ struct ComplexSIMD[dtype: DType, width: Int = 1]():
         Returns:
             String: The string representation of the ComplexSIMD instance.
         """
-        return "ComplexSIMD[{}]({}, {})".format(
+        return String("ComplexSIMD[{}]({}, {})").format(
             String(Self.dtype), self.re, self.im
         )
 

--- a/numojo/core/datatypes.mojo
+++ b/numojo/core/datatypes.mojo
@@ -7,7 +7,6 @@ Datatypes Module - Implements datatypes aliases, conversions
 # ===----------------------------------------------------------------------=== #
 
 # Rust-like or numpy-like data type alias
-"""alias for `DType.int8`"""
 alias i8 = DType.int8
 """Data type alias for DType.int8"""
 alias i16 = DType.int16

--- a/numojo/core/flags.mojo
+++ b/numojo/core/flags.mojo
@@ -169,8 +169,8 @@ struct Flags:
             raise Error(
                 String(
                     "\nError in `Flags.__getitem__()`: "
-                    "Invalid field name or short name: {}".format(key)
-                )
+                    "Invalid field name or short name: {}"
+                ).format(key)
             )
         if (key == "C_CONTIGUOUS") or (key == "C"):
             return self.C_CONTIGUOUS

--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -141,7 +141,7 @@ struct Item(CollectionElement):
             remainder %= strides._buf[i]
 
     @always_inline("nodebug")
-    fn __copyinit__(mut self, other: Self):
+    fn __copyinit__(out self, other: Self):
         """Copy construct the tuple.
 
         Args:
@@ -303,7 +303,7 @@ struct _ItemIter[
     var length: Int
 
     fn __init__(
-        mut self,
+        out self,
         item: Item,
         length: Int,
     ):

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -113,7 +113,7 @@ struct Matrix[dtype: DType = DType.float64](
 
     @always_inline("nodebug")
     fn __init__(
-        mut self,
+        out self,
         shape: Tuple[Int, Int],
         order: String = "C",
     ):
@@ -139,7 +139,7 @@ struct Matrix[dtype: DType = DType.float64](
 
     @always_inline("nodebug")
     fn __init__(
-        mut self,
+        out self,
         data: Self,
     ):
         """
@@ -150,7 +150,7 @@ struct Matrix[dtype: DType = DType.float64](
 
     @always_inline("nodebug")
     fn __init__(
-        mut self,
+        out self,
         data: NDArray[dtype],
     ) raises:
         """
@@ -187,7 +187,7 @@ struct Matrix[dtype: DType = DType.float64](
                     self._store(i, j, data._getitem(i, j))
 
     @always_inline("nodebug")
-    fn __copyinit__(mut self, other: Self):
+    fn __copyinit__(out self, other: Self):
         """
         Copy other into self.
         """
@@ -199,7 +199,7 @@ struct Matrix[dtype: DType = DType.float64](
         self.flags = other.flags
 
     @always_inline("nodebug")
-    fn __moveinit__(mut self, owned other: Self):
+    fn __moveinit__(out self, owned other: Self):
         """
         Move other into self.
         """
@@ -211,10 +211,11 @@ struct Matrix[dtype: DType = DType.float64](
 
     @always_inline("nodebug")
     fn __del__(owned self):
-        var owndata = True
+        var owndata: Bool
         try:
             owndata = self.flags["OWNDATA"]
         except:
+            owndata = True
             print("Invalid `OWNDATA` flag. Treat as `True`.")
         if owndata:
             self._buf.ptr.free()
@@ -1031,7 +1032,7 @@ struct Matrix[dtype: DType = DType.float64](
         """
         Returns the order.
         """
-        var order = "F"
+        var order: String = "F"
         if self.flags.C_CONTIGUOUS:
             order = "C"
         return order
@@ -1283,7 +1284,7 @@ struct Matrix[dtype: DType = DType.float64](
         try:
             var np = Python.import_module("numpy")
 
-            var np_arr_dim = PythonObject([])
+            var np_arr_dim = Python.list()
             np_arr_dim.append(self.shape[0])
             np_arr_dim.append(self.shape[1])
 
@@ -1572,7 +1573,7 @@ struct _MatrixIter[
     var length: Int
 
     fn __init__(
-        mut self,
+        out self,
         matrix: Matrix[dtype],
         length: Int,
     ):

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -192,7 +192,7 @@ struct NDArray[dtype: DType = DType.float64](
         self = Self(Shape(shape), order)
 
     fn __init__(
-        mut self,
+        out self,
         shape: List[Int],
         offset: Int,
         strides: List[Int],
@@ -271,7 +271,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    fn __copyinit__(mut self, other: Self):
+    fn __copyinit__(out self, other: Self):
         """
         Copy other into self.
         It is a deep copy. So the new array owns the data.
@@ -293,7 +293,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    fn __moveinit__(mut self, owned existing: Self):
+    fn __moveinit__(out self, owned existing: Self):
         """
         Move other into self.
 
@@ -578,7 +578,7 @@ struct NDArray[dtype: DType = DType.float64](
         var nshape = List[Int]()
         var ncoefficients = List[Int]()
         var noffset = 0
-        var nnum_elements = 1
+        var nnum_elements: Int = 1
 
         for i in range(self.ndim):
             if spec[i] != 1:
@@ -589,7 +589,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if nshape.__len__() == 0:
             nshape.append(1)
-            nnum_elements = 1
+            # nnum_elements = 1
             ncoefficients.append(1)
 
         # Calculate strides based on memory layout: only C & F order are supported
@@ -2115,8 +2115,8 @@ struct NDArray[dtype: DType = DType.float64](
                 String(
                     "\nError in `numojo.NDArray.store[width: Int](*indices:"
                     " Int, val: SIMD[dtype, width])`:\nLength of indices {}"
-                    " does not match ndim {}".format(len(indices), self.ndim)
-                )
+                    " does not match ndim {}"
+                ).format(len(indices), self.ndim)
             )
 
         for i in range(self.ndim):
@@ -2663,7 +2663,10 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return comparison.greater_equal[dtype](self, other)
 
-    """ ARITHMETIC OPERATORS """
+    # ===-------------------------------------------------------------------===#
+    # ARITHMETIC OPERATORS
+    # ===-------------------------------------------------------------------===#
+
     # fn __add__[
     #     OtherDType: DType,
     #     ResultDType: DType = TypeCoercion.result[dtype, OtherDType](),

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -64,9 +64,12 @@ struct NDArrayShape(Stringable, Writable):
         """
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
+
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
         for i in range(self.ndim):
@@ -90,8 +93,10 @@ struct NDArrayShape(Stringable, Writable):
         """
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -116,8 +121,10 @@ struct NDArrayShape(Stringable, Writable):
         """
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
         self.ndim = len(shape)
         self._buf = UnsafePointer[Int]().alloc(self.ndim)
@@ -143,8 +150,10 @@ struct NDArrayShape(Stringable, Writable):
 
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
 
         self.ndim = len(shape)
@@ -171,8 +180,10 @@ struct NDArrayShape(Stringable, Writable):
 
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
 
         self.ndim = len(shape)
@@ -199,8 +210,10 @@ struct NDArrayShape(Stringable, Writable):
 
         if len(shape) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(len(shape))
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(shape))
             )
 
         self.ndim = len(shape)

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -43,10 +43,10 @@ struct NDArrayStrides(Stringable):
         """
         if len(strides) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(
-                    len(strides)
-                )
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(strides))
             )
 
         self.ndim = len(strides)
@@ -67,10 +67,10 @@ struct NDArrayStrides(Stringable):
         """
         if len(strides) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(
-                    len(strides)
-                )
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(strides))
             )
 
         self.ndim = len(strides)
@@ -91,10 +91,10 @@ struct NDArrayStrides(Stringable):
         """
         if len(strides) <= 0:
             raise Error(
-                "\nError in `NDArrayShape.__init__()`: Number of dimensions of"
-                " array must be positive. However, it is {}.".format(
-                    len(strides)
-                )
+                String(
+                    "\nError in `NDArrayShape.__init__()`: Number of dimensions"
+                    " of array must be positive. However, it is {}."
+                ).format(len(strides))
             )
 
         self.ndim = len(strides)

--- a/numojo/core/traits/backend.mojo
+++ b/numojo/core/traits/backend.mojo
@@ -11,7 +11,7 @@ trait Backend:
     A trait that defines backends for calculations in the rest of the library.
     """
 
-    fn __init__(mut self: Self):
+    fn __init__(out self: Self):
         """
         Initialize the backend.
         """

--- a/numojo/core/utility.mojo
+++ b/numojo/core/utility.mojo
@@ -378,7 +378,7 @@ fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
         np.set_printoptions(4)
 
         var dimension = array.ndim
-        var np_arr_dim = PythonObject([])
+        var np_arr_dim = Python.list()
 
         for i in range(dimension):
             np_arr_dim.append(array.shape[i])

--- a/numojo/routines/constants.mojo
+++ b/numojo/routines/constants.mojo
@@ -30,7 +30,7 @@ struct Constants(AnyType):
     alias e = 2.71828182845904523536028747135266249775724609375
     alias hbar = 1.0545718176461563912626e-34
 
-    fn __init__(mut self):
+    fn __init__(out self):
         """
         Initializes the constants.
         """

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -130,9 +130,9 @@ fn arangeC[
     var num_im: Int = ((stop.im - start.im) / step.im).__int__()
     if num_re != num_im:
         raise Error(
-            "Number of real and imaginary parts are not equal {} != {}".format(
-                num_re, num_im
-            )
+            String(
+                "Number of real and imaginary parts are not equal {} != {}"
+            ).format(num_re, num_im)
         )
     var result: ComplexNDArray[dtype] = ComplexNDArray[dtype](Shape(num_re))
     for idx in range(num_re):
@@ -157,9 +157,9 @@ fn arangeC[
     var size_im = Int(stop.im)
     if size_re != size_im:
         raise Error(
-            "Number of real and imaginary parts are not equal {} != {}".format(
-                size_re, size_im
-            )
+            String(
+                "Number of real and imaginary parts are not equal {} != {}"
+            ).format(size_re, size_im)
         )
 
     var result: ComplexNDArray[dtype] = ComplexNDArray[dtype](Shape(size_re))
@@ -1933,15 +1933,11 @@ fn fromstring[
         order: Memory order C or F.
     """
 
-    var data = List[Scalar[dtype]]()
-    """Inferred data buffer of the array"""
-    var shape = List[Int]()
-    """Inferred shape of the array"""
+    var data = List[Scalar[dtype]]()  # Inferred data buffer of the array
+    var shape = List[Int]()  # Inferred shape of the array
     var bytes = text.as_bytes()
-    var ndim = 0
-    """Inferred number_as_str of dimensions."""
-    var level = 0
-    """Current level of the array."""
+    var ndim = 0  # Inferred number_as_str of dimensions.
+    var level = 0  # Current level of the array.
     var number_as_str: String = ""
     for i in range(len(bytes)):
         var b = bytes[i]

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -340,16 +340,16 @@ fn apply_along_axis[
 # `func` operates on scalars.
 # ===----------------------------------------------------------------------=== #
 
-"""
-If a and b have the same shape and strides, the function will be applied
-element-wise to the two arrays.
+# """
+# If a and b have the same shape and strides, the function will be applied
+# element-wise to the two arrays.
 
-Else if a and b have the same shape and the strides are both 1 for axis -1 or 0
-(C or F contiguous is not sufficient due to broadcasted views),
-the function with be applied by axis -1 or axis 0.
+# Else if a and b have the same shape and the strides are both 1 for axis -1 or 0
+# (C or F contiguous is not sufficient due to broadcasted views),
+# the function with be applied by axis -1 or axis 0.
 
-Else, conduct item-wise calculation.
+# Else, conduct item-wise calculation.
 
-If a and b have different shape (including when b is scalar), 
-conduct a broadcasting.
-"""
+# If a and b have different shape (including when b is scalar),
+# conduct a broadcasting.
+# """

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -116,8 +116,8 @@ fn compress[
         raise Error(
             String(
                 "\nError in `compress`: Axis {} is out of bound for array with"
-                " {} dimensions".format(axis, a.ndim)
-            )
+                " {} dimensions"
+            ).format(axis, a.ndim)
         )
 
     if condition.ndim != 1:
@@ -130,10 +130,8 @@ fn compress[
         raise Error(
             String(
                 "\nError in `compress`: Condition length {} is out of bound for"
-                " axis {} with size {}".format(
-                    condition.size, axis, a.shape[normalized_axis]
-                )
-            )
+                " axis {} with size {}"
+            ).format(condition.size, axis, a.shape[normalized_axis])
         )
 
     var number_of_true: Int = 0
@@ -294,8 +292,8 @@ fn take_along_axis[
         raise Error(
             String(
                 "\nError in `take_along_axis`: The ndim of arr and indices must"
-                " be same. Got {} and {}.".format(arr.ndim, indices.ndim)
-            )
+                " be same. Got {} and {}."
+            ).format(arr.ndim, indices.ndim)
         )
 
     # broadcast indices to the shape of arr if necessary

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -60,7 +60,7 @@ struct PrintOptions:
     var suppress_scientific: Bool
 
     fn __init__(
-        mut self,
+        out self,
         precision: Int = DEFAULT_PRECISION,
         suppress_small: Bool = DEFAULT_SUPPRESS_SMALL,
         separator: String = DEFAULT_SEPARATOR,

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -348,7 +348,7 @@ fn qr[
     """
     var inner: Int
     var reorder: Bool = False
-    var reduce: Bool = False
+    var reduce: Bool
 
     var m = A.shape[0]
     var n = A.shape[1]
@@ -364,7 +364,7 @@ fn qr[
     else:
         raise Error(String("Invalid mode: {}").format(mode))
 
-    var R: Matrix[dtype] = A
+    var R: Matrix[dtype]
 
     if A.flags.C_CONTIGUOUS:
         reorder = True
@@ -445,7 +445,7 @@ fn eig[
 
     var Q_total = Matrix.identity[dtype](n)
 
-    for k in range(max_iter):
+    for _k in range(max_iter):
         var Qk: Matrix[dtype]
         var Rk: Matrix[dtype]
         Qk, Rk = qr(T, mode="complete")

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -171,8 +171,8 @@ fn matmul_1darray[
         raise Error(
             String(
                 "matmul: a mismatch in core dimension 0: "
-                "size {} is different from {}".format(A.size, B.size)
-            )
+                "size {} is different from {}"
+            ).format(A.size, B.size)
         )
     else:
         C._buf.ptr.init_pointee_copy(sum(A * B))
@@ -230,19 +230,15 @@ fn matmul_2darray[
     if (A.ndim == 1) or (B.ndim == 1):
         raise Error(
             String(
-                "matmul: a mismatch in shapes: {} is different from {}".format(
-                    A.shape[-1], B.shape[0]
-                )
-            )
+                "matmul: a mismatch in shapes: {} is different from {}"
+            ).format(A.shape[-1], B.shape[0])
         )
 
     if A.shape[1] != B.shape[0]:
         raise Error(
             String(
-                "matmul: a mismatch in shapes: {} is different from {}".format(
-                    A.shape[1], B.shape[0]
-                )
-            )
+                "matmul: a mismatch in shapes: {} is different from {}"
+            ).format(A.shape[1], B.shape[0])
         )
 
     var C: NDArray[dtype] = zeros[dtype](Shape(A.shape[0], B.shape[1]))

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -123,7 +123,7 @@ fn inv[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
         raise Error(
             String("{}x{} matrix is not square.").format(A.shape[0], A.shape[1])
         )
-    var order = "F"
+    var order: String = "F"
     if A.flags.C_CONTIGUOUS:
         order = "C"
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -283,7 +283,7 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Transpose of matrix.
     """
-    var order = "F"
+    var order: String = "F"
     if A.flags.C_CONTIGUOUS:
         order = "C"
 
@@ -470,8 +470,7 @@ fn broadcast_to[
     Broadcasts the scalar to the given shape.
     """
 
-    var B = Matrix[dtype](shape)
-    B = Matrix.full[dtype](shape, A, order=order)
+    var B: Matrix[dtype] = Matrix.full[dtype](shape, A, order=order)
     return B^
 
 

--- a/numojo/routines/math/differences.mojo
+++ b/numojo/routines/math/differences.mojo
@@ -11,10 +11,9 @@ from numojo.routines.creation import arange
 from numojo.core.ndarray import NDArray
 from numojo.core.utility import is_inttype, is_floattype
 
-"""TODO: 
-1) add a Variant[NDArray, Scalar, ...] to include all possibilities
-2) add edge_order
-"""
+# TODO:
+# 1) add a Variant[NDArray, Scalar, ...] to include all possibilities
+# 2) add edge_order
 
 
 fn gradient[

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -150,7 +150,7 @@ fn roundeven[
 
     This rounding goes to the nearest integer with ties toward the nearest even integer.
     """
-    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.roundeven](
+    return backend().math_func_1_array_in_one_array_out[dtype, SIMD.__round__](
         array
     )
 

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -753,8 +753,8 @@ fn _sort_inplace[dtype: DType](mut A: NDArray[dtype], axis: Int) raises:
         )
 
     var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
+    # Contiguously stored axis. -1 if row-major, -2 if col-major.
     var continous_axis = A.ndim - 1 if array_order == "C" else A.ndim - 2
-    """Contiguously stored axis. -1 if row-major, -2 if col-major."""
 
     if axis == continous_axis:  # Last axis
         for i in range(A.size // A.shape[continous_axis]):
@@ -804,8 +804,8 @@ fn _sort_inplace[
         )
 
     var array_order = "C" if A.flags.C_CONTIGUOUS else "F"
+    # Contiguously stored axis. -1 if row-major, -2 if col-major.
     var continous_axis = A.ndim - 1 if array_order == "C" else A.ndim - 2
-    """Contiguously stored axis. -1 if row-major, -2 if col-major."""
 
     if axis == continous_axis:  # Last axis
         I = NDArray[DType.index](shape=A.shape)

--- a/numojo/science/interpolate.mojo
+++ b/numojo/science/interpolate.mojo
@@ -9,11 +9,9 @@ Interpolate Module - Implements interpolation functions
 
 from numojo.core.ndarray import NDArray, NDArrayShape
 
-"""
 # TODO:
-1) Cross check all the functions with numpy
-2) Add support for axis argument
-"""
+# 1) Cross check all the functions with numpy
+# 2) Add support for axis argument
 
 
 fn interp1d[

--- a/tests/core/test_array_indexing_and_slicing.mojo
+++ b/tests/core/test_array_indexing_and_slicing.mojo
@@ -17,7 +17,7 @@ def test_setitem():
     var arr = nm.NDArray(Shape(4, 4))
     var np_arr = arr.to_numpy()
     arr.itemset(List(2, 2), 1000)
-    np_arr[(2, 2)] = 1000
+    np_arr[2, 2] = 1000
     check_is_close(arr, np_arr, "Itemset is broken")
 
 

--- a/tests/core/test_array_methods.mojo
+++ b/tests/core/test_array_methods.mojo
@@ -85,7 +85,7 @@ def test_iterator():
     # NDArrayIter
     var a_iter_over_dimension = a.__iter__()
     var anp_iter_over_dimension = anp.__iter__()
-    for i in range(a.shape[0]):
+    for _ in range(a.shape[0]):
         check(
             a_iter_over_dimension.__next__(),
             anp_iter_over_dimension.__next__(),
@@ -94,7 +94,7 @@ def test_iterator():
 
     var a_iter_over_dimension_reversed = a.__reversed__()
     var anp_iter_over_dimension_reversed = py.reversed(anp)
-    for i in range(a.shape[0]):
+    for _ in range(a.shape[0]):
         check(
             a_iter_over_dimension_reversed.__next__(),
             anp_iter_over_dimension_reversed.__next__(),
@@ -104,7 +104,7 @@ def test_iterator():
     # NDIter of C-order array
     var a_nditer = a.nditer()
     var anp_nditer = np.nditer(anp)
-    for i in range(a.size):
+    for _ in range(a.size):
         check_values_close(
             a_nditer.__next__(),
             anp_nditer.__next__(),
@@ -123,7 +123,7 @@ def test_iterator():
 
     var a_nditer_f = a.nditer(order="F")
     var anp_nditer_f = np.nditer(anp, order="F")
-    for i in range(a.size):
+    for _ in range(a.size):
         check_values_close(
             a_nditer_f.__next__(),
             anp_nditer_f.__next__(),
@@ -133,7 +133,7 @@ def test_iterator():
     # NDIter of F-order array
     var f_nditer = f.nditer()
     var fnp_nditer = np.nditer(fnp)
-    for i in range(f.size):
+    for _ in range(f.size):
         check_values_close(
             f_nditer.__next__(),
             fnp_nditer.__next__(),
@@ -142,7 +142,7 @@ def test_iterator():
 
     var f_nditer_f = f.nditer(order="F")
     var fnp_nditer_f = np.nditer(fnp, order="F")
-    for i in range(f.size):
+    for _ in range(f.size):
         check_values_close(
             f_nditer_f.__next__(),
             fnp_nditer_f.__next__(),

--- a/tests/core/test_bool_masks.mojo
+++ b/tests/core/test_bool_masks.mojo
@@ -8,7 +8,7 @@ from python import Python
 # TODO: there's something wrong with bool comparision even though result looks same.
 def test_bool_masks_gt():
     var np = Python.import_module("numpy")
-    var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
+    var np_A = np.arange(0, 24, dtype=np.int16).reshape(3, 2, 4)
     var A = nm.arange[nm.i16](0, 24)
     A = A.reshape(Shape(3, 2, 4))
 
@@ -26,7 +26,7 @@ def test_bool_masks_lt():
     var np = Python.import_module("numpy")
 
     # Create NumPy and NuMojo arrays using arange and reshape
-    var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
+    var np_A = np.arange(0, 24, dtype=np.int16).reshape(3, 2, 4)
     var A = nm.arange[nm.i16](0, 24)
     A = A.reshape(Shape(3, 2, 4))
 
@@ -45,7 +45,7 @@ def test_bool_masks_eq():
     var np = Python.import_module("numpy")
 
     # Create NumPy and NuMojo arrays using arange and reshape
-    var np_A = np.arange(0, 24, dtype=np.int16).reshape((3, 2, 4))
+    var np_A = np.arange(0, 24, dtype=np.int16).reshape(3, 2, 4)
     var A = nm.arange[nm.i16](0, 24)
     A = A.reshape(Shape(3, 2, 4))
 

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -52,12 +52,12 @@ def test_manipulation():
 
     check_matrices_equal(
         A.reshape((50, 2)),
-        Anp.reshape((50, 2)),
+        Anp.reshape(50, 2),
         "Reshape is broken",
     )
 
     _ = A.resize((1000, 100))
-    _ = Anp.resize((1000, 100))
+    _ = Anp.resize(1000, 100)
     check_matrices_equal(
         A,
         Anp,
@@ -74,7 +74,7 @@ def test_full():
     var np = Python.import_module("numpy")
     check_matrices_equal(
         Matrix.full[f64]((10, 10), 10, order=order),
-        np.full((10, 10), 10, dtype=np.float64),
+        np.full(Python.tuple(10, 10), fill_value=10, dtype=np.float64),
         "Full is broken",
     )
 
@@ -83,7 +83,7 @@ def test_zeros():
     var np = Python.import_module("numpy")
     check_matrices_equal(
         Matrix.zeros[f64](shape=(10, 10), order=order),
-        np.zeros((10, 10), dtype=np.float64),
+        np.zeros(Python.tuple(10, 10), dtype=np.float64),
         "Zeros is broken",
     )
 

--- a/tests/routines/test_creation.mojo
+++ b/tests/routines/test_creation.mojo
@@ -8,6 +8,7 @@ from testing.testing import (
     assert_raises,
 )
 from python import Python, PythonObject
+import random as builtin_random
 from tensor import Tensor, TensorShape
 from utils_for_test import check, check_is_close
 
@@ -57,7 +58,7 @@ def test_zeros():
     var np = Python.import_module("numpy")
     check(
         nm.zeros[f64](Shape(10, 10, 10, 10)),
-        np.zeros((10, 10, 10, 10), dtype=np.float64),
+        np.zeros(Python.tuple(10, 10, 10, 10), dtype=np.float64),
         "Zeros is broken",
     )
 
@@ -66,7 +67,7 @@ def test_ones_from_shape():
     var np = Python.import_module("numpy")
     check(
         nm.ones[nm.f64](Shape(10, 10, 10, 10)),
-        np.ones((10, 10, 10, 10), dtype=np.float64),
+        np.ones(Python.tuple(10, 10, 10, 10), dtype=np.float64),
         "Ones is broken",
     )
 
@@ -75,7 +76,7 @@ def test_ones_from_list():
     var np = Python.import_module("numpy")
     check(
         nm.ones[nm.f64](List[Int](10, 10, 10, 10)),
-        np.ones((10, 10, 10, 10), dtype=np.float64),
+        np.ones(Python.tuple(10, 10, 10, 10), dtype=np.float64),
         "Ones is broken",
     )
 
@@ -84,7 +85,7 @@ def test_ones_from_vlist():
     var np = Python.import_module("numpy")
     check(
         nm.ones[nm.f64](VariadicList[Int](10, 10, 10, 10)),
-        np.ones((10, 10, 10, 10), dtype=np.float64),
+        np.ones(Python.tuple(10, 10, 10, 10), dtype=np.float64),
         "Ones is broken",
     )
 
@@ -93,7 +94,7 @@ def test_full():
     var np = Python.import_module("numpy")
     check(
         nm.full[nm.f64](Shape(10, 10, 10, 10), fill_value=10),
-        np.full((10, 10, 10, 10), 10, dtype=np.float64),
+        np.full(Python.tuple(10, 10, 10, 10), 10, dtype=np.float64),
         "Full is broken",
     )
 
@@ -102,7 +103,7 @@ def test_full_from_shape():
     var np = Python.import_module("numpy")
     check(
         nm.full[nm.f64](Shape(10, 10, 10, 10), fill_value=10),
-        np.full((10, 10, 10, 10), 10, dtype=np.float64),
+        np.full(Python.tuple(10, 10, 10, 10), 10, dtype=np.float64),
         "Full is broken",
     )
 
@@ -111,7 +112,7 @@ def test_full_from_list():
     var np = Python.import_module("numpy")
     check(
         nm.full[nm.f64](List[Int](10, 10, 10, 10), fill_value=10),
-        np.full((10, 10, 10, 10), 10, dtype=np.float64),
+        np.full(Python.tuple(10, 10, 10, 10), 10, dtype=np.float64),
         "Full is broken",
     )
 
@@ -120,7 +121,7 @@ def test_full_from_vlist():
     var np = Python.import_module("numpy")
     check(
         nm.full[nm.f64](VariadicList[Int](10, 10, 10, 10), fill_value=10),
-        np.full((10, 10, 10, 10), 10, dtype=np.float64),
+        np.full(Python.tuple(10, 10, 10, 10), 10, dtype=np.float64),
         "Full is broken",
     )
 
@@ -351,7 +352,8 @@ def test_arr_manipulation():
 
 
 def test_tensor_conversion():
-    var image = Tensor[DType.float32].rand(TensorShape(256, 256, 3))
+    var image = Tensor[DType.float32](TensorShape(256, 256, 3))
+    builtin_random.rand(image.unsafe_ptr(), image.num_elements())
     var image_converted_via_array = nm.array(image).to_tensor()
     assert_equal(
         image == image_converted_via_array, True, "Tensor conversion is broken"

--- a/tests/routines/test_indexing.mojo
+++ b/tests/routines/test_indexing.mojo
@@ -23,44 +23,46 @@ fn test_compress() raises:
 
     check(
         numojo.indexing.compress(nm.array[boolean]("[0, 1, 1, 0]"), b),
-        np.compress(np.array([0, 1, 1, 0]), bnp),
+        np.compress(np.array(Python.list(0, 1, 1, 0)), bnp),
         "`compress` 1-d array is broken",
     )
     check(
         numojo.indexing.compress(
             nm.array[boolean]("[0,1,1,0,1,0,1,0,1,1,1]"), a
         ),
-        np.compress(np.array([0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1]), anp),
+        np.compress(
+            np.array(Python.list(0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1)), anp
+        ),
         "`compress` 3-d array without `axis` is broken",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[0, 1]"), a, axis=0),
-        np.compress(np.array([0, 1]), anp, axis=0),
+        np.compress(np.array(Python.list(0, 1)), anp, axis=0),
         "`compress` 3-d array by axis 0 is broken",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[1]"), a, axis=0),
-        np.compress(np.array([1]), anp, axis=0),
+        np.compress(np.array(Python.list(1)), anp, axis=0),
         "`compress` 3-d array by axis 0 is broken",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[1, 0, 1]"), a, axis=1),
-        np.compress(np.array([1, 0, 1]), anp, axis=1),
+        np.compress(np.array(Python.list(1, 0, 1)), anp, axis=1),
         "`compress` 3-d array by axis 1 is broken (#1)",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[0, 1]"), a, axis=1),
-        np.compress(np.array([0, 1]), anp, axis=1),
+        np.compress(np.array(Python.list(0, 1)), anp, axis=1),
         "`compress` 3-d array by axis 1 is broken (#2)",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[1, 0, 1, 1]"), a, axis=2),
-        np.compress(np.array([1, 0, 1, 1]), anp, axis=2),
+        np.compress(np.array(Python.list(1, 0, 1, 1)), anp, axis=2),
         "`compress` 3-d array by axis 2 is broken",
     )
     check(
         nm.indexing.compress(nm.array[boolean]("[0, 1]"), a, axis=2),
-        np.compress(np.array([0, 1]), anp, axis=2),
+        np.compress(np.array(Python.list(0, 1)), anp, axis=2),
         "`compress` 3-d array by axis 2 is broken",
     )
 

--- a/tests/routines/test_linalg.mojo
+++ b/tests/routines/test_linalg.mojo
@@ -12,7 +12,7 @@ from utils_for_test import check, check_is_close, check_values_close
 def test_matmul_small():
     var np = Python.import_module("numpy")
     var arr = nm.ones[i8](Shape(4, 4))
-    var np_arr = np.ones((4, 4), dtype=np.int8)
+    var np_arr = np.ones(Python.tuple(4, 4), dtype=np.int8)
     check_is_close(
         arr @ arr, np.matmul(np_arr, np_arr), "Dunder matmul is broken"
     )

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -62,22 +62,22 @@ def test_ravel_reshape():
     # Test reshape
     check_is_close(
         nm.reshape(c, Shape(4, 2, 2), "C"),
-        np.reshape(cnp, (4, 2, 2), "C"),
+        np.reshape(cnp, Python.tuple(4, 2, 2), "C"),
         "`reshape` C by C is broken",
     )
     check_is_close(
         nm.reshape(c, Shape(4, 2, 2), "F"),
-        np.reshape(cnp, (4, 2, 2), "F"),
+        np.reshape(cnp, Python.tuple(4, 2, 2), "F"),
         "`reshape` C by F is broken",
     )
     check_is_close(
         nm.reshape(f, Shape(4, 2, 2), "C"),
-        np.reshape(fnp, (4, 2, 2), "C"),
+        np.reshape(fnp, Python.tuple(4, 2, 2), "C"),
         "`reshape` F by C is broken",
     )
     check_is_close(
         nm.reshape(f, Shape(4, 2, 2), "F"),
-        np.reshape(fnp, (4, 2, 2), "F"),
+        np.reshape(fnp, Python.tuple(4, 2, 2), "F"),
         "`reshape` F by F is broken",
     )
 
@@ -109,7 +109,7 @@ def test_transpose():
     )
     check_is_close(
         nm.transpose(A, axes=List(1, 3, 0, 2)),
-        np.transpose(Anp, [1, 3, 0, 2]),
+        np.transpose(Anp, Python.list(1, 3, 0, 2)),
         "4-d `transpose` with arbitrary `axes` is broken.",
     )
 
@@ -120,11 +120,11 @@ def test_broadcast():
     var Anp = a.to_numpy()
     check(
         nm.broadcast_to(a, Shape(2, 2, 3)),
-        np.broadcast_to(a.to_numpy(), (2, 2, 3)),
+        np.broadcast_to(a.to_numpy(), Python.tuple(2, 2, 3)),
         "`broadcast_to` fails.",
     )
     check(
         nm.broadcast_to(a, Shape(2, 2, 2, 3)),
-        np.broadcast_to(a.to_numpy(), (2, 2, 2, 3)),
+        np.broadcast_to(a.to_numpy(), Python.tuple(2, 2, 2, 3)),
         "`broadcast_to` fails.",
     )

--- a/tests/routines/test_math.mojo
+++ b/tests/routines/test_math.mojo
@@ -28,7 +28,7 @@ def test_sum_prod():
         check_is_close(
             nm.sum(A, axis=i),
             np.sum(Anp, axis=i),
-            String("`sum` by axis {} fails.".format(i)),
+            String("`sum` by axis {} fails.").format(i),
         )
 
     check_is_close(
@@ -40,7 +40,7 @@ def test_sum_prod():
         check_is_close(
             nm.cumsum(A, axis=i),
             np.cumsum(Anp, axis=i),
-            String("`cumsum` by axis {} fails.".format(i)),
+            String("`cumsum` by axis {} fails.").format(i),
         )
 
     check_values_close(
@@ -52,7 +52,7 @@ def test_sum_prod():
         check_is_close(
             nm.prod(A, axis=i),
             np.prod(Anp, axis=i),
-            String("`prod` by axis {} fails.".format(i)),
+            String("`prod` by axis {} fails.").format(i),
         )
 
     check_is_close(
@@ -64,7 +64,7 @@ def test_sum_prod():
         check_is_close(
             nm.cumprod(A, axis=i),
             np.cumprod(Anp, axis=i),
-            String("`cumprod` by axis {} fails.".format(i)),
+            String("`cumprod` by axis {} fails.").format(i),
         )
 
 

--- a/tests/routines/test_searching.mojo
+++ b/tests/routines/test_searching.mojo
@@ -87,7 +87,9 @@ fn test_argmax() raises:
         check(
             nm.argmax(a3d_f, axis=i),
             np.argmax(a3d_f_np, axis=i),
-            "`argmax` with F-order 3D array on axis={} is broken".format(i),
+            String(
+                "`argmax` with F-order 3D array on axis={} is broken"
+            ).format(i),
         )
 
 
@@ -175,7 +177,9 @@ fn test_argmin() raises:
         check(
             nm.argmin(a3d_f, axis=i),
             np.argmin(a3d_f_np, axis=i),
-            "`argmin` with F-order 3D array on axis={} is broken".format(i),
+            String(
+                "`argmin` with F-order 3D array on axis={} is broken"
+            ).format(i),
         )
 
 

--- a/tests/routines/test_statistics.mojo
+++ b/tests/routines/test_statistics.mojo
@@ -24,7 +24,7 @@ def test_mean_median_var_std():
         check_is_close(
             nm.mean(A, axis=axis),
             np.mean(Anp, axis=axis),
-            String("`mean` is broken for axis {}".format(axis)),
+            String("`mean` is broken for axis {}").format(axis),
         )
 
     assert_true(
@@ -35,7 +35,7 @@ def test_mean_median_var_std():
         check_is_close(
             nm.median(A, axis),
             np.median(Anp, axis),
-            String("`median` is broken for axis {}".format(axis)),
+            String("`median` is broken for axis {}").format(axis),
         )
 
     assert_true(
@@ -50,7 +50,7 @@ def test_mean_median_var_std():
         check_is_close(
             nm.mode(A, axis),
             sp.stats.mode(Anp, axis).mode,
-            String("`mode` is broken for axis {}".format(axis)),
+            String("`mode` is broken for axis {}").format(axis),
         )
 
     assert_true(
@@ -61,7 +61,7 @@ def test_mean_median_var_std():
         check_is_close(
             nm.variance(A, axis),
             np.`var`(Anp, axis),
-            String("`variance` is broken for axis {}".format(axis)),
+            String("`variance` is broken for axis {}").format(axis),
         )
 
     assert_true(
@@ -72,5 +72,5 @@ def test_mean_median_var_std():
         check_is_close(
             nm.std(A, axis),
             np.std(Anp, axis),
-            String("`std` is broken for axis {}".format(axis)),
+            String("`std` is broken for axis {}").format(axis),
         )


### PR DESCRIPTION
- Update the syntax to accommodate the changes in Mojo 25.3.
  - Changes in constructing of Python Objects.
  - Deprecation of `mut` keywords in `__init__`.
  - Deprecation of `format` methods for string literal.
  - Removal of unused variables.
  - Change string literal in the program into commenting lines.
  - etc.
- Update the `numpy` version to `>=2.0`.
- Update the channel priority.