### PR TITLE
[mojo] fix: Rename `MutOrigin.external` to `MutExternalOrigin`.

### DIFF
--- a/numojo/core/item.mojo
+++ b/numojo/core/item.mojo
@@ -48,7 +48,7 @@ struct Item(
     # Aliases
     comptime element_type: DType = DType.int
     """The data type of the Item elements."""
-    comptime _origin: MutOrigin = MutOrigin.external
+    comptime _origin: MutOrigin = MutExternalOrigin
     """Internal origin of the Item instance."""
 
     # Fields

--- a/numojo/core/matrix.mojo
+++ b/numojo/core/matrix.mojo
@@ -37,7 +37,7 @@ from numojo.routines.linalg.misc import issymmetric
 # ===----------------------------------------------------------------------===#
 
 
-comptime Matrix = MatrixBase[_, own_data=True, origin = MutOrigin.external]
+comptime Matrix = MatrixBase[_, own_data=True, origin = MutExternalOrigin]
 """
 Primary Matrix type for creating and manipulating 2D matrices in NuMojo.
 
@@ -154,7 +154,7 @@ struct MatrixBase[
                   its own memory. When False, it's a view into externally-owned data.
         origin: Tracks the lifetime and mutability of the underlying data buffer,
                 enabling compile-time safety checks to prevent use-after-free and
-                other memory safety issues. Default is MutOrigin.external.
+                other memory safety issues. Default is MutExternalOrigin.
 
     Memory Layout:
         Matrices can be stored in either:

--- a/numojo/core/ndshape.mojo
+++ b/numojo/core/ndshape.mojo
@@ -48,7 +48,7 @@ struct NDArrayShape(
     # Aliases
     comptime element_type: DType = DType.int
     """The data type of the NDArrayShape elements."""
-    comptime _origin: MutOrigin = MutOrigin.external
+    comptime _origin: MutOrigin = MutExternalOrigin
     """Internal origin of the NDArrayShape instance."""
 
     # Fields

--- a/numojo/core/ndstrides.mojo
+++ b/numojo/core/ndstrides.mojo
@@ -32,7 +32,7 @@ struct NDArrayStrides(
     # Aliases
     comptime element_type: DType = DType.int
     """The data type of the NDArrayStrides elements."""
-    comptime _origin: MutOrigin = MutOrigin.external
+    comptime _origin: MutOrigin = MutExternalOrigin
     """Internal origin of the NDArrayStrides instance."""
 
     # Fields


### PR DESCRIPTION
Context: https://github.com/modular/modular/commit/dc86dfa474ae0520af437312a0f893c329d8a2ff