### PR TITLE
[routines] Add stable sort and re-write in-place sort

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4434,7 +4434,7 @@ struct NDArray[dtype: DType = DType.float64](
             buffer.store(i, self._buf.ptr.load[width=1](i + id * width))
         return buffer
 
-    fn sort(mut self, axis: Int = -1) raises:
+    fn sort(mut self, axis: Int = -1, stable: Bool = False) raises:
         """
         Sorts the array in-place along the given axis using quick sort method.
         The deault axis is -1.
@@ -4442,11 +4442,11 @@ struct NDArray[dtype: DType = DType.float64](
 
         Args:
             axis: The axis along which the array is sorted. Defaults to -1.
+            stable: If True, the sort is stable. Defaults to False.
 
         Raises:
             Error: If the axis is out of bound for the given array.
         """
-
         var normalized_axis: Int = axis
         if normalized_axis < 0:
             normalized_axis += self.ndim
@@ -4457,8 +4457,7 @@ struct NDArray[dtype: DType = DType.float64](
                     "Axis ({}) is not in valid range [-{}, {})."
                 ).format(axis, self.ndim, self.ndim)
             )
-
-        numojo.sorting._sort_inplace(self, axis=normalized_axis)
+        numojo.sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
 
     fn std[
         returned_dtype: DType = DType.float64

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -510,10 +510,8 @@ fn quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     """
     if a.ndim != 1:
         raise Error(
-            String(
-                "Error in `quick_sort_inplace_1d`: "
-                "The input array must be 1-d array."
-            )
+            "Error in `quick_sort_inplace_1d`: "
+            "The input array must be 1-d array."
         )
     _quick_sort_inplace(a)
     return

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -92,5 +92,36 @@ fn test_sorting() raises:
         check(
             C,
             Cnp,
-            String("`NDArray.sort()` 3d by axis {} is broken").format(i),
+            String("`NDArray.sort()` 3d in-place by axis {} is broken").format(
+                i
+            ),
+        )
+
+    # Sort stably
+    check(
+        nm.sort(A, axis=0, stable=True),
+        np.sort(A.to_numpy(), axis=0, stable=True),
+        "`sort` 1d stably is broken",
+    )
+    check(
+        nm.sort(B, axis=0, stable=True),
+        np.sort(B.to_numpy(), axis=0, stable=True),
+        "`sort` 2d stably by axis 0 is broken",
+    )
+    check(
+        nm.sort(B, axis=1, stable=True),
+        np.sort(B.to_numpy(), axis=1, stable=True),
+        "`sort` 2d stably by axis 1 is broken",
+    )
+    for i in range(3):
+        check(
+            nm.sort(C, axis=i, stable=True),
+            np.sort(C.to_numpy(), axis=i, stable=True),
+            String("`sort` 3d stably by axis {} is broken").format(i),
+        )
+    for i in range(6):
+        check(
+            nm.sort(S, axis=i, stable=True),
+            np.sort(S.to_numpy(), axis=i, stable=True),
+            String("`sort` 6d stably by axis {} is broken").format(i),
         )


### PR DESCRIPTION
This PR:

- Add stable sort to the function `sort()`. Users can use the argument `stable` to make a stable sort.
- Re-write the in-place sort (instable and stable) using the `apply_long_axis()` function, so that we do not need to several transposes.
- Add an override for `apply_long_axis()`, which apply the function in-place.