### PR TITLE
[core] Deprecate `fn` keyword in favor of `def`

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -77,7 +77,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # Generate two 1000x1000 matrices with random float64 values
     var A = nm.random.randn(Shape(1000, 1000)) # Shape is used for all shape related operations in numojo. 
     var B = nm.random.randn(Shape(1000, 1000))
@@ -109,7 +109,7 @@ from numojo import Matrix
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # Generate two 1000x1000 matrices with random float64 values
     var A = Matrix.rand(shape=(1000, 1000))
     var B = Matrix.rand(shape=(1000, 1000))
@@ -160,7 +160,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # Create a complex scalar 5 + 5j
     # cf32 is the complex version of f32 (DType.float32) used to identify complex types in numojo.
     var complexscalar = CScalar[cf32](5) # Equivalently ComplexSIMD[cf32](5, 5)

--- a/benchmark/benchmark_dlpack.mojo
+++ b/benchmark/benchmark_dlpack.mojo
@@ -4,11 +4,11 @@ from python import Python
 import benchmark
 
 
-fn main() raises:
+def main() raises:
     var np = Python.import_module("numpy")
     var numpy_data = np.linspace(0, 5, 6, dtype=np.float32)
 
-    fn make_view() raises capturing -> None:
+    def make_view() raises capturing -> None:
         var mojo_arr = from_dlpack[f32](numpy_data)
 
     var report = benchmark.run[make_view]()

--- a/docs/developer-guide/style-guide.md
+++ b/docs/developer-guide/style-guide.md
@@ -29,8 +29,9 @@ Description of the function.
 Next add the parameters, arguments, and returns if there are any separated from the summary by a new line. For functions and parameters start with either `Parameters:` or `Args:` followed by a new line-separated list of the parameters or arguments with the name of the parameter/arg followed by a `:` and a description the description should be a sentence starting with a capital letter and ending with a period. For returns separated from previous lines by a new line and start with `Returns:` then go to a new line and write a brief description of the return value, again as a sentence starting with a capitol letter and ending with a period. If the function does not return the `Returns:` section should be omitted. 
 
 There is no need to add the type name to the arguments or parameters as the compiler handles that.
+
 ```mojo
-fn func[param:Copyable](arg1:param)->param:
+def func[param:Copyable](arg1:param)->param:
     """
 
     Description of the function.

--- a/docs/developer-guide/style_example.mojo
+++ b/docs/developer-guide/style_example.mojo
@@ -10,7 +10,7 @@ comptime Example = Int
 """Aliases can be explained with docstrings and should if they exist in the global scope."""
 
 
-fn func[param: Copyable](arg1: param) -> param:
+def func[param: Copyable](arg1: param) -> param:
     """
     Description of the function.
 
@@ -29,7 +29,7 @@ fn func[param: Copyable](arg1: param) -> param:
     return arg1
 
 
-fn func1[param: Copyable](arg1: param) raises -> param:
+def func1[param: Copyable](arg1: param) raises -> param:
     """
     Description of the function.
 
@@ -62,7 +62,7 @@ struct AStruct[param: AnyType](AnyType):
     var field: Int64
     """Field Descriptions go below each field."""
 
-    fn func(self) -> None:
+    def func(self) -> None:
         """
         Function docstring like previosly shown.
         """
@@ -74,7 +74,7 @@ trait ATrait:
     Describe the trait.
     """
 
-    fn func(self) -> None:
+    def func(self) -> None:
         """
         Function docstring like previosly shown.
         """

--- a/docs/getting-started/readme_jp.md
+++ b/docs/getting-started/readme_jp.md
@@ -75,7 +75,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # ランダムなfloat64値で2つの1000x1000行列を生成
     var A = nm.random.randn(Shape(1000, 1000))
     var B = nm.random.randn(Shape(1000, 1000))
@@ -107,7 +107,7 @@ from numojo import Matrix
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # ランダムなfloat64値で2つの1000x1000行列を生成
     var A = Matrix.rand(shape=(1000, 1000))
     var B = Matrix.rand(shape=(1000, 1000))
@@ -158,7 +158,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 複素数スカラー 5 + 5j を作成
     var complexscalar = ComplexSIMD[f32](re=5, im=5)
     # 複素数配列を作成

--- a/docs/getting-started/readme_kr.md
+++ b/docs/getting-started/readme_kr.md
@@ -75,7 +75,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 랜덤한 float64 값으로 두 개의 1000x1000 행렬 생성
     var A = nm.random.randn(Shape(1000, 1000))
     var B = nm.random.randn(Shape(1000, 1000))
@@ -107,7 +107,7 @@ from numojo import Matrix
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 랜덤한 float64 값으로 두 개의 1000x1000 행렬 생성
     var A = Matrix.rand(shape=(1000, 1000))
     var B = Matrix.rand(shape=(1000, 1000))
@@ -158,7 +158,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 복소수 스칼라 5 + 5j 생성
     var complexscalar = ComplexSIMD[f32](re=5, im=5)
     # 복소수 배열 생성

--- a/docs/getting-started/readme_zhs.md
+++ b/docs/getting-started/readme_zhs.md
@@ -60,7 +60,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 生成两个 1000x1000 矩阵，使用随机 float64 值
     var A = nm.random.randn(Shape(1000, 1000))
     var B = nm.random.randn(Shape(1000, 1000))
@@ -93,7 +93,7 @@ from numojo import Matrix
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 生成两个 1000x1000 矩阵，使用随机 float64 值
     var A = Matrix.rand(shape=(1000, 1000))
     var B = Matrix.rand(shape=(1000, 1000))
@@ -144,7 +144,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 创建复数标量 5 + 5j
     var complexscalar = ComplexSIMD[f32](re=5, im=5)
     # 创建复数数组

--- a/docs/getting-started/readme_zht.md
+++ b/docs/getting-started/readme_zht.md
@@ -60,7 +60,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 生成兩個 1000x1000 矩陣，使用隨機 float64 值
     var A = nm.random.randn(Shape(1000, 1000))
     var B = nm.random.randn(Shape(1000, 1000))
@@ -93,7 +93,7 @@ from numojo import Matrix
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 生成兩個 1000x1000 矩陣，使用隨機 float64 值
     var A = Matrix.rand(shape=(1000, 1000))
     var B = Matrix.rand(shape=(1000, 1000))
@@ -144,7 +144,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     # 創建複數標量 5 + 5j
     var complexscalar = ComplexSIMD[f32](re=5, im=5)
     # 創建複數數組

--- a/examples/quickstart.mojo
+++ b/examples/quickstart.mojo
@@ -2,7 +2,7 @@ import numojo as nm
 from numojo.prelude import *
 
 
-fn main() raises:
+def main() raises:
     var A = nm.random.randn(Shape(3, 3))
     var B = nm.random.randn(Shape(3, 3))
 

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -74,13 +74,13 @@ struct Device(
     # Constructors
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self):
+    def __init__(out self):
         """Initialize a default CPU device."""
         self.type = "cpu"
         self.name = ""
         self.id = 0
 
-    fn __init__(out self, text: String) raises:
+    def __init__(out self, text: String) raises:
         """Initialize a device by parsing a torch-style device string.
 
         Supported formats: "cpu", "cuda", "cuda:0", "rocm", "rocm:1",
@@ -97,7 +97,7 @@ struct Device(
         self.name = parsed.name
         self.id = parsed.id
 
-    fn __init__(out self, type: String, name: String, id: Int):
+    def __init__(out self, type: String, name: String, id: Int):
         """Initialize a device with explicit type, name, and index.
 
         Validates the arguments and falls back to CPU if the requested
@@ -156,7 +156,7 @@ struct Device(
         self.id = id
 
     @staticmethod
-    fn _unchecked_init(out device: Device, type: String, name: String, id: Int):
+    def _unchecked_init(out device: Device, type: String, name: String, id: Int):
         """Create a device without any validation. For internal/comptime use."""
         device = Device()
         device.type = type
@@ -164,7 +164,7 @@ struct Device(
         device.id = id
 
     @staticmethod
-    fn _cpu_fallback() -> Device:
+    def _cpu_fallback() -> Device:
         """Return a default CPU device."""
         return Device()
 
@@ -172,7 +172,7 @@ struct Device(
     # Trait implementations
     # ===------------------------------------------------------------------=== #
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Return a human-readable string representation.
 
         Returns:
@@ -188,7 +188,7 @@ struct Device(
             + ")"
         )
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """Return the canonical string representation.
 
         Returns:
@@ -197,7 +197,7 @@ struct Device(
         # TODO: repr is deprecated in favor of write_repr_to
         return self.__str__()
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -208,7 +208,7 @@ struct Device(
         """
         writer.write(self.__str__())
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -219,7 +219,7 @@ struct Device(
         """
         writer.write(self.__str__())
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """Check equality with another device.
 
         Args:
@@ -234,7 +234,7 @@ struct Device(
             and self.id == other.id
         )
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """Check inequality with another device.
 
         Args:
@@ -249,7 +249,7 @@ struct Device(
     # Instance methods
     # ===------------------------------------------------------------------=== #
 
-    fn is_cpu(self) -> Bool:
+    def is_cpu(self) -> Bool:
         """Check if this is a CPU device.
 
         Returns:
@@ -257,7 +257,7 @@ struct Device(
         """
         return self.type == "cpu"
 
-    fn is_gpu(self) -> Bool:
+    def is_gpu(self) -> Bool:
         """Check if this is a GPU device.
 
         Returns:
@@ -265,7 +265,7 @@ struct Device(
         """
         return self.type == "gpu"
 
-    fn is_available(self) -> Bool:
+    def is_available(self) -> Bool:
         """Check if this device is available on the current system.
 
         Returns:
@@ -287,7 +287,7 @@ struct Device(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn default_device() -> Device:
+    def default_device() -> Device:
         """Return the best available device: GPU if present, otherwise CPU.
 
         Returns:
@@ -303,7 +303,7 @@ struct Device(
 
     @staticmethod
     @parameter
-    fn available_gpu() raises -> String:
+    def available_gpu() raises -> String:
         """Return the name of the best available GPU backend.
 
         Checks in order: CUDA → ROCm → MPS.
@@ -332,7 +332,7 @@ struct Device(
 
     @staticmethod
     @parameter
-    fn available_devices() -> String:
+    def available_devices() -> String:
         """List all available devices on the current system.
 
         Returns:
@@ -361,7 +361,7 @@ struct Device(
 
     @staticmethod
     @parameter
-    fn parse_device_string(text: String) raises -> Device:
+    def parse_device_string(text: String) raises -> Device:
         """Parse a torch-style device string into a `Device`.
 
         Supported formats:
@@ -438,7 +438,7 @@ struct Device(
 
 
 @parameter
-fn is_accelerator_available[device: Device]() -> Bool:
+def is_accelerator_available[device: Device]() -> Bool:
     """Check at compile time whether the given device's GPU accelerator exists.
 
     Parameters:

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -156,7 +156,9 @@ struct Device(
         self.id = id
 
     @staticmethod
-    def _unchecked_init(out device: Device, type: String, name: String, id: Int):
+    def _unchecked_init(
+        out device: Device, type: String, name: String, id: Int
+    ):
         """Create a device without any validation. For internal/comptime use."""
         device = Device()
         device.type = type

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -153,7 +153,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
     # --- Life cycle methods ---
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self, var re: NDArray[Self.dtype], var im: NDArray[Self.dtype]
     ) raises:
         """
@@ -188,7 +188,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         order: String = "C",
@@ -221,7 +221,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: List[Int],
         order: String = "C",
@@ -254,7 +254,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: VariadicList[Int, _],
         order: String = "C",
@@ -286,7 +286,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             precision=2, edge_items=2, line_width=100, formatted_width=6
         )
 
-    fn __init__(
+    def __init__(
         out self,
         shape: List[Int],
         offset: Int,
@@ -329,7 +329,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             precision=2, edge_items=2, line_width=100, formatted_width=6
         )
 
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         strides: NDArrayStrides,
@@ -379,7 +379,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
 
     # FIXME: temporarily disabled this constructor until we setup views for NDArray.
-    # fn __init__(
+    # def __init__(
     #     out self,
     #     shape: NDArrayShape,
     #     ref buffer_re: UnsafePointer[Scalar[Self.dtype]],
@@ -421,7 +421,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     #     )
 
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Copy copy into self.
         """
@@ -435,7 +435,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.print_options = copy.print_options
 
     @always_inline("nodebug")
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """
         Move other into self.
         """
@@ -454,35 +454,35 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     # FIXME: currently most of the getitem and setitem methods don't match exactly between NDArray and ComplexNDArray in it's implementation, docstring, argument mutability etc. Fix this.
 
     # 1. Basic Indexing Operations
-    # fn _getitem(self, *indices: Int) -> ComplexSIMD[Self.cdtype]                         # Direct unsafe getter
-    # fn _getitem(self, indices: List[Int]) -> ComplexSIMD[Self.cdtype]                         # Direct unsafe getter
-    # fn __getitem__(self) raises -> ComplexSIMD[Self.cdtype]                             # Get 0d array value
-    # fn __getitem__(self, index: Item) raises -> ComplexSIMD[Self.cdtype]                # Get by coordinate list
+    # def _getitem(self, *indices: Int) -> ComplexSIMD[Self.cdtype]                         # Direct unsafe getter
+    # def _getitem(self, indices: List[Int]) -> ComplexSIMD[Self.cdtype]                         # Direct unsafe getter
+    # def __getitem__(self) raises -> ComplexSIMD[Self.cdtype]                             # Get 0d array value
+    # def __getitem__(self, index: Item) raises -> ComplexSIMD[Self.cdtype]                # Get by coordinate list
     #
     # 2. Single Index Slicing
-    # fn __getitem__(self, idx: Int) raises -> Self                             # Get by single index
+    # def __getitem__(self, idx: Int) raises -> Self                             # Get by single index
     #
     # 3. Multi-dimensional Slicing
-    # fn __getitem__(self, *slices: Slice) raises -> Self                       # Get by variable slices
-    # fn __getitem__(self, slice_list: List[Slice]) raises -> Self              # Get by list of slices
-    # fn __getitem__(self, *slices: Variant[Slice, Int]) raises -> Self         # Get by mix of slices/ints
+    # def __getitem__(self, *slices: Slice) raises -> Self                       # Get by variable slices
+    # def __getitem__(self, slice_list: List[Slice]) raises -> Self              # Get by list of slices
+    # def __getitem__(self, *slices: Variant[Slice, Int]) raises -> Self         # Get by mix of slices/ints
     #
     # 4. Advanced Indexing
-    # fn __getitem__(self, indices: NDArray[DType.int]) raises -> Self        # Get by index array
-    # fn __getitem__(self, indices: List[Int]) raises -> Self                   # Get by list of indices
-    # fn __getitem__(self, mask: NDArray[DType.bool]) raises -> Self            # Get by boolean mask
-    # fn __getitem__(self, mask: List[Bool]) raises -> Self                     # Get by boolean list
+    # def __getitem__(self, indices: NDArray[DType.int]) raises -> Self        # Get by index array
+    # def __getitem__(self, indices: List[Int]) raises -> Self                   # Get by list of indices
+    # def __getitem__(self, mask: NDArray[DType.bool]) raises -> Self            # Get by boolean mask
+    # def __getitem__(self, mask: List[Bool]) raises -> Self                     # Get by boolean list
     #
     # 5. Low-level Access
-    # fn item(self, var index: Int) raises -> ComplexSIMD[Self.dtype]                   # Get item by linear index
-    # fn item(self, *index: Int) raises -> ComplexSIMD[Self.dtype]                        # Get item by coordinates
-    # fn load(self, var index: Int) raises -> ComplexSIMD[Self.dtype]                   # Load with bounds check
-    # fn load[width: Int](self, index: Int) raises -> ComplexSIMD[Self.dtype, width]        # Load SIMD value
-    # fn load[width: Int](self, *indices: Int) raises -> ComplexSIMD[Self.dtype, width]     # Load SIMD at coordinates
+    # def item(self, var index: Int) raises -> ComplexSIMD[Self.dtype]                   # Get item by linear index
+    # def item(self, *index: Int) raises -> ComplexSIMD[Self.dtype]                        # Get item by coordinates
+    # def load(self, var index: Int) raises -> ComplexSIMD[Self.dtype]                   # Load with bounds check
+    # def load[width: Int](self, index: Int) raises -> ComplexSIMD[Self.dtype, width]        # Load SIMD value
+    # def load[width: Int](self, *indices: Int) raises -> ComplexSIMD[Self.dtype, width]     # Load SIMD at coordinates
     # ===-------------------------------------------------------------------===#
 
     @always_inline
-    fn normalize(self, idx: Int, dim: Int) -> Int:
+    def normalize(self, idx: Int, dim: Int) -> Int:
         """
         Normalize a potentially negative index to its positive equivalent
         within the bounds of the given dimension.
@@ -500,7 +500,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             idx_norm = dim + idx_norm
         return idx_norm
 
-    fn _getitem(self, *indices: Int) -> ComplexSIMD[Self.cdtype]:
+    def _getitem(self, *indices: Int) -> ComplexSIMD[Self.cdtype]:
         """
         Get item at indices and bypass all boundary checks.
         ***UNSAFE!*** No boundary checks made, for internal use only.
@@ -529,7 +529,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr[index_of_buffer],
         )
 
-    fn _getitem(self, indices: List[Int]) -> ComplexScalar[Self.cdtype]:
+    def _getitem(self, indices: List[Int]) -> ComplexScalar[Self.cdtype]:
         """
         Get item at indices and bypass all boundary checks.
         ***UNSAFE!*** No boundary checks made, for internal use only.
@@ -558,7 +558,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr[index_of_buffer],
         )
 
-    fn __getitem__(self) raises -> ComplexSIMD[Self.cdtype, 1]:
+    def __getitem__(self) raises -> ComplexSIMD[Self.cdtype, 1]:
         """
         Gets the value of the 0-D Complex array.
 
@@ -594,7 +594,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr[],
         )
 
-    fn __getitem__(self, index: Item) raises -> ComplexSIMD[Self.cdtype, 1]:
+    def __getitem__(self, index: Item) raises -> ComplexSIMD[Self.cdtype, 1]:
         """
         Get the value at the index list.
 
@@ -647,7 +647,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr.load[width=1](idx),
         )
 
-    fn __getitem__(self, idx: Int) raises -> Self:
+    def __getitem__(self, idx: Int) raises -> Self:
         """Single-axis integer slice (first dimension).
         Returns a slice of the complex array taken at axis 0 position `idx`.
         Dimensionality is reduced by exactly one; a 1-D source produces a
@@ -753,7 +753,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
             return result^
 
-    fn __getitem__(self, var *slices: Slice) raises -> Self:
+    def __getitem__(self, var *slices: Slice) raises -> Self:
         """
         Retrieves a slice or sub-array from the current array using variadic slice arguments.
 
@@ -807,7 +807,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var narr: Self = self[slice_list^]
         return narr^
 
-    fn _calculate_strides(self, shape: List[Int]) -> List[Int]:
+    def _calculate_strides(self, shape: List[Int]) -> List[Int]:
         var strides = List[Int](capacity=len(shape))
 
         if self.flags.C_CONTIGUOUS:  # C_CONTIGUOUS
@@ -827,7 +827,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return strides^
 
-    fn __getitem__(self, var slice_list: List[Slice]) raises -> Self:
+    def __getitem__(self, var slice_list: List[Slice]) raises -> Self:
         """
         Retrieves a sub-array from the current array using a list of slice objects, enabling advanced slicing operations across multiple dimensions.
 
@@ -938,7 +938,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return narr^
 
-    fn __getitem__(self, var *slices: Variant[Slice, Int]) raises -> Self:
+    def __getitem__(self, var *slices: Variant[Slice, Int]) raises -> Self:
         """
         Get items of ComplexNDArray with a series of either slices or integers.
 
@@ -1026,7 +1026,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         narr = self.__getitem__(slice_list^)
         return narr^
 
-    fn __getitem__(self, indices: NDArray[DType.int]) raises -> Self:
+    def __getitem__(self, indices: NDArray[DType.int]) raises -> Self:
         """
         Get items from 0-th dimension of a ComplexNDArray of indices.
         If the original array is of shape (i,j,k) and
@@ -1085,7 +1085,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return result^
 
-    fn __getitem__(self, indices: List[Int]) raises -> Self:
+    def __getitem__(self, indices: List[Int]) raises -> Self:
         """
         Get items from 0-th dimension of a ComplexNDArray of indices.
         It is an overload of
@@ -1110,7 +1110,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return self[indices_array]
 
-    fn __getitem__(self, mask: NDArray[DType.bool]) raises -> Self:
+    def __getitem__(self, mask: NDArray[DType.bool]) raises -> Self:
         """
         Get item from a ComplexNDArray according to a mask array.
         If array shape is equal to mask shape, it returns a flattened array of
@@ -1220,7 +1220,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return result^
 
-    fn __getitem__(self, mask: List[Bool]) raises -> Self:
+    def __getitem__(self, mask: List[Bool]) raises -> Self:
         """
         Get items from 0-th dimension of a ComplexNDArray according to mask.
 
@@ -1240,7 +1240,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return self[mask_array]
 
-    fn item(self, var index: Int) raises -> ComplexSIMD[Self.cdtype]:
+    def item(self, var index: Int) raises -> ComplexSIMD[Self.cdtype]:
         """
         Return the scalar at the coordinates.
         If one index is given, get the i-th item of the complex array (not buffer).
@@ -1314,7 +1314,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 im=(self._im._buf.ptr + index)[],
             )
 
-    fn item(self, *index: Int) raises -> ComplexSIMD[Self.cdtype]:
+    def item(self, *index: Int) raises -> ComplexSIMD[Self.cdtype]:
         """
         Return the scalar at the coordinates.
         If one index is given, get the i-th item of the complex array (not buffer).
@@ -1391,7 +1391,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )[],
         )
 
-    fn load(self, var index: Int) raises -> ComplexSIMD[Self.cdtype]:
+    def load(self, var index: Int) raises -> ComplexSIMD[Self.cdtype]:
         """
         Safely retrieve i-th item from the underlying buffer.
 
@@ -1435,7 +1435,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr[index],
         )
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, index: Int) raises -> ComplexSIMD[Self.cdtype, width]:
         """
@@ -1471,7 +1471,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr.load[width=1](index),
         )
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, *indices: Int) raises -> ComplexSIMD[Self.cdtype, width=width]:
         """
@@ -1537,7 +1537,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             im=self._im._buf.ptr.load[width=width](idx),
         )
 
-    fn _adjust_slice(self, slice_list: List[Slice]) raises -> List[Slice]:
+    def _adjust_slice(self, slice_list: List[Slice]) raises -> List[Slice]:
         """
         Adjusts slice values to handle all possible slicing scenarios including:
         - Negative indices (Python-style wrapping)
@@ -1626,7 +1626,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return slices^
 
-    fn _setitem(self, *indices: Int, val: ComplexSIMD[Self.cdtype]):
+    def _setitem(self, *indices: Int, val: ComplexSIMD[Self.cdtype]):
         """
         (UNSAFE! for internal use only.)
         Set item at indices and bypass all boundary checks.
@@ -1653,7 +1653,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re._buf.ptr[index_of_buffer] = val.re
         self._im._buf.ptr[index_of_buffer] = val.im
 
-    fn __setitem__(mut self, idx: Int, val: Self) raises:
+    def __setitem__(mut self, idx: Int, val: Self) raises:
         """Assign a single first-axis slice.
         Replaces the sub-array at axis 0 position `idx` with `val`.
         The shape of `val` must exactly match `self.shape[1:]` and its
@@ -1747,7 +1747,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self[Self.dtype]._re._write_first_axis_slice(self._re, norm, val._re)
         self[Self.dtype]._im._write_first_axis_slice(self._im, norm, val._im)
 
-    fn __setitem__(
+    def __setitem__(
         mut self, var index: Item, val: ComplexSIMD[Self.cdtype]
     ) raises:
         """
@@ -1806,7 +1806,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re._buf.ptr.store(idx, val.re)
         self._im._buf.ptr.store(idx, val.im)
 
-    fn __setitem__(
+    def __setitem__(
         mut self,
         mask: ComplexNDArray[Self.cdtype],
         value: ComplexSIMD[Self.cdtype],
@@ -1834,7 +1834,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             if mask._im._buf.ptr.load[width=1](i):
                 self._im._buf.ptr.store(i, value.im)
 
-    fn __setitem__(
+    def __setitem__(
         mut self, var *slices: Slice, val: ComplexNDArray[Self.cdtype]
     ) raises:
         """
@@ -1849,7 +1849,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         # self.__setitem__(slices=slice_list, val=val)
         self[slice_list^] = val
 
-    fn __setitem__(
+    def __setitem__(
         mut self, slices: List[Slice], val: ComplexNDArray[Self.cdtype]
     ) raises:
         """
@@ -1959,7 +1959,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
 
     ## compiler doesn't accept this.
-    fn __setitem__(
+    def __setitem__(
         self, var *slices: Variant[Slice, Int], val: ComplexNDArray[Self.cdtype]
     ) raises:
         """
@@ -2000,7 +2000,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         # self.__setitem__(slices=slice_list, val=val)
         self[slice_list^] = val
 
-    fn __setitem__(self, index: NDArray[DType.int], val: Self) raises:
+    def __setitem__(self, index: NDArray[DType.int], val: Self) raises:
         """
         Returns the items of the ComplexNDArray from an array of indices.
 
@@ -2016,7 +2016,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
 
     # TODO: implement itemset().
-    fn __setitem__(
+    def __setitem__(
         mut self,
         mask: ComplexNDArray[Self.cdtype],
         val: ComplexNDArray[Self.cdtype],
@@ -2038,7 +2038,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             if mask._im._buf.ptr.load(i):
                 self._im._buf.ptr.store(i, val._im._buf.ptr.load(i))
 
-    fn __pos__(self) raises -> Self:
+    def __pos__(self) raises -> Self:
         """
         Unary positive returns self unless boolean type.
         """
@@ -2049,7 +2049,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
         return self.copy()
 
-    fn __neg__(self) raises -> Self:
+    def __neg__(self) raises -> Self:
         """
         Unary negative returns self unless boolean type.
 
@@ -2062,7 +2062,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
         return self * ComplexSIMD[Self.cdtype](-1.0, -1.0)
 
-    fn __bool__(self) raises -> Bool:
+    def __bool__(self) raises -> Bool:
         """
         Check if the complex array is non-zero.
 
@@ -2097,7 +2097,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 "ambiguous. Use a.any() or a.all()."
             )
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """
         Gets `Int` representation of the complex array's real part.
 
@@ -2128,7 +2128,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 "can be converted to scalars."
             )
 
-    fn __float__(self) raises -> Float64:
+    def __float__(self) raises -> Float64:
         """
         Gets `Float64` representation of the complex array's magnitude.
 
@@ -2162,7 +2162,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 "can be converted to scalars."
             )
 
-    fn __abs__(self) raises -> NDArray[Self.dtype]:
+    def __abs__(self) raises -> NDArray[Self.dtype]:
         """
         Compute the magnitude (absolute value) of each complex element.
 
@@ -2185,7 +2185,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var sum_sq = re_sq + im_sq
         return misc.sqrt[Self.dtype](sum_sq)
 
-    fn __pow__(self, p: Int) raises -> Self:
+    def __pow__(self, p: Int) raises -> Self:
         """
         Raise complex array to integer power element-wise.
 
@@ -2226,7 +2226,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 result = temp^
             return result^
 
-    fn __pow__(self, rhs: Scalar[Self.dtype]) raises -> Self:
+    def __pow__(self, rhs: Scalar[Self.dtype]) raises -> Self:
         """
         Raise complex array to real scalar power element-wise.
 
@@ -2254,7 +2254,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return Self(result_re^, result_im^)
 
-    fn __pow__(
+    def __pow__(
         self, p: Self
     ) raises -> Self where Self.dtype.is_floating_point():
         """
@@ -2308,7 +2308,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return Self(result_re^, result_im^)
 
-    fn __ipow__(mut self, p: Int) raises:
+    def __ipow__(mut self, p: Int) raises:
         """
         In-place raise to integer power.
 
@@ -2325,7 +2325,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self = self.__pow__(p)
 
     @always_inline("nodebug")
-    fn __eq__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __eq__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise equivalence.
         """
@@ -2334,7 +2334,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ) and comparison.equal[Self.dtype](self._im, other._im)
 
     @always_inline("nodebug")
-    fn __eq__(
+    def __eq__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2345,7 +2345,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ) and comparison.equal[Self.dtype](self._im, other.im)
 
     @always_inline("nodebug")
-    fn __ne__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __ne__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise non-equivalence.
         """
@@ -2354,7 +2354,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ) and comparison.not_equal[Self.dtype](self._im, other._im)
 
     @always_inline("nodebug")
-    fn __ne__(
+    def __ne__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2365,7 +2365,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ) and comparison.not_equal[Self.dtype](self._im, other.im)
 
     @always_inline("nodebug")
-    fn __lt__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __lt__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise less than comparison by magnitude.
 
@@ -2395,7 +2395,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __lt__(
+    def __lt__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2412,7 +2412,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __lt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __lt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
         """
         Itemwise less than comparison with real scalar by magnitude.
 
@@ -2427,7 +2427,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __le__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __le__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise less than or equal comparison by magnitude.
 
@@ -2452,7 +2452,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less_equal[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __le__(
+    def __le__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2469,7 +2469,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less_equal[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __le__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __le__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
         """
         Itemwise less than or equal comparison with real scalar by magnitude.
 
@@ -2484,7 +2484,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.less_equal[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __gt__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __gt__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise greater than comparison by magnitude.
 
@@ -2513,7 +2513,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.greater[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __gt__(
+    def __gt__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2530,7 +2530,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.greater[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __gt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __gt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
         """
         Itemwise greater than comparison with real scalar by magnitude.
 
@@ -2545,7 +2545,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.greater[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __ge__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __ge__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise greater than or equal comparison by magnitude.
 
@@ -2570,7 +2570,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.greater_equal[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __ge__(
+    def __ge__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
         """
@@ -2587,7 +2587,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         return comparison.greater_equal[Self.dtype](self_mag, other_mag)
 
     @always_inline("nodebug")
-    fn __ge__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __ge__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
         """
         Itemwise greater than or equal comparison with real scalar by magnitude.
 
@@ -2605,7 +2605,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     # ARITHMETIC OPERATIONS
     # ===------------------------------------------------------------------=== #
 
-    fn __add__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __add__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexNDArray + ComplexSIMD`.
         """
@@ -2613,7 +2613,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other.im)
         return Self(real^, imag^)
 
-    fn __add__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __add__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray + Scalar`.
         """
@@ -2621,7 +2621,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __add__(self, other: Self) raises -> Self:
+    def __add__(self, other: Self) raises -> Self:
         """
         Enables `ComplexNDArray + ComplexNDArray`.
         """
@@ -2634,7 +2634,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(real^, imag^)
 
-    fn __add__(self, other: NDArray[Self.dtype]) raises -> Self:
+    def __add__(self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray + NDArray`.
         """
@@ -2642,7 +2642,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __radd__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __radd__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexSIMD + ComplexNDArray`.
         """
@@ -2650,7 +2650,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other.im)
         return Self(real^, imag^)
 
-    fn __radd__(mut self, other: Scalar[Self.dtype]) raises -> Self:
+    def __radd__(mut self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `Scalar + ComplexNDArray`.
         """
@@ -2658,7 +2658,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __radd__(mut self, other: NDArray[Self.dtype]) raises -> Self:
+    def __radd__(mut self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `NDArray + ComplexNDArray`.
         """
@@ -2666,35 +2666,35 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.add[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __iadd__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
+    def __iadd__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
         """
         Enables `ComplexNDArray += ComplexSIMD`.
         """
         self._re += other.re
         self._im += other.im
 
-    fn __iadd__(mut self, other: Scalar[Self.dtype]) raises:
+    def __iadd__(mut self, other: Scalar[Self.dtype]) raises:
         """
         Enables `ComplexNDArray += Scalar`.
         """
         self._re += other
         self._im += other
 
-    fn __iadd__(mut self, other: Self) raises:
+    def __iadd__(mut self, other: Self) raises:
         """
         Enables `ComplexNDArray += ComplexNDArray`.
         """
         self._re += other._re
         self._im += other._im
 
-    fn __iadd__(mut self, other: NDArray[Self.dtype]) raises:
+    def __iadd__(mut self, other: NDArray[Self.dtype]) raises:
         """
         Enables `ComplexNDArray += NDArray`.
         """
         self._re += other
         self._im += other
 
-    fn __sub__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __sub__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexNDArray - ComplexSIMD`.
         """
@@ -2702,7 +2702,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.sub[Self.dtype](self._im, other.im)
         return Self(real^, imag^)
 
-    fn __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray - Scalar`.
         """
@@ -2714,7 +2714,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(real^, imag^)
 
-    fn __sub__(self, other: Self) raises -> Self:
+    def __sub__(self, other: Self) raises -> Self:
         """
         Enables `ComplexNDArray - ComplexNDArray`.
         """
@@ -2726,7 +2726,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(real^, imag^)
 
-    fn __sub__(self, other: NDArray[Self.dtype]) raises -> Self:
+    def __sub__(self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray - NDArray`.
         """
@@ -2734,7 +2734,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.sub[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __rsub__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __rsub__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexSIMD - ComplexNDArray`.
         """
@@ -2742,7 +2742,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.sub[Self.dtype](other.im, self._im)
         return Self(real^, imag^)
 
-    fn __rsub__(mut self, other: Scalar[Self.dtype]) raises -> Self:
+    def __rsub__(mut self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `Scalar - ComplexNDArray`.
         """
@@ -2750,7 +2750,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.sub[Self.dtype](other, self._im)
         return Self(real^, imag^)
 
-    fn __rsub__(mut self, other: NDArray[Self.dtype]) raises -> Self:
+    def __rsub__(mut self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `NDArray - ComplexNDArray`.
         """
@@ -2758,35 +2758,35 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.sub[Self.dtype](other, self._im)
         return Self(real^, imag^)
 
-    fn __isub__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
+    def __isub__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
         """
         Enables `ComplexNDArray -= ComplexSIMD`.
         """
         self._re -= other.re
         self._im -= other.im
 
-    fn __isub__(mut self, other: Scalar[Self.dtype]) raises:
+    def __isub__(mut self, other: Scalar[Self.dtype]) raises:
         """
         Enables `ComplexNDArray -= Scalar`.
         """
         self._re -= other
         self._im -= other
 
-    fn __isub__(mut self, other: Self) raises:
+    def __isub__(mut self, other: Self) raises:
         """
         Enables `ComplexNDArray -= ComplexNDArray`.
         """
         self._re -= other._re
         self._im -= other._im
 
-    fn __isub__(mut self, other: NDArray[Self.dtype]) raises:
+    def __isub__(mut self, other: NDArray[Self.dtype]) raises:
         """
         Enables `ComplexNDArray -= NDArray`.
         """
         self._re -= other
         self._im -= other
 
-    fn __matmul__(self, other: Self) raises -> Self:
+    def __matmul__(self, other: Self) raises -> Self:
         var re_re: NDArray[Self.dtype] = linalg.matmul[Self.dtype](
             self._re, other._re
         )
@@ -2801,7 +2801,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(re_re - im_im, re_im + im_re)
 
-    fn __mul__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __mul__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexNDArray * ComplexSIMD`.
         """
@@ -2819,7 +2819,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(re_re - im_im, re_im + im_re)
 
-    fn __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray * Scalar`.
         """
@@ -2827,7 +2827,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.mul[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __mul__(self, other: Self) raises -> Self:
+    def __mul__(self, other: Self) raises -> Self:
         """
         Enables `ComplexNDArray * ComplexNDArray`.
         """
@@ -2845,7 +2845,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         )
         return Self(re_re - im_im, re_im + im_re)
 
-    fn __mul__(self, other: NDArray[Self.dtype]) raises -> Self:
+    def __mul__(self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray * NDArray`.
         """
@@ -2853,7 +2853,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.mul[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __rmul__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __rmul__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexSIMD * ComplexNDArray`.
         """
@@ -2861,7 +2861,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.mul[Self.dtype](self._im, other.re)
         return Self(real^, imag^)
 
-    fn __rmul__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __rmul__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `Scalar * ComplexNDArray`.
         """
@@ -2869,7 +2869,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.mul[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __rmul__(self, other: NDArray[Self.dtype]) raises -> Self:
+    def __rmul__(self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `NDArray * ComplexNDArray`.
         """
@@ -2877,35 +2877,35 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.mul[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __imul__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
+    def __imul__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
         """
         Enables `ComplexNDArray *= ComplexSIMD`.
         """
         self._re *= other.re
         self._im *= other.im
 
-    fn __imul__(mut self, other: Scalar[Self.dtype]) raises:
+    def __imul__(mut self, other: Scalar[Self.dtype]) raises:
         """
         Enables `ComplexNDArray *= Scalar`.
         """
         self._re *= other
         self._im *= other
 
-    fn __imul__(mut self, other: Self) raises:
+    def __imul__(mut self, other: Self) raises:
         """
         Enables `ComplexNDArray *= ComplexNDArray`.
         """
         self._re *= other._re
         self._im *= other._im
 
-    fn __imul__(mut self, other: NDArray[Self.dtype]) raises:
+    def __imul__(mut self, other: NDArray[Self.dtype]) raises:
         """
         Enables `ComplexNDArray *= NDArray`.
         """
         self._re *= other
         self._im *= other
 
-    fn __truediv__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __truediv__(self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexNDArray / ComplexSIMD`.
         """
@@ -2913,7 +2913,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var result = self * other.conj() * (1.0 / other_square.re)
         return result^
 
-    fn __truediv__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __truediv__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray / ComplexSIMD`.
         """
@@ -2921,7 +2921,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.div[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __truediv__(self, other: ComplexNDArray[Self.cdtype]) raises -> Self:
+    def __truediv__(self, other: ComplexNDArray[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexNDArray / ComplexNDArray`.
         """
@@ -2931,7 +2931,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag = numer._im / denom._re
         return Self(real^, imag^)
 
-    fn __truediv__(self, other: NDArray[Self.dtype]) raises -> Self:
+    def __truediv__(self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `ComplexNDArray / NDArray`.
         """
@@ -2939,7 +2939,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag: NDArray[Self.dtype] = math.div[Self.dtype](self._im, other)
         return Self(real^, imag^)
 
-    fn __rtruediv__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
+    def __rtruediv__(mut self, other: ComplexSIMD[Self.cdtype]) raises -> Self:
         """
         Enables `ComplexSIMD / ComplexNDArray`.
         """
@@ -2949,7 +2949,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag = numer._im / denom.re
         return Self(real^, imag^)
 
-    fn __rtruediv__(mut self, other: Scalar[Self.dtype]) raises -> Self:
+    def __rtruediv__(mut self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `Scalar / ComplexNDArray`.
         """
@@ -2959,7 +2959,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag = numer._im / denom._re
         return Self(real^, imag^)
 
-    fn __rtruediv__(mut self, other: NDArray[Self.dtype]) raises -> Self:
+    def __rtruediv__(mut self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `NDArray / ComplexNDArray`.
         """
@@ -2969,28 +2969,28 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var imag = numer._im / denom._re
         return Self(real^, imag^)
 
-    fn __itruediv__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
+    def __itruediv__(mut self, other: ComplexSIMD[Self.cdtype]) raises:
         """
         Enables `ComplexNDArray /= ComplexSIMD`.
         """
         self._re /= other.re
         self._im /= other.im
 
-    fn __itruediv__(mut self, other: Scalar[Self.dtype]) raises:
+    def __itruediv__(mut self, other: Scalar[Self.dtype]) raises:
         """
         Enables `ComplexNDArray /= Scalar`.
         """
         self._re /= other
         self._im /= other
 
-    fn __itruediv__(mut self, other: Self) raises:
+    def __itruediv__(mut self, other: Self) raises:
         """
         Enables `ComplexNDArray /= ComplexNDArray`.
         """
         self._re /= other._re
         self._im /= other._im
 
-    fn __itruediv__(mut self, other: NDArray[Self.dtype]) raises:
+    def __itruediv__(mut self, other: NDArray[Self.dtype]) raises:
         """
         Enables `ComplexNDArray /= NDArray`.
         """
@@ -3000,7 +3000,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     # ===-------------------------------------------------------------------===#
     # Trait implementations
     # ===-------------------------------------------------------------------===#
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Enables String(array).
         """
@@ -3012,7 +3012,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return res
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Writes the array to a writer.
 
@@ -3055,7 +3055,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             except e:
                 writer.write("Cannot convert array to string.\n" + String(e))
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -3067,12 +3067,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         # TODO: Deprecate `__repr__` and move its body directly into this method.
         writer.write(self.__repr__())
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Compute the "official" string representation of ComplexNDArray.
         An example is:
         ```
-        fn main() raises:
+        def main() raises:
             var A = ComplexNDArray[f32](List[ComplexSIMD[f32]](14,97,-59,-4,112,), shape=List[Int](5,))
             print(repr(A))
         ```
@@ -3105,7 +3105,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             print("Cannot convert array to string", e)
             return ""
 
-    fn _array_to_string(
+    def _array_to_string(
         self,
         dimension: Int,
         offset: Int,
@@ -3216,10 +3216,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         result += "]"
         return result^
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         return Int(self._re.size)
 
-    fn store[
+    def store[
         width: Int = 1
     ](mut self, index: Int, val: ComplexSIMD[Self.cdtype]) raises:
         """
@@ -3247,7 +3247,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re._buf.ptr.store(index, val.re)
         self._im._buf.ptr.store(index, val.im)
 
-    fn store[
+    def store[
         width: Int = 1
     ](mut self, *indices: Int, val: ComplexSIMD[Self.cdtype]) raises:
         """
@@ -3291,7 +3291,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re._buf.ptr.store(idx, val.re)
         self._im._buf.ptr.store(idx, val.im)
 
-    fn reshape(self, shape: NDArrayShape, order: String = "C") raises -> Self:
+    def reshape(self, shape: NDArrayShape, order: String = "C") raises -> Self:
         """
         Returns an array of the same data with a new shape.
 
@@ -3310,7 +3310,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         result._im.flags = self._im.flags
         return result^
 
-    fn __iter__(
+    def __iter__(
         mut self,
     ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
         """
@@ -3325,7 +3325,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             dimension=0,
         )
 
-    fn __reversed__(
+    def __reversed__(
         mut self,
     ) raises -> _ComplexNDArrayIter[
         origin_of(self), Self.cdtype, forward=False
@@ -3343,7 +3343,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             dimension=0,
         )
 
-    fn itemset(
+    def itemset(
         mut self,
         index: Variant[Int, List[Int]],
         item: ComplexSIMD[Self.cdtype],
@@ -3433,13 +3433,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 IndexMethods.get_1d_index(indices, self.strides), item.im
             )
 
-    fn conj(self) raises -> Self:
+    def conj(self) raises -> Self:
         """
         Return the complex conjugate of the ComplexNDArray.
         """
         return Self(self._re.copy(), -self._im.copy())
 
-    fn to_ndarray(
+    def to_ndarray(
         self, type: String = "re"
     ) raises -> NDArray[dtype=Self.dtype]:
         if type == "re":
@@ -3467,7 +3467,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-    fn squeeze(mut self, axis: Int) raises:
+    def squeeze(mut self, axis: Int) raises:
         """
         Remove (squeeze) a single dimension of size 1 from the array shape.
 
@@ -3512,7 +3512,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     # Statistical and Reduction Methods
     # ===-------------------------------------------------------------------===#
 
-    fn all(self) raises -> Bool:
+    def all(self) raises -> Bool:
         """
         Check if all complex elements are non-zero.
 
@@ -3537,7 +3537,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 return False
         return True
 
-    fn any(self) raises -> Bool:
+    def any(self) raises -> Bool:
         """
         Check if any complex element is non-zero.
 
@@ -3562,7 +3562,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 return True
         return False
 
-    fn sum(self) raises -> ComplexSIMD[Self.cdtype]:
+    def sum(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Sum of all complex array elements.
 
@@ -3585,7 +3585,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return ComplexSIMD[Self.cdtype](sum_re, sum_im)
 
-    fn prod(self) raises -> ComplexSIMD[Self.cdtype]:
+    def prod(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Product of all complex array elements.
 
@@ -3612,7 +3612,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return ComplexSIMD[Self.cdtype](prod_re, prod_im)
 
-    fn mean(self) raises -> ComplexSIMD[Self.cdtype]:
+    def mean(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Mean (average) of all complex array elements.
 
@@ -3630,7 +3630,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var n = Scalar[Self.dtype](self.size)
         return ComplexSIMD[Self.cdtype](total.re / n, total.im / n)
 
-    fn max(self) raises -> ComplexSIMD[Self.cdtype]:
+    def max(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Find the complex element with maximum magnitude.
 
@@ -3667,7 +3667,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             self._re._buf.ptr.load(max_idx), self._im._buf.ptr.load(max_idx)
         )
 
-    fn min(self) raises -> ComplexSIMD[Self.cdtype]:
+    def min(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Find the complex element with minimum magnitude.
 
@@ -3704,7 +3704,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             self._re._buf.ptr.load(min_idx), self._im._buf.ptr.load(min_idx)
         )
 
-    fn argmax(self) raises -> Int:
+    def argmax(self) raises -> Int:
         """
         Return the index of the element with maximum magnitude.
 
@@ -3739,7 +3739,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return max_idx
 
-    fn argmin(self) raises -> Int:
+    def argmin(self) raises -> Int:
         """
         Return the index of the element with minimum magnitude.
 
@@ -3774,7 +3774,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return min_idx
 
-    fn cumsum(self) raises -> Self:
+    def cumsum(self) raises -> Self:
         """
         Cumulative sum of complex array elements.
 
@@ -3803,7 +3803,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return result^
 
-    fn cumprod(self) raises -> Self:
+    def cumprod(self) raises -> Self:
         """
         Cumulative product of complex array elements.
 
@@ -3840,7 +3840,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     # Array Manipulation Methods
     # ===-------------------------------------------------------------------===#
 
-    fn flatten(self, order: String = "C") raises -> Self:
+    def flatten(self, order: String = "C") raises -> Self:
         """
         Return a copy of the array collapsed into one dimension.
 
@@ -3861,7 +3861,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var flat_im = self._im.flatten(order)
         return Self(flat_re^, flat_im^)
 
-    fn fill(mut self, val: ComplexSIMD[Self.cdtype]):
+    def fill(mut self, val: ComplexSIMD[Self.cdtype]):
         """
         Fill all items of array with a complex value.
 
@@ -3878,7 +3878,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re.fill(val.re)
         self._im.fill(val.im)
 
-    fn row(self, id: Int) raises -> Self:
+    def row(self, id: Int) raises -> Self:
         """
         Get the ith row of the matrix.
 
@@ -3918,7 +3918,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             result._im._buf.ptr.store(i, self._im._buf.ptr.load(idx))
         return result^
 
-    fn col(self, id: Int) raises -> Self:
+    def col(self, id: Int) raises -> Self:
         """
         Get the ith column of the matrix.
 
@@ -3959,7 +3959,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             result._im._buf.ptr.store(i, self._im._buf.ptr.load(idx))
         return result^
 
-    fn clip(
+    def clip(
         self, a_min: Scalar[Self.dtype], a_max: Scalar[Self.dtype]
     ) raises -> Self:
         """
@@ -4012,7 +4012,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return result^
 
-    fn round(self) raises -> Self:
+    def round(self) raises -> Self:
         """
         Round the real and imaginary parts of each element to the nearest integer.
 
@@ -4031,7 +4031,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var rounded_im = rounding.tround[Self.dtype](self._im)
         return Self(rounded_re^, rounded_im^)
 
-    fn T(self) raises -> Self:
+    def T(self) raises -> Self:
         """
         Transpose the complex array (reverse all axes).
 
@@ -4049,7 +4049,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var transposed_im = self._im.T()
         return Self(transposed_re^, transposed_im^)
 
-    fn T(self, axes: List[Int]) raises -> Self:
+    def T(self, axes: List[Int]) raises -> Self:
         """
         Transpose the complex array according to the given axes permutation.
 
@@ -4070,7 +4070,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var transposed_im = self._im.T(axes)
         return Self(transposed_re^, transposed_im^)
 
-    fn diagonal(self, offset: Int = 0) raises -> Self:
+    def diagonal(self, offset: Int = 0) raises -> Self:
         """
         Extract the diagonal from a 2D complex array.
 
@@ -4107,7 +4107,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var diag_im = self[Self.dtype]._im.diagonal(offset)
         return Self(diag_re^, diag_im^)
 
-    fn trace(self) raises -> ComplexSIMD[Self.cdtype]:
+    def trace(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Return the sum of the diagonal elements (trace of the matrix).
 
@@ -4127,7 +4127,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var diag = self.diagonal()
         return diag.sum()
 
-    fn tolist(self) -> List[ComplexSIMD[Self.cdtype]]:
+    def tolist(self) -> List[ComplexSIMD[Self.cdtype]]:
         """
         Convert the complex array to a List of complex scalars.
 
@@ -4150,7 +4150,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
         return result^
 
-    fn num_elements(self) -> Int:
+    def num_elements(self) -> Int:
         """
         Return the total number of elements in the array.
 
@@ -4166,7 +4166,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         return self.size
 
-    fn resize(mut self, shape: NDArrayShape) raises:
+    def resize(mut self, shape: NDArrayShape) raises:
         """
         Change shape and size of array in-place.
 
@@ -4229,7 +4229,7 @@ struct _ComplexNDArrayIter[
     var ndim: Int
     var size_of_item: Int
 
-    fn __init__(
+    def __init__(
         out self, read a: ComplexNDArray[Self.cdtype], read dimension: Int
     ) raises:
         """
@@ -4265,10 +4265,10 @@ struct _ComplexNDArrayIter[
         # Status of the iterator
         self.index = 0 if Self.forward else a.shape[dimension] - 1
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self.copy()
 
-    fn __next__(mut self) raises -> ComplexNDArray[Self.cdtype]:
+    def __next__(mut self) raises -> ComplexNDArray[Self.cdtype]:
         var result = ComplexNDArray[Self.cdtype](self.shape.pop(self.dimension))
         var current_index = self.index
 
@@ -4301,19 +4301,19 @@ struct _ComplexNDArrayIter[
         return result^
 
     @always_inline
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:
             return self.index
 
-    fn ith(self, index: Int) raises -> ComplexNDArray[Self.cdtype]:
+    def ith(self, index: Int) raises -> ComplexNDArray[Self.cdtype]:
         """
         Gets the i-th array of the iterator.
 

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -67,12 +67,12 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     # --- Internal helper for broadcasting scalar to SIMD lanes ---
     @staticmethod
     @always_inline
-    fn _broadcast(val: Scalar[Self.dtype]) -> SIMD[Self.dtype, Self.width]:
+    def _broadcast(val: Scalar[Self.dtype]) -> SIMD[Self.dtype, Self.width]:
         return SIMD[Self.dtype, Self.width](val)
 
     # --- Constructors ---
     @always_inline
-    fn __init__(out self, other: Self):
+    def __init__(out self, other: Self):
         """
         Copy constructor for ComplexSIMD.
 
@@ -81,7 +81,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self = other
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         re: SIMD[Self.dtype, Self.width],
         im: SIMD[Self.dtype, Self.width],
@@ -97,7 +97,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = im
 
     @always_inline
-    fn __init__(out self, val: SIMD[Self.dtype, Self.width]):
+    def __init__(out self, val: SIMD[Self.dtype, Self.width]):
         """
         Constructs a ComplexSIMD where both real and imaginary parts are set to the same SIMD value.
 
@@ -108,7 +108,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = val
 
     @always_inline
-    fn __init__(out self, re: Int, im: Int):
+    def __init__(out self, re: Int, im: Int):
         """
         Constructs a ComplexSIMD from scalar integer real and imaginary values, broadcasted to SIMD lanes.
 
@@ -120,7 +120,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = Self._broadcast(Scalar[Self.dtype](im))
 
     @always_inline
-    fn __init__(out self, val: Int):
+    def __init__(out self, val: Int):
         """
         Constructs a ComplexSIMD where both real and imaginary parts are set to the same integer value broadcasted to SIMD lanes.
 
@@ -133,7 +133,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
 
     # Factory constructors.
     @staticmethod
-    fn zero() -> Self:
+    def zero() -> Self:
         """
         Returns a ComplexSIMD instance with all real and imaginary components set to zero.
 
@@ -146,7 +146,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(Self._broadcast(0), Self._broadcast(0))
 
     @staticmethod
-    fn one() -> Self:
+    def one() -> Self:
         """
         Returns a ComplexSIMD instance representing the complex number 1 + 0j.
 
@@ -159,7 +159,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(Self._broadcast(1), Self._broadcast(0))
 
     @staticmethod
-    fn i() -> Self:
+    def i() -> Self:
         """
         Returns a ComplexSIMD instance representing the imaginary unit 0 + 1j.
 
@@ -182,7 +182,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(Self._broadcast(0), Self._broadcast(1))
 
     @staticmethod
-    fn from_real_imag(re: Scalar[Self.dtype], im: Scalar[Self.dtype]) -> Self:
+    def from_real_imag(re: Scalar[Self.dtype], im: Scalar[Self.dtype]) -> Self:
         """
         Constructs a ComplexSIMD instance from scalar real and imaginary values.
 
@@ -199,7 +199,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(re, im)
 
     @staticmethod
-    fn from_polar(
+    def from_polar(
         r: Scalar[Self.dtype], theta: Scalar[Self.dtype]
     ) -> Self where Self.dtype.is_floating_point():
         """
@@ -224,7 +224,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         )
 
     # --- Arithmetic operators ---
-    fn __add__(self, other: Self) -> Self:
+    def __add__(self, other: Self) -> Self:
         """
         Returns the element-wise sum of two ComplexSIMD instances.
 
@@ -236,7 +236,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re + other.re, self.im + other.im)
 
-    fn __add__(self, other: Scalar[Self.dtype]) -> Self:
+    def __add__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the sum of this ComplexSIMD instance and a scalar added to the real part.
 
@@ -249,7 +249,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(self.re + Self._broadcast(other), self.im)
 
     # FIXME: currently mojo doesn't allow overloading with both SIMD[Self.dtype, Self.width] and SIMD[..., size=Self.width]. So keep SIMD[..., size=Self.width] only for now. We need this method to create complex numbers with syntax like (1 + 2 * `1j`).
-    fn __add__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __add__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the sum of this ComplexSIMD instance and a SIMD vector added to the real part.
 
@@ -261,7 +261,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re + other.cast[Self.dtype](), self.im)
 
-    fn __add__(self, other: ImaginaryUnit) -> Self:
+    def __add__(self, other: ImaginaryUnit) -> Self:
         """
         Returns the sum of this ComplexSIMD instance and the imaginary unit 1j.
 
@@ -283,7 +283,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re, self.im + Self._broadcast(1))
 
-    fn __iadd__(mut self, other: Self):
+    def __iadd__(mut self, other: Self):
         """
         In-place addition of another ComplexSIMD instance.
 
@@ -293,7 +293,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re += other.re
         self.im += other.im
 
-    fn __iadd__(mut self, other: Scalar[Self.dtype]):
+    def __iadd__(mut self, other: Scalar[Self.dtype]):
         """
         In-place addition of a scalar to the real part of this ComplexSIMD instance.
 
@@ -302,7 +302,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re += Self._broadcast(other)
 
-    fn __iadd__(mut self, other: SIMD[..., size=Self.width]):
+    def __iadd__(mut self, other: SIMD[..., size=Self.width]):
         """
         In-place addition of a SIMD vector to the real part of this ComplexSIMD instance.
 
@@ -311,7 +311,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re += other.cast[Self.dtype]()
 
-    fn __iadd__(mut self, other: ImaginaryUnit):
+    def __iadd__(mut self, other: ImaginaryUnit):
         """
         In-place addition of the imaginary unit 1j to this ComplexSIMD instance.
 
@@ -329,7 +329,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.im += Self._broadcast(1)
 
-    fn __radd__(self, other: Scalar[Self.dtype]) -> Self:
+    def __radd__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the sum of a scalar and this ComplexSIMD instance, adding to the real part.
 
@@ -341,7 +341,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(Self._broadcast(other) + self.re, self.im)
 
-    fn __radd__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __radd__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the sum of a SIMD vector and this ComplexSIMD instance, adding to the real part.
 
@@ -353,7 +353,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(other.cast[Self.dtype]() + self.re, self.im)
 
-    fn __radd__(self, other: ImaginaryUnit) -> Self:
+    def __radd__(self, other: ImaginaryUnit) -> Self:
         """
         Returns the sum of the imaginary unit 1j and this ComplexSIMD instance.
 
@@ -375,7 +375,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re, self.im + Self._broadcast(1))
 
-    fn __sub__(self, other: Self) -> Self:
+    def __sub__(self, other: Self) -> Self:
         """
         Returns the element-wise difference of two ComplexSIMD instances.
 
@@ -387,7 +387,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re - other.re, self.im - other.im)
 
-    fn __sub__(self, other: Scalar[Self.dtype]) -> Self:
+    def __sub__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the difference of this ComplexSIMD instance and a scalar subtracted from the real part.
 
@@ -399,7 +399,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re - Self._broadcast(other), self.im)
 
-    fn __sub__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __sub__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the difference of this ComplexSIMD instance and a SIMD vector subtracted from the real part.
 
@@ -411,7 +411,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re - other.cast[Self.dtype](), self.im)
 
-    fn __sub__(self, other: ImaginaryUnit) -> Self:
+    def __sub__(self, other: ImaginaryUnit) -> Self:
         """
         Subtracts the imaginary unit 1j from this ComplexSIMD instance.
 
@@ -433,7 +433,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re, self.im - Self._broadcast(1))
 
-    fn __isub__(mut self, other: Self):
+    def __isub__(mut self, other: Self):
         """
         In-place subtraction of another ComplexSIMD instance.
 
@@ -443,7 +443,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re -= other.re
         self.im -= other.im
 
-    fn __isub__(mut self, other: Scalar[Self.dtype]):
+    def __isub__(mut self, other: Scalar[Self.dtype]):
         """
         In-place subtraction of a scalar from the real part of this ComplexSIMD instance.
 
@@ -452,7 +452,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re -= Self._broadcast(other)
 
-    fn __isub__(mut self, other: SIMD[..., size=Self.width]):
+    def __isub__(mut self, other: SIMD[..., size=Self.width]):
         """
         In-place subtraction of a SIMD vector from the real part of this ComplexSIMD instance.
 
@@ -461,7 +461,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re -= other.cast[Self.dtype]()
 
-    fn __isub__(mut self, other: ImaginaryUnit):
+    def __isub__(mut self, other: ImaginaryUnit):
         """
         In-place subtraction of the imaginary unit 1j from this ComplexSIMD instance.
 
@@ -479,7 +479,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.im -= Self._broadcast(1)
 
-    fn __rsub__(self, other: Scalar[Self.dtype]) -> Self:
+    def __rsub__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the difference of a scalar and this ComplexSIMD instance, subtracting from the real part.
 
@@ -491,7 +491,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(Self._broadcast(other) - self.re, -self.im)
 
-    fn __rsub__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rsub__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the difference of a SIMD vector and this ComplexSIMD instance, subtracting from the real part.
 
@@ -504,7 +504,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var other_casted = other.cast[Self.dtype]()
         return Self(other_casted - self.re, -self.im)
 
-    fn __rsub__(self, other: ImaginaryUnit) -> Self:
+    def __rsub__(self, other: ImaginaryUnit) -> Self:
         """
         Returns the difference of the imaginary unit 1j and this ComplexSIMD instance.
 
@@ -526,7 +526,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(-self.re, Self._broadcast(1) - self.im)
 
-    fn __mul__(self, other: Self) -> Self:
+    def __mul__(self, other: Self) -> Self:
         """
         Returns the element-wise product of two ComplexSIMD instances.
 
@@ -541,7 +541,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             self.re * other.im + self.im * other.re,
         )
 
-    fn __mul__(self, other: Scalar[Self.dtype]) -> Self:
+    def __mul__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the product of this ComplexSIMD instance and a scalar.
 
@@ -554,7 +554,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(self.re * scalar_simd, self.im * scalar_simd)
 
-    fn __mul__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __mul__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the product of this ComplexSIMD instance and a SIMD vector.
 
@@ -567,7 +567,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var other_casted = other.cast[Self.dtype]()
         return Self(self.re * other_casted, self.im * other_casted)
 
-    fn __mul__(self, other: ImaginaryUnit) -> Self:
+    def __mul__(self, other: ImaginaryUnit) -> Self:
         """
         Returns the product of this ComplexSIMD instance and the imaginary unit 1j.
 
@@ -589,7 +589,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(-self.im, self.re)
 
-    fn __imul__(mut self, other: Self):
+    def __imul__(mut self, other: Self):
         """
         In-place complex multiplication with another ComplexSIMD instance.
 
@@ -600,7 +600,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = self.re * other.im + self.im * other.re
         self.re = new_re
 
-    fn __imul__(mut self, other: Scalar[Self.dtype]):
+    def __imul__(mut self, other: Scalar[Self.dtype]):
         """
         In-place multiplication of this ComplexSIMD instance by a scalar.
 
@@ -611,7 +611,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re *= scalar_simd
         self.im *= scalar_simd
 
-    fn __imul__(mut self, other: SIMD[..., size=Self.width]):
+    def __imul__(mut self, other: SIMD[..., size=Self.width]):
         """
         In-place multiplication of this ComplexSIMD instance by a SIMD vector.
 
@@ -622,7 +622,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re *= other_casted
         self.im *= other_casted
 
-    fn __imul__(mut self, other: ImaginaryUnit):
+    def __imul__(mut self, other: ImaginaryUnit):
         """
         In-place multiplication of this ComplexSIMD instance by the imaginary unit 1j.
 
@@ -642,7 +642,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = self.re
         self.re = new_re
 
-    fn __rmul__(self, other: Scalar[Self.dtype]) -> Self:
+    def __rmul__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Returns the product of a scalar and this ComplexSIMD instance.
 
@@ -655,7 +655,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(scalar_simd * self.re, scalar_simd * self.im)
 
-    fn __rmul__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rmul__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Returns the product of a SIMD vector and this ComplexSIMD instance.
 
@@ -668,7 +668,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var other_casted = other.cast[Self.dtype]()
         return Self(other_casted * self.re, other_casted * self.im)
 
-    fn __rmul__(self, other: ImaginaryUnit) -> Self:
+    def __rmul__(self, other: ImaginaryUnit) -> Self:
         """
         Returns the product of the imaginary unit 1j and this ComplexSIMD instance.
 
@@ -690,7 +690,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(-self.im, self.re)
 
-    fn __truediv__(self, other: Self) -> Self:
+    def __truediv__(self, other: Self) -> Self:
         """
         Performs element-wise complex division of two ComplexSIMD instances.
 
@@ -708,7 +708,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             (self.im * other.re - self.re * other.im) / denom,
         )
 
-    fn __truediv__(self, other: Scalar[Self.dtype]) -> Self:
+    def __truediv__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Performs element-wise division of this ComplexSIMD instance by a scalar.
 
@@ -721,7 +721,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(self.re / scalar_simd, self.im / scalar_simd)
 
-    fn __truediv__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __truediv__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Performs element-wise division of this ComplexSIMD instance by a SIMD vector.
 
@@ -734,7 +734,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var other_casted = other.cast[Self.dtype]()
         return Self(self.re / other_casted, self.im / other_casted)
 
-    fn __truediv__(self, other: ImaginaryUnit) -> Self:
+    def __truediv__(self, other: ImaginaryUnit) -> Self:
         """
         Performs division of this ComplexSIMD instance by the imaginary unit 1j.
 
@@ -756,7 +756,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.im, -self.re)
 
-    fn __itruediv__(mut self, other: Self):
+    def __itruediv__(mut self, other: Self):
         """
         Performs in-place element-wise complex division of self by another ComplexSIMD instance.
 
@@ -768,7 +768,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = (self.im * other.re - self.re * other.im) / denom
         self.re = new_re
 
-    fn __itruediv__(mut self, other: Scalar[Self.dtype]):
+    def __itruediv__(mut self, other: Scalar[Self.dtype]):
         """
         Performs in-place element-wise division of this ComplexSIMD instance by a scalar.
 
@@ -779,7 +779,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re /= scalar_simd
         self.im /= scalar_simd
 
-    fn __itruediv__(mut self, other: SIMD[..., size=Self.width]):
+    def __itruediv__(mut self, other: SIMD[..., size=Self.width]):
         """
         Performs in-place element-wise division of this ComplexSIMD instance by a SIMD vector.
 
@@ -790,7 +790,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re /= other_casted
         self.im /= other_casted
 
-    fn __itruediv__(mut self, other: ImaginaryUnit):
+    def __itruediv__(mut self, other: ImaginaryUnit):
         """
         Performs in-place division of this ComplexSIMD instance by the imaginary unit 1j.
 
@@ -810,7 +810,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.im = -self.re
         self.re = new_re
 
-    fn __rtruediv__(self, other: Scalar[Self.dtype]) -> Self:
+    def __rtruediv__(self, other: Scalar[Self.dtype]) -> Self:
         """
         Performs element-wise division of a scalar by this ComplexSIMD instance.
 
@@ -829,7 +829,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             (-scalar_simd * self.im) / denom,
         )
 
-    fn __rtruediv__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rtruediv__(self, other: SIMD[..., size=Self.width]) -> Self:
         """
         Performs element-wise division of a SIMD vector by this ComplexSIMD instance.
 
@@ -848,7 +848,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             (-other_casted * self.im) / denom,
         )
 
-    fn __rtruediv__(self, other: ImaginaryUnit) -> Self:
+    def __rtruediv__(self, other: ImaginaryUnit) -> Self:
         """
         Performs division of the imaginary unit 1j by this ComplexSIMD instance.
 
@@ -874,7 +874,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             -self.re / denom,
         )
 
-    fn reciprocal(self) raises -> Self:
+    def reciprocal(self) raises -> Self:
         """
         Returns the element-wise reciprocal (1 / self) of the ComplexSIMD instance.
 
@@ -890,7 +890,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(self.re / d, -self.im / d)
 
     # --- Power helpers ---
-    fn elem_pow(self, other: Self) -> Self:
+    def elem_pow(self, other: Self) -> Self:
         """
         Raises each component of this ComplexSIMD to the power of the corresponding component in another ComplexSIMD.
 
@@ -902,7 +902,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re**other.re, self.im**other.im)
 
-    fn elem_pow(self, exponent: Scalar[Self.dtype]) -> Self:
+    def elem_pow(self, exponent: Scalar[Self.dtype]) -> Self:
         """
         Raises each component of this ComplexSIMD to a scalar exponent.
 
@@ -914,7 +914,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re**exponent, self.im**exponent)
 
-    fn __pow__(self, n: Int) -> Self:
+    def __pow__(self, n: Int) -> Self:
         """
         Raises this ComplexSIMD to an integer.
 
@@ -943,7 +943,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return result
 
     # --- Unary operators ---
-    fn __pos__(self) -> Self:
+    def __pos__(self) -> Self:
         """
         Returns the positive value of this ComplexSIMD (identity operation).
 
@@ -952,7 +952,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return self
 
-    fn __neg__(self) -> Self:
+    def __neg__(self) -> Self:
         """
         Returns the negation of this ComplexSIMD.
 
@@ -961,7 +961,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(-self.re, -self.im)
 
-    fn __invert__(
+    def __invert__(
         self,
     ) -> Self where (
         Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
@@ -975,7 +975,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return Self(~self.re, ~self.im)
 
     # --- Comparison operators ---
-    fn __and__(
+    def __and__(
         self, other: Self
     ) -> Self where (
         Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
@@ -991,7 +991,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re & other.re, self.im & other.im)
 
-    fn __or__(
+    def __or__(
         self, other: Self
     ) -> Self where (
         Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
@@ -1007,7 +1007,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re | other.re, self.im | other.im)
 
-    fn __xor__(
+    def __xor__(
         self, other: Self
     ) -> Self where (
         Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
@@ -1026,13 +1026,13 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     # --- Helpers ---
     @staticmethod
     @always_inline
-    fn _abs_simd(
+    def _abs_simd(
         x: SIMD[Self.dtype, Self.width]
     ) -> SIMD[Self.dtype, Self.width]:
         return sqrt(x * x)
 
     # --- Equality ---
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks if two ComplexSIMD instances are exactly equal.
 
@@ -1041,7 +1041,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return (self.re == other.re) and (self.im == other.im)
 
-    fn __eq__(self, other: ImaginaryUnit) -> Bool:
+    def __eq__(self, other: ImaginaryUnit) -> Bool:
         """
         Checks if this ComplexSIMD instance is equal to the imaginary unit 1j.
 
@@ -1065,7 +1065,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             self.im == Self._broadcast(1)
         )
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks if two ComplexSIMD instances are not equal.
 
@@ -1074,7 +1074,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return ~(self == other)
 
-    fn __ne__(self, other: ImaginaryUnit) -> Bool:
+    def __ne__(self, other: ImaginaryUnit) -> Bool:
         """
         Checks if this ComplexSIMD instance is not equal to the imaginary unit 1j.
 
@@ -1096,7 +1096,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return ~(self == other)
 
-    fn allclose(
+    def allclose(
         self,
         other: Self,
         *,
@@ -1133,10 +1133,10 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return ok_re and ok_im
 
     # --- Representations ---
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         return String.write(self)
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Returns a string representation of the ComplexSIMD instance.
 
@@ -1157,7 +1157,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         except e:
             writer.write("<<ComplexSIMD formatting error>>")
 
-    fn __repr__(self) raises -> String:
+    def __repr__(self) raises -> String:
         """
         Returns a string representation of the ComplexSIMD instance for debugging. `ComplexSIMD[dtype](re=<real SIMD>, im=<imag SIMD>)`.
         """
@@ -1166,7 +1166,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         )
 
     # --- Indexing ---
-    fn __getitem__(self, idx: Int) raises -> ComplexScalar[Self.cdtype]:
+    def __getitem__(self, idx: Int) raises -> ComplexScalar[Self.cdtype]:
         """
         Returns the complex number at the specified lane index.
 
@@ -1191,7 +1191,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             raise Error("Lane index out of range for SIMD width")
         return ComplexScalar[Self.cdtype](self.re[idx], self.im[idx])
 
-    fn __setitem__(
+    def __setitem__(
         mut self, idx: Int, value: ComplexScalar[Self.cdtype]
     ) raises:
         """
@@ -1217,7 +1217,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re[idx] = value.re
         self.im[idx] = value.im
 
-    fn item[name: String](self, idx: Int) raises -> Scalar[Self.dtype]:
+    def item[name: String](self, idx: Int) raises -> Scalar[Self.dtype]:
         """
         Returns the scalar value for the specified lane index and component.
 
@@ -1252,7 +1252,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         else:
             raise Error("Invalid component name: {}".format(name))
 
-    fn itemset[
+    def itemset[
         name: String
     ](mut self, idx: Int, val: Scalar[Self.dtype]) raises:
         """
@@ -1287,7 +1287,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         else:
             raise Error("Invalid component name: {}".format(name))
 
-    fn real(self) -> SIMD[Self.dtype, Self.width]:
+    def real(self) -> SIMD[Self.dtype, Self.width]:
         """
         Returns the real part(s) of the complex number(s).
 
@@ -1296,7 +1296,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return self.re
 
-    fn imag(self) -> SIMD[Self.dtype, Self.width]:
+    def imag(self) -> SIMD[Self.dtype, Self.width]:
         """
         Returns the imaginary part(s) of the complex number(s).
 
@@ -1306,7 +1306,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         return self.im
 
     # --- Magnitude / norm / conjugate ---
-    fn __abs__(self) -> SIMD[Self.dtype, Self.width]:
+    def __abs__(self) -> SIMD[Self.dtype, Self.width]:
         """
         Returns the magnitude (absolute value) of the complex number(s).
 
@@ -1315,7 +1315,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return sqrt(self.re * self.re + self.im * self.im)
 
-    fn norm(self) -> SIMD[Self.dtype, Self.width]:
+    def norm(self) -> SIMD[Self.dtype, Self.width]:
         """
         Returns the squared magnitude (norm) of the complex number(s).
 
@@ -1324,7 +1324,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return self.re * self.re + self.im * self.im
 
-    fn conj(self) -> Self:
+    def conj(self) -> Self:
         """
         Returns the complex conjugate of the ComplexSIMD instance.
 
@@ -1369,7 +1369,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         ```
     """
 
-    fn __init__(out self):
+    def __init__(out self):
         """
         Constructor for ImaginaryUnit.
 
@@ -1377,7 +1377,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         pass
 
-    fn conj(self) -> ComplexSIMD[cf64, 1]:
+    def conj(self) -> ComplexSIMD[cf64, 1]:
         """
         Returns the complex conjugate of the imaginary unit.
 
@@ -1396,7 +1396,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
 
     # --- Arithmetic operators with SIMD and Scalar types ---
     # Addition: 1j + SIMD -> ComplexSIMD
-    fn __add__[
+    def __add__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1423,7 +1423,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Addition: 1j + Scalar -> ComplexScalar
-    fn __add__[
+    def __add__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1448,7 +1448,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
             other, 1
         )
 
-    fn __add__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __add__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         """
         Returns the sum of the imaginary unit 1j and an integer.
 
@@ -1468,7 +1468,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         return ComplexSIMD[ComplexDType.int, 1](Scalar[DType.int](other), 1)
 
     # SIMD + 1j -> ComplexSIMD
-    fn __radd__[
+    def __radd__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1479,7 +1479,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Addition: Scalar + 1j -> ComplexScalar
-    fn __radd__[
+    def __radd__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1490,12 +1490,12 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Addition: Int + 1j -> ComplexScalar
-    fn __radd__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __radd__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         """Returns the sum of an integer and the imaginary unit."""
         return ComplexSIMD[ComplexDType.int, 1](Scalar[DType.int](other), 1)
 
     # Subtraction: 1j - SIMD -> ComplexSIMD
-    fn __sub__[
+    def __sub__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1506,7 +1506,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Subtraction: 1j - Scalar -> ComplexScalar
-    fn __sub__[
+    def __sub__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1516,12 +1516,12 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
             -other, 1
         )
 
-    fn __sub__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __sub__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         """Returns the difference of the imaginary unit and an integer."""
         return ComplexSIMD[ComplexDType.int, 1](Scalar[DType.int](-other), 1)
 
     # Subtraction: SIMD - 1j -> ComplexSIMD
-    fn __rsub__[
+    def __rsub__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1532,7 +1532,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Subtraction: Scalar - 1j -> ComplexScalar
-    fn __rsub__[
+    def __rsub__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1543,12 +1543,12 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Subtraction: Int - 1j -> ComplexScalar
-    fn __rsub__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __rsub__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         """Returns the difference of an integer and the imaginary unit."""
         return ComplexSIMD[ComplexDType.int, 1](Scalar[DType.int](other), -1)
 
     # Multiplication: 1j * SIMD -> ComplexSIMD
-    fn __mul__[
+    def __mul__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1558,7 +1558,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Multiplication: 1j * Scalar -> ComplexScalar
-    fn __mul__[
+    def __mul__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1568,10 +1568,10 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Multiplication: 1j * Int -> ComplexScalar
-    fn __mul__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __mul__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         return ComplexSIMD[ComplexDType.int, 1](0, Scalar[DType.int](other))
 
-    fn __rmul__[
+    def __rmul__[
         dtype: DType,
         width: Int,
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
@@ -1581,7 +1581,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
             SIMD[dtype, width](0), other
         )
 
-    fn __rmul__[
+    def __rmul__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1591,11 +1591,11 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Multiplication: Scalar * 1j -> ComplexScalar
-    fn __rmul__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __rmul__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         return ComplexSIMD[ComplexDType.int, 1](0, Scalar[DType.int](other))
 
     # Division: 1j / SIMD -> ComplexSIMD
-    fn __truediv__[
+    def __truediv__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1606,7 +1606,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Division: 1j / Scalar -> ComplexScalar
-    fn __truediv__[
+    def __truediv__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1617,7 +1617,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Division: SIMD / 1j -> ComplexSIMD
-    fn __rtruediv__[
+    def __rtruediv__[
         dtype: DType, width: Int
     ](self, other: SIMD[dtype, width]) -> ComplexSIMD[
         ComplexDType(mlir_value=dtype._mlir_value), width
@@ -1636,7 +1636,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Division: Scalar / 1j -> ComplexScalar
-    fn __rtruediv__[
+    def __rtruediv__[
         dtype: DType
     ](self, other: Scalar[dtype]) -> ComplexScalar[
         ComplexDType(mlir_value=dtype._mlir_value)
@@ -1655,7 +1655,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         )
 
     # Division: Int / 1j -> ComplexScalar
-    fn __rtruediv__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
+    def __rtruediv__(self, other: Int) -> ComplexScalar[ComplexDType.int]:
         """
         Returns the division of an integer by the imaginary unit.
 
@@ -1668,7 +1668,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         return ComplexSIMD[ComplexDType.int, 1](0, Scalar[DType.int](-other))
 
     # Self-operations: 1j with 1j
-    fn __mul__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
+    def __mul__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
         """
         Returns the product of the imaginary unit with itself: 1j * 1j = -1.
 
@@ -1688,7 +1688,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return -1
 
-    fn __add__(self, other: ImaginaryUnit) -> ComplexScalar[cf64]:
+    def __add__(self, other: ImaginaryUnit) -> ComplexScalar[cf64]:
         """
         Returns the sum of the imaginary unit with itself: 1j + 1j = 2j.
 
@@ -1708,7 +1708,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return ComplexSIMD[cf64, 1](0, 2)
 
-    fn __sub__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
+    def __sub__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
         """
         Returns the difference of the imaginary unit with itself: 1j - 1j = 0.
 
@@ -1728,7 +1728,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return 0
 
-    fn __truediv__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
+    def __truediv__(self, other: ImaginaryUnit) -> Scalar[DType.float64]:
         """
         Returns the division of the imaginary unit by itself: 1j / 1j = 1.
 
@@ -1748,7 +1748,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return 1
 
-    fn __pow__(self, exponent: Int) -> ComplexScalar[cf64]:
+    def __pow__(self, exponent: Int) -> ComplexScalar[cf64]:
         """
         Returns the imaginary unit raised to an integer power.
 
@@ -1786,7 +1786,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         else:
             return ComplexSIMD[cf64, 1](0, -1)
 
-    fn __neg__(self) -> ComplexScalar[cf64]:
+    def __neg__(self) -> ComplexScalar[cf64]:
         """
         Returns the negation of the imaginary unit: -1j.
 
@@ -1803,7 +1803,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return ComplexSIMD[cf64, 1](0, -1)
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns the string representation of the imaginary unit.
 
@@ -1812,7 +1812,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         return "(0 + 1 j)"
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Writes the string representation of the imaginary unit to a writer.
 
@@ -1821,7 +1821,7 @@ struct ImaginaryUnit(Boolable, TrivialRegisterPassable, Writable):
         """
         writer.write("(0 + 1 j)")
 
-    fn __bool__(self) -> Bool:
+    def __bool__(self) -> Bool:
         """
         Returns the boolean value of the imaginary unit.
 

--- a/numojo/core/dtype/complex_dtype.mojo
+++ b/numojo/core/dtype/complex_dtype.mojo
@@ -192,7 +192,7 @@ struct ComplexDType(
     # ===-------------------------------------------------------------------===#
 
     @always_inline("builtin")
-    fn __init__(out self, *, mlir_value: Self._mlir_type):
+    def __init__(out self, *, mlir_value: Self._mlir_type):
         """Construct a ComplexDType from MLIR ComplexDType.
 
         Args:
@@ -201,7 +201,7 @@ struct ComplexDType(
         self.dtype = DType(mlir_value=mlir_value)
 
     @staticmethod
-    fn _from_str(str: StringSlice) -> ComplexDType:
+    def _from_str(str: StringSlice) -> ComplexDType:
         """Construct a ComplexDType from a string.
 
         Args:
@@ -261,7 +261,7 @@ struct ComplexDType(
             return ComplexDType.invalid
 
     @no_inline
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Gets the name of the ComplexDType.
 
         Returns:
@@ -271,7 +271,7 @@ struct ComplexDType(
         return String.write(self)
 
     @no_inline
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Formats this ComplexDType to the provided Writer.
 
@@ -329,7 +329,7 @@ struct ComplexDType(
         return writer.write("<<unknown>>")
 
     @always_inline("nodebug")
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """Gets the representation of the ComplexDType e.g. `"ComplexDType.float32"`.
 
         Returns:
@@ -337,7 +337,7 @@ struct ComplexDType(
         """
         return String.write("ComplexDType.", self)
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -350,7 +350,7 @@ struct ComplexDType(
         writer.write(self.__repr__())
 
     @always_inline("nodebug")
-    fn get_value(self) -> __mlir_type.`!kgen.dtype`:
+    def get_value(self) -> __mlir_type.`!kgen.dtype`:
         """Gets the associated internal kgen.ComplexDType value.
 
         Returns:
@@ -361,7 +361,7 @@ struct ComplexDType(
     @doc_private
     @staticmethod
     @always_inline("nodebug")
-    fn _from_ui8(ui8: UInt8._mlir_type) -> ComplexDType:
+    def _from_ui8(ui8: UInt8._mlir_type) -> ComplexDType:
         var res = __mlir_op.`pop.dtype.from_ui8`(
             __mlir_op.`pop.cast_to_builtin`[_type=__mlir_type.ui8](ui8)
         )
@@ -369,14 +369,14 @@ struct ComplexDType(
 
     @doc_private
     @always_inline("nodebug")
-    fn _as_ui8(self) -> UInt8._mlir_type:
+    def _as_ui8(self) -> UInt8._mlir_type:
         return __mlir_op.`pop.cast_from_builtin`[_type=UInt8._mlir_type](
             __mlir_op.`pop.dtype.to_ui8`(self.dtype.get_value())
         )
 
     @doc_private
     @always_inline("nodebug")
-    fn _match(self, mask: UInt8) -> Bool:
+    def _match(self, mask: UInt8) -> Bool:
         var res = __mlir_op.`pop.cmp`[pred=__mlir_attr.`#pop<cmp_pred ne>`](
             __mlir_op.`pop.simd.and`(self._as_ui8(), mask._mlir_value),
             __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
@@ -384,7 +384,7 @@ struct ComplexDType(
         return Bool(mlir_value=res)
 
     @always_inline("nodebug")
-    fn __is__(self, rhs: ComplexDType) -> Bool:
+    def __is__(self, rhs: ComplexDType) -> Bool:
         """Compares one ComplexDType to another for equality.
 
         Args:
@@ -396,7 +396,7 @@ struct ComplexDType(
         return self == rhs
 
     @always_inline("nodebug")
-    fn __isnot__(self, rhs: ComplexDType) -> Bool:
+    def __isnot__(self, rhs: ComplexDType) -> Bool:
         """Compares one ComplexDType to another for equality.
 
         Args:
@@ -408,7 +408,7 @@ struct ComplexDType(
         return ~(self == rhs)
 
     @always_inline("nodebug")
-    fn __eq__(self, rhs: ComplexDType) -> Bool:
+    def __eq__(self, rhs: ComplexDType) -> Bool:
         """Compares one ComplexDType to another for equality.
 
         Args:
@@ -423,7 +423,7 @@ struct ComplexDType(
         return Bool(mlir_value=res)
 
     @always_inline("nodebug")
-    fn __ne__(self, rhs: ComplexDType) -> Bool:
+    def __ne__(self, rhs: ComplexDType) -> Bool:
         """Compares one ComplexDType to another for inequality.
 
         Args:
@@ -437,7 +437,7 @@ struct ComplexDType(
         )
         return Bool(mlir_value=res)
 
-    fn __hash__[H: Hasher](self, mut hasher: H):
+    def __hash__[H: Hasher](self, mut hasher: H):
         """Updates hasher with this `ComplexDType` value.
 
         Parameters:
@@ -449,7 +449,7 @@ struct ComplexDType(
         hasher._update_with_simd(UInt8(mlir_value=self._as_ui8()))
 
     @always_inline("nodebug")
-    fn is_unsigned(self) -> Bool:
+    def is_unsigned(self) -> Bool:
         """Returns True if the type parameter is unsigned and False otherwise.
 
         Returns:
@@ -458,7 +458,7 @@ struct ComplexDType(
         return self._is_non_index_integral() and not self._match(_mIsSigned)
 
     @always_inline("nodebug")
-    fn is_signed(self) -> Bool:
+    def is_signed(self) -> Bool:
         """Returns True if the type parameter is signed and False otherwise.
 
         Returns:
@@ -469,7 +469,7 @@ struct ComplexDType(
         return self.is_integral() and self._match(_mIsSigned)
 
     @always_inline("nodebug")
-    fn _is_non_index_integral(self) -> Bool:
+    def _is_non_index_integral(self) -> Bool:
         """Returns True if the type parameter is a non-index integer value and False otherwise.
 
         Returns:
@@ -478,7 +478,7 @@ struct ComplexDType(
         return self._match(_mIsInteger)
 
     @always_inline("nodebug")
-    fn is_integral(self) -> Bool:
+    def is_integral(self) -> Bool:
         """Returns True if the type parameter is an integer and False otherwise.
 
         Returns:
@@ -490,7 +490,7 @@ struct ComplexDType(
         )
 
     @always_inline("nodebug")
-    fn is_floating_point(self) -> Bool:
+    def is_floating_point(self) -> Bool:
         """Returns True if the type parameter is a floating-point and False
         otherwise.
 
@@ -500,7 +500,7 @@ struct ComplexDType(
         return self._match(_mIsFloat)
 
     @always_inline("nodebug")
-    fn is_float8(self) -> Bool:
+    def is_float8(self) -> Bool:
         """Returns True if the ComplexDType is a 8bit-precision floating point type,
         e.g. float8_e5m2, float8_e5m2fnuz, float8_e4m3fn and float8_e4m3fnuz.
 
@@ -517,7 +517,7 @@ struct ComplexDType(
         )
 
     @always_inline("nodebug")
-    fn is_half_float(self) -> Bool:
+    def is_half_float(self) -> Bool:
         """Returns True if the ComplexDType is a half-precision floating point type,
         e.g. either fp16 or bf16.
 
@@ -528,7 +528,7 @@ struct ComplexDType(
         return self in (ComplexDType.bfloat16, ComplexDType.float16)
 
     @always_inline("nodebug")
-    fn is_numeric(self) -> Bool:
+    def is_numeric(self) -> Bool:
         """Returns True if the type parameter is numeric (i.e. you can perform
         arithmetic operations on).
 
@@ -539,7 +539,7 @@ struct ComplexDType(
         return self.is_integral() or self.is_floating_point()
 
     @always_inline
-    fn size_of(self) -> Int:
+    def size_of(self) -> Int:
         """Returns the size in bytes of the current DType.
 
         Returns:
@@ -597,7 +597,7 @@ struct ComplexDType(
         return size_of[DType.invalid]()
 
     @always_inline
-    fn bitwidth(self) -> Int:
+    def bitwidth(self) -> Int:
         """Returns the size in bits of the current ComplexDType.
 
         Returns:
@@ -607,7 +607,7 @@ struct ComplexDType(
             2 * 8 * self.size_of()
         )  # 2 * because complex number has real and imaginary parts
 
-    fn component_bitwidth(self) -> Int:
+    def component_bitwidth(self) -> Int:
         """Returns the size in bits of the component type of the current ComplexDType.
 
         Returns:
@@ -619,7 +619,7 @@ struct ComplexDType(
     # __mlir_type
     # ===-------------------------------------------------------------------===#
     @always_inline("nodebug")
-    fn __mlir_type(self) -> __mlir_type.`!kgen.deferred`:
+    def __mlir_type(self) -> __mlir_type.`!kgen.deferred`:
         """Returns the MLIR type of the current DType as an MLIR type.
 
         Returns:
@@ -680,11 +680,11 @@ struct ComplexDType(
 
         abort("invalid dtype")
 
-    fn component_dtype(self) -> DType:
+    def component_dtype(self) -> DType:
         return self.dtype
 
 
-fn _concise_dtype_str(cdtype: ComplexDType) -> String:
+def _concise_dtype_str(cdtype: ComplexDType) -> String:
     """Returns a concise string representation of the complex data type."""
     if cdtype == ci8:
         return "ci8"

--- a/numojo/core/dtype/default_dtype.mojo
+++ b/numojo/core/dtype/default_dtype.mojo
@@ -53,7 +53,7 @@ comptime boolean = DType.bool
 # ===----------------------------------------------------------------------=== #
 
 
-fn _concise_dtype_str(dtype: DType) -> String:
+def _concise_dtype_str(dtype: DType) -> String:
     """Returns a concise string representation of the data type."""
     if dtype == i8:
         return "i8"

--- a/numojo/core/dtype/utility.mojo
+++ b/numojo/core/dtype/utility.mojo
@@ -12,7 +12,7 @@ This module provides utility functions for checking properties of data types (DT
 
 
 @parameter
-fn is_inttype[dtype: DType]() -> Bool:
+def is_inttype[dtype: DType]() -> Bool:
     """
     Check if the given dtype is an integer type at compile time.
 
@@ -33,7 +33,7 @@ fn is_inttype[dtype: DType]() -> Bool:
     return False
 
 
-fn is_inttype(dtype: DType) -> Bool:
+def is_inttype(dtype: DType) -> Bool:
     """
     Check if the given dtype is an integer type at run time.
 
@@ -54,7 +54,7 @@ fn is_inttype(dtype: DType) -> Bool:
 
 
 @parameter
-fn is_floattype[dtype: DType]() -> Bool:
+def is_floattype[dtype: DType]() -> Bool:
     """
     Check if the given dtype is a floating point type at compile time.
 
@@ -74,7 +74,7 @@ fn is_floattype[dtype: DType]() -> Bool:
     return False
 
 
-fn is_floattype(dtype: DType) -> Bool:
+def is_floattype(dtype: DType) -> Bool:
     """
     Check if the given dtype is a floating point type at run time.
 
@@ -94,7 +94,7 @@ fn is_floattype(dtype: DType) -> Bool:
 
 
 @parameter
-fn is_booltype[dtype: DType]() -> Bool:
+def is_booltype[dtype: DType]() -> Bool:
     """
     Check if the given dtype is a boolean type at compile time.
 
@@ -110,7 +110,7 @@ fn is_booltype[dtype: DType]() -> Bool:
     return False
 
 
-fn is_booltype(dtype: DType) -> Bool:
+def is_booltype(dtype: DType) -> Bool:
     """
     Check if the given dtype is a boolean type at run time.
 

--- a/numojo/core/error.mojo
+++ b/numojo/core/error.mojo
@@ -56,7 +56,7 @@ struct NumojoError(Writable):
     var message: String
     var location: Optional[String]
 
-    fn __init__(
+    def __init__(
         out self,
         category: StringLiteral,
         message: StringLiteral,
@@ -70,7 +70,7 @@ struct NumojoError(Writable):
         self.message = message
         self.location = location
 
-    fn __init__(
+    def __init__(
         out self,
         category: StringLiteral,
         message: String,
@@ -84,7 +84,7 @@ struct NumojoError(Writable):
         self.message = message
         self.location = location
 
-    fn __init__(
+    def __init__(
         out self,
         category: StringLiteral,
         message: TString,
@@ -98,7 +98,7 @@ struct NumojoError(Writable):
         self.message = String(message)
         self.location = location
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         var result = (
             RED_COLOR + String(self.category) + String(": ") + self.message
         )
@@ -107,7 +107,7 @@ struct NumojoError(Writable):
         result += END_COLOR
         return result
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Write error information to a writer."""
         writer.write(
             RED_COLOR + String(self.category) + String(": ") + self.message
@@ -118,6 +118,6 @@ struct NumojoError(Writable):
 
 
 # Use this for fatal errors that should abort the program.
-fn terminate(message: String):
+def terminate(message: String):
     """Abort the program with the given error message."""
     abort(RED_COLOR + message + END_COLOR)

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -51,7 +51,7 @@ struct IndexBuffer(
     # Lifecycle Methods
     # ===----------------------------------------------------------------------=== #
     # TODO: add `abort()` for cases where we have ndim < 0 since they are invalid.
-    fn __init__(out self, *, size: Int):
+    def __init__(out self, *, size: Int):
         """
         Initialize an IndexBuffer of given size.
 
@@ -66,7 +66,7 @@ struct IndexBuffer(
             self.ptr = alloc[Scalar[Self.element_type]](size)
             memset_zero(self.ptr, size)
 
-    fn __init__(
+    def __init__(
         out self,
         ptr: UnsafePointer[Scalar[Self.element_type], Self._origin],
         size: Int,
@@ -81,14 +81,14 @@ struct IndexBuffer(
         self.ptr = ptr
         self.ndim = size
 
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initialize an empty IndexBuffer.
         """
         self.ndim = 0
         self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
 
-    fn __init__(out self, *values: Int):
+    def __init__(out self, *values: Int):
         """
         Initialize an IndexBuffer with given Int values.
 
@@ -106,7 +106,7 @@ struct IndexBuffer(
             )
 
     # NOTE: In future this will be equivalent to Int.
-    fn __init__(out self, *values: Scalar[Self.element_type]):
+    def __init__(out self, *values: Scalar[Self.element_type]):
         """
         Initialize an IndexBuffer with given values.
 
@@ -121,7 +121,7 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr + i).init_pointee_copy(values[i])
 
-    fn __init__(out self, values: List[Scalar[Self.element_type]]):
+    def __init__(out self, values: List[Scalar[Self.element_type]]):
         """
         Initialize an IndexBuffer with a list of values.
 
@@ -136,7 +136,7 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr + i).init_pointee_copy(values[i])
 
-    fn __init__(out self, values: List[Int]):
+    def __init__(out self, values: List[Int]):
         """
         Initialize an IndexBuffer with a list of Int values.
 
@@ -153,7 +153,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type](values[i])
             )
 
-    fn __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
+    def __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
         """
         Initialize an IndexBuffer with a range of values.
 
@@ -168,7 +168,7 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr + i).init_pointee_copy(values[i])
 
-    fn __init__(out self, values: VariadicList[Int, _]):
+    def __init__(out self, values: VariadicList[Int, _]):
         """
         Initialize an IndexBuffer with a range of values.
 
@@ -185,7 +185,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type](values[i])
             )
 
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Copy-initialize an IndexBuffer from ancopy IndexBuffer.
 
@@ -199,7 +199,7 @@ struct IndexBuffer(
         self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
         memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
 
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """
         Deinitialize the IndexBuffer and free resources.
         """
@@ -209,7 +209,7 @@ struct IndexBuffer(
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
-    fn get_ptr(
+    def get_ptr(
         ref self,
     ) -> ref[self.ptr] UnsafePointer[Scalar[Self.element_type], Self._origin]:
         """
@@ -223,7 +223,7 @@ struct IndexBuffer(
         """
         return self.ptr
 
-    fn offset(
+    def offset(
         ref self, offset: Int
     ) -> UnsafePointer[Scalar[Self.element_type], Self._origin]:
         """
@@ -237,7 +237,7 @@ struct IndexBuffer(
         """
         return self.ptr + offset
 
-    fn __getitem__(self, idx: Int) raises -> Int:
+    def __getitem__(self, idx: Int) raises -> Int:
         """
         Get the element at the given index.
 
@@ -258,7 +258,7 @@ struct IndexBuffer(
             )
         return Int(self.ptr[index])
 
-    fn __getitem__(
+    def __getitem__(
         self, idx: Scalar[Self.element_type]
     ) raises -> Scalar[Self.element_type]:
         """
@@ -281,7 +281,7 @@ struct IndexBuffer(
             )
         return self.ptr[index]
 
-    fn __getitem__(self, slice: Slice) raises -> Self:
+    def __getitem__(self, slice: Slice) raises -> Self:
         """
         Get a sub-buffer using a slice.
 
@@ -312,7 +312,7 @@ struct IndexBuffer(
 
         return new_buffer^
 
-    fn __setitem__(mut self, idx: Int, value: Int) raises:
+    def __setitem__(mut self, idx: Int, value: Int) raises:
         """
         Set the element at the given index.
 
@@ -331,7 +331,7 @@ struct IndexBuffer(
             )
         self.ptr[index] = Scalar[Self.element_type](value)
 
-    fn __setitem__(
+    def __setitem__(
         mut self,
         idx: Scalar[Self.element_type],
         value: Scalar[Self.element_type],
@@ -354,7 +354,7 @@ struct IndexBuffer(
             )
         self.ptr[index] = value
 
-    fn __setitem__(mut self, slice: Slice, value: Self) raises:
+    def __setitem__(mut self, slice: Slice, value: Self) raises:
         """
         Set a sub-buffer using a slice.
 
@@ -392,7 +392,7 @@ struct IndexBuffer(
             self.ptr[i] = value.ptr[idx]
             idx += 1
 
-    fn unsafe_load[
+    def unsafe_load[
         width: Int = 1
     ](self, idx: Int) -> SIMD[Self.element_type, width]:
         """
@@ -409,7 +409,7 @@ struct IndexBuffer(
         """
         return self.ptr.load[width=width](idx)
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]):
         """
@@ -424,7 +424,7 @@ struct IndexBuffer(
         """
         self.ptr.store[width=width](idx, value)
 
-    fn unsafe_load[
+    def unsafe_load[
         width: Int = 1
     ](self, idx: Scalar[Self.element_type]) -> SIMD[Self.element_type, width]:
         """
@@ -441,7 +441,7 @@ struct IndexBuffer(
         """
         return self.ptr.load[width=width](idx)
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](
         self,
@@ -464,7 +464,7 @@ struct IndexBuffer(
     # Transformation Methods
     # ===----------------------------------------------------------------------=== #
 
-    fn extend(self, *values: Int) -> Self:
+    def extend(self, *values: Int) -> Self:
         """
         Extend the buffer by appending additional integer values.
 
@@ -482,7 +482,7 @@ struct IndexBuffer(
             new_buf.ptr[self.ndim + j] = Scalar[Self.element_type](values[j])
         return new_buf^
 
-    fn extend(self, values: List[Int]) -> Self:
+    def extend(self, values: List[Int]) -> Self:
         """
         Extend the buffer by appending additional integer values from a List.
 
@@ -500,7 +500,7 @@ struct IndexBuffer(
             new_buf.ptr[self.ndim + j] = Scalar[Self.element_type](values[j])
         return new_buf^
 
-    fn flip(mut self):
+    def flip(mut self):
         """
         Flip the items in-place.
         """
@@ -509,7 +509,7 @@ struct IndexBuffer(
             self.ptr[i] = self.ptr[self.ndim - 1 - i]
             self.ptr[self.ndim - 1 - i] = temp
 
-    fn flipped(self) -> Self:
+    def flipped(self) -> Self:
         """
         Returns a new IndexBuffer by reversing the items.
 
@@ -521,7 +521,7 @@ struct IndexBuffer(
             res.ptr[i] = self.ptr[self.ndim - 1 - i]
         return res^
 
-    fn move_axis_to_end(self, axis: Int) -> Self:
+    def move_axis_to_end(self, axis: Int) -> Self:
         """
         Returns a new IndexBuffer by moving the value at axis to the end.
 
@@ -543,7 +543,7 @@ struct IndexBuffer(
         res.ptr[self.ndim - 1] = self.ptr[ax]
         return res^
 
-    fn pop(self, axis: Int) raises -> Self:
+    def pop(self, axis: Int) raises -> Self:
         """
         Drops the item at the given axis (index).
 
@@ -581,7 +581,7 @@ struct IndexBuffer(
             idx += 1
         return res^
 
-    fn insert(self, axis: Int, value: Int) raises -> Self:
+    def insert(self, axis: Int, value: Int) raises -> Self:
         """
         Inserts a value at the given axis (index).
 
@@ -608,7 +608,7 @@ struct IndexBuffer(
             res.ptr[i + 1] = self.ptr[i]
         return res^
 
-    fn join(self, *others: Self) -> Self:
+    def join(self, *others: Self) -> Self:
         """
         Join multiple IndexBuffers into a single IndexBuffer.
 
@@ -633,7 +633,7 @@ struct IndexBuffer(
             offset += others[i].ndim
         return res^
 
-    fn join(self, others: List[Self]) -> Self:
+    def join(self, others: List[Self]) -> Self:
         """
         Join multiple IndexBuffers into a single IndexBuffer from a List.
 
@@ -658,7 +658,7 @@ struct IndexBuffer(
             offset += others[i].ndim
         return res^
 
-    fn sort(mut self, order: Bool):
+    def sort(mut self, order: Bool):
         """
         Sort the IndexBuffer in-place.
 
@@ -674,7 +674,7 @@ struct IndexBuffer(
                     self.ptr[j] = self.ptr[j + 1]
                     self.ptr[j + 1] = temp
 
-    fn sorted(self, order: Bool) -> Self:
+    def sorted(self, order: Bool) -> Self:
         """
         Returns a new IndexBuffer that is sorted.
 
@@ -693,7 +693,7 @@ struct IndexBuffer(
     # Static Constructors
     # ===----------------------------------------------------------------------=== #
     @staticmethod
-    fn arange(start: Int, end: Int, step: Int = 1) raises -> Self:
+    def arange(start: Int, end: Int, step: Int = 1) raises -> Self:
         """
         Create a IndexBuffer with a range of values.
 
@@ -729,7 +729,7 @@ struct IndexBuffer(
         return result^
 
     @staticmethod
-    fn fill(size: Int, value: Int) -> Self:
+    def fill(size: Int, value: Int) -> Self:
         """
         Create a IndexBuffer filled with the given value.
 
@@ -746,7 +746,7 @@ struct IndexBuffer(
         return res^
 
     @staticmethod
-    fn zeros(size: Int) -> Self:
+    def zeros(size: Int) -> Self:
         """
         Create a IndexBuffer filled with zeros.
 
@@ -761,7 +761,7 @@ struct IndexBuffer(
         return res^
 
     @staticmethod
-    fn ones(size: Int) -> Self:
+    def ones(size: Int) -> Self:
         """
         Create a IndexBuffer filled with ones.
 
@@ -777,7 +777,7 @@ struct IndexBuffer(
         return res^
 
     @staticmethod
-    fn linspace(start: Int, end: Int, num: Int) raises -> Self:
+    def linspace(start: Int, end: Int, num: Int) raises -> Self:
         """
         Create a IndexBuffer with linearly spaced values.
 
@@ -810,7 +810,7 @@ struct IndexBuffer(
         return res^
 
     @staticmethod
-    fn invert_permutation(perm: Self) -> Self:
+    def invert_permutation(perm: Self) -> Self:
         """
         Invert a permutation.
 
@@ -829,7 +829,7 @@ struct IndexBuffer(
     # ===----------------------------------------------------------------------=== #
     # Properties
     # ===----------------------------------------------------------------------=== #
-    fn rank(self) -> Int:
+    def rank(self) -> Int:
         """
         Get the number of elements in the IndexBuffer.
 
@@ -838,7 +838,7 @@ struct IndexBuffer(
         """
         return self.ndim
 
-    fn is_empty(self) -> Bool:
+    def is_empty(self) -> Bool:
         """
         Check if the IndexBuffer is empty.
 
@@ -847,7 +847,7 @@ struct IndexBuffer(
         """
         return self.ndim == 0
 
-    fn sum(self) -> Scalar[Self.element_type]:
+    def sum(self) -> Scalar[Self.element_type]:
         """
         Compute the sum of all elements in the IndexBuffer.
 
@@ -855,14 +855,14 @@ struct IndexBuffer(
             Sum of all elements in the IndexBuffer.
         """
         var total: Scalar[Self.element_type] = 0
-        # fn closure[width: Int](i: Int) unified {mut total, read self}:
+        # def closure[width: Int](i: Int) unified {mut total, read self}:
         #     total += self.load[width](i).reduce_add()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):
             total += self.ptr[i]
         return total
 
-    fn product(self) -> Scalar[Self.element_type]:
+    def product(self) -> Scalar[Self.element_type]:
         """
         Compute the product of all elements in the IndexBuffer.
 
@@ -870,7 +870,7 @@ struct IndexBuffer(
             Product of all elements in the IndexBuffer.
         """
         var total: Scalar[Self.element_type] = 1
-        # fn closure[width: Int](i: Int) unified {mut total, read self}:
+        # def closure[width: Int](i: Int) unified {mut total, read self}:
         #     total += self.load[width](i).reduce_mul()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):
@@ -880,7 +880,7 @@ struct IndexBuffer(
     # ===----------------------------------------------------------------------=== #
     # Traits
     # ===----------------------------------------------------------------------=== #
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """
         Get the number of elements in the IndexBuffer.
 
@@ -889,7 +889,7 @@ struct IndexBuffer(
         """
         return self.ndim
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Get the official string representation of the IndexBuffer.
 
@@ -898,7 +898,7 @@ struct IndexBuffer(
         """
         return self.__str__()
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Get the string representation of the IndexBuffer.
 
@@ -913,7 +913,7 @@ struct IndexBuffer(
         res += String("])")
         return res^
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Write the IndexBuffer to a writer.
         """
@@ -924,7 +924,7 @@ struct IndexBuffer(
                 writer.write(", ")
         writer.write("])")
 
-    fn __contains__(self, value: Scalar[Self.element_type]) -> Bool:
+    def __contains__(self, value: Scalar[Self.element_type]) -> Bool:
         """
         Check if the IndexBuffer contains the given value.
 
@@ -940,7 +940,7 @@ struct IndexBuffer(
         return False
 
     # TODO: We can remove this overload once Mojo unified Scalar[DType.int] with Int
-    fn __contains__(self, value: Int) -> Bool:
+    def __contains__(self, value: Int) -> Bool:
         """
         Check if the IndexBuffer contains the given value.
 
@@ -955,7 +955,7 @@ struct IndexBuffer(
                 return True
         return False
 
-    fn __eq__(self, other: IndexBuffer) -> Bool:
+    def __eq__(self, other: IndexBuffer) -> Bool:
         """
         Check if two IndexBuffers are equal.
 
@@ -972,7 +972,7 @@ struct IndexBuffer(
                 return False
         return True
 
-    fn __ne__(self, other: IndexBuffer) -> Bool:
+    def __ne__(self, other: IndexBuffer) -> Bool:
         """
         Check if two IndexBuffers are not equal.
 
@@ -987,7 +987,7 @@ struct IndexBuffer(
     # ===----------------------------------------------------------------------=== #
     # Utility Methods
     # ===----------------------------------------------------------------------=== #
-    fn init_value(mut self, idx: Int, value: Scalar[Self.element_type]):
+    def init_value(mut self, idx: Int, value: Scalar[Self.element_type]):
         """
         Initialize the element at the given index.
         No bounds checking.
@@ -999,7 +999,7 @@ struct IndexBuffer(
         # self.ptr[idx] = value
         (self.ptr + idx).init_pointee_copy(value)
 
-    fn tolist(self) -> List[Scalar[Self.element_type]]:
+    def tolist(self) -> List[Scalar[Self.element_type]]:
         """
         Convert the buffer to a list.
         """
@@ -1013,7 +1013,7 @@ struct IndexBuffer(
     # ===----------------------------------------------------------------------=== #
     # Iterators
     # ===----------------------------------------------------------------------=== #
-    fn __iter__(
+    def __iter__(
         ref self,
     ) -> _IndexBufferIter[Self.element_type, origin_of(self), True]:
         """
@@ -1026,7 +1026,7 @@ struct IndexBuffer(
             Pointer(to=self), self.ndim
         )
 
-    fn __reversed__(
+    def __reversed__(
         ref self,
     ) -> _IndexBufferIter[Self.element_type, origin_of(self), False]:
         """
@@ -1060,7 +1060,7 @@ struct _IndexBufferIter[
     var item: Pointer[IndexBuffer, Self.origin]
     var length: Int
 
-    fn __init__(
+    def __init__(
         out self,
         item: Pointer[IndexBuffer, Self.origin],
         length: Int,
@@ -1069,16 +1069,16 @@ struct _IndexBufferIter[
         self.length = length
         self.item = item
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __next__(mut self) raises -> Scalar[Self.dtype]:
+    def __next__(mut self) raises -> Scalar[Self.dtype]:
         comptime if Self.forward:
             var current_index = self.index
             self.index += 1
@@ -1088,7 +1088,7 @@ struct _IndexBufferIter[
             self.index -= 1
             return Scalar[Self.dtype](self.item[].__getitem__(current_index))
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -73,7 +73,7 @@ struct Item(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes an empty Item.
         """
@@ -81,7 +81,7 @@ struct Item(
         self._buf = IndexBuffer()
 
     @always_inline("nodebug")
-    fn __init__(out self, buf: IndexBuffer):
+    def __init__(out self, buf: IndexBuffer):
         """
         Initializes the Item from an IndexBuffer.
 
@@ -92,7 +92,7 @@ struct Item(
         self._buf = buf
 
     @always_inline("nodebug")
-    fn __init__[T: Indexer](out self, *args: T):
+    def __init__[T: Indexer](out self, *args: T):
         """Construct the Item with variable arguments.
 
         Parameters:
@@ -109,7 +109,7 @@ struct Item(
             )
 
     @always_inline("nodebug")
-    fn __init__[T: IndexerCollectionElement](out self, args: List[T]):
+    def __init__[T: IndexerCollectionElement](out self, args: List[T]):
         """Construct the Item from a list.
 
         Parameters:
@@ -126,7 +126,7 @@ struct Item(
             )
 
     @always_inline("nodebug")
-    fn __init__(out self, args: List[Int]):
+    def __init__(out self, args: List[Int]):
         """Construct the Item from a list.
 
         Args:
@@ -138,7 +138,7 @@ struct Item(
             self._buf.init_value(i, Scalar[Self.element_type](args[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, args: VariadicList[Int, _]):
+    def __init__(out self, args: VariadicList[Int, _]):
         """Construct the Item from a variadic list.
 
         Args:
@@ -150,7 +150,7 @@ struct Item(
             self._buf.init_value(i, Scalar[Self.element_type](args[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, *, ndim: Int):
+    def __init__(out self, *, ndim: Int):
         """Construct the Item with given length and initialize to zero.
 
         Args:
@@ -161,7 +161,7 @@ struct Item(
         memset_zero(self._buf.ptr, ndim)
 
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """Copy construct the Item.
 
         Args:
@@ -176,7 +176,7 @@ struct Item(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) raises -> Int:
+    def __getitem__(self, idx: Int) raises -> Int:
         """Gets the value at the specified index.
 
         Args:
@@ -191,7 +191,7 @@ struct Item(
         return Int(self._buf[idx])
 
     @always_inline("nodebug")
-    fn __getitem__(self, slice_index: Slice) raises -> Self:
+    def __getitem__(self, slice_index: Slice) raises -> Self:
         """
         Return a sliced view of the item as a new Item.
 
@@ -204,7 +204,7 @@ struct Item(
         return Self(self._buf[slice_index])
 
     @always_inline("nodebug")
-    fn __setitem__(mut self, idx: Int, val: Int) raises:
+    def __setitem__(mut self, idx: Int, val: Int) raises:
         """Set the value at the specified index.
 
         Args:
@@ -216,7 +216,7 @@ struct Item(
         """
         self._buf[idx] = val
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, idx: Int) raises -> SIMD[Self.element_type, width]:
         """
@@ -247,7 +247,7 @@ struct Item(
             )
         return self._buf.unsafe_load[width=width](idx)
 
-    fn store[
+    def store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]) raises:
         """
@@ -277,7 +277,7 @@ struct Item(
             )
         self._buf.unsafe_store[width=width](idx, value)
 
-    fn unsafe_load[
+    def unsafe_load[
         width: Int = 1
     ](self, idx: Int) -> SIMD[Self.element_type, width]:
         """
@@ -294,7 +294,7 @@ struct Item(
         """
         return self._buf.unsafe_load[width=width](idx)
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]):
         """
@@ -313,7 +313,7 @@ struct Item(
     # Transformation Methods
     # ===----------------------------------------------------------------------=== #
 
-    fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
+    def swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
         """
         Returns a new item with the given axes swapped.
 
@@ -331,7 +331,7 @@ struct Item(
         res[axis2] = val1
         return res
 
-    fn join(self, *others: Self) -> Self:
+    def join(self, *others: Self) -> Self:
         """
         Join multiple items into a single item.
 
@@ -346,7 +346,7 @@ struct Item(
             bufs.append(others[i]._buf)
         return Self(self._buf.join(bufs))
 
-    fn extend(self, *values: Int) -> Self:
+    def extend(self, *values: Int) -> Self:
         """
         Extend the shape by sizes of extended dimensions.
 
@@ -361,13 +361,13 @@ struct Item(
             new_vals.append(values[i])
         return Self(self._buf.extend(new_vals))
 
-    fn flip(mut self):
+    def flip(mut self):
         """
         Flip the items in-place.
         """
         self._buf.flip()
 
-    fn flipped(self) -> Self:
+    def flipped(self) -> Self:
         """
         Returns a new item by flipping the items.
 
@@ -376,7 +376,7 @@ struct Item(
         """
         return Self(self._buf.flipped())
 
-    fn move_axis_to_end(self, axis: Int) -> Self:
+    def move_axis_to_end(self, axis: Int) -> Self:
         """
         Returns a new item by moving the value of axis to the end.
 
@@ -388,7 +388,7 @@ struct Item(
         """
         return Self(self._buf.move_axis_to_end(axis))
 
-    fn pop(self, axis: Int) raises -> Self:
+    def pop(self, axis: Int) raises -> Self:
         """
         Drops information of certain axis.
 
@@ -404,7 +404,7 @@ struct Item(
     # Properties
     # ===----------------------------------------------------------------------=== #
     @always_inline("nodebug")
-    fn rank(self) -> Int:
+    def rank(self) -> Int:
         """
         Returns the number of dimensions of the Item.
 
@@ -413,7 +413,7 @@ struct Item(
         """
         return self.ndim
 
-    fn sum(self) -> Scalar[Self.element_type]:
+    def sum(self) -> Scalar[Self.element_type]:
         """
         Compute the sum of all elements in Item.
 
@@ -422,7 +422,7 @@ struct Item(
         """
         return self._buf.sum()
 
-    fn product(self) -> Scalar[Self.element_type]:
+    def product(self) -> Scalar[Self.element_type]:
         """
         Compute the product of all elements in the Item.
 
@@ -436,7 +436,7 @@ struct Item(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """Get the length of the Item.
 
         Returns:
@@ -445,7 +445,7 @@ struct Item(
         return self.ndim
 
     @always_inline("nodebug")
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Returns a string representation of the Item.
 
@@ -454,7 +454,7 @@ struct Item(
         """
         return "numojo.Item" + self.__str__()
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -464,7 +464,7 @@ struct Item(
         writer.write(self.__repr__())
 
     @always_inline("nodebug")
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns a string representation of the Item.
 
@@ -479,14 +479,14 @@ struct Item(
         result += ")"
         return result
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Writes the Item representation to a writer.
         """
         writer.write("Coordinates: " + self.__str__() + "  ")
 
     @always_inline("nodebug")
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks if two items have identical dimensions and values.
 
@@ -499,7 +499,7 @@ struct Item(
         return self._buf == other._buf
 
     @always_inline("nodebug")
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks if two items have different dimensions or values.
 
@@ -511,7 +511,7 @@ struct Item(
         """
         return not self.__eq__(other)
 
-    fn __contains__(self, val: Scalar[Self.element_type]) -> Bool:
+    def __contains__(self, val: Scalar[Self.element_type]) -> Bool:
         """
         Check if the Item contains the given value.
 
@@ -524,7 +524,7 @@ struct Item(
         return val in self._buf
 
     @always_inline("nodebug")
-    fn __contains__(self, val: Int) -> Bool:
+    def __contains__(self, val: Int) -> Bool:
         """
         Checks if the given value is present in the item.
 
@@ -541,7 +541,7 @@ struct Item(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn tolist(self) -> List[Int]:
+    def tolist(self) -> List[Int]:
         """
         Convert the Item to a list of integers.
 
@@ -554,7 +554,7 @@ struct Item(
         return res^
 
     @always_inline("nodebug")
-    fn normalize_index(self, index: Int) -> Int:
+    def normalize_index(self, index: Int) -> Int:
         """
         Normalizes the given index to be within the valid range [0, ndim).
 
@@ -572,7 +572,7 @@ struct Item(
     # ===----------------------------------------------------------------------=== #
     # Iterators
     # ===----------------------------------------------------------------------=== #
-    fn __iter__(ref self) -> _ItemIter[origin_of(self), True]:
+    def __iter__(ref self) -> _ItemIter[origin_of(self), True]:
         """Iterate over elements of the Item.
 
         Returns:
@@ -583,7 +583,7 @@ struct Item(
             length=self.ndim,
         )
 
-    fn __reversed__(ref self) -> _ItemIter[origin_of(self), False]:
+    def __reversed__(ref self) -> _ItemIter[origin_of(self), False]:
         """Iterate over elements of the Item in reverse.
 
         Returns:
@@ -610,7 +610,7 @@ struct _ItemIter[
     var item: Pointer[Item, Self.origin]
     var length: Int
 
-    fn __init__(
+    def __init__(
         out self,
         item: Pointer[Item, Self.origin],
         length: Int,
@@ -619,16 +619,16 @@ struct _ItemIter[
         self.length = length
         self.item = item
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __next__(mut self) raises -> Scalar[DType.int]:
+    def __next__(mut self) raises -> Scalar[DType.int]:
         comptime if Self.forward:
             var current_index = self.index
             self.index += 1
@@ -638,7 +638,7 @@ struct _ItemIter[
             self.index -= 1
             return Scalar[DType.int](self.item[].__getitem__(current_index))
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:

--- a/numojo/core/indexing/offset.mojo
+++ b/numojo/core/indexing/offset.mojo
@@ -20,7 +20,7 @@ from numojo.core.indexing.item import Item
 # TODO: Define a IndexContainerLike trait and use that to replace many of these get_1d_index overloads.
 struct IndexMethods:
     @staticmethod
-    fn get_1d_index(indices: List[Int], strides: NDArrayStrides) -> Int:
+    def get_1d_index(indices: List[Int], strides: NDArrayStrides) -> Int:
         """
         Get the flat index from a list of indices and NDArrayStrides.
 
@@ -37,7 +37,7 @@ struct IndexMethods:
         return idx
 
     @staticmethod
-    fn get_1d_index(indices: Item, strides: NDArrayStrides) -> Int:
+    def get_1d_index(indices: Item, strides: NDArrayStrides) -> Int:
         """
         Get the flat index from an Item and NDArrayStrides.
 
@@ -54,7 +54,7 @@ struct IndexMethods:
         return idx
 
     @staticmethod
-    fn get_1d_index(
+    def get_1d_index(
         indices: VariadicList[Int, _], strides: NDArrayStrides
     ) -> Int:
         """
@@ -73,7 +73,7 @@ struct IndexMethods:
         return idx
 
     @staticmethod
-    fn get_1d_index(indices: List[Int], strides: List[Int]) -> Int:
+    def get_1d_index(indices: List[Int], strides: List[Int]) -> Int:
         """
         Get the flat index from a list of indices and a list of strides.
 
@@ -90,7 +90,7 @@ struct IndexMethods:
         return idx
 
     @staticmethod
-    fn get_1d_index(
+    def get_1d_index(
         indices: VariadicList[Int, _], strides: VariadicList[Int, _]
     ) -> Int:
         """
@@ -109,7 +109,7 @@ struct IndexMethods:
         return idx
 
     @staticmethod
-    fn get_1d_index(indices: Tuple[Int, Int], strides: Tuple[Int, Int]) -> Int:
+    def get_1d_index(indices: Tuple[Int, Int], strides: Tuple[Int, Int]) -> Int:
         """
         Get the flat index for a 2D matrix from tuples of indices and strides.
 
@@ -123,7 +123,7 @@ struct IndexMethods:
         return indices[0] * strides[0] + indices[1] * strides[1]
 
     @staticmethod
-    fn transfer_offset(offset: Int, strides: NDArrayStrides) raises -> Int:
+    def transfer_offset(offset: Int, strides: NDArrayStrides) raises -> Int:
         """
         Transfers the offset by flipping the strides information.
         Used to transfer between C-contiguous and F-continuous memory layouts.

--- a/numojo/core/indexing/slicing.mojo
+++ b/numojo/core/indexing/slicing.mojo
@@ -22,7 +22,7 @@ struct IndexTypeInfo(ImplicitlyCopyable):
     var is_ellipsis: Bool
     var is_newaxis: Bool
 
-    fn __init__(
+    def __init__(
         out self,
         is_integer: Bool = False,
         is_slice: Bool = False,
@@ -34,7 +34,7 @@ struct IndexTypeInfo(ImplicitlyCopyable):
         self.is_ellipsis = is_ellipsis
         self.is_newaxis = is_newaxis
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         return (
             "IndexTypeInfo(is_integer={}, is_slice={}, is_ellipsis={},"
             " is_newaxis={})".format(
@@ -45,7 +45,7 @@ struct IndexTypeInfo(ImplicitlyCopyable):
             )
         )
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         return (
             "IndexTypeInfo(is_integer={}, is_slice={}, is_ellipsis={},"
             " is_newaxis={})".format(
@@ -56,7 +56,7 @@ struct IndexTypeInfo(ImplicitlyCopyable):
             )
         )
 
-    fn size(self) -> Int:
+    def size(self) -> Int:
         """
         Returns the number of active index types in this IndexTypeInfo.
         """
@@ -80,38 +80,38 @@ struct InternalSlice(ImplicitlyCopyable):
     var end: Int
     var step: Int
 
-    fn __init__(out self, start: Int, end: Int, step: Int):
+    def __init__(out self, start: Int, end: Int, step: Int):
         self.start = start
         self.end = end
         self.step = step
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         return "InternalSlice(start={}, end={}, step={})".format(
             self.start, self.end, self.step
         )
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         return "InternalSlice(start={}, end={}, step={})".format(
             self.start, self.end, self.step
         )
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         return (
             self.start == other.start
             and self.end == other.end
             and self.step == other.step
         )
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         return not self.__eq__(other)
 
-    fn to_tuple(self) -> Tuple[Int, Int, Int]:
+    def to_tuple(self) -> Tuple[Int, Int, Int]:
         return (self.start, self.end, self.step)
 
-    fn to_slice(self) -> Slice:
+    def to_slice(self) -> Slice:
         return Slice(self.start, self.end, self.step)
 
-    fn normalize(self, dim: Int) -> InternalSlice:
+    def normalize(self, dim: Int) -> InternalSlice:
         var start_norm = self.start
         var end_norm = self.end
 
@@ -122,7 +122,7 @@ struct InternalSlice(ImplicitlyCopyable):
 
         return InternalSlice(start_norm, end_norm, self.step)
 
-    fn check_bounds(self, dim: Int) raises:
+    def check_bounds(self, dim: Int) raises:
         if self.start < 0 or self.start >= dim:
             raise Error(
                 NumojoError(
@@ -155,7 +155,7 @@ struct InternalSlice(ImplicitlyCopyable):
             )
 
     @staticmethod
-    fn get_slice_info(s: Slice, dim: Int) -> Tuple[Int, Int, Int, Int]:
+    def get_slice_info(s: Slice, dim: Int) -> Tuple[Int, Int, Int, Int]:
         """
         Get complete slice information for a given dimension.
 
@@ -193,7 +193,7 @@ struct InternalSlice(ImplicitlyCopyable):
 
         return (start, end, step, length)
 
-    fn get_slice_info(self, dim: Int) -> Tuple[Int, Int, Int, Int]:
+    def get_slice_info(self, dim: Int) -> Tuple[Int, Int, Int, Int]:
         """
         Get complete slice information for a given dimension.
 

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -21,7 +21,7 @@ from numojo.core.error import NumojoError
 
 struct TraverseMethods:
     @staticmethod
-    fn traverse_buffer_according_to_shape_and_strides[
+    def traverse_buffer_according_to_shape_and_strides[
         origin: MutOrigin
     ](
         mut ptr: UnsafePointer[Scalar[DType.int], origin=origin],
@@ -63,7 +63,7 @@ struct TraverseMethods:
                 )
 
     @staticmethod
-    fn traverse_iterative[
+    def traverse_iterative[
         dtype: DType
     ](
         orig: NDArray[dtype],
@@ -114,7 +114,7 @@ struct TraverseMethods:
                 index[d] = 0
 
     @staticmethod
-    fn traverse_iterative_setter[
+    def traverse_iterative_setter[
         dtype: DType
     ](
         orig: NDArray[dtype],

--- a/numojo/core/indexing/utility.mojo
+++ b/numojo/core/indexing/utility.mojo
@@ -32,13 +32,13 @@ comptime newaxis: NewAxis = NewAxis()
 
 # TODO: add an initializer with int field to specify number of new axes to add!
 struct NewAxis(Writable):
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes a NewAxis instance.
         """
         pass
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Returns a string representation of the NewAxis instance.
 
@@ -47,7 +47,7 @@ struct NewAxis(Writable):
         """
         return "numojo.newaxis()"
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns a string representation of the NewAxis instance.
 
@@ -56,13 +56,13 @@ struct NewAxis(Writable):
         """
         return "numojo.newaxis()"
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks equality between two NewAxis instances.
         """
         return True
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks inequality between two NewAxis instances.
         """
@@ -74,7 +74,7 @@ struct NewAxis(Writable):
 # ===----------------------------------------------------------------------=== #
 
 
-fn bool_to_numeric[
+def bool_to_numeric[
     dtype: DType
 ](array: NDArray[DType.bool]) raises -> NDArray[dtype]:
     """
@@ -103,7 +103,7 @@ fn bool_to_numeric[
 # ===----------------------------------------------------------------------=== #
 # Numojo.NDArray to other collections
 # ===----------------------------------------------------------------------=== #
-fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
+def to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
     """
     Convert a NDArray to a numpy array.
 
@@ -184,7 +184,7 @@ fn to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
 # ===----------------------------------------------------------------------=== #
 
 
-fn _list_of_range(n: Int) -> List[Int]:
+def _list_of_range(n: Int) -> List[Int]:
     """
     Generate a list of integers starting from 0 and of size n.
     """
@@ -195,7 +195,7 @@ fn _list_of_range(n: Int) -> List[Int]:
     return list_of_range^
 
 
-fn _list_of_flipped_range(n: Int) -> List[Int]:
+def _list_of_flipped_range(n: Int) -> List[Int]:
     """
     Generate a list of integers starting from n-1 to 0 and of size n.
     """

--- a/numojo/core/indexing/validation.mojo
+++ b/numojo/core/indexing/validation.mojo
@@ -16,7 +16,7 @@ from numojo.core.layout import NDArrayShape, NDArrayStrides
 
 struct Validator:
     @staticmethod
-    fn normalize(index: Int, dim: Int) -> Int:
+    def normalize(index: Int, dim: Int) -> Int:
         """
         Normalize a possibly negative index.
 
@@ -30,7 +30,7 @@ struct Validator:
         return index if index >= 0 else index + dim
 
     @staticmethod
-    fn check_bounds(index: Int, dim: Int, axis: Int = 0) raises:
+    def check_bounds(index: Int, dim: Int, axis: Int = 0) raises:
         """
         Check if an index is within bounds for a dimension.
 
@@ -57,7 +57,7 @@ struct Validator:
             )
 
     @staticmethod
-    fn validate_reshape(current_size: Int, new_shape: NDArrayShape) raises:
+    def validate_reshape(current_size: Int, new_shape: NDArrayShape) raises:
         """
         Validate if a reshape operation is valid.
 
@@ -81,7 +81,7 @@ struct Validator:
             )
 
     @staticmethod
-    fn validate_and_normalize_axes(
+    def validate_and_normalize_axes(
         rank: Int, axes: List[Int]
     ) raises -> List[Int]:
         """

--- a/numojo/core/layout/array_methods.mojo
+++ b/numojo/core/layout/array_methods.mojo
@@ -36,7 +36,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
 
     var num: Int
 
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes a `NewAxis` instance with a default of one new axis.
 
@@ -44,7 +44,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
         """
         self.num = 0
 
-    fn __init__(out self, num: Int):
+    def __init__(out self, num: Int):
         """
         Initializes a `NewAxis` instance with a specified number of new axes.
 
@@ -53,7 +53,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
         """
         self.num = num
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Returns a string representation of the `NewAxis` instance.
 
@@ -62,7 +62,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
         """
         return "numojo.newaxis()"
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns a string representation of the `NewAxis` instance.
 
@@ -71,7 +71,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
         """
         return "numojo.newaxis()"
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks equality between two `NewAxis` instances.
 
@@ -80,7 +80,7 @@ struct NewAxis(Hashable, ImplicitlyCopyable, Movable, Writable):
         """
         return True
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks inequality between two `NewAxis` instances.
 

--- a/numojo/core/layout/flags.mojo
+++ b/numojo/core/layout/flags.mojo
@@ -45,7 +45,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
     # Life cycle dunder methods
     # === ---------------------------------------------------------------- === #
 
-    fn __init__(
+    def __init__(
         out self,
         c_contiguous: Bool,
         f_contiguous: Bool,
@@ -69,7 +69,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
         self.WRITEABLE = writeable and owndata
         self.FORC = f_contiguous or c_contiguous
 
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         strides: NDArrayStrides,
@@ -126,7 +126,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
         self.WRITEABLE = writeable and owndata
         self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
-    fn __init__(
+    def __init__(
         out self,
         shape: Tuple[Int, Int],
         strides: Tuple[Int, Int],
@@ -154,7 +154,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
         self.WRITEABLE = writeable and owndata
         self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Initializes the Flags object by copying the information from
         ancopy Flags object.
@@ -173,7 +173,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
     # Get and set dunder methods
     # === ---------------------------------------------------------------- === #
 
-    fn __getitem__(self, key: String) raises -> Bool:
+    def __getitem__(self, key: String) raises -> Bool:
         """
         Get the value of the fields with the given key.
         The Flags object can be accessed dictionary-like.

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -68,7 +68,7 @@ struct NDArrayShape(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes an empty NDArrayShape.
         """
@@ -76,7 +76,7 @@ struct NDArrayShape(
         self._buf = IndexBuffer()
 
     @always_inline("nodebug")
-    fn __init__(out self, var buf: IndexBuffer):
+    def __init__(out self, var buf: IndexBuffer):
         """
         Initializes the NDArrayShape from an IndexBuffer.
 
@@ -87,7 +87,7 @@ struct NDArrayShape(
         self._buf = buf^
 
     @always_inline("nodebug")
-    fn __init__(out self, *shape: Int) raises:
+    def __init__(out self, *shape: Int) raises:
         """
         Initializes the NDArrayShape with variable shape dimensions.
 
@@ -115,7 +115,7 @@ struct NDArrayShape(
             self._buf.init_value(i, Scalar[DType.int](shape[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, shape: List[Int]) raises:
+    def __init__(out self, shape: List[Int]) raises:
         """
         Initializes the NDArrayShape with a list of shape dimensions.
 
@@ -155,7 +155,7 @@ struct NDArrayShape(
             self._buf.init_value(i, Scalar[DType.int](shape[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, shape: VariadicList[Int, _]) raises:
+    def __init__(out self, shape: VariadicList[Int, _]) raises:
         """
         Initializes the NDArrayShape with a list of shape dimensions.
 
@@ -198,7 +198,7 @@ struct NDArrayShape(
             self._buf.init_value(i, Scalar[DType.int](shape[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, shape: NDArrayShape):
+    def __init__(out self, shape: NDArrayShape):
         """
         Initializes the NDArrayShape from another NDArrayShape.
         A deep copy of the data buffer is conducted.
@@ -211,7 +211,7 @@ struct NDArrayShape(
         memcpy(dest=self._buf.ptr, src=shape._buf.ptr, count=shape.ndim)
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         *,
         ndim: Int,
@@ -263,7 +263,7 @@ struct NDArrayShape(
                     self._buf.init_value(i, 1)
 
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Initializes the NDArrayShape from ancopy NDArrayShape.
         A deep copy of the data buffer is conducted.
@@ -288,7 +288,7 @@ struct NDArrayShape(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __getitem__(self, index: Int) raises -> Int:
+    def __getitem__(self, index: Int) raises -> Int:
         """
         Gets shape dimension at specified index.
 
@@ -304,7 +304,7 @@ struct NDArrayShape(
         return Int(self._buf[index])
 
     @always_inline("nodebug")
-    fn __getitem__(
+    def __getitem__(
         self, index: Scalar[Self.element_type]
     ) raises -> Scalar[Self.element_type]:
         """
@@ -319,7 +319,7 @@ struct NDArrayShape(
         return self._buf[index]
 
     @always_inline("nodebug")
-    fn __getitem__(self, slice_index: Slice) raises -> NDArrayShape:
+    def __getitem__(self, slice_index: Slice) raises -> NDArrayShape:
         """
         Return a sliced view of the dimension tuple as a new NDArrayShape.
 
@@ -332,7 +332,7 @@ struct NDArrayShape(
         return Self(self._buf[slice_index])
 
     @always_inline("nodebug")
-    fn __setitem__(
+    def __setitem__(
         mut self,
         index: Scalar[Self.element_type],
         val: Scalar[Self.element_type],
@@ -350,7 +350,7 @@ struct NDArrayShape(
         self._buf[index] = val
 
     @always_inline("nodebug")
-    fn __setitem__(mut self, index: Int, val: Int) raises:
+    def __setitem__(mut self, index: Int, val: Int) raises:
         """
         Sets shape at specified index.
 
@@ -363,7 +363,7 @@ struct NDArrayShape(
         """
         self._buf[index] = val
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, idx: Int) raises -> SIMD[Self.element_type, width]:
         """
@@ -395,7 +395,7 @@ struct NDArrayShape(
             )
         return self._buf.ptr.load[width=width](idx)
 
-    fn store[
+    def store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]) raises:
         """
@@ -425,7 +425,7 @@ struct NDArrayShape(
             )
         self._buf.ptr.store[width=width](idx, value)
 
-    fn unsafe_load[
+    def unsafe_load[
         width: Int = 1
     ](self, idx: Int) -> SIMD[Self.element_type, width]:
         """
@@ -442,7 +442,7 @@ struct NDArrayShape(
         """
         return self._buf.unsafe_load[width=width](idx)
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]):
         """
@@ -461,7 +461,7 @@ struct NDArrayShape(
     # Transformation Methods
     # ===----------------------------------------------------------------------=== #
 
-    fn row_major(self) raises -> NDArrayStrides:
+    def row_major(self) raises -> NDArrayStrides:
         """
         Create row-major (C-style) strides from a shape.
 
@@ -473,7 +473,7 @@ struct NDArrayShape(
         """
         return NDArrayStrides(shape=self, order="C")
 
-    fn col_major(self) raises -> NDArrayStrides:
+    def col_major(self) raises -> NDArrayStrides:
         """
         Create column-major (Fortran-style) strides from a shape.
 
@@ -485,7 +485,7 @@ struct NDArrayShape(
         """
         return NDArrayStrides(shape=self, order="F")
 
-    fn reverse(self) -> Self:
+    def reverse(self) -> Self:
         """
         Return a new shape with dimensions reversed.
 
@@ -494,7 +494,7 @@ struct NDArrayShape(
         """
         return Self(self._buf.flipped())
 
-    fn permute(self, axes: List[Int]) raises -> Self:
+    def permute(self, axes: List[Int]) raises -> Self:
         """
         Return a new shape with axes reordered.
 
@@ -558,7 +558,7 @@ struct NDArrayShape(
             )
         return result^
 
-    fn join(self, *shapes: Self) -> Self:
+    def join(self, *shapes: Self) -> Self:
         """
         Join multiple shapes into a single shape.
 
@@ -573,7 +573,7 @@ struct NDArrayShape(
             bufs.append(shapes[i]._buf)
         return Self(self._buf.join(bufs))
 
-    fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
+    def swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
         """
         Returns a new shape with the given axes swapped.
 
@@ -591,7 +591,7 @@ struct NDArrayShape(
         res[axis2] = val1
         return res
 
-    fn extend(self, *values: Int) -> Self:
+    def extend(self, *values: Int) -> Self:
         """
         Extend the shape by sizes of extended dimensions.
 
@@ -606,13 +606,13 @@ struct NDArrayShape(
             new_vals.append(values[i])
         return Self(self._buf.extend(new_vals))
 
-    fn flip(mut self):
+    def flip(mut self):
         """
         Flip the items in-place.
         """
         self._buf.flip()
 
-    fn flipped(self) -> Self:
+    def flipped(self) -> Self:
         """
         Returns a new shape by flipping the items.
 
@@ -621,7 +621,7 @@ struct NDArrayShape(
         """
         return Self(self._buf.flipped())
 
-    fn move_axis_to_end(self, axis: Int) -> Self:
+    def move_axis_to_end(self, axis: Int) -> Self:
         """
         Returns a new shape by moving the value of axis to the end.
 
@@ -633,7 +633,7 @@ struct NDArrayShape(
         """
         return Self(self._buf.move_axis_to_end(axis))
 
-    fn pop(self, axis: Int) raises -> Self:
+    def pop(self, axis: Int) raises -> Self:
         """
         Drops the item at the given axis (index).
 
@@ -650,7 +650,7 @@ struct NDArrayShape(
     # Properties
     # ===----------------------------------------------------------------------=== #
     @always_inline("nodebug")
-    fn rank(self) -> Int:
+    def rank(self) -> Int:
         """
         Returns the number of dimensions of the shape.
 
@@ -659,7 +659,7 @@ struct NDArrayShape(
         """
         return self.ndim
 
-    fn size(self) -> Int:
+    def size(self) -> Int:
         """
         Returns the total number of elements in the array.
 
@@ -668,7 +668,7 @@ struct NDArrayShape(
         """
         return Int(self._buf.product())
 
-    fn sum(self) -> Scalar[Self.element_type]:
+    def sum(self) -> Scalar[Self.element_type]:
         """
         Compute the sum of all elements in NDArrayShape.
 
@@ -677,7 +677,7 @@ struct NDArrayShape(
         """
         return self._buf.sum()
 
-    fn product(self) -> Scalar[Self.element_type]:
+    def product(self) -> Scalar[Self.element_type]:
         """
         Compute the product of all elements in the IndexBuffer.
 
@@ -690,7 +690,7 @@ struct NDArrayShape(
     # Traits
     # ===----------------------------------------------------------------------=== #
     @always_inline("nodebug")
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """
         Gets number of elements in the shape.
         It equals the number of dimensions of the array.
@@ -701,7 +701,7 @@ struct NDArrayShape(
         return self.ndim
 
     @always_inline("nodebug")
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Returns a string of the shape of the array.
 
@@ -710,7 +710,7 @@ struct NDArrayShape(
         """
         return "numojo.Shape" + self.__str__()
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -720,7 +720,7 @@ struct NDArrayShape(
         writer.write(self.__repr__())
 
     @always_inline("nodebug")
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns a string of the shape of the array.
 
@@ -735,7 +735,7 @@ struct NDArrayShape(
         result += ")"
         return result
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Writes the shape representation to a writer.
         """
@@ -744,7 +744,7 @@ struct NDArrayShape(
         )
 
     @always_inline("nodebug")
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks if two shapes have identical dimensions and values.
 
@@ -757,7 +757,7 @@ struct NDArrayShape(
         return self._buf == other._buf
 
     @always_inline("nodebug")
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks if two shapes have identical dimensions and values.
 
@@ -770,7 +770,7 @@ struct NDArrayShape(
         return not self.__eq__(other)
 
     @always_inline("nodebug")
-    fn __contains__(self, val: Int) -> Bool:
+    def __contains__(self, val: Int) -> Bool:
         """
         Checks if the given value is present in the shape dimensions.
 
@@ -783,7 +783,7 @@ struct NDArrayShape(
         return val in self._buf
 
     @always_inline("nodebug")
-    fn __contains__(self, val: Scalar[Self.element_type]) -> Bool:
+    def __contains__(self, val: Scalar[Self.element_type]) -> Bool:
         """
         Check if the NDArrayShape contains the given value.
 
@@ -799,7 +799,7 @@ struct NDArrayShape(
     # Utility Methods
     # ===----------------------------------------------------------------------=== #
     @always_inline("nodebug")
-    fn tolist(self) -> List[Int]:
+    def tolist(self) -> List[Int]:
         """
         Convert the shape to a list of integers.
 
@@ -812,7 +812,7 @@ struct NDArrayShape(
         return res^
 
     @always_inline("nodebug")
-    fn normalize_index(self, index: Int) -> Int:
+    def normalize_index(self, index: Int) -> Int:
         """
         Normalizes the given index to be within the valid range [0, ndim).
 
@@ -830,7 +830,7 @@ struct NDArrayShape(
     # ===----------------------------------------------------------------------=== #
     # Iterators
     # ===----------------------------------------------------------------------=== #
-    fn __iter__(ref self) -> _ShapeIter[origin_of(self), True]:
+    def __iter__(ref self) -> _ShapeIter[origin_of(self), True]:
         """
         Iterate over elements of the NDArrayShape, returning copied values.
 
@@ -842,7 +842,7 @@ struct NDArrayShape(
             length=self.ndim,
         )
 
-    fn __reversed__(ref self) -> _ShapeIter[origin_of(self), False]:
+    def __reversed__(ref self) -> _ShapeIter[origin_of(self), False]:
         """
         Iterate over elements of the NDArrayShape in reverse order, returning copied values.
 
@@ -873,7 +873,7 @@ struct _ShapeIter[
     var shape: Pointer[NDArrayShape, Self.origin]
     var length: Int
 
-    fn __init__(
+    def __init__(
         out self,
         shape: Pointer[NDArrayShape, Self.origin],
         length: Int,
@@ -882,16 +882,16 @@ struct _ShapeIter[
         self.length = length
         self.shape = shape
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __next__(mut self) raises -> Scalar[DType.int]:
+    def __next__(mut self) raises -> Scalar[DType.int]:
         comptime if Self.forward:
             var current_index = self.index
             self.index += 1
@@ -901,7 +901,7 @@ struct _ShapeIter[
             self.index -= 1
             return Scalar[DType.int](self.shape[].__getitem__(current_index))
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -55,7 +55,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes an empty NDArrayStrides.
         """
@@ -63,7 +63,7 @@ struct NDArrayStrides(
         self._buf = IndexBuffer()
 
     @always_inline("nodebug")
-    fn __init__(out self, buf: IndexBuffer):
+    def __init__(out self, buf: IndexBuffer):
         """
         Initializes the NDArrayStrides from an IndexBuffer.
 
@@ -74,7 +74,7 @@ struct NDArrayStrides(
         self._buf = buf
 
     @always_inline("nodebug")
-    fn __init__(out self, *strides: Int) raises:
+    def __init__(out self, *strides: Int) raises:
         """
         Initializes the NDArrayStrides from strides.
 
@@ -102,7 +102,7 @@ struct NDArrayStrides(
             self._buf.init_value(i, Scalar[DType.int](strides[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, strides: List[Int]) raises:
+    def __init__(out self, strides: List[Int]) raises:
         """
         Initializes the NDArrayStrides from a list of strides.
 
@@ -130,7 +130,7 @@ struct NDArrayStrides(
             self._buf.init_value(i, Scalar[DType.int](strides[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, strides: VariadicList[Int, _]) raises:
+    def __init__(out self, strides: VariadicList[Int, _]) raises:
         """
         Initializes the NDArrayStrides from a variadic list of strides.
 
@@ -162,7 +162,7 @@ struct NDArrayStrides(
             self._buf.init_value(i, Scalar[DType.int](strides[i]))
 
     @always_inline("nodebug")
-    fn __init__(out self, strides: NDArrayStrides):
+    def __init__(out self, strides: NDArrayStrides):
         """
         Initializes the NDArrayStrides from another strides.
         A deep-copy of the elements is conducted.
@@ -179,7 +179,7 @@ struct NDArrayStrides(
         )
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         order: String = "C",
@@ -224,7 +224,7 @@ struct NDArrayStrides(
             )
 
     @always_inline("nodebug")
-    fn __init__(out self, *shape: Int, order: String) raises:
+    def __init__(out self, *shape: Int, order: String) raises:
         """
         Overloads the function `__init__(shape: NDArrayStrides, order: String)`.
         Initializes the NDArrayStrides from a given shapes and an order.
@@ -240,7 +240,7 @@ struct NDArrayStrides(
         self = Self(shape=NDArrayShape(shape), order=order)
 
     @always_inline("nodebug")
-    fn __init__(out self, shape: List[Int], order: String = "C") raises:
+    def __init__(out self, shape: List[Int], order: String = "C") raises:
         """
         Overloads the function `__init__(shape: NDArrayStrides, order: String)`.
         Initializes the NDArrayStrides from a given shapes and an order.
@@ -256,7 +256,7 @@ struct NDArrayStrides(
         self = Self(shape=NDArrayShape(shape), order=order)
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: VariadicList[Int, _],
         order: String = "C",
@@ -276,7 +276,7 @@ struct NDArrayStrides(
         self = Self(shape=NDArrayShape(shape), order=order)
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         *,
         ndim: Int,
@@ -322,7 +322,7 @@ struct NDArrayStrides(
                     self._buf.init_value(i, 0)
 
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Initializes the NDArrayStrides from ancopy strides.
         A deep-copy of the elements is conducted.
@@ -347,7 +347,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __getitem__(self, index: Int) raises -> Int:
+    def __getitem__(self, index: Int) raises -> Int:
         """
         Gets stride at specified index.
 
@@ -360,7 +360,7 @@ struct NDArrayStrides(
         return Int(self._buf[index])
 
     @always_inline("nodebug")
-    fn __getitem__(
+    def __getitem__(
         self, index: Scalar[Self.element_type]
     ) raises -> Scalar[Self.element_type]:
         """
@@ -375,7 +375,7 @@ struct NDArrayStrides(
         return self._buf[index]
 
     @always_inline("nodebug")
-    fn __getitem__(self, slice_index: Slice) raises -> NDArrayStrides:
+    def __getitem__(self, slice_index: Slice) raises -> NDArrayStrides:
         """
         Return a sliced view of the strides as a new NDArrayStrides.
 
@@ -388,7 +388,7 @@ struct NDArrayStrides(
         return Self(self._buf[slice_index])
 
     @always_inline("nodebug")
-    fn __setitem__(
+    def __setitem__(
         mut self,
         index: Scalar[Self.element_type],
         val: Scalar[Self.element_type],
@@ -406,7 +406,7 @@ struct NDArrayStrides(
         self._buf[Int(index)] = Int(val)
 
     @always_inline("nodebug")
-    fn __setitem__(mut self, index: Int, val: Int) raises:
+    def __setitem__(mut self, index: Int, val: Int) raises:
         """
         Sets stride at specified index.
 
@@ -419,7 +419,7 @@ struct NDArrayStrides(
         """
         self._buf[index] = val
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, idx: Int) raises -> SIMD[Self.element_type, width]:
         """
@@ -451,7 +451,7 @@ struct NDArrayStrides(
             )
         return self._buf.unsafe_load[width=width](idx)
 
-    fn store[
+    def store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]) raises:
         """
@@ -481,7 +481,7 @@ struct NDArrayStrides(
             )
         self._buf.unsafe_store[width=width](idx, value)
 
-    fn unsafe_load[
+    def unsafe_load[
         width: Int = 1
     ](self, idx: Int) -> SIMD[Self.element_type, width]:
         """
@@ -498,7 +498,7 @@ struct NDArrayStrides(
         """
         return self._buf.unsafe_load[width=width](idx)
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](self, idx: Int, value: SIMD[Self.element_type, width]):
         """
@@ -517,7 +517,7 @@ struct NDArrayStrides(
     # Transformation Methods
     # ===----------------------------------------------------------------------=== #
 
-    fn permute(self, axes: List[Int]) raises -> Self:
+    def permute(self, axes: List[Int]) raises -> Self:
         """
         Return new strides with axes reordered.
 
@@ -581,7 +581,7 @@ struct NDArrayStrides(
             )
         return result^
 
-    fn swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
+    def swapaxes(self, axis1: Int, axis2: Int) raises -> Self:
         """
         Returns a new strides with the given axes swapped.
 
@@ -599,7 +599,7 @@ struct NDArrayStrides(
         res[axis2] = val1
         return res
 
-    fn join(self, *strides: Self) -> Self:
+    def join(self, *strides: Self) -> Self:
         """
         Join multiple strides into a single strides.
 
@@ -614,7 +614,7 @@ struct NDArrayStrides(
             bufs.append(strides[i]._buf)
         return Self(self._buf.join(bufs))
 
-    fn extend(self, *values: Int) -> Self:
+    def extend(self, *values: Int) -> Self:
         """
         Extend the shape by sizes of extended dimensions.
 
@@ -629,13 +629,13 @@ struct NDArrayStrides(
             new_vals.append(values[i])
         return Self(self._buf.extend(new_vals))
 
-    fn flip(mut self):
+    def flip(mut self):
         """
         Flip the items in-place.
         """
         self._buf.flip()
 
-    fn flipped(self) -> Self:
+    def flipped(self) -> Self:
         """
         Returns a new strides by flipping the items.
 
@@ -644,7 +644,7 @@ struct NDArrayStrides(
         """
         return Self(self._buf.flipped())
 
-    fn move_axis_to_end(self, axis: Int) -> Self:
+    def move_axis_to_end(self, axis: Int) -> Self:
         """
         Returns a new strides by moving the value of axis to the end.
 
@@ -656,7 +656,7 @@ struct NDArrayStrides(
         """
         return Self(self._buf.move_axis_to_end(axis))
 
-    fn pop(self, axis: Int) raises -> Self:
+    def pop(self, axis: Int) raises -> Self:
         """
         Drops information of certain axis.
 
@@ -672,7 +672,7 @@ struct NDArrayStrides(
     # Properties
     # ===----------------------------------------------------------------------=== #
 
-    fn is_contiguous(self, shape: NDArrayShape) raises -> Bool:
+    def is_contiguous(self, shape: NDArrayShape) raises -> Bool:
         """
         Check if strides represent a contiguous layout for the shape.
 
@@ -707,7 +707,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """
         Gets number of elements in the strides.
         It equals to the number of dimensions of the array.
@@ -718,7 +718,7 @@ struct NDArrayStrides(
         return self.ndim
 
     @always_inline("nodebug")
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """
         Returns a string of the strides of the array.
 
@@ -728,7 +728,7 @@ struct NDArrayStrides(
         return "numojo.Strides" + self.__str__()
 
     @always_inline("nodebug")
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Returns a string of the strides of the array.
 
@@ -743,7 +743,7 @@ struct NDArrayStrides(
         result = result + ")"
         return result
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -752,7 +752,7 @@ struct NDArrayStrides(
         # TODO: Deprecate `__repr__` and move its body directly into this method.
         writer.write(self.__repr__())
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Writes the strides representation to a writer.
         """
@@ -761,7 +761,7 @@ struct NDArrayStrides(
         )
 
     @always_inline("nodebug")
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Checks if two strides have identical dimensions and values.
 
@@ -774,7 +774,7 @@ struct NDArrayStrides(
         return self._buf == other._buf
 
     @always_inline("nodebug")
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Checks if two strides have identical dimensions and values.
 
@@ -787,7 +787,7 @@ struct NDArrayStrides(
         return not self.__eq__(other)
 
     @always_inline("nodebug")
-    fn __contains__(self, val: Int) -> Bool:
+    def __contains__(self, val: Int) -> Bool:
         """
         Checks if the given value is present in the strides.
 
@@ -800,7 +800,7 @@ struct NDArrayStrides(
         return val in self._buf
 
     @always_inline("nodebug")
-    fn __contains__(self, val: Scalar[Self.element_type]) -> Bool:
+    def __contains__(self, val: Scalar[Self.element_type]) -> Bool:
         """
         Check if the NDArrayStrides contains the given value.
 
@@ -817,7 +817,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
 
     @staticmethod
-    fn row_major(shape: NDArrayShape) raises -> NDArrayStrides:
+    def row_major(shape: NDArrayShape) raises -> NDArrayStrides:
         """
         Create row-major (C-style) strides from a shape.
 
@@ -830,7 +830,7 @@ struct NDArrayStrides(
         return NDArrayStrides(shape=shape, order="C")
 
     @staticmethod
-    fn col_major(shape: NDArrayShape) raises -> NDArrayStrides:
+    def col_major(shape: NDArrayShape) raises -> NDArrayStrides:
         """
         Create column-major (Fortran-style) strides from a shape.
 
@@ -843,7 +843,7 @@ struct NDArrayStrides(
         return NDArrayStrides(shape=shape, order="F")
 
     @staticmethod
-    fn default(shape: NDArrayShape) raises -> NDArrayStrides:
+    def default(shape: NDArrayShape) raises -> NDArrayStrides:
         """
         Create default (row-major) strides from a shape.
 
@@ -860,7 +860,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
 
     @always_inline("nodebug")
-    fn tolist(self) -> List[Int]:
+    def tolist(self) -> List[Int]:
         """
         Convert the strides to a list of integers.
 
@@ -873,7 +873,7 @@ struct NDArrayStrides(
         return res^
 
     @always_inline("nodebug")
-    fn normalize_index(self, index: Int) -> Int:
+    def normalize_index(self, index: Int) -> Int:
         """
         Normalizes the given index to be within the valid range [0, ndim).
 
@@ -891,7 +891,7 @@ struct NDArrayStrides(
     # ===----------------------------------------------------------------------=== #
     # Iterators
     # ===----------------------------------------------------------------------=== #
-    fn __iter__(ref self) -> _StrideIter[origin_of(self), True]:
+    def __iter__(ref self) -> _StrideIter[origin_of(self), True]:
         """
         Iterate over elements of the NDArrayStrides, returning copied values.
 
@@ -903,7 +903,7 @@ struct NDArrayStrides(
             length=self.ndim,
         )
 
-    fn __reversed__(ref self) -> _StrideIter[origin_of(self), False]:
+    def __reversed__(ref self) -> _StrideIter[origin_of(self), False]:
         """
         Iterate over elements of the NDArrayStrides, returning copied values.
 
@@ -931,7 +931,7 @@ struct _StrideIter[
     var strides: Pointer[NDArrayStrides, Self.origin]
     var length: Int
 
-    fn __init__(
+    def __init__(
         out self,
         strides: Pointer[NDArrayStrides, Self.origin],
         length: Int,
@@ -940,16 +940,16 @@ struct _StrideIter[
         self.length = length
         self.strides = strides
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __next__(mut self) raises -> Scalar[DType.int]:
+    def __next__(mut self) raises -> Scalar[DType.int]:
         comptime if Self.forward:
             var current_index = self.index
             self.index += 1
@@ -959,7 +959,7 @@ struct _StrideIter[
             self.index -= 1
             return Scalar[DType.int](self.strides[].__getitem__(current_index))
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -1713,7 +1713,9 @@ struct Matrix[
             self.offset + x * self.strides[0] + y * self.strides[1], simd
         )
 
-    def _store_idx[width: Int = 1](self, idx: Int, val: SIMD[Self.dtype, width]):
+    def _store_idx[
+        width: Int = 1
+    ](self, idx: Int, val: SIMD[Self.dtype, width]):
         """
         `__setitem__` with width.
         Unsafe: No boundary check!
@@ -3187,7 +3189,9 @@ struct Matrix[
         """
         return self != broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    def __matmul__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __matmul__(
+        self, other: Matrix[Self.dtype]
+    ) raises -> Matrix[Self.dtype]:
         """
         Matrix multiplication using the @ operator.
 

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -160,7 +160,7 @@ struct Matrix[
     # ===-------------------------------------------------------------------===#
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: Tuple[Int, Int],
         order: String = "C",
@@ -198,7 +198,7 @@ struct Matrix[
 
     # * Should we take var ref and transfer ownership or take a read ref and copy the data?
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         var data: Self,
     ):
@@ -227,7 +227,7 @@ struct Matrix[
         self = data^
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         data: Self,
     ):
@@ -252,7 +252,7 @@ struct Matrix[
                     self._store(i, j, data._load(i, j))
 
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         data: NDArray[Self.dtype],
     ) raises:
@@ -314,7 +314,7 @@ struct Matrix[
     # TODO: Add a own_data flag constructor so that we can use the overload to
     # create deep copy of arrays by providing new datacontainer.
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         var data: DataContainer[Self.dtype],
         is_view: Bool,  # maybe make this a parameter in future.
@@ -354,7 +354,7 @@ struct Matrix[
     # TODO: prevent copying from views to views or views to owning matrices right now.`where` clause isn't working here either for now, So we use constrained. Move to 'where` clause when it's stable.
     # TODO: Current copyinit creates an instance with same origin. This should be external origin. fix this so that we can use default `.copy()` method and remove `create_copy()` method.
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Initialize a new matrix by copying data from ancopy matrix.
 
@@ -380,7 +380,7 @@ struct Matrix[
         )
 
     # NOTE: perhaps remove this?
-    fn deep_copy(self) -> Self:
+    def deep_copy(self) -> Self:
         """
         Returns a deep copy of the matrix.
 
@@ -407,7 +407,7 @@ struct Matrix[
             offset=self.offset,
         )
 
-    fn view(mut self) raises -> Self:
+    def view(mut self) raises -> Self:
         """
         Returns a non-owning view of the current matrix.
 
@@ -432,7 +432,7 @@ struct Matrix[
         )
 
     @always_inline("nodebug")
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """
         Transfer ownership of resources from `other` to `self`.
 
@@ -455,7 +455,7 @@ struct Matrix[
         self.flags = take.flags^
 
     @always_inline("nodebug")
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """
         Destructor for the matrix instance.
 
@@ -470,7 +470,7 @@ struct Matrix[
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing methods
     # ===-------------------------------------------------------------------===#
-    fn validate_and_normalize(self, x: Int, y: Int) raises -> Tuple[Int, Int]:
+    def validate_and_normalize(self, x: Int, y: Int) raises -> Tuple[Int, Int]:
         """
         Validate and normalize the provided row and column indices.
 
@@ -518,7 +518,7 @@ struct Matrix[
         var y_norm = Validator.normalize(y, self.shape[1])
         return (x_norm, y_norm)
 
-    fn __getitem__(self, x: Int, y: Int) raises -> Scalar[Self.dtype]:
+    def __getitem__(self, x: Int, y: Int) raises -> Scalar[Self.dtype]:
         """
         Retrieve the scalar value at the specified row and column indices.
 
@@ -548,7 +548,7 @@ struct Matrix[
         ]
 
     # TODO: temporarily renaming all view returning functions to be `get` or `set` due to a Mojo bug with overloading `__getitem__` and `__setitem__` with different argument types. Created an issue in Mojo GitHub
-    fn get(mut self, var x: Int) raises -> Matrix[Self.dtype]:
+    def get(mut self, var x: Int) raises -> Matrix[Self.dtype]:
         """
         Retrieve a view of the specified row in the matrix. This method returns a non-owning `Matrix` that references the data of the specified row in the original matrix. The view does not allocate new memory and directly points to the existing data buffer of the matrix.
 
@@ -593,7 +593,7 @@ struct Matrix[
         )
 
     # for creating a copy of the row.
-    fn __getitem__(self, var x: Int) raises -> Matrix[Self.dtype]:
+    def __getitem__(self, var x: Int) raises -> Matrix[Self.dtype]:
         """
         Retrieve a copy of the specified row in the matrix. This method creates and returns a new `Matrix` instance that contains a copy of the data from the specified row of the original matrix. The returned matrix is a row vector with a shape of (1, number_of_columns).
 
@@ -639,7 +639,7 @@ struct Matrix[
 
         return result^
 
-    fn get(mut self, x: Slice, y: Slice) raises -> Matrix[Self.dtype]:
+    def get(mut self, x: Slice, y: Slice) raises -> Matrix[Self.dtype]:
         """
         Retrieve a view of the specified slice in the matrix.
 
@@ -678,7 +678,7 @@ struct Matrix[
         )
 
     # for creating a copy of the slice.
-    fn __getitem__(self, x: Slice, y: Slice) -> Matrix[Self.dtype]:
+    def __getitem__(self, x: Slice, y: Slice) -> Matrix[Self.dtype]:
         """
         Retrieve a copy of the specified slice in the matrix. This method creates and returns a new `Matrix` instance that contains a copy of the data from the specified slice of the original matrix. The returned matrix will have the shape determined by the slice ranges.
 
@@ -729,7 +729,7 @@ struct Matrix[
 
         return B^
 
-    fn get(mut self, x: Slice, var y: Int) raises -> Matrix[Self.dtype]:
+    def get(mut self, x: Slice, var y: Int) raises -> Matrix[Self.dtype]:
         """
         Retrieve a view of a specific column slice in the matrix. This method returns a non-owning `Matrix` that references the data of the specified column slice in the original matrix. The view does not allocate new memory and directly points to the existing data buffer of the matrix.
 
@@ -784,7 +784,7 @@ struct Matrix[
             offset=self.offset + offset,
         )
 
-    fn __getitem__(self, x: Slice, var y: Int) -> Matrix[Self.dtype]:
+    def __getitem__(self, x: Slice, var y: Int) -> Matrix[Self.dtype]:
         """
         Retrieve a copy of a specific column slice in the matrix. This method creates and returns a new `Matrix` instance that contains a copy
         of the data from the specified and column slice of the original matrix. The returned matrix will have a shape determined by the row slice and a single column.
@@ -828,7 +828,7 @@ struct Matrix[
             row += 1
         return res^
 
-    fn get(mut self, var x: Int, y: Slice) raises -> Matrix[Self.dtype]:
+    def get(mut self, var x: Int, y: Slice) raises -> Matrix[Self.dtype]:
         """
         Retrieve a view of a specific row slice in the matrix. This method returns a non-owning `Matrix` that references the data of the specified row slice in the original matrix. The view does not allocate new memory and directly points to the existing data buffer of the matrix.
 
@@ -883,7 +883,7 @@ struct Matrix[
             offset=self.offset + offset,
         )
 
-    fn __getitem__(self, var x: Int, y: Slice) raises -> Matrix[Self.dtype]:
+    def __getitem__(self, var x: Int, y: Slice) raises -> Matrix[Self.dtype]:
         """
         Retrieve a copy of a specific row slice in the matrix. This method creates and returns a new `Matrix` instance that contains a copy
         of the data from the specified row and column slice of the original matrix. The returned matrix will have a shape of (1, number_of_columns_in_slice).
@@ -936,7 +936,7 @@ struct Matrix[
 
         return B^
 
-    fn __getitem__(self, indices: List[Int]) raises -> Matrix[Self.dtype]:
+    def __getitem__(self, indices: List[Int]) raises -> Matrix[Self.dtype]:
         """
         Retrieve a copy of specific rows in the matrix based on the provided indices. This method creates and returns a new `Matrix` instance that contains a copy of the data from the specified rows of the original matrix. The returned matrix will have a shape of (number_of_indices, number_of_columns).
 
@@ -980,7 +980,7 @@ struct Matrix[
             selected_rows[i] = self[indices[i]]
         return selected_rows^
 
-    fn load[width: Int = 1](self, idx: Int) raises -> SIMD[Self.dtype, width]:
+    def load[width: Int = 1](self, idx: Int) raises -> SIMD[Self.dtype, width]:
         """
         Load a SIMD element from the matrix at the specified linear index.
 
@@ -1019,7 +1019,7 @@ struct Matrix[
         var idx_norm = Validator.normalize(idx, self.size)
         return self._buf.ptr.load[width=width](self.offset + idx_norm)
 
-    fn _load[width: Int = 1](self, x: Int, y: Int) -> SIMD[Self.dtype, width]:
+    def _load[width: Int = 1](self, x: Int, y: Int) -> SIMD[Self.dtype, width]:
         """
         `__getitem__` with width.
         Unsafe: No boundary check!
@@ -1028,14 +1028,14 @@ struct Matrix[
             self.offset + x * self.strides[0] + y * self.strides[1]
         )
 
-    fn _load[width: Int = 1](self, idx: Int) -> SIMD[Self.dtype, width]:
+    def _load[width: Int = 1](self, idx: Int) -> SIMD[Self.dtype, width]:
         """
         `__getitem__` with width.
         Unsafe: No boundary check!
         """
         return self._buf.ptr.load[width=width](self.offset + idx)
 
-    fn __setitem__(mut self, x: Int, y: Int, value: Scalar[Self.dtype]) raises:
+    def __setitem__(mut self, x: Int, y: Int, value: Scalar[Self.dtype]) raises:
         """
         Set the value at the specified row and column indices in the matrix.
 
@@ -1089,7 +1089,7 @@ struct Matrix[
         )
 
     # FIXME: Setting with views is currently only supported through `.set()` method of the Matrix. Once Mojo resolve the symmetric getter setter issue, we can remove `.set()` methods.
-    fn __setitem__(self, var x: Int, value: Matrix[Self.dtype]) raises:
+    def __setitem__(self, var x: Int, value: Matrix[Self.dtype]) raises:
         """
         Assign a row in the matrix at the specified index with the given matrix. This method replaces the row at the specified index `x` with the data from
         the provided `value` matrix. The `value` matrix must be a row vector with
@@ -1180,7 +1180,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(x, j, value._load(0, j))
 
-    fn set(self, var x: Int, value: Matrix[Self.dtype]) raises:
+    def set(self, var x: Int, value: Matrix[Self.dtype]) raises:
         """
         Assign a row in the matrix at the specified index with the given matrix. This method replaces the row at the specified index `x` with the data from
         the provided `value` matrix. The `value` matrix must be a row vector with
@@ -1274,7 +1274,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(x, j, value._load(0, j))
 
-    fn __setitem__(self, x: Slice, y: Int, value: Matrix[Self.dtype]) raises:
+    def __setitem__(self, x: Slice, y: Int, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a column in the matrix at the specified column index `y`
         and row slice `x` with the given matrix. This method replaces the values
@@ -1347,7 +1347,7 @@ struct Matrix[
             self._store(i, y_norm, value._load(row, 0))
             row += 1
 
-    fn set(self, x: Slice, y: Int, value: Matrix[Self.dtype]) raises:
+    def set(self, x: Slice, y: Int, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a column in the matrix at the specified column index `y`
         and row slice `x` with the given matrix. This method replaces the values
@@ -1427,7 +1427,7 @@ struct Matrix[
             self._store(i, y_norm, value._load(row, 0))
             row += 1
 
-    fn __setitem__(self, x: Int, y: Slice, value: Matrix[Self.dtype]) raises:
+    def __setitem__(self, x: Int, y: Slice, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a row in the matrix at the specified row index `x`
         and column slice `y` with the given matrix. This method replaces the values in the specified row and column slice with the data from the provided `value` matrix.
@@ -1498,7 +1498,7 @@ struct Matrix[
             self._store(x_norm, j, value._load(0, col))
             col += 1
 
-    fn set(self, x: Int, y: Slice, value: Matrix[Self.dtype]) raises:
+    def set(self, x: Int, y: Slice, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a row in the matrix at the specified row index `x`
         and column slice `y` with the given matrix. This method replaces the values in the specified row and column slice with the data from the provided `value` matrix.
@@ -1576,7 +1576,7 @@ struct Matrix[
             self._store(x_norm, j, value._load(0, col))
             col += 1
 
-    fn __setitem__(self, x: Slice, y: Slice, value: Matrix[Self.dtype]) raises:
+    def __setitem__(self, x: Slice, y: Slice, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a submatrix of the matrix defined by row slice `x` and column slice `y` using the provided `value` matrix. This method replaces the elements in the specified row and column slices with the corresponding elements from `value`.
 
@@ -1636,7 +1636,7 @@ struct Matrix[
                 col += 1
             row += 1
 
-    fn set(self, x: Slice, y: Slice, value: Matrix[Self.dtype]) raises:
+    def set(self, x: Slice, y: Slice, value: Matrix[Self.dtype]) raises:
         """
         Assign values to a submatrix of the matrix defined by row slice `x` and column slice `y` using the provided `value` matrix. This method replaces the elements in the specified row and column slices with the corresponding elements from `value`.
 
@@ -1702,7 +1702,7 @@ struct Matrix[
                 col += 1
             row += 1
 
-    fn _store[
+    def _store[
         width: Int = 1
     ](self, x: Int, y: Int, simd: SIMD[Self.dtype, width]):
         """
@@ -1713,14 +1713,14 @@ struct Matrix[
             self.offset + x * self.strides[0] + y * self.strides[1], simd
         )
 
-    fn _store_idx[width: Int = 1](self, idx: Int, val: SIMD[Self.dtype, width]):
+    def _store_idx[width: Int = 1](self, idx: Int, val: SIMD[Self.dtype, width]):
         """
         `__setitem__` with width.
         Unsafe: No boundary check!
         """
         self._buf.ptr.store(self.offset + idx, val)
 
-    fn store[
+    def store[
         width: Int = 1
     ](self, idx: Int, val: SIMD[Self.dtype, width]) raises:
         """
@@ -1763,7 +1763,7 @@ struct Matrix[
     # ===-------------------------------------------------------------------===#
     # Other dunders and auxiliary methods
     # ===-------------------------------------------------------------------===#
-    # fn view(self) -> Matrix[Self.dtype]:
+    # def view(self) -> Matrix[Self.dtype]:
     #     """
     #     Return a non-owning view of the matrix. This method creates and returns a `Matrix` that references the data of the original matrix. The view does not allocate new memory and directly points to the existing data buffer. Modifications to the view affect the original matrix.
 
@@ -1783,7 +1783,7 @@ struct Matrix[
     #         data=self._buf.share(),
     #     )
 
-    fn __iter__(ref self) -> Self.IteratorType[True, True]:
+    def __iter__(ref self) -> Self.IteratorType[True, True]:
         """
         Returns an iterator over the rows of the Matrix. Each iteration yields a Matrix representing a single row.
 
@@ -1805,7 +1805,7 @@ struct Matrix[
             strides=self.strides,
         )
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """
         Return the number of rows in the matrix (length of the first dimension).
 
@@ -1822,7 +1822,7 @@ struct Matrix[
         return self.shape[0]
 
     # TODO: The creation of iterators are a bit convoluted rn, clean it up
-    fn __reversed__(
+    def __reversed__(
         ref self,
     ) -> Self.IteratorType[True, False]:
         """
@@ -1838,7 +1838,7 @@ struct Matrix[
             strides=self.strides,
         )
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Return a string representation of the matrix.
 
@@ -1847,7 +1847,7 @@ struct Matrix[
         """
         return String.write(self)
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Write the string representation of the matrix to a writer.
 
@@ -1855,7 +1855,7 @@ struct Matrix[
             writer: The writer to output the matrix string to.
         """
 
-        fn print_row(self: Self, i: Int, sep: String) raises -> String:
+        def print_row(self: Self, i: Int, sep: String) raises -> String:
             var result: String = String("[")
             var number_of_sep: Int = 1
             if self.shape[1] <= 6:
@@ -1922,7 +1922,7 @@ struct Matrix[
     # Arithmetic dunder methods
     # ===-------------------------------------------------------------------===#
 
-    fn __add__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __add__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Add two matrices element-wise.
 
@@ -1960,7 +1960,7 @@ struct Matrix[
                 Self.dtype, SIMD.__add__
             ](self, broadcast_to[Self.dtype](other, self.shape, self.order()))
 
-    fn __add__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __add__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Add a scalar to every element of the matrix.
 
@@ -1979,7 +1979,7 @@ struct Matrix[
         """
         return self + broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __radd__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __radd__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Add a matrix to a scalar (right-hand side).
 
@@ -1998,7 +1998,7 @@ struct Matrix[
         """
         return broadcast_to[Self.dtype](other, self.shape, self.order()) + self
 
-    fn __sub__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __sub__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Subtract two matrices element-wise.
 
@@ -2036,7 +2036,7 @@ struct Matrix[
                 Self.dtype, SIMD.__sub__
             ](self, broadcast_to(other, self.shape, self.order()))
 
-    fn __sub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __sub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Subtract a scalar from every element of the matrix.
 
@@ -2055,7 +2055,7 @@ struct Matrix[
         """
         return self - broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __rsub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __rsub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Subtract a matrix from a scalar (right-hand side).
 
@@ -2074,7 +2074,7 @@ struct Matrix[
         """
         return broadcast_to[Self.dtype](other, self.shape, self.order()) - self
 
-    fn __mul__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __mul__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Multiply two matrices element-wise.
 
@@ -2112,7 +2112,7 @@ struct Matrix[
                 Self.dtype, SIMD.__mul__
             ](self, broadcast_to(other, self.shape, self.order()))
 
-    fn __mul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __mul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Multiply matrix by scalar.
 
@@ -2131,7 +2131,7 @@ struct Matrix[
         """
         return self * broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __rmul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __rmul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Multiply scalar by matrix (right-hand side).
 
@@ -2150,7 +2150,7 @@ struct Matrix[
         """
         return broadcast_to[Self.dtype](other, self.shape, self.order()) * self
 
-    fn __truediv__(
+    def __truediv__(
         self, other: Matrix[Self.dtype]
     ) raises -> Matrix[Self.dtype]:
         """
@@ -2190,7 +2190,7 @@ struct Matrix[
                 Self.dtype, SIMD.__truediv__
             ](self, broadcast_to(other, self.shape, self.order()))
 
-    fn __truediv__(
+    def __truediv__(
         self, other: Scalar[Self.dtype]
     ) raises -> Matrix[Self.dtype]:
         """
@@ -2213,7 +2213,7 @@ struct Matrix[
             other, self.shape, order=self.order()
         )
 
-    fn __pow__(self, rhs: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __pow__(self, rhs: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Raise each element of the matrix to the power of `rhs`.
 
@@ -2238,14 +2238,14 @@ struct Matrix[
         comptime width = simd_width_of[Self.dtype]()
 
         @parameter
-        fn vec_pow[w: Int](i: Int) unified {mut result, read self, read rhs}:
+        def vec_pow[w: Int](i: Int) unified {mut result, read self, read rhs}:
             var vec = self._buf.ptr.load[width=w](i)
             result._buf.ptr.store(i, vec.__pow__(rhs))
 
         vectorize[width](self.size, vec_pow)
         return result^
 
-    fn __iadd__(mut self, other: Matrix[Self.dtype]) raises:
+    def __iadd__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Add another matrix to this matrix in-place.
 
@@ -2285,7 +2285,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_add[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a + b)
@@ -2296,7 +2296,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) + other._load(i, j))
 
-    fn __iadd__(mut self, other: Scalar[Self.dtype]):
+    def __iadd__(mut self, other: Scalar[Self.dtype]):
         """
         Add a scalar to this matrix in-place.
 
@@ -2314,7 +2314,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_add_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add_scalar[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a + other)
 
@@ -2324,7 +2324,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) + other)
 
-    fn __isub__(mut self, other: Matrix[Self.dtype]) raises:
+    def __isub__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Subtract another matrix from this matrix in-place.
 
@@ -2364,7 +2364,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_sub[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a - b)
@@ -2375,7 +2375,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) - other._load(i, j))
 
-    fn __isub__(mut self, other: Scalar[Self.dtype]):
+    def __isub__(mut self, other: Scalar[Self.dtype]):
         """
         Subtract a scalar from this matrix in-place.
 
@@ -2393,7 +2393,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_sub_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub_scalar[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a - other)
 
@@ -2403,7 +2403,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) - other)
 
-    fn __imul__(mut self, other: Matrix[Self.dtype]) raises:
+    def __imul__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Multiply this matrix by another matrix element-wise in-place.
 
@@ -2443,7 +2443,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_mul[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a * b)
@@ -2454,7 +2454,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) * other._load(i, j))
 
-    fn __imul__(mut self, other: Scalar[Self.dtype]):
+    def __imul__(mut self, other: Scalar[Self.dtype]):
         """
         Multiply this matrix by a scalar in-place.
 
@@ -2472,7 +2472,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_mul_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul_scalar[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a * other)
 
@@ -2482,7 +2482,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) * other)
 
-    fn __itruediv__(mut self, other: Matrix[Self.dtype]) raises:
+    def __itruediv__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Divide this matrix by another matrix element-wise in-place.
 
@@ -2522,7 +2522,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_div[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a / b)
@@ -2533,7 +2533,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) / other._load(i, j))
 
-    fn __itruediv__(mut self, other: Scalar[Self.dtype]):
+    def __itruediv__(mut self, other: Scalar[Self.dtype]):
         """
         Divide this matrix by a scalar in-place.
 
@@ -2551,7 +2551,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_div_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div_scalar[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a / other)
 
@@ -2561,7 +2561,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) / other)
 
-    fn __floordiv__(
+    def __floordiv__(
         self, other: Matrix[Self.dtype]
     ) raises -> Matrix[Self.dtype]:
         """
@@ -2601,7 +2601,7 @@ struct Matrix[
                 Self.dtype, SIMD.__floordiv__
             ](self, broadcast_to(other, self.shape, self.order()))
 
-    fn __floordiv__(
+    def __floordiv__(
         self, other: Scalar[Self.dtype]
     ) raises -> Matrix[Self.dtype]:
         """
@@ -2622,7 +2622,7 @@ struct Matrix[
         """
         return self // broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __ifloordiv__(mut self, other: Matrix[Self.dtype]) raises:
+    def __ifloordiv__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Floor divide this matrix by another matrix element-wise in-place.
 
@@ -2664,7 +2664,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_floordiv[w: Int](i: Int) unified {mut self, read other}:
+            def vec_floordiv[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a // b)
@@ -2675,7 +2675,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) // other._load(i, j))
 
-    fn __ifloordiv__(mut self, other: Scalar[Self.dtype]):
+    def __ifloordiv__(mut self, other: Scalar[Self.dtype]):
         """
         Floor divide this matrix by a scalar in-place.
 
@@ -2693,7 +2693,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_floordiv_scalar[
+            def vec_floordiv_scalar[
                 w: Int
             ](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
@@ -2705,7 +2705,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) // other)
 
-    fn __mod__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __mod__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Compute element-wise modulo of two matrices.
 
@@ -2743,7 +2743,7 @@ struct Matrix[
                 Self.dtype, SIMD.__mod__
             ](self, broadcast_to(other, self.shape, self.order()))
 
-    fn __mod__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __mod__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Compute element-wise modulo of matrix with scalar.
 
@@ -2762,7 +2762,7 @@ struct Matrix[
         """
         return self % broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __imod__(mut self, other: Matrix[Self.dtype]) raises:
+    def __imod__(mut self, other: Matrix[Self.dtype]) raises:
         """
         Compute element-wise modulo with another matrix in-place.
 
@@ -2803,7 +2803,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_mod[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a % b)
@@ -2814,7 +2814,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) % other._load(i, j))
 
-    fn __imod__(mut self, other: Scalar[Self.dtype]):
+    def __imod__(mut self, other: Scalar[Self.dtype]):
         """
         Compute element-wise modulo with a scalar in-place.
 
@@ -2832,7 +2832,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            fn vec_mod_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod_scalar[w: Int](i: Int) unified {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a % other)
 
@@ -2842,7 +2842,7 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._store(i, j, self._load(i, j) % other)
 
-    fn __lt__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __lt__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for less-than.
 
@@ -2880,7 +2880,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __lt__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __lt__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for less-than.
 
@@ -2899,7 +2899,7 @@ struct Matrix[
         """
         return self < broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __le__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __le__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for less-than-or-equal.
 
@@ -2937,7 +2937,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __le__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __le__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for less-than-or-equal.
 
@@ -2956,7 +2956,7 @@ struct Matrix[
         """
         return self <= broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __gt__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __gt__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for greater-than.
 
@@ -2994,7 +2994,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __gt__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __gt__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for greater-than.
 
@@ -3013,7 +3013,7 @@ struct Matrix[
         """
         return self > broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __ge__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __ge__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for greater-than-or-equal.
 
@@ -3051,7 +3051,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __ge__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __ge__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for greater-than-or-equal.
 
@@ -3073,7 +3073,7 @@ struct Matrix[
         """
         return self >= broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __eq__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __eq__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for equality.
 
@@ -3111,7 +3111,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __eq__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __eq__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for equality.
 
@@ -3130,7 +3130,7 @@ struct Matrix[
         """
         return self == broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __ne__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __ne__(self, other: Matrix[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare two matrices element-wise for inequality.
 
@@ -3168,7 +3168,7 @@ struct Matrix[
                 self, broadcast_to(other, self.shape, self.order())
             )
 
-    fn __ne__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
+    def __ne__(self, other: Scalar[Self.dtype]) raises -> Matrix[DType.bool]:
         """
         Compare each element of the matrix to a scalar for inequality.
 
@@ -3187,7 +3187,7 @@ struct Matrix[
         """
         return self != broadcast_to[Self.dtype](other, self.shape, self.order())
 
-    fn __matmul__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
+    def __matmul__(self, other: Matrix[Self.dtype]) raises -> Matrix[Self.dtype]:
         """
         Matrix multiplication using the @ operator.
 
@@ -3215,7 +3215,7 @@ struct Matrix[
     # # ===-------------------------------------------------------------------===#
 
     # FIXME: These return types be Scalar[DType.bool] or Matrix[DType.bool] instead to match numpy. Fix the docstring examples too.
-    fn all(self) -> Scalar[Self.dtype]:
+    def all(self) -> Scalar[Self.dtype]:
         """
         Returns True if all elements of the matrix evaluate to True.
 
@@ -3233,7 +3233,7 @@ struct Matrix[
         """
         return numojo.logic.all(self)
 
-    fn all(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def all(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Returns a matrix indicating whether all elements along the specified axis evaluate to True.
 
@@ -3255,7 +3255,7 @@ struct Matrix[
         """
         return numojo.logic.all[Self.dtype](self, axis=axis)
 
-    fn any(self) -> Scalar[Self.dtype]:
+    def any(self) -> Scalar[Self.dtype]:
         """
         Returns True if any element of the matrix evaluates to True.
 
@@ -3273,7 +3273,7 @@ struct Matrix[
         """
         return numojo.logic.any(self)
 
-    fn any(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def any(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Returns a matrix indicating whether any element along the specified axis evaluates to True.
 
@@ -3285,7 +3285,7 @@ struct Matrix[
         """
         return numojo.logic.any(self, axis=axis)
 
-    fn argmax(self) raises -> Scalar[DType.int]:
+    def argmax(self) raises -> Scalar[DType.int]:
         """
         Returns the index of the maximum element in the flattened matrix.
 
@@ -3301,7 +3301,7 @@ struct Matrix[
         """
         return numojo.math.argmax(self)
 
-    fn argmax(self, axis: Int) raises -> Matrix[DType.int]:
+    def argmax(self, axis: Int) raises -> Matrix[DType.int]:
         """
         Returns the indices of the maximum elements along the specified axis.
 
@@ -3321,7 +3321,7 @@ struct Matrix[
         """
         return numojo.math.argmax(self, axis=axis)
 
-    fn argmin(self) raises -> Scalar[DType.int]:
+    def argmin(self) raises -> Scalar[DType.int]:
         """
         Returns the index of the minimum element in the flattened matrix.
 
@@ -3337,7 +3337,7 @@ struct Matrix[
         """
         return numojo.math.argmin(self)
 
-    fn argmin(self, axis: Int) raises -> Matrix[DType.int]:
+    def argmin(self, axis: Int) raises -> Matrix[DType.int]:
         """
         Returns the indices of the minimum elements along the specified axis.
 
@@ -3357,7 +3357,7 @@ struct Matrix[
         """
         return numojo.math.argmin(self, axis=axis)
 
-    fn argsort(self) raises -> Matrix[DType.int]:
+    def argsort(self) raises -> Matrix[DType.int]:
         """
         Returns the indices that would sort the flattened matrix.
 
@@ -3373,7 +3373,7 @@ struct Matrix[
         """
         return numojo.math.argsort(self)
 
-    fn argsort(self, axis: Int) raises -> Matrix[DType.int]:
+    def argsort(self, axis: Int) raises -> Matrix[DType.int]:
         """
         Returns the indices that would sort the matrix along the specified axis.
 
@@ -3393,7 +3393,7 @@ struct Matrix[
         """
         return numojo.math.argsort(self, axis=axis)
 
-    fn astype[asdtype: DType](self) -> Matrix[asdtype]:
+    def astype[asdtype: DType](self) -> Matrix[asdtype]:
         """
         Returns a copy of the matrix cast to the specified data type.
 
@@ -3419,7 +3419,7 @@ struct Matrix[
             casted_matrix._buf.ptr[i] = src._buf.ptr[i].cast[asdtype]()
         return casted_matrix^
 
-    fn cumprod(self) raises -> Matrix[Self.dtype]:
+    def cumprod(self) raises -> Matrix[Self.dtype]:
         """
         Compute the cumulative product of all elements in the matrix, flattened into a single dimension.
 
@@ -3435,7 +3435,7 @@ struct Matrix[
         """
         return numojo.math.cumprod(self)
 
-    fn cumprod(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def cumprod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Compute the cumulative product of elements along a specified axis.
 
@@ -3455,7 +3455,7 @@ struct Matrix[
         """
         return numojo.math.cumprod(self, axis=axis)
 
-    fn cumsum(self) raises -> Matrix[Self.dtype]:
+    def cumsum(self) raises -> Matrix[Self.dtype]:
         """
         Compute the cumulative sum of all elements in the matrix, flattened into a single dimension.
 
@@ -3471,7 +3471,7 @@ struct Matrix[
         """
         return numojo.math.cumsum(self)
 
-    fn cumsum(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def cumsum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Compute the cumulative sum of elements along a specified axis.
 
@@ -3491,7 +3491,7 @@ struct Matrix[
         """
         return numojo.math.cumsum(self, axis=axis)
 
-    fn fill(self, fill_value: Scalar[Self.dtype]):
+    def fill(self, fill_value: Scalar[Self.dtype]):
         """
         Fill the matrix with the specified value. This method sets every element of the matrix to `fill_value`.
 
@@ -3517,7 +3517,7 @@ struct Matrix[
                     self._store(i, j, fill_value)
 
     # * Make it inplace?
-    fn flatten(self) -> Matrix[Self.dtype]:
+    def flatten(self) -> Matrix[Self.dtype]:
         """
         Return a flattened copy of the matrix. This method returns a new matrix containing all elements of the original matrix in a single row (shape (1, size)), preserving the order.
 
@@ -3536,7 +3536,7 @@ struct Matrix[
         memcpy(dest=res._buf.ptr, src=src._buf.ptr, count=res.size)
         return res^
 
-    fn inv(self) raises -> Matrix[Self.dtype]:
+    def inv(self) raises -> Matrix[Self.dtype]:
         """
         Compute the inverse of the matrix.
 
@@ -3555,7 +3555,7 @@ struct Matrix[
         """
         return numojo.linalg.inv(self)
 
-    fn order(self) -> String:
+    def order(self) -> String:
         """
         Return the memory layout order of the matrix.
 
@@ -3575,7 +3575,7 @@ struct Matrix[
         return order
 
     @always_inline
-    fn is_c_contiguous(self) -> Bool:
+    def is_c_contiguous(self) -> Bool:
         """Checks if the matrix is strictly C-contiguous (dense row-major).
 
         For a 2-D matrix this means `strides == (shape[1], 1)`.
@@ -3589,7 +3589,7 @@ struct Matrix[
         return self.strides[1] == 1 and self.strides[0] == self.shape[1]
 
     @always_inline
-    fn is_f_contiguous(self) -> Bool:
+    def is_f_contiguous(self) -> Bool:
         """Checks if the matrix is strictly F-contiguous (dense column-major).
 
         For a 2-D matrix this means `strides == (1, shape[0])`.
@@ -3602,7 +3602,7 @@ struct Matrix[
         return self.strides[0] == 1 and self.strides[1] == self.shape[0]
 
     @always_inline
-    fn is_row_contiguous(self) -> Bool:
+    def is_row_contiguous(self) -> Bool:
         """Checks if elements within each row are contiguous.
 
         This is a relaxation of C-contiguous: only `stride[1] == 1`.
@@ -3614,7 +3614,7 @@ struct Matrix[
         return self.strides[1] == 1
 
     @always_inline
-    fn is_col_contiguous(self) -> Bool:
+    def is_col_contiguous(self) -> Bool:
         """Checks if elements within each column are contiguous.
 
         This is a relaxation of F-contiguous: only `stride[0] == 1`.
@@ -3625,7 +3625,7 @@ struct Matrix[
         """
         return self.strides[0] == 1
 
-    fn contiguous(self) -> Self:
+    def contiguous(self) -> Self:
         """Returns a new C-contiguous matrix owning a copy of the data.
 
         Always creates a new owned matrix, even if the source is already
@@ -3651,7 +3651,7 @@ struct Matrix[
                     )
         return result^
 
-    fn max(self) raises -> Scalar[Self.dtype]:
+    def max(self) raises -> Scalar[Self.dtype]:
         """
         Return the maximum element in the matrix.
 
@@ -3669,7 +3669,7 @@ struct Matrix[
         """
         return numojo.math.extrema.max(self)
 
-    fn max(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def max(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Return the maximum values along the specified axis.
 
@@ -3689,7 +3689,7 @@ struct Matrix[
         """
         return numojo.math.extrema.max(self, axis=axis)
 
-    fn mean[
+    def mean[
         returned_dtype: DType = DType.float64
     ](self) raises -> Scalar[returned_dtype]:
         """
@@ -3707,7 +3707,7 @@ struct Matrix[
         """
         return numojo.statistics.mean[returned_dtype](self)
 
-    fn mean[
+    def mean[
         returned_dtype: DType = DType.float64
     ](self, axis: Int) raises -> Matrix[returned_dtype]:
         """
@@ -3729,7 +3729,7 @@ struct Matrix[
         """
         return numojo.statistics.mean[returned_dtype](self, axis=axis)
 
-    fn min(self) raises -> Scalar[Self.dtype]:
+    def min(self) raises -> Scalar[Self.dtype]:
         """
         Return the minimum element in the matrix.
 
@@ -3747,7 +3747,7 @@ struct Matrix[
         """
         return numojo.math.extrema.min(self)
 
-    fn min(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def min(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Return the minimum values along the specified axis.
 
@@ -3767,7 +3767,7 @@ struct Matrix[
         """
         return numojo.math.extrema.min(self, axis=axis)
 
-    fn prod(self) -> Scalar[Self.dtype]:
+    def prod(self) -> Scalar[Self.dtype]:
         """
         Compute the product of all elements in the matrix.
 
@@ -3783,7 +3783,7 @@ struct Matrix[
         """
         return numojo.math.prod(self)
 
-    fn prod(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def prod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Compute the product of elements along the specified axis.
 
@@ -3803,7 +3803,7 @@ struct Matrix[
         """
         return numojo.math.prod(self, axis=axis)
 
-    fn reshape(
+    def reshape(
         self, shape: Tuple[Int, Int], order: String = "C"
     ) raises -> Matrix[Self.dtype]:
         """
@@ -3873,7 +3873,7 @@ struct Matrix[
         return res^
 
     # NOTE: not sure if `where` clause works correctly here yet.
-    fn resize(mut self, shape: Tuple[Int, Int]) raises:
+    def resize(mut self, shape: Tuple[Int, Int]) raises:
         """
         Change the shape and size of the matrix in-place.
 
@@ -3934,7 +3934,7 @@ struct Matrix[
             else:
                 self.strides[1] = shape[0]
 
-    fn round(self, decimals: Int) raises -> Matrix[Self.dtype]:
+    def round(self, decimals: Int) raises -> Matrix[Self.dtype]:
         """
         Round each element of the matrix to the specified number of decimals.
 
@@ -3954,7 +3954,7 @@ struct Matrix[
         """
         return numojo.math.rounding.round(self, decimals=decimals)
 
-    fn std[
+    def std[
         returned_dtype: DType = DType.float64
     ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
         """
@@ -3975,7 +3975,7 @@ struct Matrix[
         """
         return numojo.statistics.std[returned_dtype](self, ddof=ddof)
 
-    fn std[
+    def std[
         returned_dtype: DType = DType.float64
     ](self, axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
         """
@@ -3998,7 +3998,7 @@ struct Matrix[
         """
         return numojo.statistics.std[returned_dtype](self, axis=axis, ddof=ddof)
 
-    fn sum(self) -> Scalar[Self.dtype]:
+    def sum(self) -> Scalar[Self.dtype]:
         """
         Compute the sum of all elements in the matrix.
 
@@ -4014,7 +4014,7 @@ struct Matrix[
         """
         return numojo.math.sum(self)
 
-    fn sum(self, axis: Int) raises -> Matrix[Self.dtype]:
+    def sum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
         Compute the sum of elements along the specified axis.
 
@@ -4034,7 +4034,7 @@ struct Matrix[
         """
         return numojo.math.sum(self, axis=axis)
 
-    fn trace(self) raises -> Scalar[Self.dtype]:
+    def trace(self) raises -> Scalar[Self.dtype]:
         """
         Compute the trace of the matrix (sum of diagonal elements).
 
@@ -4052,7 +4052,7 @@ struct Matrix[
         """
         return numojo.linalg.trace(self)
 
-    fn issymmetric(self) -> Bool:
+    def issymmetric(self) -> Bool:
         """
         Check if the matrix is symmetric (equal to its transpose).
 
@@ -4070,7 +4070,7 @@ struct Matrix[
         """
         return issymmetric(self)
 
-    fn transpose(self) -> Matrix[Self.dtype]:
+    def transpose(self) -> Matrix[Self.dtype]:
         """
         Return the transpose of the matrix.
 
@@ -4087,7 +4087,7 @@ struct Matrix[
         return transpose(self)
 
     # TODO: we should only allow this for owndata. not for views, it'll lead to weird origin behaviours.
-    fn reorder_layout(self) raises -> Matrix[Self.dtype]:
+    def reorder_layout(self) raises -> Matrix[Self.dtype]:
         """
         Reorder the memory layout of the matrix to match its current order ("C" or "F"). This method returns a new matrix with the same data but stored in the requested memory layout. Only allowed for matrices with own_data=True.
 
@@ -4107,7 +4107,7 @@ struct Matrix[
         """
         return reorder_layout(self)
 
-    fn T(self) -> Matrix[Self.dtype]:
+    def T(self) -> Matrix[Self.dtype]:
         """
         Return the transpose of the matrix.
 
@@ -4123,7 +4123,7 @@ struct Matrix[
         """
         return transpose(self)
 
-    fn variance[
+    def variance[
         returned_dtype: DType = DType.float64
     ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
         """
@@ -4144,7 +4144,7 @@ struct Matrix[
         """
         return numojo.statistics.variance[returned_dtype](self, ddof=ddof)
 
-    fn variance[
+    def variance[
         returned_dtype: DType = DType.float64
     ](self, axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
         """
@@ -4173,7 +4173,7 @@ struct Matrix[
     # # To other data types
     # # ===-------------------------------------------------------------------===#
 
-    fn to_ndarray(self) raises -> NDArray[Self.dtype]:
+    def to_ndarray(self) raises -> NDArray[Self.dtype]:
         """Create `NDArray` from `Matrix`.
 
         Returns a new NDArray with the same shape and data as the Matrix.
@@ -4199,7 +4199,7 @@ struct Matrix[
 
         return ndarray^
 
-    fn to_numpy(self) raises -> PythonObject:
+    def to_numpy(self) raises -> PythonObject:
         """
         Convert the Matrix to a NumPy ndarray.
 
@@ -4276,7 +4276,7 @@ struct Matrix[
     # ===-----------------------------------------------------------------------===#
 
     @staticmethod
-    fn full[
+    def full[
         datatype: DType = DType.float64
     ](
         shape: Tuple[Int, Int],
@@ -4305,14 +4305,14 @@ struct Matrix[
         comptime width = simd_width_of[datatype]()
 
         @parameter
-        fn vec_fill[w: Int](i: Int) unified {mut matrix, read fill_value}:
+        def vec_fill[w: Int](i: Int) unified {mut matrix, read fill_value}:
             matrix._buf.ptr.store(i, SIMD[datatype, w](fill_value))
 
         vectorize[width](matrix.size, vec_fill)
         return matrix^
 
     @staticmethod
-    fn zeros[
+    def zeros[
         datatype: DType = DType.float64
     ](shape: Tuple[Int, Int], order: String = "C") -> Matrix[datatype]:
         """
@@ -4337,7 +4337,7 @@ struct Matrix[
         return res^
 
     @staticmethod
-    fn ones[
+    def ones[
         datatype: DType = DType.float64
     ](shape: Tuple[Int, Int], order: String = "C") -> Matrix[datatype]:
         """
@@ -4360,7 +4360,7 @@ struct Matrix[
         return Matrix.full[datatype](shape=shape, fill_value=1, order=order)
 
     @staticmethod
-    fn identity[
+    def identity[
         datatype: DType = DType.float64
     ](len: Int, order: String = "C") -> Matrix[datatype]:
         """
@@ -4388,7 +4388,7 @@ struct Matrix[
         return matrix^
 
     @staticmethod
-    fn rand[
+    def rand[
         datatype: DType = DType.float64
     ](shape: Tuple[Int, Int], order: String = "C") -> Matrix[datatype]:
         """
@@ -4411,7 +4411,7 @@ struct Matrix[
         comptime width = simd_width_of[datatype]()
 
         @parameter
-        fn vec_rand[w: Int](i: Int) unified {mut result}:
+        def vec_rand[w: Int](i: Int) unified {mut result}:
             var rand_vec = SIMD[datatype, w]()
             for j in range(w):
                 rand_vec[j] = random_float64(0, 1).cast[datatype]()
@@ -4421,7 +4421,7 @@ struct Matrix[
         return result^
 
     @staticmethod
-    fn empty[
+    def empty[
         datatype: DType = DType.float64
     ](shape: Tuple[Int, Int], order: String = "C") -> Matrix[datatype]:
         """
@@ -4448,7 +4448,7 @@ struct Matrix[
         return Matrix[datatype](shape, order)
 
     @staticmethod
-    fn arange[
+    def arange[
         datatype: DType = DType.float64
     ](
         start: Scalar[datatype],
@@ -4523,7 +4523,7 @@ struct Matrix[
         return result^
 
     @staticmethod
-    fn linspace[
+    def linspace[
         datatype: DType = DType.float64
     ](
         start: Scalar[datatype],
@@ -4573,7 +4573,7 @@ struct Matrix[
         return result^
 
     @staticmethod
-    fn diag[
+    def diag[
         datatype: DType = DType.float64
     ](diagonal: Matrix[datatype], order: String = "C") raises -> Matrix[
         datatype
@@ -4628,7 +4628,7 @@ struct Matrix[
             return result^
 
     @staticmethod
-    fn zeros_like[
+    def zeros_like[
         datatype: DType = DType.float64
     ](other: Matrix[datatype]) -> Matrix[datatype]:
         """
@@ -4650,7 +4650,7 @@ struct Matrix[
         return Matrix.zeros[datatype](other.shape, other.order())
 
     @staticmethod
-    fn ones_like[
+    def ones_like[
         datatype: DType = DType.float64
     ](other: Matrix[datatype]) -> Matrix[datatype]:
         """
@@ -4672,7 +4672,7 @@ struct Matrix[
         return Matrix.ones[datatype](other.shape, other.order())
 
     @staticmethod
-    fn empty_like[
+    def empty_like[
         datatype: DType = DType.float64
     ](other: Matrix[datatype]) -> Matrix[datatype]:
         """
@@ -4697,7 +4697,7 @@ struct Matrix[
         return Matrix.empty[datatype](other.shape, other.order())
 
     @staticmethod
-    fn fromlist[
+    def fromlist[
         datatype: DType = DType.float64
     ](
         object: List[Scalar[datatype]],
@@ -4749,7 +4749,7 @@ struct Matrix[
         return M^
 
     @staticmethod
-    fn fromstring[
+    def fromstring[
         datatype: DType = DType.float64
     ](
         text: String, shape: Tuple[Int, Int] = (0, 0), order: String = "C"
@@ -4872,7 +4872,7 @@ struct _MatrixIter[
     var strides: Tuple[Int, Int]
     """Strides of the matrix being iterated."""
 
-    fn __init__(
+    def __init__(
         out self,
         index: Int,
         matrix_buf: DataContainer[Self.dtype],
@@ -4893,12 +4893,12 @@ struct _MatrixIter[
         self.strides = strides
 
     @always_inline
-    fn __iter__(ref self) -> Self:
+    def __iter__(ref self) -> Self:
         """Return a copy of the iterator for iteration protocol."""
         return self.copy()
 
     @always_inline
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         """Check if there are more rows to iterate over.
 
         Returns:
@@ -4910,7 +4910,7 @@ struct _MatrixIter[
         else:
             return self.index >= 0
 
-    fn __next__(mut self) raises -> Matrix[Self.dtype]:
+    def __next__(mut self) raises -> Matrix[Self.dtype]:
         """Return a view of the next row.
 
         Returns:
@@ -4941,7 +4941,7 @@ struct _MatrixIter[
             )
 
     @always_inline
-    fn bounds(self) -> Tuple[Int, Optional[Int]]:
+    def bounds(self) -> Tuple[Int, Optional[Int]]:
         """Return the iteration bounds.
 
         Returns:
@@ -4963,7 +4963,7 @@ struct _MatrixIter[
 
 
 # TODO: we can move the checks in these functions to the caller functions to avoid redundant checks.
-fn _arithmetic_func_matrix_matrix_to_matrix[
+def _arithmetic_func_matrix_matrix_to_matrix[
     dtype: DType,
     simd_func: fn[type: DType, simd_width: Int](
         SIMD[type, simd_width], SIMD[type, simd_width]
@@ -5019,7 +5019,7 @@ fn _arithmetic_func_matrix_matrix_to_matrix[
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
     @parameter
-    fn vec_func[simd_width: Int](i: Int) unified {mut res, read A, read B}:
+    def vec_func[simd_width: Int](i: Int) unified {mut res, read A, read B}:
         res._buf.ptr.store(
             i,
             simd_func(
@@ -5032,7 +5032,7 @@ fn _arithmetic_func_matrix_matrix_to_matrix[
     return res^
 
 
-fn _arithmetic_func_matrix_to_matrix[
+def _arithmetic_func_matrix_to_matrix[
     dtype: DType,
     simd_func: fn[type: DType, simd_width: Int](SIMD[type, simd_width]) -> SIMD[
         type, simd_width
@@ -5059,7 +5059,7 @@ fn _arithmetic_func_matrix_to_matrix[
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
     @parameter
-    fn vec_func[simd_width: Int](i: Int) unified {mut C, read A}:
+    def vec_func[simd_width: Int](i: Int) unified {mut C, read A}:
         C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
@@ -5067,7 +5067,7 @@ fn _arithmetic_func_matrix_to_matrix[
     return C^
 
 
-fn _logic_func_matrix_matrix_to_matrix[
+def _logic_func_matrix_matrix_to_matrix[
     dtype: DType,
     simd_func: fn[type: DType, simd_width: Int](
         SIMD[type, simd_width], SIMD[type, simd_width]
@@ -5127,7 +5127,7 @@ fn _logic_func_matrix_matrix_to_matrix[
     # Use vectorized comparison for better performance
     # Process elements using input dtype width, then store results as bool
     @parameter
-    fn vec_compare[w: Int](i: Int) unified {mut C, read A, read B}:
+    def vec_compare[w: Int](i: Int) unified {mut C, read A, read B}:
         var a_vec = A._buf.ptr.load[width=w](i)
         var b_vec = B._buf.ptr.load[width=w](i)
         var result = simd_func[dtype, w](a_vec, b_vec)

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -353,7 +353,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr.load[width=width](offset)
 
     @always_inline
-    def store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
+    def store[
+        width: Int
+    ](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """
         Store a SIMD vector of the specified width at the given offset.
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -36,31 +36,31 @@ struct Ownership(ImplicitlyCopyable):
     comptime External = Ownership(False._mlir_value)
     """Container views externally managed data."""
 
-    fn __init__(out self, value: __mlir_type.i1):
+    def __init__(out self, value: __mlir_type.i1):
         """
         Initialize Ownership with the given status.
         """
         self.value = value
 
-    fn __eq__(self, other: Self) -> Bool:
+    def __eq__(self, other: Self) -> Bool:
         """
         Return True if both Ownership instances have the same status.
         """
         return ~(self != other)
 
-    fn __ne__(self, other: Self) -> Bool:
+    def __ne__(self, other: Self) -> Bool:
         """
         Return True if Ownership instances have different statuses.
         """
         return self ^ other
 
-    fn __xor__(self, other: Self) -> Bool:
+    def __xor__(self, other: Self) -> Bool:
         """
         Return True if Ownership statuses differ.
         """
         return __mlir_op.`pop.xor`(self.value, other.value)
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """
         Return "Managed" or "External" based on ownership status.
         """
@@ -69,7 +69,7 @@ struct Ownership(ImplicitlyCopyable):
         else:
             return "External"
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """
         Write the ownership status as a string to the writer.
         """
@@ -113,7 +113,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     # Constructors and Destructor
     # ===----------------------------------------------------------------------===#
     @always_inline
-    fn __init__(out self):
+    def __init__(out self):
         """
         Create an empty, managed DataContainer.
         """
@@ -124,7 +124,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = 0
 
     @always_inline
-    fn __init__(out self, size: Int):
+    def __init__(out self, size: Int):
         """
         Create a managed DataContainer with a buffer of `size` elements.
 
@@ -145,7 +145,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
         size: Int,
@@ -180,7 +180,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             self.ownership = Ownership.External
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         *,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
@@ -206,7 +206,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """
         Copy constructor.
 
@@ -223,7 +223,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         if self.is_refcounted():
             _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
 
-    fn deep_copy(self) -> Self:
+    def deep_copy(self) -> Self:
         """
         Create a deep copy of the DataContainer.
 
@@ -238,7 +238,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return result^
 
     @always_inline
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """
         Move constructor.
 
@@ -253,7 +253,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = take.size
 
     @always_inline
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """
         Destructor.
 
@@ -277,7 +277,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     # Data Access Methods
     # ===----------------------------------------------------------------------===#
     @always_inline
-    fn get_ptr(
+    def get_ptr(
         ref self,
     ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
         """
@@ -289,7 +289,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr
 
     @always_inline
-    fn offset(
+    def offset(
         self, offset: Int
     ) -> UnsafePointer[Scalar[Self.dtype], Self.origin]:
         """
@@ -304,7 +304,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr + offset
 
     @always_inline
-    fn __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:
+    def __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:
         """
         Return the element at the specified index.
 
@@ -320,7 +320,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr[idx]
 
     @always_inline
-    fn __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
+    def __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
         """
         Set the element at the specified index to the given value.
 
@@ -334,7 +334,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ptr[idx] = val
 
     @always_inline
-    fn load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
+    def load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
         """
         Load a SIMD vector of the specified width from the given offset.
 
@@ -353,7 +353,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr.load[width=width](offset)
 
     @always_inline
-    fn store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
+    def store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """
         Store a SIMD vector of the specified width at the given offset.
 
@@ -373,7 +373,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     # Trait Implementations
     # ===----------------------------------------------------------------------===#
     @always_inline
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """
         Return the size of the container.
 
@@ -383,7 +383,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.size
 
     @always_inline
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         if self.ownership == Ownership.External:
             return "DataContainer(external, size=" + String(self.size) + ")"
         return (
@@ -395,7 +395,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         )
 
     @always_inline
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         if self.ownership == Ownership.External:
             writer.write("DataContainer(external, size=")
             writer.write(String(self.size))
@@ -411,7 +411,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     # Reference Counting and Sharing
     # ===----------------------------------------------------------------------===#
     @always_inline
-    fn is_refcounted(ref self) -> Bool:
+    def is_refcounted(ref self) -> Bool:
         """
         Check if this container has refcounting enabled.
 
@@ -423,7 +423,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         )
 
     @always_inline
-    fn ref_count(ref self) -> UInt64:
+    def ref_count(ref self) -> UInt64:
         """
         Get the current reference count.
 
@@ -434,7 +434,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             return 0
         return self._refcount[].load[ordering=Consistency.MONOTONIC]()
 
-    fn share(mut self) raises -> DataContainer[Self.dtype]:
+    def share(mut self) raises -> DataContainer[Self.dtype]:
         """
         Create a shared view into this container.
         Increments the existing refcount for managed containers.

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -22,7 +22,7 @@ Example:
     from numojo.core.memory.dlpack import from_dlpack
     from python import Python
 
-    fn main() raises:
+    def main() raises:
         # Create a NuMojo array
         var arr = nm.linspace[f32](0, 5, 6)
 
@@ -80,7 +80,7 @@ struct DLPackVersion(ImplicitlyCopyable, Movable, TrivialRegisterPassable):
     comptime CURRENT_MINOR: UInt32 = 8
     comptime LATEST = DLPackVersion(Self.CURRENT_MAJOR, Self.CURRENT_MINOR)
 
-    fn __init__(out self, major: UInt32, minor: UInt32):
+    def __init__(out self, major: UInt32, minor: UInt32):
         self.major = major
         self.minor = minor
 
@@ -120,7 +120,7 @@ struct DLDevice(ImplicitlyCopyable, Movable, TrivialRegisterPassable):
     var device_id: Int32
     """Device ID (for multiple devices of same type)."""
 
-    fn __init__(out self, device_type: Int32 = Self.CPU, device_id: Int32 = 0):
+    def __init__(out self, device_type: Int32 = Self.CPU, device_id: Int32 = 0):
         self.device_type = device_type
         self.device_id = device_id
 
@@ -159,13 +159,13 @@ struct DLDataType(ImplicitlyCopyable, Movable, TrivialRegisterPassable):
     var lanes: UInt16
     """Number of lanes (1 for scalar, >1 for vector types)."""
 
-    fn __init__(out self, code: UInt8, bits: UInt8, lanes: UInt16 = 1):
+    def __init__(out self, code: UInt8, bits: UInt8, lanes: UInt16 = 1):
         self.code = code
         self.bits = bits
         self.lanes = lanes
 
     @staticmethod
-    fn from_dtype[dtype: DType]() -> Self:
+    def from_dtype[dtype: DType]() -> Self:
         """Converts a Mojo DType to a DLDataType descriptor.
 
         This static method maps Mojo's native data types to the DLPack type
@@ -194,7 +194,7 @@ struct DLDataType(ImplicitlyCopyable, Movable, TrivialRegisterPassable):
 
         return Self(code, bits, 1)
 
-    fn to_dtype(self) raises -> DType:
+    def to_dtype(self) raises -> DType:
         """Converts a DLDataType descriptor to a Mojo DType.
 
         This method maps DLPack type descriptors back to Mojo's native data types,
@@ -292,7 +292,7 @@ struct DLTensor(ImplicitlyCopyable, Movable):
     var byte_offset: UInt64
     """Byte offset from data pointer to first element."""
 
-    fn __init__(
+    def __init__(
         out self,
         data: UnsafePointer[NoneType, MutAnyOrigin],
         device: DLDevice,
@@ -345,7 +345,7 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
     var deleter: DLManagedTensorDeleter
     """Cleanup function called when consumer is done."""
 
-    fn __init__(
+    def __init__(
         out self,
         dl_tensor: DLTensor,
         manager_ctx: UnsafePointer[NoneType, MutAnyOrigin],
@@ -384,7 +384,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
     var ndim: Int
     var data_container: DataContainer[Self.dtype]
 
-    fn __init__(
+    def __init__(
         out self,
         shape: UnsafePointer[Int64, MutAnyOrigin],
         strides: UnsafePointer[Int64, MutAnyOrigin],
@@ -396,13 +396,13 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         self.ndim = ndim
         self.data_container = data_container^
 
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         self.shape = copy.shape
         self.strides = copy.strides
         self.ndim = copy.ndim
         self.data_container = copy.data_container.copy()
 
-    fn __del__(deinit self):
+    def __del__(deinit self):
         if self.shape:
             self.shape.free()
         if self.strides:
@@ -416,7 +416,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 # ===-------------------------------------------------------------------===#
 
 
-fn _dlpack_deleter_impl[
+def _dlpack_deleter_impl[
     dtype: DType
 ](managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]) -> None:
     """Type-specific deleter callback for DLManagedTensor."""
@@ -437,7 +437,7 @@ fn _dlpack_deleter_impl[
 # ===-------------------------------------------------------------------===#
 
 
-fn to_dlpack[
+def to_dlpack[
     dtype: DType
 ](arr: NDArray[dtype]) raises -> UnsafePointer[DLManagedTensor, MutAnyOrigin]:
     """Exports a NuMojo NDArray to a DLPack managed tensor for zero-copy sharing.
@@ -511,7 +511,7 @@ fn to_dlpack[
     return managed
 
 
-fn _extract_dlpack_pointer(
+def _extract_dlpack_pointer(
     capsule: PythonObject,
 ) raises -> UnsafePointer[DLManagedTensor, MutAnyOrigin]:
     """Extracts the DLManagedTensor pointer from a PyCapsule.
@@ -554,7 +554,7 @@ fn _extract_dlpack_pointer(
     return p.bitcast[DLManagedTensor]()
 
 
-fn _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:
+def _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:
     ctypes = Python.import_module("ctypes")
 
     return ctypes.cast(
@@ -568,7 +568,7 @@ fn _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:
 # ===-------------------------------------------------------------------===#
 
 
-fn from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
+def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
     """Imports a tensor from any DLPack-compatible library into a NuMojo NDArray
     using zero-copy.
     This function accepts a Python object that implements the DLPack protocol
@@ -659,7 +659,7 @@ fn from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
     return result^
 
 
-fn from_numpy[dtype: DType](array: PythonObject) raises -> NDArray[dtype]:
+def from_numpy[dtype: DType](array: PythonObject) raises -> NDArray[dtype]:
     """Imports a NumPy array into a NuMojo NDArray via zero-copy.
 
     This is a fast path specifically optimized for NumPy that uses the

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -292,7 +292,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr.load[width=width](offset)
 
     @always_inline
-    def store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
+    def store[
+        width: Int
+    ](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """Store a SIMD vector of `width` elements starting at `offset`.
 
         No bounds checking is performed.

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -71,7 +71,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn __init__(out self):
+    def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
         self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
         self._refcount = alloc[Atomic[DType.uint64]](1)
@@ -80,7 +80,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = 0
 
     @always_inline
-    fn __init__(out self, size: Int):
+    def __init__(out self, size: Int):
         """Create a managed container with a buffer of `size` elements.
 
         The buffer is allocated but not initialized.  The reference count
@@ -103,7 +103,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
         size: Int,
@@ -139,7 +139,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             self.ownership = Ownership.External
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         *,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
@@ -165,7 +165,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """Shallow-copy constructor.
 
         Copies the pointer and refcount, then atomically increments the
@@ -183,7 +183,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
 
     @always_inline
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """Move constructor.
 
         Transfers all fields without touching the reference count.
@@ -197,7 +197,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = take.size
 
     @always_inline
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """Destructor.
 
         For managed containers the reference count is atomically
@@ -224,7 +224,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn unsafe_ptr(
+    def unsafe_ptr(
         ref self,
     ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
         """Return a reference to the raw data pointer.
@@ -235,7 +235,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr
 
     @always_inline
-    fn offset(
+    def offset(
         self, offset: Int
     ) -> UnsafePointer[Scalar[Self.dtype], Self.origin]:
         """Return a pointer advanced by `offset` elements.
@@ -249,7 +249,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr + offset
 
     @always_inline
-    fn __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:
+    def __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:
         """Return the element at index `idx`.
 
         No bounds checking is performed.
@@ -263,7 +263,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr[idx]
 
     @always_inline
-    fn __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
+    def __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
         """Set the element at index `idx` to `val`.
 
         No bounds checking is performed.
@@ -275,7 +275,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ptr[idx] = val
 
     @always_inline
-    fn load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
+    def load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
         """Load a SIMD vector of `width` elements starting at `offset`.
 
         No bounds checking is performed.
@@ -292,7 +292,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.ptr.load[width=width](offset)
 
     @always_inline
-    fn store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
+    def store[width: Int](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """Store a SIMD vector of `width` elements starting at `offset`.
 
         No bounds checking is performed.
@@ -311,7 +311,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """Return the number of elements.
 
         Returns:
@@ -320,7 +320,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         return self.size
 
     @always_inline
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Return a human-readable summary of the container.
 
         Returns:
@@ -339,7 +339,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         )
 
     @always_inline
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Write a human-readable summary to `writer`.
 
         Parameters:
@@ -364,7 +364,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn is_refcounted(ref self) -> Bool:
+    def is_refcounted(ref self) -> Bool:
         """Return True if this container tracks a reference count.
 
         External containers and containers whose refcount pointer is null
@@ -378,7 +378,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         )
 
     @always_inline
-    fn ref_count(ref self) -> UInt64:
+    def ref_count(ref self) -> UInt64:
         """Return the current reference count, or 0 if not tracked.
 
         Returns:
@@ -388,7 +388,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             return 0
         return self._refcount[].load[ordering=Consistency.MONOTONIC]()
 
-    fn deep_copy(self) -> Self:
+    def deep_copy(self) -> Self:
         """Create an independent managed copy of this container.
 
         The returned container has its own allocation and a refcount of 1,
@@ -404,7 +404,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         memcpy(dest=result.ptr, src=self.ptr, count=self.size)
         return result^
 
-    fn share(mut self) raises -> HostStorage[Self.dtype]:
+    def share(mut self) raises -> HostStorage[Self.dtype]:
         """Create a new handle that shares this container's data and refcount.
 
         The reference count is atomically incremented so both the original
@@ -465,7 +465,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
     # Constructors
     # ===----------------------------------------------------------------------===#
 
-    fn __init__(out self, size: Int) raises:
+    def __init__(out self, size: Int) raises:
         """Allocate a new GPU buffer for `size` elements.
 
         Args:
@@ -482,7 +482,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = DeviceContext().enqueue_create_buffer[Self.dtype](size)
         self.size = size
 
-    fn __init__(
+    def __init__(
         out self,
         buffer: DeviceBuffer[Self.dtype],
         size: Int,
@@ -496,7 +496,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = buffer
         self.size = size
 
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """Shallow-copy constructor.
 
         Copies the `DeviceBuffer` handle.  The GPU runtime determines
@@ -508,7 +508,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = copy.buffer
         self.size = copy.size
 
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """Move constructor.
 
         Transfers the buffer handle without copying.
@@ -524,7 +524,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """Return the number of elements.
 
         Returns:
@@ -533,7 +533,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         return self.size
 
     @always_inline
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Return a human-readable summary of the container.
 
         Returns:
@@ -549,7 +549,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         )
 
     @always_inline
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Write a human-readable summary to `writer`.
 
         Parameters:
@@ -564,7 +564,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
     # Access
     # ===----------------------------------------------------------------------===#
 
-    fn get_buffer(ref self) -> ref[self.buffer] DeviceBuffer[Self.dtype]:
+    def get_buffer(ref self) -> ref[self.buffer] DeviceBuffer[Self.dtype]:
         """Return a reference to the underlying `DeviceBuffer`.
 
         Returns:
@@ -572,7 +572,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         """
         return self.buffer
 
-    fn unsafe_ptr(ref self) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
+    def unsafe_ptr(ref self) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         """Return the raw device pointer to the buffer's data.
 
         Returns:
@@ -625,7 +625,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn __init__(out self, size: Int) raises:
+    def __init__(out self, size: Int) raises:
         """Allocate storage for `size` elements on the target device.
 
         Args:
@@ -659,14 +659,14 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
             raise Error("Unsupported device type: " + String(Self.device.type))
 
     @always_inline
-    fn __init__(out self):
+    def __init__(out self):
         """Create an empty container with no storage allocated."""
         self.host_storage = None
         self.device_storage = None
         self.size = 0
 
     @always_inline
-    fn __init__(
+    def __init__(
         out self,
         ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         size: Int,
@@ -705,7 +705,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.device_storage = None
 
     @always_inline
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """Shallow-copy constructor.
 
         Shares the underlying storage.  For CPU containers this increments
@@ -720,7 +720,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.size = copy.size
 
     @always_inline
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """Move constructor.
 
         Transfers all fields without touching reference counts.
@@ -737,7 +737,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn offset(
+    def offset(
         self, offset: Int
     ) -> UnsafePointer[Scalar[Self.dtype], MutExternalOrigin] where (
         Self.device.type == "cpu"
@@ -756,7 +756,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         return self.host_storage.unsafe_value().ptr + offset
 
     @always_inline
-    fn __getitem__(
+    def __getitem__(
         self, idx: Int
     ) -> Scalar[Self.dtype] where Self.device.type == "cpu":
         """Return the element at index `idx`.
@@ -775,7 +775,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         return self.host_storage.unsafe_value().ptr[idx]
 
     @always_inline
-    fn __setitem__(
+    def __setitem__(
         mut self, idx: Int, val: Scalar[Self.dtype]
     ) where Self.device.type == "cpu":
         """Set the element at index `idx` to `val`.
@@ -792,7 +792,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.host_storage.unsafe_value().ptr[idx] = val
 
     @always_inline
-    fn load[
+    def load[
         width: Int
     ](self, offset: Int) -> SIMD[Self.dtype, width] where (
         Self.device.type == "cpu"
@@ -816,7 +816,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         return self.host_storage.unsafe_value().ptr.load[width=width](offset)
 
     @always_inline
-    fn store[
+    def store[
         width: Int
     ](mut self, offset: Int, value: SIMD[Self.dtype, width]) where (
         Self.device.type == "cpu"
@@ -842,7 +842,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # ===----------------------------------------------------------------------===#
 
     @always_inline
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """Return the number of elements.
 
         Returns:
@@ -851,7 +851,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         return self.size
 
     @always_inline
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Return a human-readable summary of the container.
 
         Returns:
@@ -873,7 +873,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
             )
 
     @always_inline
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Write a human-readable summary to `writer`.
 
         Parameters:
@@ -888,7 +888,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # Reference Counting and Sharing
     # ===----------------------------------------------------------------------===#
 
-    fn deep_copy(self) raises -> Self:
+    def deep_copy(self) raises -> Self:
         """Create an independent managed copy of this container.
 
         For CPU containers the data is copied via `memcpy`.  For GPU
@@ -921,7 +921,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
             )
             return result^
 
-    fn share(
+    def share(
         mut self,
     ) raises -> AcceleratorDataContainer[Self.dtype, Self.device]:
         """Create a new handle that shares this container's storage.
@@ -956,31 +956,31 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # ===----------------------------------------------------------------------===#
 
     @parameter
-    fn is_cpu(self) -> Bool:
+    def is_cpu(self) -> Bool:
         """Return True if this container targets a CPU device."""
         return Self.device.type == "cpu"
 
     @parameter
-    fn is_gpu(self) -> Bool:
+    def is_gpu(self) -> Bool:
         """Return True if this container targets a GPU device."""
         return Self.device.type == "gpu"
 
     @parameter
-    fn is_cuda(self) -> Bool:
+    def is_cuda(self) -> Bool:
         """Return True if this container targets an NVIDIA CUDA device."""
         return Self.device == Device.CUDA
 
     @parameter
-    fn is_rocm(self) -> Bool:
+    def is_rocm(self) -> Bool:
         """Return True if this container targets an AMD ROCm device."""
         return Self.device == Device.ROCM
 
     @parameter
-    fn is_mps(self) -> Bool:
+    def is_mps(self) -> Bool:
         """Return True if this container targets an Apple Metal device."""
         return Self.device == Device.MPS
 
-    fn host_ptr(
+    def host_ptr(
         self,
     ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device == Device.CPU
@@ -995,7 +995,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         """
         return self.host_storage.unsafe_value().unsafe_ptr()
 
-    fn device_ptr(
+    def device_ptr(
         self,
     ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device == Device.CUDA
@@ -1012,7 +1012,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         """
         return self.device_storage.unsafe_value().unsafe_ptr()
 
-    fn host_buffer(
+    def host_buffer(
         self,
     ) -> HostStorage[Self.dtype] where Self.device == Device.CPU:
         """Return a shallow copy of the underlying `HostStorage`.
@@ -1028,7 +1028,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         """
         return self.host_storage.unsafe_value().copy()
 
-    fn device_buffer(
+    def device_buffer(
         self,
     ) -> DeviceStorage[Self.dtype, Self.device] where (
         Self.device == Device.CUDA

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -144,7 +144,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     # default constructor
     @always_inline("nodebug")
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         order: String = "C",
@@ -180,7 +180,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
         self.print_options = PrintOptions()
 
-    fn __init__(
+    def __init__(
         out self,
         shape: List[Int],
         strides: List[Int],
@@ -223,7 +223,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
         self.print_options = PrintOptions()
 
-    fn __init__(
+    def __init__(
         out self,
         shape: NDArrayShape,
         strides: NDArrayStrides,
@@ -267,7 +267,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = PrintOptions()
 
     # View constructor using DataContainer refcounting
-    fn __init__(
+    def __init__(
         out self,
         var data: DataContainer[Self.dtype],
         is_view: Bool,
@@ -315,7 +315,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = PrintOptions()
 
     @always_inline("nodebug")
-    fn __copyinit__(out self, copy: Self):
+    def __copyinit__(out self, copy: Self):
         """Copies `copy` into `self`.
 
         Performs a deep copy. The new array owns its data.
@@ -337,7 +337,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
         self.print_options = copy.print_options
 
-    fn deep_copy(self) raises -> Self:
+    def deep_copy(self) raises -> Self:
         """
         Create a deep copy of the NDArray.
 
@@ -361,7 +361,7 @@ struct NDArray[dtype: DType = DType.float64](
             offset=self.offset,
         )
 
-    fn view(mut self) raises -> Self:
+    def view(mut self) raises -> Self:
         """
         Create a non-owning view of the current NDArray.
 
@@ -384,7 +384,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    fn __moveinit__(out self, deinit take: Self):
+    def __moveinit__(out self, deinit take: Self):
         """Moves `take` into `self`.
 
         Args:
@@ -400,7 +400,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = take.print_options
 
     @always_inline("nodebug")
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """Destroys all elements and frees memory."""
         # if self.flags.OWNDATA:
         #     self._buf.ptr.free()
@@ -415,35 +415,35 @@ struct NDArray[dtype: DType = DType.float64](
     # Getter dunders and other getter methods
     #
     # 1. Basic Indexing Operations
-    # fn _getitem(self, *indices: Int) -> Scalar[dtype]                         # Direct unsafe getter
-    # fn _getitem(self, indices: List[Int]) -> Scalar[dtype]                    # Direct unsafe getter
-    # fn __getitem__(self) raises -> SIMD[dtype, 1]                             # Get 0d array value
-    # fn __getitem__(self, index: Item) raises -> SIMD[dtype, 1]                # Get by coordinate list
+    # def _getitem(self, *indices: Int) -> Scalar[dtype]                         # Direct unsafe getter
+    # def _getitem(self, indices: List[Int]) -> Scalar[dtype]                    # Direct unsafe getter
+    # def __getitem__(self) raises -> SIMD[dtype, 1]                             # Get 0d array value
+    # def __getitem__(self, index: Item) raises -> SIMD[dtype, 1]                # Get by coordinate list
     #
     # 2. Single Index Slicing
-    # fn __getitem__(self, idx: Int) raises -> Self                             # Get by single index
+    # def __getitem__(self, idx: Int) raises -> Self                             # Get by single index
     #
     # 3. Multi-dimensional Slicing
-    # fn __getitem__(self, *slices: Slice) raises -> Self                       # Get by variable slices
-    # fn __getitem__(self, slice_list: List[Slice]) raises -> Self              # Get by list of slices
-    # fn __getitem__(self, *slices: Variant[Slice, Int]) raises -> Self         # Get by mix of slices/ints
+    # def __getitem__(self, *slices: Slice) raises -> Self                       # Get by variable slices
+    # def __getitem__(self, slice_list: List[Slice]) raises -> Self              # Get by list of slices
+    # def __getitem__(self, *slices: Variant[Slice, Int]) raises -> Self         # Get by mix of slices/ints
     #
     # 4. Advanced Indexing
-    # fn __getitem__(self, indices: NDArray[DType.int]) raises -> Self        # Get by index array
-    # fn __getitem__(self, indices: List[Int]) raises -> Self                   # Get by list of indices
-    # fn __getitem__(self, mask: NDArray[DType.bool]) raises -> Self            # Get by boolean mask
-    # fn __getitem__(self, mask: List[Bool]) raises -> Self                     # Get by boolean list
+    # def __getitem__(self, indices: NDArray[DType.int]) raises -> Self        # Get by index array
+    # def __getitem__(self, indices: List[Int]) raises -> Self                   # Get by list of indices
+    # def __getitem__(self, mask: NDArray[DType.bool]) raises -> Self            # Get by boolean mask
+    # def __getitem__(self, mask: List[Bool]) raises -> Self                     # Get by boolean list
     #
     # 5. Low-level Access
-    # fn item(self, var index: Int) raises -> Scalar[dtype]                   # Get item by linear index
-    # fn item(self, *index: Int) raises -> Scalar[dtype]                        # Get item by coordinates
-    # fn load(self, var index: Int) raises -> Scalar[dtype]                   # Load with bounds check
-    # fn load[width: Int](self, index: Int) raises -> SIMD[dtype, width]        # Load SIMD value
-    # fn load[width: Int](self, *indices: Int) raises -> SIMD[dtype, width]     # Load SIMD at coordinates
+    # def item(self, var index: Int) raises -> Scalar[dtype]                   # Get item by linear index
+    # def item(self, *index: Int) raises -> Scalar[dtype]                        # Get item by coordinates
+    # def load(self, var index: Int) raises -> Scalar[dtype]                   # Load with bounds check
+    # def load[width: Int](self, index: Int) raises -> SIMD[dtype, width]        # Load SIMD value
+    # def load[width: Int](self, *indices: Int) raises -> SIMD[dtype, width]     # Load SIMD at coordinates
     # ===-------------------------------------------------------------------===#
 
     @always_inline
-    fn normalize(self, idx: Int, dim: Int) -> Int:
+    def normalize(self, idx: Int, dim: Int) -> Int:
         """Normalizes a potentially negative index to its positive equivalent
         within the bounds of the given dimension.
 
@@ -460,7 +460,7 @@ struct NDArray[dtype: DType = DType.float64](
             idx_norm = dim + idx_norm
         return idx_norm
 
-    fn _getitem(self, *indices: Int) -> Scalar[Self.dtype]:
+    def _getitem(self, *indices: Int) -> Scalar[Self.dtype]:
         """Gets the item at indices, bypassing all boundary checks.
 
         ***UNSAFE!*** No boundary checks are made; for internal use only.
@@ -488,7 +488,7 @@ struct NDArray[dtype: DType = DType.float64](
         index_of_buffer += self.offset
         return self._buf.ptr[index_of_buffer]
 
-    fn _getitem(self, indices: List[Int]) -> Scalar[Self.dtype]:
+    def _getitem(self, indices: List[Int]) -> Scalar[Self.dtype]:
         """Gets the item at indices, bypassing all boundary checks.
 
         ***UNSAFE!*** No boundary checks are made; for internal use only.
@@ -517,7 +517,7 @@ struct NDArray[dtype: DType = DType.float64](
         index_of_buffer += self.offset
         return self._buf.ptr[index_of_buffer]
 
-    fn __getitem__(self) raises -> SIMD[Self.dtype, 1]:
+    def __getitem__(self) raises -> SIMD[Self.dtype, 1]:
         """Gets the value of the 0-D array.
 
         Returns:
@@ -547,7 +547,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
         return (self._buf.ptr + self.offset)[]
 
-    fn __getitem__(self, index: Item) raises -> SIMD[Self.dtype, 1]:
+    def __getitem__(self, index: Item) raises -> SIMD[Self.dtype, 1]:
         """Gets the value at the index list.
 
         Args:
@@ -602,7 +602,7 @@ struct NDArray[dtype: DType = DType.float64](
         return self._buf.ptr.load[width=1](self.offset + idx)
 
     # Can be faster if we only return a view since we are not copying the data.
-    fn __getitem__(self, idx: Int) raises -> Self:
+    def __getitem__(self, idx: Int) raises -> Self:
         """Gets a single first-axis slice (first dimension).
 
         Returns a slice of the array taken at the first (axis 0) position
@@ -699,7 +699,7 @@ struct NDArray[dtype: DType = DType.float64](
             return result^
 
     # perhaps move these to a utility module
-    fn _copy_first_axis_slice(
+    def _copy_first_axis_slice(
         self,
         src: NDArray[Self.dtype],
         norm_idx: Int,
@@ -728,7 +728,7 @@ struct NDArray[dtype: DType = DType.float64](
                 dst_off += coords[d] * Int(dst.strides.unsafe_load(d))
             dst._buf.ptr[dst_off] = src._buf.ptr[off]
 
-    fn __getitem__(self, var *slices: Slice) raises -> Self:
+    def __getitem__(self, var *slices: Slice) raises -> Self:
         """Retrieves a slice or sub-array from the current array using variadic
         slice arguments.
 
@@ -795,7 +795,7 @@ struct NDArray[dtype: DType = DType.float64](
         var narr: Self = self.__getitem__(slice_list^, index_type_list^)
         return narr^
 
-    fn _calculate_strides(self, shape: List[Int]) -> List[Int]:
+    def _calculate_strides(self, shape: List[Int]) -> List[Int]:
         """Calculates strides for a given shape based on the array's memory
         layout (C or F contiguous).
 
@@ -845,7 +845,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return strides^
 
-    fn __getitem__(
+    def __getitem__(
         self,
         var slice_list: List[Slice],
         var index_type_list: List[IndexTypeInfo],
@@ -988,7 +988,7 @@ struct NDArray[dtype: DType = DType.float64](
         narr.ndim = new_ndim
         return narr^
 
-    fn _getitem_list_slices(self, var slice_list: List[Slice]) raises -> Self:
+    def _getitem_list_slices(self, var slice_list: List[Slice]) raises -> Self:
         """Gets a sub-array by a list of slices with dimension reduction.
 
         Unlike `__getitem__(slice_list: List[Slice])` which is compatible with
@@ -1078,7 +1078,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return narr^
 
-    fn __getitem__(self, *slices: IndexTypes) raises -> Self:
+    def __getitem__(self, *slices: IndexTypes) raises -> Self:
         """Gets items of an NDArray with a series of either slices or integers.
 
         Args:
@@ -1333,7 +1333,7 @@ struct NDArray[dtype: DType = DType.float64](
         narr = self.__getitem__(slice_list^, index_type_list^)
         return narr^
 
-    fn __getitem__(self, indices: NDArray[DType.int]) raises -> Self:
+    def __getitem__(self, indices: NDArray[DType.int]) raises -> Self:
         """Gets items from the 0-th dimension of an array by an array of
         indices.
 
@@ -1414,7 +1414,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return result^
 
-    fn __getitem__(self, indices: List[Int]) raises -> Self:
+    def __getitem__(self, indices: List[Int]) raises -> Self:
         # TODO: Use trait IntLike when it is supported by Mojo.
         """Gets items from the 0-th dimension of an array by a list of integer
         indices.
@@ -1468,7 +1468,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return self[indices_array]
 
-    fn __getitem__(self, mask: NDArray[DType.bool]) raises -> Self:
+    def __getitem__(self, mask: NDArray[DType.bool]) raises -> Self:
         # TODO: Extend the mask into multiple dimensions.
         """Gets items from an array according to a boolean mask array.
 
@@ -1582,7 +1582,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-    fn __getitem__(self, mask: List[Bool]) raises -> Self:
+    def __getitem__(self, mask: List[Bool]) raises -> Self:
         """Gets items from the 0-th dimension of an array according to a boolean
         list mask.
 
@@ -1629,7 +1629,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return self[mask_array]
 
-    fn item(self, var index: Int) raises -> Scalar[Self.dtype]:
+    def item(self, var index: Int) raises -> Scalar[Self.dtype]:
         """Returns the scalar at the given linear index.
 
         If one index is given, gets the i-th item of the array (not buffer). It
@@ -1718,7 +1718,7 @@ struct NDArray[dtype: DType = DType.float64](
             self.offset + IndexMethods.get_1d_index(item, self.strides)
         ]
 
-    fn item(self, *index: Int) raises -> Scalar[Self.dtype]:
+    def item(self, *index: Int) raises -> Scalar[Self.dtype]:
         """Returns the scalar at the given coordinates.
 
         If one index is given, gets the i-th item of the array (not buffer). It
@@ -1797,7 +1797,7 @@ struct NDArray[dtype: DType = DType.float64](
             + IndexMethods.get_1d_index(index, self.strides)
         )[]
 
-    fn unsafe_load[width: Int = 1](self, index: Int) -> SIMD[Self.dtype, width]:
+    def unsafe_load[width: Int = 1](self, index: Int) -> SIMD[Self.dtype, width]:
         """Unsafely retrieves the i-th item from the underlying buffer as a SIMD
         element of size `width`.
 
@@ -1812,7 +1812,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return self._buf.ptr.load[width=width](self.offset + index)
 
-    fn load(self, var index: Int) raises -> Scalar[Self.dtype]:
+    def load(self, var index: Int) raises -> Scalar[Self.dtype]:
         """Safely retrieves the i-th item from the underlying buffer.
 
         `A.load(i)` differs from `A._buf.ptr[i]` due to boundary check.
@@ -1858,7 +1858,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return self._buf.ptr[self.offset + index]
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, var index: Int) raises -> SIMD[Self.dtype, width]:
         """Safely loads a SIMD element of size `width` at `index` from the
@@ -1896,7 +1896,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return self._buf.ptr.load[width=width](self.offset + index)
 
-    fn load[
+    def load[
         width: Int = 1
     ](self, *indices: Int) raises -> SIMD[Self.dtype, width]:
         """Safely loads a SIMD element of size `width` at given variadic indices
@@ -1969,28 +1969,28 @@ struct NDArray[dtype: DType = DType.float64](
     # Setter dunders and other setter methods
 
     # Basic Setter Methods
-    # fn _setitem(self, *indices: Int, val: Scalar[dtype])                      # Direct unsafe setter
-    # fn __setitem__(mut self, idx: Int, val: Self) raises                      # Set by single index
-    # fn __setitem__(mut self, index: Item, val: Scalar[dtype]) raises          # Set by coordinate list
-    # fn __setitem__(mut self, mask: NDArray[DType.bool], value: Scalar[dtype]) # Set by boolean mask
+    # def _setitem(self, *indices: Int, val: Scalar[dtype])                      # Direct unsafe setter
+    # def __setitem__(mut self, idx: Int, val: Self) raises                      # Set by single index
+    # def __setitem__(mut self, index: Item, val: Scalar[dtype]) raises          # Set by coordinate list
+    # def __setitem__(mut self, mask: NDArray[DType.bool], value: Scalar[dtype]) # Set by boolean mask
 
     # Slice-based Setters
-    # fn __setitem__(mut self, *slices: Slice, val: Self) raises                # Set by variable slices
-    # fn __setitem__(mut self, slices: List[Slice], val: Self) raises           # Set by list of slices
-    # fn __setitem__(mut self, *slices: Variant[Slice, Int], val: Self) raises  # Set by mix of slices/ints
+    # def __setitem__(mut self, *slices: Slice, val: Self) raises                # Set by variable slices
+    # def __setitem__(mut self, slices: List[Slice], val: Self) raises           # Set by list of slices
+    # def __setitem__(mut self, *slices: Variant[Slice, Int], val: Self) raises  # Set by mix of slices/ints
 
     # Index-based Setters
-    # fn __setitem__(self, indices: NDArray[DType.int], val: NDArray) raises  # Set by index array
-    # fn __setitem__(mut self, mask: NDArray[DType.bool], val: NDArray[dtype])  # Set by boolean mask array
+    # def __setitem__(self, indices: NDArray[DType.int], val: NDArray) raises  # Set by index array
+    # def __setitem__(mut self, mask: NDArray[DType.bool], val: NDArray[dtype])  # Set by boolean mask array
 
     # Helper Methods
-    # fn itemset(mut self, index: Variant[Int, List[Int]], item: Scalar[dtype]) # Set single item
-    # fn store(self, var index: Int, val: Scalar[dtype]) raises               # Store with bounds checking
-    # fn store[width: Int](mut self, index: Int, val: SIMD[dtype, width])       # Store SIMD value
-    # fn store[width: Int = 1](mut self, *indices: Int, val: SIMD[dtype, width])# Store SIMD at coordinates
+    # def itemset(mut self, index: Variant[Int, List[Int]], item: Scalar[dtype]) # Set single item
+    # def store(self, var index: Int, val: Scalar[dtype]) raises               # Store with bounds checking
+    # def store[width: Int](mut self, index: Int, val: SIMD[dtype, width])       # Store SIMD value
+    # def store[width: Int = 1](mut self, *indices: Int, val: SIMD[dtype, width])# Store SIMD at coordinates
     # ===-------------------------------------------------------------------===#
 
-    fn _setitem(self, *indices: Int, val: Scalar[Self.dtype]):
+    def _setitem(self, *indices: Int, val: Scalar[Self.dtype]):
         """Sets item at indices, bypassing all boundary checks.
 
         (UNSAFE! For internal use only.)
@@ -2016,7 +2016,7 @@ struct NDArray[dtype: DType = DType.float64](
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
         self._buf.ptr[self.offset + index_of_buffer] = val
 
-    fn __setitem__(self, idx: Int, val: Self) raises:
+    def __setitem__(self, idx: Int, val: Self) raises:
         """Assigns a single first-axis slice.
 
         Replaces the sub-array at axis-0 position `idx` with `val`. The shape of
@@ -2107,7 +2107,7 @@ struct NDArray[dtype: DType = DType.float64](
         self._write_first_axis_slice(self, norm, val)
 
     # perhaps move these to a utility module
-    fn _write_first_axis_slice(
+    def _write_first_axis_slice(
         self, dst: NDArray[Self.dtype], norm_idx: Int, src: NDArray[Self.dtype]
     ):
         var out_ndim = src.ndim
@@ -2134,7 +2134,7 @@ struct NDArray[dtype: DType = DType.float64](
                 src_off += c * stride_src
             dst._buf.ptr[dst_off] = src._buf.ptr[src_off]
 
-    fn __setitem__(mut self, var index: Item, val: Scalar[Self.dtype]) raises:
+    def __setitem__(mut self, var index: Item, val: Scalar[Self.dtype]) raises:
         """Sets the value at the index list.
 
         Args:
@@ -2189,7 +2189,7 @@ struct NDArray[dtype: DType = DType.float64](
         self._buf.ptr.store(self.offset + idx, val)
 
     # only works if array is called as array.__setitem__(), mojo compiler doesn't parse it implicitly
-    fn __setitem__(
+    def __setitem__(
         mut self, mask: NDArray[DType.bool], value: Scalar[Self.dtype]
     ) raises:
         """Sets the value of the array at the indices where the mask is `True`.
@@ -2232,7 +2232,7 @@ struct NDArray[dtype: DType = DType.float64](
             if mask_c._buf.ptr.load[width=1](i):
                 self.itemset(i, value)
 
-    fn __setitem__(mut self, *slices: Slice, val: Self) raises:
+    def __setitem__(mut self, *slices: Slice, val: Self) raises:
         """Sets the elements of the array at the slices with the given array.
 
         Args:
@@ -2257,7 +2257,7 @@ struct NDArray[dtype: DType = DType.float64](
             slice_list.append(slices[i])
         self.__setitem__(slices=slice_list, val=val)
 
-    fn __setitem__(mut self, slices: List[Slice], val: Self) raises:
+    def __setitem__(mut self, slices: List[Slice], val: Self) raises:
         """Sets the slices of an array from a list of slices and an array.
 
         Args:
@@ -2401,7 +2401,7 @@ struct NDArray[dtype: DType = DType.float64](
             index,
         )
 
-    fn __setitem__(mut self, *slices: Variant[Slice, Int], val: Self) raises:
+    def __setitem__(mut self, *slices: Variant[Slice, Int], val: Self) raises:
         """Sets items by a series of either slices or integers.
 
         Args:
@@ -2467,7 +2467,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.__setitem__(slices=slice_list, val=val)
 
     # TODO: fix this setter, add bound checks. Not sure about it's use case.
-    fn __setitem__(
+    def __setitem__(
         mut self, index: NDArray[DType.int], val: NDArray[Self.dtype]
     ) raises:
         """Sets the items of the array from an array of indices.
@@ -2557,7 +2557,7 @@ struct NDArray[dtype: DType = DType.float64](
         # for i in range(len(index)):
         # self.store(Int(index.load(i)), rebind[Scalar[dtype]](val.load(i)))
 
-    fn __setitem__(
+    def __setitem__(
         mut self, mask: NDArray[DType.bool], val: NDArray[Self.dtype]
     ) raises:
         """Sets the value of the array at the indices where the mask is `True`.
@@ -2601,7 +2601,7 @@ struct NDArray[dtype: DType = DType.float64](
             if mask_c._buf.ptr.load(i):
                 self.itemset(i, val_c._buf.ptr.load(i))
 
-    fn itemset(mut self, index: Int, item: Scalar[Self.dtype]) raises:
+    def itemset(mut self, index: Int, item: Scalar[Self.dtype]) raises:
         """Sets the scalar at the given coordinate.
 
         Args:
@@ -2618,7 +2618,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         ```
         import numojo as nm
-        fn main() raises:
+        def main() raises:
             var A = nm.zeros[nm.i16](3, 3)
             print(A)
             A.itemset(5, 256)
@@ -2666,7 +2666,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-    fn itemset(
+    def itemset(
         mut self, var indices: List[Int], item: Scalar[Self.dtype]
     ) raises:
         """Sets the scalar at the given coordinates.
@@ -2688,7 +2688,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         ```
         import numojo as nm
-        fn main() raises:
+        def main() raises:
             var A = nm.zeros[nm.i16](3, 3)
             print(A)
             A.itemset(List(1,1), 1024)
@@ -2740,7 +2740,7 @@ struct NDArray[dtype: DType = DType.float64](
             item,
         )
 
-    fn unsafe_store[
+    def unsafe_store[
         width: Int = 1
     ](mut self, index: Int, val: SIMD[Self.dtype, width]):
         """Unsafely stores a SIMD element to the i-th item of the underlying
@@ -2756,7 +2756,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         self._buf.ptr.store(self.offset + index, val)
 
-    fn store(self, var index: Int, val: Scalar[Self.dtype]) raises:
+    def store(self, var index: Int, val: Scalar[Self.dtype]) raises:
         """Safely stores a scalar to the i-th item of the underlying buffer.
 
         `A.store(i, a)` differs from `A._buf.ptr[i] = a` due to boundary check.
@@ -2795,7 +2795,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         self._buf.ptr[self.offset + index] = val
 
-    fn store[
+    def store[
         width: Int
     ](mut self, index: Int, val: SIMD[Self.dtype, width]) raises:
         """Safely stores a SIMD element of size `width` at `index` of the
@@ -2836,7 +2836,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         self._buf.ptr.store(self.offset + index, val)
 
-    fn store[
+    def store[
         width: Int = 1
     ](mut self, *indices: Int, val: SIMD[Self.dtype, width]) raises:
         """Safely stores a SIMD element of size `width` at given variadic
@@ -2900,7 +2900,7 @@ struct NDArray[dtype: DType = DType.float64](
     # ===-------------------------------------------------------------------===#
 
     # TODO: We should make a version that checks nonzero/not_nan
-    fn __bool__(self) raises -> Bool:
+    def __bool__(self) raises -> Bool:
         """Returns `True` if all elements are truthy.
 
         Raises:
@@ -2926,7 +2926,7 @@ struct NDArray[dtype: DType = DType.float64](
                 "ambiguous. Use a.any() or a.all()."
             )
 
-    fn __int__(self) raises -> Int:
+    def __int__(self) raises -> Int:
         """
         Gets `Int` representation of the array.
 
@@ -2961,7 +2961,7 @@ struct NDArray[dtype: DType = DType.float64](
                 "can be converted to scalars."
             )
 
-    fn __float__(self) raises -> Float64:
+    def __float__(self) raises -> Float64:
         """
         Gets `Float64` representation of the array.
 
@@ -2982,7 +2982,7 @@ struct NDArray[dtype: DType = DType.float64](
                 "can be converted to scalars."
             )
 
-    fn __pos__(self) raises -> Self:
+    def __pos__(self) raises -> Self:
         """Returns a positive copy of the array.
 
         Does not accept boolean type arrays.
@@ -2993,7 +2993,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
         return self.copy()
 
-    fn __neg__(self) raises -> Self:
+    def __neg__(self) raises -> Self:
         """Returns a negated copy of the array.
 
         For boolean arrays, use `__invert__` (`~`).
@@ -3005,7 +3005,7 @@ struct NDArray[dtype: DType = DType.float64](
         return self * Scalar[Self.dtype](-1.0)
 
     @always_inline("nodebug")
-    fn __eq__(self, other: Self) raises -> NDArray[DType.bool]:
+    def __eq__(self, other: Self) raises -> NDArray[DType.bool]:
         """Computes itemwise equality.
 
         Args:
@@ -3017,7 +3017,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __eq__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __eq__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise equality with a scalar.
 
         Args:
@@ -3029,7 +3029,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __ne__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __ne__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise inequality with a scalar.
 
         Args:
@@ -3041,7 +3041,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.not_equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __ne__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __ne__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
         """Computes itemwise inequality with an array.
 
         Args:
@@ -3053,7 +3053,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.not_equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __lt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __lt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise less-than with a scalar.
 
         Args:
@@ -3065,7 +3065,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.less[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __lt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __lt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
         """Computes itemwise less-than with an array.
 
         Args:
@@ -3077,7 +3077,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.less[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __le__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __le__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise less-than-or-equal-to with a scalar.
 
         Args:
@@ -3089,7 +3089,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.less_equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __le__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __le__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
         """Computes itemwise less-than-or-equal-to with an array.
 
         Args:
@@ -3101,7 +3101,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.less_equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __gt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __gt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise greater-than with a scalar.
 
         Args:
@@ -3113,7 +3113,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.greater[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __gt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __gt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
         """Computes itemwise greater-than with an array.
 
         Args:
@@ -3125,7 +3125,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.greater[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __ge__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
+    def __ge__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
         """Computes itemwise greater-than-or-equal-to with a scalar.
 
         Args:
@@ -3137,7 +3137,7 @@ struct NDArray[dtype: DType = DType.float64](
         return comparison.greater_equal[Self.dtype](self, other)
 
     @always_inline("nodebug")
-    fn __ge__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
+    def __ge__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
         """Computes itemwise greater-than-or-equal-to with an array.
 
         Args:
@@ -3151,19 +3151,19 @@ struct NDArray[dtype: DType = DType.float64](
     # ===-------------------------------------------------------------------===#
     # ARITHMETIC OPERATORS
     # ===-------------------------------------------------------------------===#
-    fn __add__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __add__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `array + scalar`.
         """
         return math.add[Self.dtype](self, other)
 
-    fn __add__(self, other: Self) raises -> Self:
+    def __add__(self, other: Self) raises -> Self:
         """
         Enables `array + array`.
         """
         return math.add[Self.dtype](self, other)
 
-    fn __radd__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __radd__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar + array`.
         """
@@ -3171,7 +3171,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     # ===--- In-place helper methods (view-safe) ---===#
 
-    fn _inplace_scalar_op[
+    def _inplace_scalar_op[
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
@@ -3192,7 +3192,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             @parameter
-            fn vec_op[w: Int](i: Int) unified {mut self, read other}:
+            def vec_op[w: Int](i: Int) unified {mut self, read other}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3215,7 +3215,7 @@ struct NDArray[dtype: DType = DType.float64](
                     self._buf.ptr[idx], other
                 )
 
-    fn _inplace_array_op[
+    def _inplace_array_op[
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
@@ -3249,7 +3249,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             @parameter
-            fn vec_op[w: Int](i: Int) unified {mut self, read other_c}:
+            def vec_op[w: Int](i: Int) unified {mut self, read other_c}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3274,73 +3274,73 @@ struct NDArray[dtype: DType = DType.float64](
 
     # ===--- In-place arithmetic operators ---===#
 
-    fn __iadd__(mut self, other: SIMD[Self.dtype, 1]) raises:
+    def __iadd__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array += scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__add__](other)
 
-    fn __iadd__(mut self, other: Self) raises:
+    def __iadd__(mut self, other: Self) raises:
         """Enables `array += array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__add__](other)
 
-    fn __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `array - scalar`.
         """
         return math.sub[Self.dtype](self, other)
 
-    fn __sub__(self, other: Self) raises -> Self:
+    def __sub__(self, other: Self) raises -> Self:
         """
         Enables `array - array`.
         """
         return math.sub[Self.dtype](self, other)
 
-    fn __rsub__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rsub__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar - array`.
         """
         return math.sub[Self.dtype](other, self)
 
-    fn __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
+    def __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array -= scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__sub__](other)
 
-    fn __isub__(mut self, other: Self) raises:
+    def __isub__(mut self, other: Self) raises:
         """Enables `array -= array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__sub__](other)
 
-    fn __matmul__(self, other: Self) raises -> Self:
+    def __matmul__(self, other: Self) raises -> Self:
         return numojo.linalg.matmul(self, other)
 
-    fn __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
+    def __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `array * scalar`.
         """
         return math.mul[Self.dtype](self, other)
 
-    fn __mul__(self, other: Self) raises -> Self:
+    def __mul__(self, other: Self) raises -> Self:
         """
         Enables `array * array`.
         """
         return math.mul[Self.dtype](self, other)
 
-    fn __rmul__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rmul__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar * array`.
         """
         return math.mul[Self.dtype](self, other)
 
-    fn __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
+    def __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array *= scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__mul__](other)
 
-    fn __imul__(mut self, other: Self) raises:
+    def __imul__(mut self, other: Self) raises:
         """Enables `array *= array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__mul__](other)
 
-    fn __abs__(self) -> Self:
+    def __abs__(self) -> Self:
         return abs(self)
 
-    fn __invert__(
+    def __invert__(
         self,
     ) raises -> Self where Self.dtype.is_integral() or Self.dtype == DType.bool:
         """Computes element-wise bitwise inversion.
@@ -3349,11 +3349,11 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return bitwise.invert[Self.dtype](self)
 
-    fn __pow__(self, p: Int) raises -> Self:
+    def __pow__(self, p: Int) raises -> Self:
         return self._elementwise_pow(p)
 
     # Shouldn't this be inplace?
-    fn __pow__(self, rhs: Scalar[Self.dtype]) raises -> Self:
+    def __pow__(self, rhs: Scalar[Self.dtype]) raises -> Self:
         """Computes element-wise power of items."""
         var src = self.contiguous()
         var result: Self = Self(shape=self.shape, order="C")
@@ -3361,7 +3361,7 @@ struct NDArray[dtype: DType = DType.float64](
             result._buf.ptr[i] = src._buf.ptr[i].__pow__(rhs)
         return result^
 
-    fn __pow__(self, p: Self) raises -> Self:
+    def __pow__(self, p: Self) raises -> Self:
         if self.size != p.size:
             raise Error(
                 String(
@@ -3377,7 +3377,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result = NDArray[Self.dtype](self.shape)
 
         @parameter
-        fn vectorized_pow[
+        def vectorized_pow[
             simd_width: Int
         ](index: Int) unified {mut result, read src, read p_c}:
             result._buf.ptr.store(
@@ -3389,12 +3389,12 @@ struct NDArray[dtype: DType = DType.float64](
         vectorize[self.width](self.size, vectorized_pow)
         return result^
 
-    fn __ipow__(mut self, p: Int) raises:
+    def __ipow__(mut self, p: Int) raises:
         """Enables `array **= int`. View-safe: modifies buffer in-place."""
         if self.is_c_contiguous():
 
             @parameter
-            fn vec_pow[w: Int](i: Int) unified {mut self, read p}:
+            def vec_pow[w: Int](i: Int) unified {mut self, read p}:
                 self._buf.ptr.store(
                     self.offset + i,
                     builtin_math.pow(
@@ -3414,11 +3414,11 @@ struct NDArray[dtype: DType = DType.float64](
                     idx += coord * Int(self.strides.unsafe_load(dim))
                 self._buf.ptr[idx] = builtin_math.pow(self._buf.ptr[idx], p)
 
-    fn _elementwise_pow(self, p: Int) raises -> Self:
+    def _elementwise_pow(self, p: Int) raises -> Self:
         var src = self.contiguous()
 
         @parameter
-        fn array_scalar_vectorize[
+        def array_scalar_vectorize[
             simd_width: Int
         ](index: Int) unified {mut src, read p} -> None:
             src._buf.ptr.store(
@@ -3429,79 +3429,79 @@ struct NDArray[dtype: DType = DType.float64](
         vectorize[self.width](self.size, array_scalar_vectorize)
         return src^
 
-    fn __truediv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __truediv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `array / scalar`.
         """
         return math.div[Self.dtype](self, other)
 
-    fn __truediv__(self, other: Self) raises -> Self:
+    def __truediv__(self, other: Self) raises -> Self:
         """
         Enables `array / array`.
         """
         return math.div[Self.dtype](self, other)
 
-    fn __itruediv__(mut self, s: SIMD[Self.dtype, 1]) raises:
+    def __itruediv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array /= scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__truediv__](s)
 
-    fn __itruediv__(mut self, other: Self) raises:
+    def __itruediv__(mut self, other: Self) raises:
         """Enables `array /= array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__truediv__](other)
 
-    fn __rtruediv__(self, s: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rtruediv__(self, s: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar / array`.
         """
         return math.div[Self.dtype](s, self)
 
-    fn __floordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __floordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `array // scalar`.
         """
         return math.floor_div[Self.dtype](self, other)
 
-    fn __floordiv__(self, other: Self) raises -> Self:
+    def __floordiv__(self, other: Self) raises -> Self:
         """
         Enables `array // array`.
         """
         return math.floor_div[Self.dtype](self, other)
 
-    fn __ifloordiv__(mut self, s: SIMD[Self.dtype, 1]) raises:
+    def __ifloordiv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array //= scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__floordiv__](s)
 
-    fn __ifloordiv__(mut self, other: Self) raises:
+    def __ifloordiv__(mut self, other: Self) raises:
         """Enables `array //= array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__floordiv__](other)
 
-    fn __rfloordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rfloordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar // array`.
         """
         return math.floor_div[Self.dtype](other, self)
 
-    fn __mod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __mod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `array % scalar`.
         """
         return math.mod[Self.dtype](self, other)
 
-    fn __mod__(mut self, other: NDArray[Self.dtype]) raises -> Self:
+    def __mod__(mut self, other: NDArray[Self.dtype]) raises -> Self:
         """
         Enables `array % array`.
         """
         return math.mod[Self.dtype](self, other)
 
-    fn __imod__(mut self, other: SIMD[Self.dtype, 1]) raises:
+    def __imod__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array %= scalar`. View-safe: modifies buffer in-place."""
         self._inplace_scalar_op[SIMD.__mod__](other)
 
-    fn __imod__(mut self, other: NDArray[Self.dtype]) raises:
+    def __imod__(mut self, other: NDArray[Self.dtype]) raises:
         """Enables `array %= array`. View-safe: modifies buffer in-place."""
         self._inplace_array_op[SIMD.__mod__](other)
 
-    fn __rmod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rmod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar % array`.
         """
@@ -3511,7 +3511,7 @@ struct NDArray[dtype: DType = DType.float64](
     # IO dunders and relevant methods
     # Trait implementations
     # ===-------------------------------------------------------------------===#
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Returns the string representation of the array.
 
         Enables `String(array)`.
@@ -3527,7 +3527,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return res
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the array to a writer.
 
         Args:
@@ -3565,7 +3565,7 @@ struct NDArray[dtype: DType = DType.float64](
             except e:
                 writer.write("Cannot convert array to string.\n" + String(e))
 
-    fn __repr__(self) -> String:
+    def __repr__(self) -> String:
         """Computes the "official" string representation of the NDArray.
 
         You can construct the array using this representation.
@@ -3604,7 +3604,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return result
 
-    fn write_repr_to[W: Writer](self, mut writer: W):
+    def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
 
         Parameters:
@@ -3618,11 +3618,11 @@ struct NDArray[dtype: DType = DType.float64](
     # Trait dunders and iterator dunders
     # ===-------------------------------------------------------------------===#
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         """Returns the length of the 0-th dimension."""
         return Int(self.shape.unsafe_load(0))
 
-    fn __iter__(
+    def __iter__(
         self,
     ) raises -> _NDArrayIter[origin_of(self), Self.dtype]:
         """Iterates over elements of the NDArray and returns sub-arrays as
@@ -3653,7 +3653,7 @@ struct NDArray[dtype: DType = DType.float64](
             dimension=0,
         )
 
-    fn __reversed__(
+    def __reversed__(
         self,
     ) raises -> _NDArrayIter[origin_of(self), Self.dtype, forward=False]:
         """Iterates backwards over elements of the NDArray, returning copied
@@ -3668,7 +3668,7 @@ struct NDArray[dtype: DType = DType.float64](
             dimension=0,
         )
 
-    fn _adjust_slice(
+    def _adjust_slice(
         self, slice_list: List[Slice]
     ) raises -> List[InternalSlice]:
         """Adjusts slice values to handle all possible slicing scenarios
@@ -3744,7 +3744,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return slices^
 
-    fn _array_to_string(
+    def _array_to_string(
         self,
         dimension: Int,
         offset: Int,
@@ -3855,7 +3855,7 @@ struct NDArray[dtype: DType = DType.float64](
         result += "]"
         return result
 
-    fn _find_max_and_min_in_printable_region(
+    def _find_max_and_min_in_printable_region(
         self,
         shape: NDArrayShape,
         strides: NDArrayStrides,
@@ -3917,7 +3917,7 @@ struct NDArray[dtype: DType = DType.float64](
     # # tobyets, tofile, view
     # ===-------------------------------------------------------------------===#
 
-    fn all(
+    def all(
         self,
     ) raises -> Bool where Self.dtype == DType.bool or Self.dtype.is_integral():
         """Returns `True` if all elements are truthy.
@@ -3934,7 +3934,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result: Bool = True
 
         @parameter
-        fn vectorized_all[
+        def vectorized_all[
             simd_width: Int
         ](idx: Int) unified {mut result, read a} -> None:
             result = result and builtin_bool.all(
@@ -3944,7 +3944,7 @@ struct NDArray[dtype: DType = DType.float64](
         vectorize[a.width](a.size, vectorized_all)
         return result
 
-    fn any(
+    def any(
         self,
     ) raises -> Bool where Self.dtype == DType.bool or Self.dtype.is_integral():
         """Returns `True` if any element is truthy.
@@ -3961,7 +3961,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result: Bool = False
 
         @parameter
-        fn vectorized_any[
+        def vectorized_any[
             simd_width: Int
         ](idx: Int) unified {mut result, read a} -> None:
             result = result or builtin_bool.any(
@@ -3971,33 +3971,33 @@ struct NDArray[dtype: DType = DType.float64](
         vectorize[a.width](a.size, vectorized_any)
         return result
 
-    fn argmax(self) raises -> Scalar[DType.int]:
+    def argmax(self) raises -> Scalar[DType.int]:
         """Returns the indices of the maximum values along an axis. When no axis
         is specified, the array is flattened. See `numojo.argmax()` for more
         details.
         """
         return searching.argmax(self)
 
-    fn argmax(self, axis: Int) raises -> NDArray[DType.int]:
+    def argmax(self, axis: Int) raises -> NDArray[DType.int]:
         """Returns the indices of the maximum values along an axis. See
         `numojo.argmax()` for more details.
         """
         return searching.argmax(self, axis=axis)
 
-    fn argmin(self) raises -> Scalar[DType.int]:
+    def argmin(self) raises -> Scalar[DType.int]:
         """Returns the indices of the minimum values along an axis. When no axis
         is specified, the array is flattened. See `numojo.argmin()` for more
         details.
         """
         return searching.argmin(self)
 
-    fn argmin(self, axis: Int) raises -> NDArray[DType.int]:
+    def argmin(self, axis: Int) raises -> NDArray[DType.int]:
         """Returns the indices of the minimum values along an axis. See
         `numojo.argmin()` for more details.
         """
         return searching.argmin(self, axis=axis)
 
-    fn argsort(mut self) raises -> NDArray[DType.int]:
+    def argsort(mut self) raises -> NDArray[DType.int]:
         """Sorts the NDArray and returns the sorted indices. See
         `numojo.argsort()` for more details.
 
@@ -4007,7 +4007,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.sorting.argsort(self)
 
-    fn argsort(mut self, axis: Int) raises -> NDArray[DType.int]:
+    def argsort(mut self, axis: Int) raises -> NDArray[DType.int]:
         """Sorts the NDArray and returns the sorted indices. See
         `numojo.argsort()` for more details.
 
@@ -4017,7 +4017,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.sorting.argsort(self, axis=axis)
 
-    fn astype[target: DType](self) raises -> NDArray[target]:
+    def astype[target: DType](self) raises -> NDArray[target]:
         """Converts the type of the array.
 
         Parameters:
@@ -4028,7 +4028,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return creation.astype[target](self)
 
-    fn clip(
+    def clip(
         self, a_min: Scalar[Self.dtype], a_max: Scalar[Self.dtype]
     ) raises -> Self:
         """Limits the values in an array between `[a_min, a_max]`.
@@ -4046,7 +4046,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.clip(self, a_min, a_max)
 
-    fn compress(self, condition: NDArray[DType.bool], axis: Int) raises -> Self:
+    def compress(self, condition: NDArray[DType.bool], axis: Int) raises -> Self:
         # TODO: @forFudan try using parallelization for this function
         """Returns selected slices of an array along a given axis.
 
@@ -4071,7 +4071,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.compress(condition=condition, a=self, axis=axis)
 
-    fn compress(self, condition: NDArray[DType.bool]) raises -> Self:
+    def compress(self, condition: NDArray[DType.bool]) raises -> Self:
         """Returns selected slices of an array along a given axis.
 
         If no axis is provided, the array is flattened before use. This is a
@@ -4094,7 +4094,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.compress(condition=condition, a=self)
 
-    fn contiguous(self) raises -> Self:
+    def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.
 
         Always creates a new owned array, even if the source is already
@@ -4143,7 +4143,7 @@ struct NDArray[dtype: DType = DType.float64](
         return result^
 
     # TODO: Remove this function, use slicing instead
-    fn col(self, id: Int) raises -> Self:
+    def col(self, id: Int) raises -> Self:
         """Gets the i-th column of the matrix.
 
         Args:
@@ -4173,7 +4173,7 @@ struct NDArray[dtype: DType = DType.float64](
             buffer._buf.ptr[i] = self._buf.ptr[src_idx]
         return buffer^
 
-    fn cumprod(self) raises -> NDArray[Self.dtype]:
+    def cumprod(self) raises -> NDArray[Self.dtype]:
         """Returns the cumulative product of all items of an array. The array is
         flattened before computation.
 
@@ -4182,7 +4182,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.math.cumprod[Self.dtype](self)
 
-    fn cumprod(self, axis: Int) raises -> NDArray[Self.dtype]:
+    def cumprod(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative product of the array along the given axis.
 
         Args:
@@ -4193,7 +4193,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.math.cumprod[Self.dtype](self.copy(), axis=axis)
 
-    fn cumsum(self) raises -> NDArray[Self.dtype]:
+    def cumsum(self) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of all items of an array. The array is
         flattened before computation.
 
@@ -4202,7 +4202,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.math.cumsum[Self.dtype](self)
 
-    fn cumsum(self, axis: Int) raises -> NDArray[Self.dtype]:
+    def cumsum(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of the array along the given axis.
 
         Args:
@@ -4213,7 +4213,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.math.cumsum[Self.dtype](self.copy(), axis=axis)
 
-    fn diagonal(self, offset: Int = 0) raises -> Self:
+    def diagonal(self, offset: Int = 0) raises -> Self:
         """Returns specific diagonals.
 
         Currently supports only 2D arrays.
@@ -4230,7 +4230,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.linalg.diagonal(self, offset=offset)
 
-    fn fill(mut self, val: Scalar[Self.dtype]):
+    def fill(mut self, val: Scalar[Self.dtype]):
         """Fills all items of the array with the given value.
 
         This method is offset- and stride-aware, so it correctly fills
@@ -4256,7 +4256,7 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 self._buf.ptr[index_of_buffer] = val
 
-    fn flatten(self, order: String = "C") raises -> Self:
+    def flatten(self, order: String = "C") raises -> Self:
         """Returns a copy of the array collapsed into one dimension.
 
         Args:
@@ -4268,7 +4268,7 @@ struct NDArray[dtype: DType = DType.float64](
         return ravel(self, order=order)
 
     @always_inline
-    fn is_c_contiguous(self) -> Bool:
+    def is_c_contiguous(self) -> Bool:
         """Checks if the array is strictly C-contiguous (dense row-major).
 
         A C-contiguous array has strides that exactly match a dense row-major
@@ -4305,7 +4305,7 @@ struct NDArray[dtype: DType = DType.float64](
         return True
 
     @always_inline
-    fn is_f_contiguous(self) -> Bool:
+    def is_f_contiguous(self) -> Bool:
         """Checks if the array is strictly F-contiguous (dense column-major).
 
         An F-contiguous array has strides that exactly match a dense
@@ -4341,7 +4341,7 @@ struct NDArray[dtype: DType = DType.float64](
         return True
 
     @always_inline
-    fn is_row_contiguous(self) -> Bool:
+    def is_row_contiguous(self) -> Bool:
         """Checks if elements within each row (last axis) are contiguous.
 
         This is a relaxation of C-contiguous: only the innermost (last)
@@ -4366,7 +4366,7 @@ struct NDArray[dtype: DType = DType.float64](
         return Int(self.strides.unsafe_load(self.ndim - 1)) == 1
 
     @always_inline
-    fn is_col_contiguous(self) -> Bool:
+    def is_col_contiguous(self) -> Bool:
         """Checks if elements within each column (first axis) are contiguous.
 
         This is a relaxation of F-contiguous: only the outermost (first)
@@ -4392,7 +4392,7 @@ struct NDArray[dtype: DType = DType.float64](
             return True
         return Int(self.strides.unsafe_load(0)) == 1
 
-    fn iter_along_axis[
+    def iter_along_axis[
         forward: Bool = True
     ](self, axis: Int, order: String = "C") raises -> Self._NDAxisIteratorType[
         forward,
@@ -4498,7 +4498,7 @@ struct NDArray[dtype: DType = DType.float64](
             size=self.size,
         )
 
-    fn iter_over_dimension[
+    def iter_over_dimension[
         forward: Bool = True
     ](read self, dimension: Int) raises -> _NDArrayIter[
         origin_of(self), Self.dtype, forward
@@ -4536,7 +4536,7 @@ struct NDArray[dtype: DType = DType.float64](
             dimension=normalized_dim,
         )
 
-    fn max(self) raises -> Scalar[Self.dtype]:
+    def max(self) raises -> Scalar[Self.dtype]:
         """Finds the max value of an array.
 
         When no axis is given, the array is flattened before sorting.
@@ -4547,7 +4547,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.math.max(self)
 
-    fn max(self, axis: Int) raises -> Self:
+    def max(self, axis: Int) raises -> Self:
         """Finds the max value of an array along the axis. The number of
         dimensions will be reduced by 1.
 
@@ -4562,7 +4562,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.math.max(self, axis=axis)
 
-    fn mean[
+    def mean[
         returned_dtype: DType = DType.float64
     ](self) raises -> Scalar[returned_dtype]:
         """Computes the mean of the array.
@@ -4572,7 +4572,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.statistics.mean[returned_dtype](self)
 
-    fn mean[
+    def mean[
         returned_dtype: DType = DType.float64
     ](self, axis: Int) raises -> NDArray[returned_dtype]:
         """Computes the mean of array elements over a given axis.
@@ -4585,7 +4585,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.statistics.mean[returned_dtype](self, axis)
 
-    fn median[
+    def median[
         returned_dtype: DType = DType.float64
     ](self) raises -> Scalar[returned_dtype]:
         """Computes the median of the array.
@@ -4595,7 +4595,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return median[returned_dtype](self)
 
-    fn median[
+    def median[
         returned_dtype: DType = DType.float64
     ](self, axis: Int) raises -> NDArray[returned_dtype]:
         """Computes the median of array elements over a given axis.
@@ -4608,7 +4608,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return median[returned_dtype](self, axis)
 
-    fn min(self) raises -> Scalar[Self.dtype]:
+    def min(self) raises -> Scalar[Self.dtype]:
         """Finds the min value of an array.
 
         When no axis is given, the array is flattened before sorting.
@@ -4619,7 +4619,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.math.min(self)
 
-    fn min(self, axis: Int) raises -> Self:
+    def min(self, axis: Int) raises -> Self:
         """Finds the min value of an array along the axis. The number of
         dimensions will be reduced by 1.
 
@@ -4634,7 +4634,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.math.min(self, axis=axis)
 
-    fn nditer(self) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
+    def nditer(self) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
         """Returns an iterator yielding the array elements according to the
         memory layout of the array.
 
@@ -4666,7 +4666,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return self.nditer(order=order)
 
-    fn nditer(
+    def nditer(
         self, order: String
     ) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
         """Returns an iterator yielding the array elements according to the
@@ -4711,7 +4711,7 @@ struct NDArray[dtype: DType = DType.float64](
             a=self, order=order, axis=axis
         )
 
-    fn prod(self) raises -> Scalar[Self.dtype]:
+    def prod(self) raises -> Scalar[Self.dtype]:
         """Computes the product of all array elements.
 
         Returns:
@@ -4719,7 +4719,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.math.prod(self)
 
-    fn prod(self, axis: Int) raises -> Self:
+    def prod(self, axis: Int) raises -> Self:
         """Computes the product of array elements over a given axis.
 
         Args:
@@ -4732,7 +4732,7 @@ struct NDArray[dtype: DType = DType.float64](
         return numojo.math.prod(self, axis=axis)
 
     # TODO: make it inplace?
-    fn reshape(
+    def reshape(
         self, shape: NDArrayShape, order: String = "C"
     ) raises -> NDArray[Self.dtype]:
         """Returns an array of the same data with a new shape.
@@ -4747,7 +4747,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result = numojo.reshape(self, shape=shape, order=order)
         return result^
 
-    fn resize(mut self, shape: NDArrayShape) raises:
+    def resize(mut self, shape: NDArrayShape) raises:
         """Changes the shape and size of the array in-place.
 
         Notes:
@@ -4775,7 +4775,7 @@ struct NDArray[dtype: DType = DType.float64](
             self.size = shape.size()
             self.strides = NDArrayStrides(shape, order=order)
 
-    fn round(self) raises -> Self:
+    def round(self) raises -> Self:
         """Rounds the elements of the array to a whole number.
 
         Returns:
@@ -4783,7 +4783,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return rounding.tround[Self.dtype](self)
 
-    fn row(self, id: Int) raises -> Self:
+    def row(self, id: Int) raises -> Self:
         """Gets the i-th row of the matrix.
 
         Args:
@@ -4821,7 +4821,7 @@ struct NDArray[dtype: DType = DType.float64](
             buffer._buf.ptr[i] = self._buf.ptr[src_idx]
         return buffer^
 
-    fn sort(mut self, axis: Int = -1, stable: Bool = False) raises:
+    def sort(mut self, axis: Int = -1, stable: Bool = False) raises:
         """Sorts the array in-place along the given axis using quick sort. The
         default axis is -1. See `numojo.sorting.sort` for more information.
 
@@ -4849,7 +4849,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
         numojo.sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
 
-    fn std[
+    def std[
         returned_dtype: DType = DType.float64
     ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
         """Computes the standard deviation. See `numojo.std`.
@@ -4863,7 +4863,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return std[returned_dtype](self, ddof=ddof)
 
-    fn std[
+    def std[
         returned_dtype: DType = DType.float64
     ](self, axis: Int, ddof: Int = 0) raises -> NDArray[returned_dtype]:
         """Computes the standard deviation along the axis. See `numojo.std`.
@@ -4878,7 +4878,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         return std[returned_dtype](self, axis=axis, ddof=ddof)
 
-    fn sum(self) raises -> Scalar[Self.dtype]:
+    def sum(self) raises -> Scalar[Self.dtype]:
         """Returns the sum of all array elements.
 
         Returns:
@@ -4886,7 +4886,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return sum(self)
 
-    fn sum(self, axis: Int) raises -> Self:
+    def sum(self, axis: Int) raises -> Self:
         """Computes the sum of array elements over a given axis.
 
         Args:
@@ -4897,7 +4897,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return sum(self, axis=axis)
 
-    fn T(self, axes: List[Int]) raises -> Self:
+    def T(self, axes: List[Int]) raises -> Self:
         """Transposes the array of any number of dimensions according to an
         arbitrary permutation of the axes.
 
@@ -4913,7 +4913,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.routines.manipulation.transpose(self, axes)
 
-    fn T(self) raises -> Self:
+    def T(self) raises -> Self:
         """Transposes the array when `axes` is not given.
 
         ***Overload*** If `axes` is not given, it is equal to flipping the axes.
@@ -4926,7 +4926,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo.routines.manipulation.transpose(self.copy())
 
-    fn tolist(self) -> List[Scalar[Self.dtype]]:
+    def tolist(self) -> List[Scalar[Self.dtype]]:
         """Converts the NDArray to a 1-D list in row-major (C) order.
 
         This method is offset- and stride-aware, so it correctly
@@ -4953,7 +4953,7 @@ struct NDArray[dtype: DType = DType.float64](
                 result.append(self._buf.ptr[index_of_buffer])
         return result^
 
-    fn to_numpy(self) raises -> PythonObject:
+    def to_numpy(self) raises -> PythonObject:
         """Converts the array to a NumPy array.
 
         Returns:
@@ -4961,7 +4961,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return to_numpy(self)
 
-    # fn to_tensor(self) raises -> Tensor[dtype]:
+    # def to_tensor(self) raises -> Tensor[dtype]:
     #     """
     #     Convert array to tensor of the same dtype.
 
@@ -4974,7 +4974,7 @@ struct NDArray[dtype: DType = DType.float64](
     #     import numojo as nm
     #     from numojo.prelude import *
 
-    #     fn main() raises:
+    #     def main() raises:
     #         var a = nm.random.randn[f16](2, 3, 4)
     #         print(a)
     #         print(a.to_tensor())
@@ -4993,7 +4993,7 @@ struct NDArray[dtype: DType = DType.float64](
     #     return to_tensor(self)
 
     # TODO: add axis parameter
-    fn trace(
+    def trace(
         self, offset: Int = 0, axis1: Int = 0, axis2: Int = 1
     ) raises -> NDArray[Self.dtype]:
         """Computes the trace of the ndarray.
@@ -5009,7 +5009,7 @@ struct NDArray[dtype: DType = DType.float64](
         return numojo.linalg.trace[Self.dtype](self, offset, axis1, axis2)
 
     # TODO: Remove the underscore in the method name when view is supported.
-    # fn _transpose(self) raises -> Self:
+    # def _transpose(self) raises -> Self:
     #     """
     #     Returns a view of transposed array.
 
@@ -5025,7 +5025,7 @@ struct NDArray[dtype: DType = DType.float64](
     #         strides=self.strides._flip(),
     #     )
 
-    fn unsafe_ptr(
+    def unsafe_ptr(
         ref self,
     ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         """Retrieves the pointer to the logical start of the array data.
@@ -5041,7 +5041,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._buf.ptr + self.offset
         )
 
-    fn variance[
+    def variance[
         returned_dtype: DType = DType.float64
     ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
         """Returns the variance of the array.
@@ -5057,7 +5057,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return variance[returned_dtype](self, ddof=ddof)
 
-    fn variance[
+    def variance[
         returned_dtype: DType = DType.float64
     ](self, axis: Int, ddof: Int = 0) raises -> NDArray[returned_dtype]:
         """Returns the variance of the array along the axis. See
@@ -5075,7 +5075,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return variance[returned_dtype](self, axis=axis, ddof=ddof)
 
-    fn squeeze(mut self, axis: Int) raises:
+    def squeeze(mut self, axis: Int) raises:
         """Removes (squeezes) a single dimension of size 1 from the array shape.
 
         Args:
@@ -5156,7 +5156,7 @@ struct _NDArrayIter[
     var ndim: Int
     var size_of_item: Int
 
-    fn __init__(
+    def __init__(
         out self, a: Pointer[NDArray[Self.dtype], Self.origin], dimension: Int
     ) raises:
         """Initializes the iterator.
@@ -5190,10 +5190,10 @@ struct _NDArrayIter[
         self.index = 0 if Self.forward else a[].shape[dimension] - 1
 
     # * Do we return a mutable ref as iter or copy?
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self.copy()
 
-    fn __next__(mut self) raises -> NDArray[Self.dtype]:
+    def __next__(mut self) raises -> NDArray[Self.dtype]:
         var new_shape = self.shape.pop(self.dimension)
         var result = NDArray[Self.dtype](self.shape.pop(self.dimension))
         var current_index = self.index
@@ -5232,19 +5232,19 @@ struct _NDArrayIter[
         return result^
 
     @always_inline
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:
             return self.index
 
-    fn ith(self, index: Int) raises -> NDArray[Self.dtype]:
+    def ith(self, index: Int) raises -> NDArray[Self.dtype]:
         """
         Gets the i-th array of the iterator.
 
@@ -5355,7 +5355,7 @@ struct _NDAxisIter[
     var size_of_item: Int
     """Size of the result 1-d array."""
 
-    fn __init__(
+    def __init__(
         out self,
         data: DataContainer[Self.dtype],
         offset: Int,
@@ -5424,22 +5424,22 @@ struct _NDAxisIter[
         # Status of the iterator
         self.index = 0 if Self.forward else self.length - 1
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         comptime if Self.forward:
             return self.index < self.length
         else:
             return self.index >= 0
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self.copy()
 
-    fn __len__(self) -> Int:
+    def __len__(self) -> Int:
         comptime if Self.forward:
             return self.length - self.index
         else:
             return self.index
 
-    fn __next__(mut self) raises -> NDArray[Self.dtype]:
+    def __next__(mut self) raises -> NDArray[Self.dtype]:
         var res = NDArray[Self.dtype](Shape(self.size_of_item))
         var current_index = self.index
 
@@ -5498,7 +5498,7 @@ struct _NDAxisIter[
 
         return res^
 
-    fn ith(self, index: Int) raises -> NDArray[Self.dtype]:
+    def ith(self, index: Int) raises -> NDArray[Self.dtype]:
         """
         Gets the i-th 1-d array of the iterator.
 
@@ -5570,7 +5570,7 @@ struct _NDAxisIter[
 
         return elements^
 
-    fn ith_with_offsets(
+    def ith_with_offsets(
         self, index: Int
     ) raises -> Tuple[NDArray[DType.int], NDArray[Self.dtype]]:
         """
@@ -5686,7 +5686,7 @@ struct _NDIter[
     var order: String
     """Order to traverse the array."""
 
-    fn __init__(
+    def __init__(
         out self, a: NDArray[Self.dtype], order: String, axis: Int
     ) raises:
         self.length = a.size
@@ -5720,16 +5720,16 @@ struct _NDIter[
 
         self.index = 0
 
-    fn __iter__(self) -> Self:
+    def __iter__(self) -> Self:
         return self.copy()
 
-    fn __has_next__(self) -> Bool:
+    def __has_next__(self) -> Bool:
         if self.index < self.length:
             return True
         else:
             return False
 
-    fn __next__(mut self) raises -> Scalar[Self.dtype]:
+    def __next__(mut self) raises -> Scalar[Self.dtype]:
         var current_index = self.index
         self.index += 1
 
@@ -5766,7 +5766,7 @@ struct _NDIter[
             self.offset + IndexMethods.get_1d_index(indices, self.strides)
         ]
 
-    fn ith(self, index: Int) raises -> Scalar[Self.dtype]:
+    def ith(self, index: Int) raises -> Scalar[Self.dtype]:
         """
         Gets the i-th element of the iterator.
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1797,7 +1797,9 @@ struct NDArray[dtype: DType = DType.float64](
             + IndexMethods.get_1d_index(index, self.strides)
         )[]
 
-    def unsafe_load[width: Int = 1](self, index: Int) -> SIMD[Self.dtype, width]:
+    def unsafe_load[
+        width: Int = 1
+    ](self, index: Int) -> SIMD[Self.dtype, width]:
         """Unsafely retrieves the i-th item from the underlying buffer as a SIMD
         element of size `width`.
 
@@ -4046,7 +4048,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         return numojo.clip(self, a_min, a_max)
 
-    def compress(self, condition: NDArray[DType.bool], axis: Int) raises -> Self:
+    def compress(
+        self, condition: NDArray[DType.bool], axis: Int
+    ) raises -> Self:
         # TODO: @forFudan try using parallelization for this function
         """Returns selected slices of an array along a given axis.
 

--- a/numojo/core/traits/array_like.mojo
+++ b/numojo/core/traits/array_like.mojo
@@ -3,12 +3,12 @@ from numojo.core.ndarray import NDArray
 # Blocked by lack of trait paramaterization
 
 # trait Arraylike:
-#     fn load[width: Int](self, idx: Int) -> SIMD[dtype, width]:
+#     def load[width: Int](self, idx: Int) -> SIMD[dtype, width]:
 #         """
 #         Loads a SIMD element of size `width` at the given index `idx`.
 #         """
 #         ...
-#     fn store[width: Int](mut self, idx: Int, val: SIMD[dtype, width]):
+#     def store[width: Int](mut self, idx: Int, val: SIMD[dtype, width]):
 #         """
 #         Stores the SIMD element of size `width` at index `idx`.
 #         """
@@ -19,13 +19,13 @@ from numojo.core.ndarray import NDArray
 #     A trait that defines backends for calculations in the rest of the library.
 #     """
 
-#     fn __init__(mut self):
+#     def __init__(mut self):
 #         """
 #         Initialize the backend.
 #         """
 #         ...
 
-#     fn math_func_1_array_in_one_array_out[
+#     def math_func_1_array_in_one_array_out[
 #         dtype: DType,
 #         func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w]) -> SIMD[
 #             type, simd_w
@@ -46,7 +46,7 @@ from numojo.core.ndarray import NDArray
 #         """
 #         ...
 
-#     fn math_func_2_array_in_one_array_out[
+#     def math_func_2_array_in_one_array_out[
 #         dtype: DType,
 #         func: fn[type: DType, simd_w: Int] (
 #             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -74,7 +74,7 @@ from numojo.core.ndarray import NDArray
 
 #         ...
 
-#     fn math_func_one_array_one_SIMD_in_one_array_out[
+#     def math_func_one_array_one_SIMD_in_one_array_out[
 #         dtype: DType,
 #         func: fn[type: DType, simd_w: Int] (
 #             SIMD[type, simd_w], SIMD[type, simd_w]

--- a/numojo/core/traits/backend.mojo
+++ b/numojo/core/traits/backend.mojo
@@ -11,13 +11,13 @@ trait Backend(ImplicitlyDestructible):
     A trait that defines backends for calculations in the rest of the library.
     """
 
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initialize the backend.
         """
         ...
 
-    fn math_func_fma[
+    def math_func_fma[
         dtype: DType,
     ](
         self,
@@ -47,7 +47,7 @@ trait Backend(ImplicitlyDestructible):
         """
         ...
 
-    fn math_func_fma[
+    def math_func_fma[
         dtype: DType,
     ](
         self,
@@ -74,7 +74,7 @@ trait Backend(ImplicitlyDestructible):
         """
         ...
 
-    fn math_func_1_array_in_one_array_out[
+    def math_func_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
@@ -95,7 +95,7 @@ trait Backend(ImplicitlyDestructible):
         """
         ...
 
-    fn math_func_2_array_in_one_array_out[
+    def math_func_2_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -127,7 +127,7 @@ trait Backend(ImplicitlyDestructible):
 
         ...
 
-    fn math_func_1_array_1_scalar_in_one_array_out[
+    def math_func_1_array_1_scalar_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -159,7 +159,7 @@ trait Backend(ImplicitlyDestructible):
 
         ...
 
-    fn math_func_1_scalar_1_array_in_one_array_out[
+    def math_func_1_scalar_1_array_in_one_array_out[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -187,7 +187,7 @@ trait Backend(ImplicitlyDestructible):
 
         ...
 
-    fn math_func_compare_2_arrays[
+    def math_func_compare_2_arrays[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -218,7 +218,7 @@ trait Backend(ImplicitlyDestructible):
         """
         ...
 
-    fn math_func_compare_array_and_scalar[
+    def math_func_compare_array_and_scalar[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -249,7 +249,7 @@ trait Backend(ImplicitlyDestructible):
         """
         ...
 
-    fn math_func_is[
+    def math_func_is[
         dtype: DType,
         func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
@@ -257,7 +257,7 @@ trait Backend(ImplicitlyDestructible):
     ](self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         ...
 
-    # fn math_func_simd_int[
+    # def math_func_simd_int[
     #     dtype: DType,
     #     func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
     #         type, simd_w

--- a/numojo/core/traits/buffered.mojo
+++ b/numojo/core/traits/buffered.mojo
@@ -13,16 +13,16 @@ trait Buffered(ImplicitlyCopyable, Movable):
     The `RefData` type will record the origin of the data to ensure safety.
     """
 
-    fn __init__(out self):
+    def __init__(out self):
         ...
 
     @staticmethod
-    fn is_own_data() -> Bool:
+    def is_own_data() -> Bool:
         ...
 
     @staticmethod
-    fn is_ref_data() -> Bool:
+    def is_ref_data() -> Bool:
         ...
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         ...

--- a/numojo/routines/bitwise.mojo
+++ b/numojo/routines/bitwise.mojo
@@ -18,7 +18,7 @@ from numojo.core.ndarray import NDArray
 # ===------------------------------------------------------------------------===#
 
 
-fn invert[
+def invert[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[dtype] where (
     dtype.is_integral() or dtype == DType.bool

--- a/numojo/routines/constants.mojo
+++ b/numojo/routines/constants.mojo
@@ -18,7 +18,7 @@ struct Constants(AnyType, Copyable, Movable):
     Use comptime for compile time evaluation of indefinite precision.
     ```mojo
     import numojo as nm
-    fn main():
+    def main():
         var pi: Float64 = nm.pi
         print("Float64:", pi*pi*pi*pi*pi*pi)
         print("Literal:", nm.pi*nm.pi*nm.pi*nm.pi*nm.pi*nm.pi)
@@ -30,13 +30,13 @@ struct Constants(AnyType, Copyable, Movable):
     comptime e = 2.71828182845904523536028747135266249775724609375
     comptime hbar = 1.0545718176461563912626e-34
 
-    fn __init__(out self):
+    def __init__(out self):
         """
         Initializes the constants.
         """
         pass
 
-    fn __del__(deinit self):
+    def __del__(deinit self):
         """
         Deletes the constants.
         """

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -48,7 +48,7 @@ from numojo.core.memory import DataContainer
 # Numerical ranges
 # ===------------------------------------------------------------------------===#
 # FIXME: a lot of the creation routines uses ._buf.ptr directly. This should be changed to ._buf[idx] once we use the new DataContainer with correct origins.
-fn arange[
+def arange[
     dtype: DType = DType.float64
 ](
     start: Scalar[dtype],
@@ -90,7 +90,7 @@ fn arange[
     return result^
 
 
-fn arange[
+def arange[
     dtype: DType = DType.float64
 ](stop: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -124,7 +124,7 @@ fn arange[
     return result^
 
 
-fn arange[
+def arange[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -176,7 +176,7 @@ fn arange[
     return result^
 
 
-fn arange[
+def arange[
     cdtype: ComplexDType = ComplexDType.float64,
 ](stop: ComplexSIMD[cdtype]) raises -> ComplexNDArray[cdtype]:
     """
@@ -215,7 +215,7 @@ fn arange[
 # ===------------------------------------------------------------------------===#
 # Linear Spacing NDArray Generation
 # ===------------------------------------------------------------------------===#
-fn linspace[
+def linspace[
     dtype: DType = DType.float64,
     parallel: Bool = False,
 ](
@@ -263,7 +263,7 @@ fn linspace[
         return _linspace_serial[dtype](start, stop, num, endpoint)
 
 
-fn _linspace_serial[
+def _linspace_serial[
     dtype: DType = DType.float64
 ](
     start: SIMD[dtype, 1],
@@ -301,7 +301,7 @@ fn _linspace_serial[
     return result^
 
 
-fn _linspace_parallel[
+def _linspace_parallel[
     dtype: DType = DType.float64
 ](
     start: SIMD[dtype, 1], stop: SIMD[dtype, 1], num: Int, endpoint: Bool = True
@@ -329,7 +329,7 @@ fn _linspace_parallel[
         var step: SIMD[dtype, 1] = (stop - start) / denominator
 
         @parameter
-        fn parallelized_linspace(idx: Int) -> None:
+        def parallelized_linspace(idx: Int) -> None:
             result._buf.ptr[idx] = start + step * Scalar[dtype](idx)
 
         parallelize[parallelized_linspace](num)
@@ -338,7 +338,7 @@ fn _linspace_parallel[
         var step: SIMD[dtype, 1] = (stop - start) / Scalar[dtype](num)
 
         @parameter
-        fn parallelized_linspace1(idx: Int) -> None:
+        def parallelized_linspace1(idx: Int) -> None:
             result._buf.ptr[idx] = start + step * Scalar[dtype](idx)
 
         parallelize[parallelized_linspace1](num)
@@ -346,7 +346,7 @@ fn _linspace_parallel[
     return result^
 
 
-fn linspace[
+def linspace[
     cdtype: ComplexDType = ComplexDType.float64,
     parallel: Bool = False,
 ](
@@ -390,7 +390,7 @@ fn linspace[
         return _linspace_serial[cdtype](start, stop, num, endpoint)
 
 
-fn _linspace_serial[
+def _linspace_serial[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -447,7 +447,7 @@ fn _linspace_serial[
     return result^
 
 
-fn _linspace_parallel[
+def _linspace_parallel[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -481,7 +481,7 @@ fn _linspace_parallel[
 
         # need better error handling here later
         @parameter
-        fn parallelized_linspace(idx: Int) -> None:
+        def parallelized_linspace(idx: Int) -> None:
             try:
                 result.store[width=1](
                     idx,
@@ -500,7 +500,7 @@ fn _linspace_parallel[
         var step_im: Scalar[dtype] = (stop.im - start.im) / Scalar[dtype](num)
 
         @parameter
-        fn parallelized_linspace1(idx: Int) -> None:
+        def parallelized_linspace1(idx: Int) -> None:
             try:
                 result.store[width=1](
                     idx,
@@ -520,7 +520,7 @@ fn _linspace_parallel[
 # ===------------------------------------------------------------------------===#
 # Logarithmic Spacing NDArray Generation
 # ===------------------------------------------------------------------------===#
-fn logspace[
+def logspace[
     dtype: DType = DType.float64,
     parallel: Bool = False,
 ](
@@ -581,7 +581,7 @@ fn logspace[
         )
 
 
-fn _logspace_serial[
+def _logspace_serial[
     dtype: DType = DType.float64
 ](
     start: Scalar[dtype],
@@ -619,7 +619,7 @@ fn _logspace_serial[
     return result^
 
 
-fn _logspace_parallel[
+def _logspace_parallel[
     dtype: DType = DType.float64
 ](
     start: Scalar[dtype],
@@ -650,7 +650,7 @@ fn _logspace_parallel[
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num - 1)
 
         @parameter
-        fn parallelized_logspace(idx: Int) -> None:
+        def parallelized_logspace(idx: Int) -> None:
             result._buf.ptr[idx] = base ** (start + step * Scalar[dtype](idx))
 
         parallelize[parallelized_logspace](num)
@@ -659,7 +659,7 @@ fn _logspace_parallel[
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num)
 
         @parameter
-        fn parallelized_logspace1(idx: Int) -> None:
+        def parallelized_logspace1(idx: Int) -> None:
             result._buf.ptr[idx] = base ** (start + step * Scalar[dtype](idx))
 
         parallelize[parallelized_logspace1](num)
@@ -667,7 +667,7 @@ fn _logspace_parallel[
     return result^
 
 
-fn logspace[
+def logspace[
     cdtype: ComplexDType = ComplexDType.float64,
     parallel: Bool = False,
 ](
@@ -714,7 +714,7 @@ fn logspace[
         )
 
 
-fn _logspace_serial[
+def _logspace_serial[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -773,7 +773,7 @@ fn _logspace_serial[
     return result^
 
 
-fn _logspace_parallel[
+def _logspace_parallel[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -812,7 +812,7 @@ fn _logspace_parallel[
         )
 
         @parameter
-        fn parallelized_logspace(idx: Int) -> None:
+        def parallelized_logspace(idx: Int) -> None:
             try:
                 result.store[1](
                     idx,
@@ -831,7 +831,7 @@ fn _logspace_parallel[
         var step_im: Scalar[dtype] = (stop.im - start.im) / Scalar[dtype](num)
 
         @parameter
-        fn parallelized_logspace1(idx: Int) -> None:
+        def parallelized_logspace1(idx: Int) -> None:
             try:
                 result.store[1](
                     idx,
@@ -849,7 +849,7 @@ fn _logspace_parallel[
 
 
 # ! Outputs wrong values for Integer type, works fine for float type.
-fn geomspace[
+def geomspace[
     dtype: DType = DType.float64
 ](
     start: Scalar[dtype],
@@ -905,7 +905,7 @@ fn geomspace[
         return result^
 
 
-fn geomspace[
+def geomspace[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     start: ComplexSIMD[cdtype],
@@ -966,7 +966,7 @@ fn geomspace[
 # ===------------------------------------------------------------------------===#
 # Commonly used NDArray Generation routines
 # ===------------------------------------------------------------------------===#
-fn empty[
+def empty[
     dtype: DType = DType.float64
 ](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
@@ -984,7 +984,7 @@ fn empty[
     return NDArray[dtype](shape=shape)
 
 
-fn empty[
+def empty[
     dtype: DType = DType.float64
 ](shape: List[Int]) raises -> NDArray[dtype]:
     """
@@ -1004,7 +1004,7 @@ fn empty[
     return empty[dtype](shape=NDArrayShape(shape))
 
 
-fn empty[
+def empty[
     dtype: DType = DType.float64
 ](shape: VariadicList[Int, _]) raises -> NDArray[dtype]:
     """
@@ -1024,7 +1024,7 @@ fn empty[
     return empty[dtype](shape=NDArrayShape(shape))
 
 
-fn empty_like[
+def empty_like[
     dtype: DType = DType.float64
 ](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -1042,7 +1042,7 @@ fn empty_like[
     return NDArray[dtype](shape=array.shape)
 
 
-fn empty[
+def empty[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: NDArrayShape) raises -> ComplexNDArray[cdtype]:
     """
@@ -1060,7 +1060,7 @@ fn empty[
     return ComplexNDArray[cdtype](shape=shape)
 
 
-fn empty[
+def empty[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: List[Int]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1080,7 +1080,7 @@ fn empty[
     return empty[cdtype](shape=NDArrayShape(shape))
 
 
-fn empty[
+def empty[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: VariadicList[Int, _]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1100,7 +1100,7 @@ fn empty[
     return empty[cdtype](shape=NDArrayShape(shape))
 
 
-fn empty_like[
+def empty_like[
     cdtype: ComplexDType = ComplexDType.float64,
 ](array: ComplexNDArray[cdtype]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1118,7 +1118,7 @@ fn empty_like[
     return ComplexNDArray[cdtype](shape=array.shape)
 
 
-fn eye[dtype: DType = DType.float64](N: Int, M: Int) raises -> NDArray[dtype]:
+def eye[dtype: DType = DType.float64](N: Int, M: Int) raises -> NDArray[dtype]:
     """
     Return a 2-D NDArray with ones on the diagonal and zeros elsewhere.
 
@@ -1149,7 +1149,7 @@ fn eye[dtype: DType = DType.float64](N: Int, M: Int) raises -> NDArray[dtype]:
     return result^
 
 
-fn eye[
+def eye[
     cdtype: ComplexDType = ComplexDType.float64,
 ](N: Int, M: Int) raises -> ComplexNDArray[cdtype]:
     """
@@ -1172,7 +1172,7 @@ fn eye[
     return result^
 
 
-fn identity[dtype: DType = DType.float64](N: Int) raises -> NDArray[dtype]:
+def identity[dtype: DType = DType.float64](N: Int) raises -> NDArray[dtype]:
     """
     Generate an identity matrix of size N x N.
 
@@ -1202,7 +1202,7 @@ fn identity[dtype: DType = DType.float64](N: Int) raises -> NDArray[dtype]:
     return result^
 
 
-fn identity[
+def identity[
     cdtype: ComplexDType = ComplexDType.float64,
 ](N: Int) raises -> ComplexNDArray[cdtype]:
     """
@@ -1224,7 +1224,7 @@ fn identity[
     return result^
 
 
-fn ones[
+def ones[
     dtype: DType = DType.float64
 ](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
@@ -1251,7 +1251,7 @@ fn ones[
     return full[dtype](shape=shape, fill_value=1)
 
 
-fn ones[
+def ones[
     dtype: DType = DType.float64
 ](shape: List[Int]) raises -> NDArray[dtype]:
     """
@@ -1269,7 +1269,7 @@ fn ones[
     return ones[dtype](shape=NDArrayShape(shape))
 
 
-fn ones[
+def ones[
     dtype: DType = DType.float64
 ](shape: VariadicList[Int, _]) raises -> NDArray[dtype]:
     """
@@ -1287,7 +1287,7 @@ fn ones[
     return ones[dtype](shape=NDArrayShape(shape))
 
 
-fn ones_like[
+def ones_like[
     dtype: DType = DType.float64
 ](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -1305,7 +1305,7 @@ fn ones_like[
     return ones[dtype](shape=array.shape)
 
 
-fn ones[
+def ones[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: NDArrayShape) raises -> ComplexNDArray[cdtype]:
     """
@@ -1323,7 +1323,7 @@ fn ones[
     return full[cdtype](shape=shape, fill_value=ComplexSIMD[cdtype](1, 1))
 
 
-fn ones[
+def ones[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: List[Int]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1341,7 +1341,7 @@ fn ones[
     return ones[cdtype](shape=NDArrayShape(shape))
 
 
-fn ones[
+def ones[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: VariadicList[Int, _]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1359,7 +1359,7 @@ fn ones[
     return ones[cdtype](shape=NDArrayShape(shape))
 
 
-fn ones_like[
+def ones_like[
     cdtype: ComplexDType = ComplexDType.float64,
 ](array: ComplexNDArray[cdtype]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1377,7 +1377,7 @@ fn ones_like[
     return full[cdtype](shape=array.shape, fill_value=ComplexSIMD[cdtype](1, 1))
 
 
-fn zeros[
+def zeros[
     dtype: DType = DType.float64
 ](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
@@ -1404,7 +1404,7 @@ fn zeros[
     return full[dtype](shape=shape, fill_value=0)
 
 
-fn zeros[
+def zeros[
     dtype: DType = DType.float64
 ](shape: List[Int]) raises -> NDArray[dtype]:
     """
@@ -1422,7 +1422,7 @@ fn zeros[
     return zeros[dtype](shape=NDArrayShape(shape))
 
 
-fn zeros[
+def zeros[
     dtype: DType = DType.float64
 ](shape: VariadicList[Int, _]) raises -> NDArray[dtype]:
     """
@@ -1440,7 +1440,7 @@ fn zeros[
     return zeros[dtype](shape=NDArrayShape(shape))
 
 
-fn zeros_like[
+def zeros_like[
     dtype: DType = DType.float64
 ](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -1458,7 +1458,7 @@ fn zeros_like[
     return full[dtype](shape=array.shape, fill_value=0)
 
 
-fn zeros[
+def zeros[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: NDArrayShape) raises -> ComplexNDArray[cdtype]:
     """
@@ -1476,7 +1476,7 @@ fn zeros[
     return full[cdtype](shape=shape, fill_value=ComplexSIMD[cdtype](0, 0))
 
 
-fn zeros[
+def zeros[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: List[Int]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1494,7 +1494,7 @@ fn zeros[
     return zeros[cdtype](shape=NDArrayShape(shape))
 
 
-fn zeros[
+def zeros[
     cdtype: ComplexDType = ComplexDType.float64,
 ](shape: VariadicList[Int, _]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1512,7 +1512,7 @@ fn zeros[
     return zeros[cdtype](shape=NDArrayShape(shape))
 
 
-fn zeros_like[
+def zeros_like[
     cdtype: ComplexDType = ComplexDType.float64,
 ](array: ComplexNDArray[cdtype]) raises -> ComplexNDArray[cdtype]:
     """
@@ -1530,7 +1530,7 @@ fn zeros_like[
     return full[cdtype](shape=array.shape, fill_value=ComplexSIMD[cdtype](0, 0))
 
 
-fn full[
+def full[
     dtype: DType = DType.float64
 ](
     shape: NDArrayShape, fill_value: Scalar[dtype], order: String = "C"
@@ -1565,7 +1565,7 @@ fn full[
     return A^
 
 
-fn full[
+def full[
     dtype: DType = DType.float64
 ](
     shape: List[Int], fill_value: Scalar[dtype], order: String = "C"
@@ -1589,7 +1589,7 @@ fn full[
     )
 
 
-fn full[
+def full[
     dtype: DType = DType.float64
 ](
     shape: VariadicList[Int, _], fill_value: Scalar[dtype], order: String = "C"
@@ -1613,7 +1613,7 @@ fn full[
     )
 
 
-fn full_like[
+def full_like[
     dtype: DType = DType.float64
 ](
     array: NDArray[dtype], fill_value: Scalar[dtype], order: String = "C"
@@ -1635,7 +1635,7 @@ fn full_like[
     return full[dtype](shape=array.shape, fill_value=fill_value, order=order)
 
 
-fn full[
+def full[
     cdtype: ComplexDType = ComplexDType.float64
 ](
     shape: NDArrayShape,
@@ -1671,7 +1671,7 @@ fn full[
     return A^
 
 
-fn full[
+def full[
     cdtype: ComplexDType = ComplexDType.float64
 ](
     shape: List[Int],
@@ -1697,7 +1697,7 @@ fn full[
     )
 
 
-fn full[
+def full[
     cdtype: ComplexDType = ComplexDType.float64
 ](
     shape: VariadicList[Int, _],
@@ -1723,7 +1723,7 @@ fn full[
     )
 
 
-fn full_like[
+def full_like[
     cdtype: ComplexDType = ComplexDType.float64
 ](
     array: ComplexNDArray[cdtype],
@@ -1750,7 +1750,7 @@ fn full_like[
 # ===------------------------------------------------------------------------===#
 # Building matrices
 # ===------------------------------------------------------------------------===#
-fn diag[
+def diag[
     dtype: DType = DType.float64
 ](v: NDArray[dtype], k: Int = 0) raises -> NDArray[dtype]:
     """
@@ -1818,7 +1818,7 @@ fn diag[
         raise Error("Arrays bigger than 2D are not supported")
 
 
-fn diag[
+def diag[
     cdtype: ComplexDType = ComplexDType.float64,
 ](v: ComplexNDArray[cdtype], k: Int = 0) raises -> ComplexNDArray[cdtype]:
     """
@@ -1841,7 +1841,7 @@ fn diag[
     )
 
 
-fn diagflat[
+def diagflat[
     dtype: DType = DType.float64
 ](v: NDArray[dtype], k: Int = 0) raises -> NDArray[dtype]:
     """
@@ -1885,7 +1885,7 @@ fn diagflat[
     return result^
 
 
-fn diagflat[
+def diagflat[
     cdtype: ComplexDType = ComplexDType.float64,
 ](v: ComplexNDArray[cdtype], k: Int = 0) raises -> ComplexNDArray[cdtype]:
     """
@@ -1907,7 +1907,7 @@ fn diagflat[
     )
 
 
-fn tri[
+def tri[
     dtype: DType = DType.float64
 ](N: Int, M: Int, k: Int = 0) raises -> NDArray[dtype]:
     """
@@ -1951,7 +1951,7 @@ fn tri[
     return result^
 
 
-fn tri[
+def tri[
     cdtype: ComplexDType = ComplexDType.float64,
 ](N: Int, M: Int, k: Int = 0) raises -> ComplexNDArray[cdtype]:
     """
@@ -1976,7 +1976,7 @@ fn tri[
     )
 
 
-fn tril[
+def tril[
     dtype: DType = DType.float64
 ](m: NDArray[dtype], k: Int = 0) raises -> NDArray[dtype]:
     """
@@ -2019,7 +2019,7 @@ fn tril[
     return result^
 
 
-fn tril[
+def tril[
     cdtype: ComplexDType = ComplexDType.float64,
 ](m: ComplexNDArray[cdtype], k: Int = 0) raises -> ComplexNDArray[cdtype]:
     """
@@ -2041,7 +2041,7 @@ fn tril[
     )
 
 
-fn triu[
+def triu[
     dtype: DType = DType.float64
 ](m: NDArray[dtype], k: Int = 0) raises -> NDArray[dtype]:
     """
@@ -2082,7 +2082,7 @@ fn triu[
     return result^
 
 
-fn triu[
+def triu[
     cdtype: ComplexDType = ComplexDType.float64,
 ](m: ComplexNDArray[cdtype], k: Int = 0) raises -> ComplexNDArray[cdtype]:
     """
@@ -2104,7 +2104,7 @@ fn triu[
     )
 
 
-fn vander[
+def vander[
     dtype: DType = DType.float64
 ](
     x: NDArray[dtype], N: Optional[Int] = None, increasing: Bool = False
@@ -2140,7 +2140,7 @@ fn vander[
     return result^
 
 
-fn vander[
+def vander[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     x: ComplexNDArray[cdtype],
@@ -2173,7 +2173,7 @@ fn vander[
 
 
 # TODO: Check whether inplace cast is needed.
-fn astype[
+def astype[
     dtype: DType, //, target: DType
 ](a: NDArray[dtype]) raises -> NDArray[target]:
     """
@@ -2196,7 +2196,7 @@ fn astype[
     comptime if target == DType.bool:
 
         @parameter
-        fn vectorized_astype[
+        def vectorized_astype[
             simd_width: Int
         ](idx: Int) unified {mut result, read a} -> None:
             (result.unsafe_ptr() + idx).strided_store[width=simd_width](
@@ -2209,7 +2209,7 @@ fn astype[
         comptime if target == DType.bool:
 
             @parameter
-            fn vectorized_astypenb_from_b[
+            def vectorized_astypenb_from_b[
                 simd_width: Int
             ](idx: Int) unified {mut result, read a} -> None:
                 result._buf.ptr.store(
@@ -2224,7 +2224,7 @@ fn astype[
         else:
 
             @parameter
-            fn vectorized_astypenb[
+            def vectorized_astypenb[
                 simd_width: Int
             ](idx: Int) unified {mut result, read a} -> None:
                 result._buf.ptr.store(
@@ -2236,7 +2236,7 @@ fn astype[
     return result^
 
 
-fn astype[
+def astype[
     cdtype: ComplexDType,
     //,
     target: ComplexDType,
@@ -2267,7 +2267,7 @@ fn astype[
 # ===------------------------------------------------------------------------===#
 
 
-fn fromstring[
+def fromstring[
     dtype: DType = DType.float64
 ](text: String, order: String = "C",) raises -> NDArray[dtype]:
     """
@@ -2283,7 +2283,7 @@ fn fromstring[
     ```
     import numojo as nm
 
-    fn main() raises:
+    def main() raises:
         var A = nm.fromstring[DType.int8]("[[[1,2],[3,4]],[[5,6],[7,8]]]")
         var B = nm.fromstring[DType.float16]("[[1,2,3,4],[5,6,7,8]]")
         var C = nm.fromstring[DType.float32]("[0.1, -2.3, 41.5, 19.29145, -199]")
@@ -2361,7 +2361,7 @@ fn fromstring[
     return result^
 
 
-# fn from_tensor[
+# def from_tensor[
 #     dtype: DType = DType.float64
 # ](data: Tensor[dtype]) raises -> NDArray[dtype]:
 #     """
@@ -2389,7 +2389,7 @@ fn fromstring[
 #     return a
 
 
-# fn from_tensorC[
+# def from_tensorC[
 #     dtype: DType = DType.float64
 # ](real: Tensor[dtype], imag: Tensor[dtype]) raises -> ComplexNDArray[cdtype]:
 #     """
@@ -2431,7 +2431,7 @@ fn fromstring[
 # ===------------------------------------------------------------------------===#
 
 
-fn array[
+def array[
     dtype: DType = DType.float64
 ](text: String, order: String = "C",) raises -> NDArray[dtype]:
     """
@@ -2440,7 +2440,7 @@ fn array[
     return fromstring[dtype](text, order)
 
 
-fn array[
+def array[
     dtype: DType = DType.float64
 ](
     data: List[Scalar[dtype]], shape: List[Int], order: String = "C"
@@ -2472,7 +2472,7 @@ fn array[
     return result^
 
 
-fn array[
+def array[
     cdtype: ComplexDType = ComplexDType.float64,
 ](
     data: List[ComplexScalar[cdtype]],
@@ -2520,7 +2520,7 @@ fn array[
     return A^
 
 
-fn array[
+def array[
     dtype: DType = DType.float64
 ](data: PythonObject, order: String = "C") raises -> NDArray[dtype]:
     """
@@ -2593,7 +2593,7 @@ fn array[
     return A^
 
 
-fn array[
+def array[
     cdtype: ComplexDType = ComplexDType.float64
 ](
     real: PythonObject, imag: PythonObject, order: String = "C"
@@ -2683,7 +2683,7 @@ fn array[
     return A^
 
 
-fn meshgrid[
+def meshgrid[
     dtype: DType = DType.float64, indexing: String = "xy"
 ](*arrays: NDArray[dtype]) raises -> List[NDArray[dtype]]:
     """
@@ -2753,7 +2753,7 @@ fn meshgrid[
 
         # for outer in range(outer_size):
         @parameter
-        fn closure(outer: Int) -> None:
+        def closure(outer: Int) -> None:
             for k in range(dim_size):
                 for inner in range(inner_size):
                     var idx = (
@@ -2771,7 +2771,7 @@ fn meshgrid[
 # Internal functions
 # ===----------------------------------------------------------------------=== #
 # for creating a 0darray (only for internal use)
-fn _0darray[
+def _0darray[
     dtype: DType
 ](val: Scalar[dtype],) raises -> NDArray[dtype]:
     """
@@ -2798,7 +2798,7 @@ fn _0darray[
     return b^
 
 
-fn _0darray[
+def _0darray[
     cdtype: ComplexDType
 ](val: ComplexSIMD[cdtype],) raises -> ComplexNDArray[cdtype]:
     """

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -32,7 +32,7 @@ from numojo.core.ndarray import NDArray
 # dimension of the input array is reduced.
 
 
-# fn apply_along_axis[
+# def apply_along_axis[
 #     dtype: DType,
 #     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
 #         dtype_func
@@ -67,7 +67,7 @@ from numojo.core.ndarray import NDArray
 #         res = NDArray[dtype](a.shape.pop(axis=axis))
 
 #         @parameter
-#         fn parallelized_func(i: Int):
+#         def parallelized_func(i: Int):
 #             try:
 #                 (res._buf.ptr + i).init_pointee_copy(
 #                     func1d[dtype](iterator.ith(i))
@@ -80,7 +80,7 @@ from numojo.core.ndarray import NDArray
 #     return res^
 
 
-fn apply_along_axis_reduce_to_int[
+def apply_along_axis_reduce_to_int[
     dtype: DType,
     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
         DType.int
@@ -116,7 +116,7 @@ fn apply_along_axis_reduce_to_int[
         res = NDArray[DType.int](a.shape.pop(axis=axis))
 
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 (res._buf.ptr + i).init_pointee_copy(
                     func1d[dtype](iterator.ith(i))
@@ -129,7 +129,7 @@ fn apply_along_axis_reduce_to_int[
     return res^
 
 
-fn apply_along_axis_reduce[
+def apply_along_axis_reduce[
     dtype: DType,
     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
         dtype_func
@@ -174,7 +174,7 @@ fn apply_along_axis_reduce[
         #     res._buf.store(i, func_result)
 
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 res._buf.store(i, func1d[dtype](iterator.ith(i)))
             except e:
@@ -191,7 +191,7 @@ fn apply_along_axis_reduce[
     return res^
 
 
-fn apply_along_axis_reduce_with_dtype[
+def apply_along_axis_reduce_with_dtype[
     dtype: DType,
     returned_dtype: DType,
     func1d: fn[dtype_func: DType, returned_dtype_func: DType](
@@ -229,7 +229,7 @@ fn apply_along_axis_reduce_with_dtype[
         res = NDArray[returned_dtype](a.shape.pop(axis=axis))
 
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 (res._buf.ptr + i).init_pointee_copy(
                     func1d[dtype, returned_dtype](iterator.ith(i))
@@ -246,7 +246,7 @@ fn apply_along_axis_reduce_with_dtype[
 # dimension of the input array is not reduced.
 
 
-fn apply_along_axis_preserve[
+def apply_along_axis_preserve[
     dtype: DType,
     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
         dtype_func
@@ -276,7 +276,7 @@ fn apply_along_axis_preserve[
     if a.is_c_contiguous() and (axis == a.ndim - 1):
         # The memory layout is C-contiguous
         @parameter
-        fn parallelized_func_c(i: Int):
+        def parallelized_func_c(i: Int):
             try:
                 var elements: NDArray[dtype] = func1d[dtype](iterator.ith(i))
                 memcpy(
@@ -292,7 +292,7 @@ fn apply_along_axis_preserve[
     else:
         # The memory layout is not contiguous
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 # The indices of the input array in each iteration
                 var indices: NDArray[DType.int]
@@ -324,7 +324,7 @@ fn apply_along_axis_preserve[
 # For example, `sort_inplace()`.
 
 
-fn apply_along_axis_inplace[
+def apply_along_axis_inplace[
     dtype: DType,
     func1d: fn[dtype_func: DType](mut NDArray[dtype_func]) raises -> None,
 ](mut a: NDArray[dtype], axis: Int) raises -> None:
@@ -347,7 +347,7 @@ fn apply_along_axis_inplace[
     if a.is_c_contiguous() and (axis == a.ndim - 1):
         # The memory layout is C-contiguous
         @parameter
-        fn parallelized_func_c(i: Int):
+        def parallelized_func_c(i: Int):
             try:
                 var elements: NDArray[dtype] = iterator.ith(i)
                 func1d[dtype](elements)
@@ -364,7 +364,7 @@ fn apply_along_axis_inplace[
     else:
         # The memory layout is not contiguous
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 # The indices of the input array in each iteration
                 var indices: NDArray[DType.int]
@@ -389,7 +389,7 @@ fn apply_along_axis_inplace[
     return None
 
 
-fn apply_along_axis_indices[
+def apply_along_axis_indices[
     dtype: DType,
     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
         DType.int
@@ -421,7 +421,7 @@ fn apply_along_axis_indices[
     if a.is_c_contiguous() and (axis == a.ndim - 1):
         # The memory layout is C-contiguous
         @parameter
-        fn parallelized_func_c(i: Int):
+        def parallelized_func_c(i: Int):
             try:
                 var elements: NDArray[DType.int] = func1d[dtype](
                     iterator.ith(i)
@@ -439,7 +439,7 @@ fn apply_along_axis_indices[
     else:
         # The memory layout is not contiguous
         @parameter
-        fn parallelized_func(i: Int):
+        def parallelized_func(i: Int):
             try:
                 # The indices of the input array in each iteration
                 var indices: NDArray[DType.int]

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -26,7 +26,7 @@ from numojo.core.indexing import IndexMethods
 # ===----------------------------------------------------------------------=== #
 
 
-fn `where`[
+def `where`[
     dtype: DType
 ](
     mut x: NDArray[dtype], scalar: SIMD[dtype, 1], mask: NDArray[DType.bool]
@@ -51,7 +51,7 @@ fn `where`[
 
 
 # TODO: do it with vectorization
-fn `where`[
+def `where`[
     dtype: DType
 ](mut x: NDArray[dtype], y: NDArray[dtype], mask: NDArray[DType.bool]) raises:
     """

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -85,7 +85,7 @@ fn `where`[
 # ===----------------------------------------------------------------------=== #
 
 
-fn compress[
+def compress[
     dtype: DType
 ](
     condition: NDArray[DType.bool], a: NDArray[dtype], axis: Int
@@ -202,7 +202,7 @@ fn compress[
     return result^
 
 
-fn compress[
+def compress[
     dtype: DType
 ](condition: NDArray[DType.bool], a: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -244,7 +244,7 @@ fn compress[
         return compress(condition, ravel(a), axis=0)
 
 
-fn take_along_axis[
+def take_along_axis[
     dtype: DType,
     //,
 ](

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -19,7 +19,7 @@ from numojo.routines.creation import fromstring
 # might consider implementing a funciton to write a .numojo file which can be read by both numpy and numojo.
 
 
-fn load[
+def load[
     dtype: DType = f64
 ](
     file: String,
@@ -55,7 +55,7 @@ fn load[
 
 
 # @parameter
-# fn _get_dtype_string[dtype: DType]() -> String:
+# def _get_dtype_string[dtype: DType]() -> String:
 #     """
 #     Get the numpy-compatible dtype string for the given DType.
 
@@ -98,7 +98,7 @@ fn load[
 #         return "'<f8'"
 
 
-# fn _write_uint16_le(mut file: FileHandle, value: UInt16) raises:
+# def _write_uint16_le(mut file: FileHandle, value: UInt16) raises:
 #     """Write a 16-bit unsigned integer in little-endian format."""
 #     var bytes_ptr = UnsafePointer[UInt8].alloc(2)
 #     bytes_ptr[0] = UInt8(value & 0xFF)
@@ -108,7 +108,7 @@ fn load[
 #     bytes_ptr.free()
 
 
-# fn savenpy[
+# def savenpy[
 #     dtype: DType = f64
 # ](fname: String, array: NDArray[dtype], allow_pickle: Bool = True) raises:
 #     """
@@ -205,7 +205,7 @@ fn load[
 #         file.close()
 
 
-fn save[
+def save[
     dtype: DType = f64
 ](fname: String, array: NDArray[dtype], allow_pickle: Bool = True,) raises:
     """
@@ -225,7 +225,7 @@ fn save[
     )
 
 
-fn loadtxt[
+def loadtxt[
     dtype: DType = f64
 ](
     fname: String,
@@ -259,7 +259,7 @@ fn loadtxt[
     return array^
 
 
-fn savetxt[
+def savetxt[
     dtype: DType = f64
 ](
     fname: String,

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -86,7 +86,7 @@ struct PrintOptions(Copyable, ImplicitlyCopyable, Movable):
     var exponent_threshold: Int
     var suppress_scientific: Bool
 
-    fn __init__(
+    def __init__(
         out self,
         precision: Int = DEFAULT_PRECISION,
         suppress_small: Bool = DEFAULT_SUPPRESS_SMALL,
@@ -120,7 +120,7 @@ struct PrintOptions(Copyable, ImplicitlyCopyable, Movable):
         self.exponent_threshold = exponent_threshold
         self.suppress_scientific = suppress_scientific
 
-    fn set_options(
+    def set_options(
         mut self,
         precision: Int = DEFAULT_PRECISION,
         suppress_small: Bool = DEFAULT_SUPPRESS_SMALL,
@@ -154,7 +154,7 @@ struct PrintOptions(Copyable, ImplicitlyCopyable, Movable):
         self.exponent_threshold = exponent_threshold
         self.suppress_scientific = suppress_scientific
 
-    fn __enter__(mut self) -> Self:
+    def __enter__(mut self) -> Self:
         var default_print_options = PrintOptions()
         default_print_options.set_options(
             precision=self.precision,
@@ -175,7 +175,7 @@ struct PrintOptions(Copyable, ImplicitlyCopyable, Movable):
         )
         return default_print_options
 
-    fn __exit__(mut self):
+    def __exit__(mut self):
         var default_print_options = PrintOptions()
         default_print_options.set_options(
             precision=DEFAULT_PRECISION,
@@ -196,7 +196,7 @@ struct PrintOptions(Copyable, ImplicitlyCopyable, Movable):
         )
 
 
-fn set_printoptions(
+def set_printoptions(
     precision: Int = DEFAULT_PRECISION,
     suppress_small: Bool = DEFAULT_SUPPRESS_SMALL,
     separator: String = DEFAULT_SEPARATOR,
@@ -214,7 +214,7 @@ fn set_printoptions(
 
 
 # FIXME: fix the problem where precision > number of digits in the mantissa results in a not so exact value.
-fn format_floating_scientific[
+def format_floating_scientific[
     dtype: DType = DType.float64
 ](
     x: Scalar[dtype],
@@ -324,7 +324,7 @@ fn format_floating_scientific[
         raise Error("dtype must be a floating-point type.")
 
 
-fn format_floating_precision[
+def format_floating_precision[
     dtype: DType
 ](
     value: Scalar[dtype],
@@ -390,7 +390,7 @@ fn format_floating_precision[
     return result
 
 
-fn format_floating_precision[
+def format_floating_precision[
     cdtype: ComplexDType
 ](
     value: ComplexSIMD[cdtype],
@@ -424,7 +424,7 @@ fn format_floating_precision[
         raise Error("Failed to format complex floating-point value.")
 
 
-fn format_value[
+def format_value[
     dtype: DType
 ](value: Scalar[dtype], print_options: PrintOptions) raises -> String:
     """
@@ -474,7 +474,7 @@ fn format_value[
         return formatted.ascii_rjust(formatted_width)
 
 
-fn format_value[
+def format_value[
     cdtype: ComplexDType
 ](value: ComplexSIMD[cdtype], print_options: PrintOptions,) raises -> String:
     """
@@ -576,7 +576,7 @@ fn format_value[
     )
 
 
-fn _trim_paranthesis_strings_cnumbers(
+def _trim_paranthesis_strings_cnumbers(
     complex_format: String,
     re_str: String,
     imag_mag_str: String,

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -21,7 +21,7 @@ from numojo.routines.creation import zeros, eye, full
 
 
 @always_inline
-fn _compute_householder[
+def _compute_householder[
     dtype: DType
 ](mut H: Matrix[dtype], mut R: Matrix[dtype], work_index: Int) raises -> None:
     comptime simd_width = simd_width_of[dtype]()
@@ -29,7 +29,7 @@ fn _compute_householder[
     var rRows = R.shape[0]
 
     @parameter
-    fn load_store_vec[
+    def load_store_vec[
         n_elements: Int
     ](i: Int) unified {mut H, mut R, read work_index}:
         var r_value = R._load[n_elements](i + work_index, work_index)
@@ -41,7 +41,7 @@ fn _compute_householder[
     var norm = Scalar[dtype](0)
 
     @parameter
-    fn calculate_norm[
+    def calculate_norm[
         width: Int
     ](i: Int) unified {mut norm, read H, read work_index}:
         norm += (H._load[width=width](i, work_index) ** 2).reduce_add()
@@ -62,7 +62,7 @@ fn _compute_householder[
     R._store(work_index, work_index, -1 / scaling_factor)
 
     @parameter
-    fn scaling_factor_vec[
+    def scaling_factor_vec[
         simd_width: Int
     ](i: Int) unified {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
@@ -77,7 +77,7 @@ fn _compute_householder[
     scaling_factor = builtin_math.sqrt(1.0 / increment)
 
     @parameter
-    fn scaling_factor_increment_vec[
+    def scaling_factor_increment_vec[
         simd_width: Int
     ](i: Int) unified {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
@@ -88,7 +88,7 @@ fn _compute_householder[
 
 
 @always_inline
-fn _apply_householder[
+def _apply_householder[
     dtype: DType
 ](
     mut H: Matrix[dtype],
@@ -104,7 +104,7 @@ fn _apply_householder[
         var dot: SIMD[dtype, 1] = 0.0
 
         @parameter
-        fn calculate_norm[
+        def calculate_norm[
             width: Int
         ](i: Int) unified {mut dot, read H, read A, read work_index, read j}:
             dot += (
@@ -114,7 +114,7 @@ fn _apply_householder[
         vectorize[simdwidth](aRows, calculate_norm)
 
         @parameter
-        fn closure[
+        def closure[
             width: Int
         ](i: Int) unified {mut A, read H, read work_index, read j, read dot}:
             val = A._load[width](i, j) - H._load[width](i, work_index) * dot
@@ -123,7 +123,7 @@ fn _apply_householder[
         vectorize[simdwidth](aRows, closure)
 
 
-fn lu_decomposition[
+def lu_decomposition[
     dtype: DType
 ](A: NDArray[dtype]) raises -> Tuple[NDArray[dtype], NDArray[dtype]]:
     """Perform LU (lower-upper) decomposition for array.
@@ -143,7 +143,7 @@ fn lu_decomposition[
     Example:
     ```
     import numojo as nm
-    fn main() raises:
+    def main() raises:
         var arr = nm.NDArray[nm.f64]("[[1,2,3], [4,5,6], [7,8,9]]")
         var U: nm.NDArray
         var L: nm.NDArray
@@ -201,7 +201,7 @@ fn lu_decomposition[
 
     # Fill in L and U
     # @parameter
-    # fn calculate(i: Int):
+    # def calculate(i: Int):
     for i in range(0, n):
         for j in range(i, n):
             # Fill in L
@@ -232,7 +232,7 @@ fn lu_decomposition[
     return L^, U^
 
 
-fn lu_decomposition[
+def lu_decomposition[
     dtype: DType
 ](A: Matrix[dtype]) raises -> Tuple[Matrix[dtype], Matrix[dtype]]:
     """
@@ -275,7 +275,7 @@ fn lu_decomposition[
     return L^, U^
 
 
-fn partial_pivoting[
+def partial_pivoting[
     dtype: DType
 ](var A: NDArray[dtype]) raises -> Tuple[NDArray[dtype], NDArray[dtype], Int]:
     """
@@ -324,7 +324,7 @@ fn partial_pivoting[
     return Tuple(A^, P^, s)
 
 
-fn partial_pivoting[
+def partial_pivoting[
     dtype: DType
 ](A: Matrix[dtype]) raises -> Tuple[Matrix[dtype], Matrix[dtype], Int]:
     """
@@ -358,7 +358,7 @@ fn partial_pivoting[
     return Tuple(result^, P^, s)
 
 
-fn qr[
+def qr[
     dtype: DType
 ](A: Matrix[dtype], mode: String = "reduced") raises -> Tuple[
     Matrix[dtype], Matrix[dtype]
@@ -446,7 +446,7 @@ fn qr[
 # ===----------------------------------------------------------------------=== #
 
 
-fn eig[
+def eig[
     dtype: DType
 ](
     A: Matrix[dtype],

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -17,7 +17,7 @@ from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 
 
-fn diagonal[
+def diagonal[
     dtype: DType
 ](a: NDArray[dtype], offset: Int = 0) raises -> NDArray[dtype]:
     """
@@ -76,7 +76,7 @@ fn diagonal[
     return result^
 
 
-fn issymmetric[
+def issymmetric[
     dtype: DType
 ](
     A: Matrix[dtype],

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -18,7 +18,7 @@ from numojo.routines.linalg.decompositions import (
 )
 
 
-fn det[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
+def det[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Find the determinant of A using LUP decomposition.
     """
@@ -56,7 +56,7 @@ fn det[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
         return -det_L * det_U
 
 
-fn det[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
+def det[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     """
     Find the determinant of A using LUP decomposition.
     """
@@ -86,7 +86,7 @@ fn det[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
 
 
 # TODO: implement for arbitrary axis
-fn trace[
+def trace[
     dtype: DType
 ](
     array: NDArray[dtype], offset: Int = 0, axis1: Int = 0, axis2: Int = 1
@@ -130,7 +130,7 @@ fn trace[
     return result^
 
 
-fn trace[
+def trace[
     dtype: DType
 ](A: Matrix[dtype], offset: Int = 0) raises -> Scalar[dtype]:
     """

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -120,7 +120,9 @@ def dot[
 
 
 # Perform 2D tiling on the iteration space defined by end_x and end_y.
-def tile[tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int](end_x: Int, end_y: Int):
+def tile[
+    tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int
+](end_x: Int, end_y: Int):
     # Note: this assumes that ends are multiples of the tiles.
     for y in range(0, end_y, tile_y):
         for x in range(0, end_x, tile_x):

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -24,7 +24,7 @@ from numojo.routines.creation import zeros
 from numojo.routines.math.sums import sum
 
 
-fn cross[
+def cross[
     dtype: DType = DType.float64
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -69,7 +69,7 @@ fn cross[
 
 
 # TODO: implement other cases for dot function
-fn dot[
+def dot[
     dtype: DType = DType.float64
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -99,7 +99,7 @@ fn dot[
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(array1.size))
 
         @parameter
-        fn vectorized_dot[
+        def vectorized_dot[
             simd_width: Int
         ](idx: Int) unified {mut result, read array1, read array2} -> None:
             result._buf.ptr.store(
@@ -120,7 +120,7 @@ fn dot[
 
 
 # Perform 2D tiling on the iteration space defined by end_x and end_y.
-fn tile[tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int](end_x: Int, end_y: Int):
+def tile[tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int](end_x: Int, end_y: Int):
     # Note: this assumes that ends are multiples of the tiles.
     for y in range(0, end_y, tile_y):
         for x in range(0, end_x, tile_x):
@@ -128,7 +128,7 @@ fn tile[tiled_fn: Tile2DFunc, tile_x: Int, tile_y: Int](end_x: Int, end_y: Int):
 
 
 # https://docs.modular.com/mojo/notebooks/Matmul
-fn matmul_tiled_unrolled_parallelized[
+def matmul_tiled_unrolled_parallelized[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -146,13 +146,13 @@ fn matmul_tiled_unrolled_parallelized[
     var t2 = B.shape[1]
 
     @parameter
-    fn calculate_A_rows(m: Int):
+    def calculate_A_rows(m: Int):
         @parameter
-        fn calc_tile[tile_x: Int, tile_y: Int](x: Int, y: Int):
+        def calc_tile[tile_x: Int, tile_y: Int](x: Int, y: Int):
             for k in range(y, y + tile_y):
 
                 @parameter
-                fn dot[
+                def dot[
                     simd_width: Int
                 ](n: Int) unified {
                     mut result,
@@ -183,7 +183,7 @@ fn matmul_tiled_unrolled_parallelized[
     return result^
 
 
-fn matmul_1darray[
+def matmul_1darray[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -207,7 +207,7 @@ fn matmul_1darray[
     return result^
 
 
-fn matmul_2darray[
+def matmul_2darray[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -279,11 +279,11 @@ fn matmul_2darray[
     var t2 = B.shape[1]
 
     @parameter
-    fn calculate_A_rows(m: Int):
+    def calculate_A_rows(m: Int):
         for k in range(t1):
 
             @parameter
-            fn dot[
+            def dot[
                 simd_width: Int
             ](n: Int) unified {
                 mut result, read A, read B, read t2, read t1, read k, read m
@@ -302,7 +302,7 @@ fn matmul_2darray[
     return result^
 
 
-fn matmul[
+def matmul[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -396,7 +396,7 @@ fn matmul[
     return result^
 
 
-fn matmul[
+def matmul[
     dtype: DType
 ](A: Matrix[dtype], B: Matrix[dtype]) raises -> Matrix[dtype]:
     """
@@ -429,11 +429,11 @@ fn matmul[
         )
 
         @parameter
-        fn calculate_resultresult(m: Int):
+        def calculate_resultresult(m: Int):
             for k in range(A.shape[1]):
 
                 @parameter
-                fn dot[
+                def dot[
                     simd_width: Int
                 ](n: Int) unified {
                     mut result, read A, read B, read m, read k
@@ -454,11 +454,11 @@ fn matmul[
         )
 
         @parameter
-        fn calculate_FF(n: Int):
+        def calculate_FF(n: Int):
             for k in range(A.shape[1]):
 
                 @parameter
-                fn dot_F[
+                def dot_F[
                     simd_width: Int
                 ](m: Int) unified {
                     mut result, read A, read B, read n, read k
@@ -479,12 +479,12 @@ fn matmul[
         )
 
         @parameter
-        fn calculate_resultF(m: Int):
+        def calculate_resultF(m: Int):
             for n in range(B.shape[1]):
                 var sum: Scalar[dtype] = 0.0
 
                 @parameter
-                fn dot_product[
+                def dot_product[
                     simd_width: Int
                 ](k: Int) unified {
                     mut sum, read A, read B, read m, read n
@@ -504,7 +504,7 @@ fn matmul[
     return result^
 
 
-fn matmul_naive[
+def matmul_naive[
     dtype: DType
 ](A: NDArray[dtype], B: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -29,7 +29,7 @@ from numojo.routines.linalg.decompositions import (
 )
 
 
-fn forward_substitution[
+def forward_substitution[
     dtype: DType
 ](L: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[dtype]:
     """Perform forward substitution to solve `Lx = y`.
@@ -63,7 +63,7 @@ fn forward_substitution[
     return x^
 
 
-fn back_substitution[
+def back_substitution[
     dtype: DType
 ](U: NDArray[dtype], y: NDArray[dtype]) raises -> NDArray[dtype]:
     """Perform forward substitution to solve `Ux = y`.
@@ -95,7 +95,7 @@ fn back_substitution[
     return x^
 
 
-fn inv[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
+def inv[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Find the inverse of a non-singular, row-major matrix.
 
@@ -122,7 +122,7 @@ fn inv[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     return solve(A, I)
 
 
-fn inv[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
+def inv[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Inverse of matrix.
     """
@@ -142,7 +142,7 @@ fn inv[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     return B^
 
 
-fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """Find the inverse of a non-singular, row-major matrix.
 
     Use LU decomposition algorithm.
@@ -179,7 +179,7 @@ fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     var X = zeros[dtype](Shape(m, m))
 
     @parameter
-    fn calculate_X(col: Int) -> None:
+    def calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
             var _temp = Y._buf.ptr.load(i * m + col)
@@ -211,7 +211,7 @@ fn inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return X^
 
 
-fn lstsq[
+def lstsq[
     dtype: DType
 ](X: Matrix[dtype], y: Matrix[dtype]) raises -> Matrix[dtype]:
     """Caclulate the OLS estimates.
@@ -246,7 +246,7 @@ fn lstsq[
     return b^
 
 
-fn solve[
+def solve[
     dtype: DType
 ](A: NDArray[dtype], Y: NDArray[dtype]) raises -> NDArray[dtype]:
     """Solve the linear system `AX = Y` for `X`.
@@ -278,7 +278,7 @@ fn solve[
 
     ```mojo
     import numojo as nm
-    fn main() raises:
+    def main() raises:
         var A = nm.fromstring("[[1, 0, 1], [0, 2, 1], [1, 1, 1]]")
         var B = nm.fromstring("[[1, 0, 0], [0, 1, 0], [0, 0, 1]]")
         var X = nm.linalg.solve(A, B)
@@ -322,7 +322,7 @@ fn solve[
     ####################################################################
 
     @parameter
-    fn calculate_X(col: Int) -> None:
+    def calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
             var _temp = Y._buf.ptr.load(i * n + col)
@@ -382,7 +382,7 @@ fn solve[
 
 
 # TODO: remove unnecessary copies going on here later.
-fn solve[
+def solve[
     dtype: DType
 ](A: Matrix[dtype], Y: Matrix[dtype]) raises -> Matrix[dtype]:
     """
@@ -415,7 +415,7 @@ fn solve[
     var PY = P @ Y
 
     @parameter
-    fn calculate_X(col: Int) -> None:
+    def calculate_X(col: Int) -> None:
         # Solve `LZ = PY` for `Z` for each col
         for i in range(m):  # row of L
             var _temp = PY._load(i, col)
@@ -446,7 +446,7 @@ fn solve[
     return X^
 
 
-fn solve_lu[
+def solve_lu[
     dtype: DType
 ](A: Matrix[dtype], Y: Matrix[dtype]) raises -> Matrix[dtype]:
     """
@@ -465,7 +465,7 @@ fn solve_lu[
     var X = Matrix.full[dtype]((m, n))
 
     @parameter
-    fn calculate_X(col: Int) -> None:
+    def calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
             var _temp = Y._load(i, col)

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -25,7 +25,7 @@ from numojo.core.error import NumojoError
 # ===------------------------------------------------------------------------===#
 
 
-fn greater[
+def greater[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -55,7 +55,7 @@ fn greater[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, array2)
 
 
-fn greater[
+def greater[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -84,7 +84,7 @@ fn greater[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, scalar)
 
 
-fn greater_equal[
+def greater_equal[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -114,7 +114,7 @@ fn greater_equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, array2)
 
 
-fn greater_equal[
+def greater_equal[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -143,7 +143,7 @@ fn greater_equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, scalar)
 
 
-fn less[
+def less[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -173,7 +173,7 @@ fn less[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, array2)
 
 
-fn less[
+def less[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -202,7 +202,7 @@ fn less[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, scalar)
 
 
-fn less_equal[
+def less_equal[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -232,7 +232,7 @@ fn less_equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, array2)
 
 
-fn less_equal[
+def less_equal[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -261,7 +261,7 @@ fn less_equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, scalar)
 
 
-fn equal[
+def equal[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -291,7 +291,7 @@ fn equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, array2)
 
 
-fn equal[
+def equal[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -320,7 +320,7 @@ fn equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, scalar)
 
 
-fn not_equal[
+def not_equal[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
@@ -350,7 +350,7 @@ fn not_equal[
     return HostExecutor.apply_binary_predicate[dtype, SIMD.ne](array1, array2)
 
 
-fn not_equal[
+def not_equal[
     dtype: DType
 ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[DType.bool]:
     """
@@ -384,7 +384,7 @@ fn not_equal[
 # ===------------------------------------------------------------------------===#
 
 
-fn allclose[
+def allclose[
     dtype: DType
 ](
     a: NDArray[dtype],
@@ -452,7 +452,7 @@ fn allclose[
     return True
 
 
-fn isclose[
+def isclose[
     dtype: DType
 ](
     a: NDArray[dtype],
@@ -523,7 +523,7 @@ fn isclose[
     return res^
 
 
-fn allclose[
+def allclose[
     dtype: DType
 ](
     a: Matrix[dtype],
@@ -591,7 +591,7 @@ fn allclose[
     return True
 
 
-fn isclose[
+def isclose[
     dtype: DType
 ](
     a: Matrix[dtype],
@@ -667,7 +667,7 @@ fn isclose[
 # ===------------------------------------------------------------------------===#
 
 
-fn array_equal[
+def array_equal[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> Bool:
     """

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -22,19 +22,19 @@ from numojo.core.matrix import Matrix
 # TODO: Implement the commented out functions now that mojo supports these functions in SIMD.
 # FIXME: Make all SIMD vectorized operations once bool bit-packing issue is resolved.
 
-# fn is_power_of_2[
+# def is_power_of_2[
 #     dtype: DType
 # ](array: NDArray[dtype]) -> NDArray[DType.bool]:
 #     return backend().math_func_is[dtype, math.is_power_of_2](array)
 
 
-# fn is_even[
+# def is_even[
 #     dtype: DType
 # ](array: NDArray[dtype]) -> NDArray[DType.bool]:
 #     return backend().math_func_is[dtype, math.is_even](array)
 
 
-# fn is_odd[
+# def is_odd[
 #     dtype: DType
 # ](array: NDArray[dtype]) -> NDArray[DType.bool]:
 #     return backend().math_func_is[dtype, math.is_odd](array)
@@ -45,7 +45,7 @@ from numojo.core.matrix import Matrix
 # ===------------------------------------------------------------------------===#
 
 
-fn isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
+def isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is infinite.
 
@@ -63,7 +63,7 @@ fn isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         from numojo.prelude import *
         from numojo.routines.logic.contents import isinf
 
-        fn main() raises:
+        def main() raises:
             var arr = linspace(0, 10, 5)  # Example array: [0.0, 2.5, 5.0, 7.5, 10.0]
             print(isinf(arr))  # Output: [False, False, False, False, False]
         ```
@@ -71,7 +71,7 @@ fn isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, math.isinf](array)
 
 
-fn isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
+def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is finite.
 
@@ -89,7 +89,7 @@ fn isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         from numojo.prelude import *
         from numojo.routines.logic.contents import isfinite
 
-        fn main() raises:
+        def main() raises:
             var arr = nm.array[nm.f64]([1.0, Float64.MAX, Float64.MIN], shape=[3])
             print(isfinite(arr))  # Output: [True, True, True]
         ```
@@ -97,7 +97,7 @@ fn isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, math.isfinite](array)
 
 
-fn isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
+def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is NaN.
 
@@ -115,7 +115,7 @@ fn isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         from numojo.prelude import *
         from numojo.routines.logic.contents import isnan
 
-        fn main() raises:
+        def main() raises:
             var arr = nm.array[nm.f64]([1.0, 0.0, Float64.MAX], shape=[3])
             print(isnan(arr))  # Output: [False, False, False]
         ```
@@ -123,7 +123,7 @@ fn isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, math.isnan](array)
 
 
-fn isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
+def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is negative infinity.
 
@@ -141,13 +141,13 @@ fn isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         from numojo.prelude import *
         from numojo.routines.logic.contents import isneginf
 
-        fn main() raises:
+        def main() raises:
             var arr = nm.array[nm.f64]([1.0, 0.0, -1.0], shape=[3])
             print(isneginf(arr))  # Output: [False, False, False]
         ```
     """
 
-    fn is_neginf[
+    def is_neginf[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
@@ -155,7 +155,7 @@ fn isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 
-fn isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
+def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is positive infinity.
 
@@ -173,13 +173,13 @@ fn isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         from numojo.prelude import *
         from numojo.routines.logic.contents import isposinf
 
-        fn main() raises:
+        def main() raises:
             var arr = nm.array[nm.f64]([1.0, 0.0, -1.0], shape=[3])
             print(isposinf(arr))  # Output: [False, False, False]
         ```
     """
 
-    fn is_posinf[
+    def is_posinf[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](inf[dtype]()))
@@ -187,7 +187,7 @@ fn isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, is_posinf](array)
 
 
-fn isneginf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:
+def isneginf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:
     """
     Checks if each element of the input Matrix is negative infinity.
 
@@ -206,7 +206,7 @@ fn isneginf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:
     return result_array^
 
 
-fn isposinf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:
+def isposinf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:
     """
     Checks if each elements of the input Matrix is positive infinity.
 

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -21,7 +21,7 @@ from numojo.core.error import NumojoError
 # ===----------------------------------------------------------------------=== #
 # Logical operations for NDArray
 # ===----------------------------------------------------------------------=== #
-fn logical_and[
+def logical_and[
     dtype: DType
 ](a: NDArray[dtype], b: NDArray[dtype]) raises -> NDArray[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -64,7 +64,7 @@ fn logical_and[
             )
         )
 
-    fn kernel[
+    def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
         return SIMD[DType.bool, width](a & b)
@@ -72,7 +72,7 @@ fn logical_and[
     return HostExecutor.apply_binary_predicate[dtype, kernel](a, b)
 
 
-fn logical_or[
+def logical_or[
     dtype: DType
 ](a: NDArray[dtype], b: NDArray[dtype]) raises -> NDArray[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -115,7 +115,7 @@ fn logical_or[
             )
         )
 
-    fn kernel[
+    def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
         return SIMD[DType.bool, width](a | b)
@@ -123,7 +123,7 @@ fn logical_or[
     return HostExecutor.apply_binary_predicate[dtype, kernel](a, b)
 
 
-fn logical_not[
+def logical_not[
     dtype: DType
 ](a: NDArray[dtype]) raises -> NDArray[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -153,7 +153,7 @@ fn logical_not[
         ```
     """
 
-    fn kernel[
+    def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
         return SIMD[DType.bool, width](~a)
@@ -161,7 +161,7 @@ fn logical_not[
     return HostExecutor.apply_unary_predicate[dtype, kernel](a)
 
 
-fn logical_xor[
+def logical_xor[
     dtype: DType
 ](a: NDArray[dtype], b: NDArray[dtype]) raises -> NDArray[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -204,7 +204,7 @@ fn logical_xor[
             )
         )
 
-    fn kernel[
+    def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
         return SIMD[DType.bool, width](a ^ b)
@@ -217,7 +217,7 @@ fn logical_xor[
 # ===----------------------------------------------------------------------=== #
 
 
-fn logical_and[
+def logical_and[
     cdtype: ComplexDType
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
@@ -267,7 +267,7 @@ fn logical_and[
     return res^
 
 
-fn logical_or[
+def logical_or[
     cdtype: ComplexDType
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
@@ -317,7 +317,7 @@ fn logical_or[
     return res^
 
 
-fn logical_not[
+def logical_not[
     cdtype: ComplexDType
 ](a: ComplexNDArray[cdtype]) raises -> ComplexNDArray[cdtype] where (
     cdtype == ComplexDType.bool or cdtype.is_integral()
@@ -352,7 +352,7 @@ fn logical_not[
     return res^
 
 
-fn logical_xor[
+def logical_xor[
     cdtype: ComplexDType
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
@@ -407,7 +407,7 @@ fn logical_xor[
 # ===----------------------------------------------------------------------=== #
 
 
-fn logical_and[
+def logical_and[
     dtype: DType
 ](a: Matrix[dtype], b: Matrix[dtype]) raises -> Matrix[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -455,7 +455,7 @@ fn logical_and[
     return res^
 
 
-fn logical_or[
+def logical_or[
     dtype: DType
 ](a: Matrix[dtype], b: Matrix[dtype]) raises -> Matrix[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -503,7 +503,7 @@ fn logical_or[
     return res^
 
 
-fn logical_not[
+def logical_not[
     dtype: DType
 ](a: Matrix[dtype]) raises -> Matrix[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()
@@ -538,7 +538,7 @@ fn logical_not[
     return res^
 
 
-fn logical_xor[
+def logical_xor[
     dtype: DType
 ](a: Matrix[dtype], b: Matrix[dtype]) raises -> Matrix[DType.bool] where (
     dtype == DType.bool or dtype.is_integral()

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -23,7 +23,7 @@ from numojo.core.matrix import Matrix
 # ===----------------------------------------------------------------------=== #
 
 
-fn all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
+def all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     """
     Checks whether all elements of the array evaluate to True.
 
@@ -46,7 +46,7 @@ fn all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
     @parameter
-    fn closure[
+    def closure[
         simd_width: Int
     ](idx: Int) unified {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
@@ -56,7 +56,7 @@ fn all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     return result
 
 
-fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
+def any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     """
     Checks whether any element of the array evaluate to True.
 
@@ -79,7 +79,7 @@ fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
     @parameter
-    fn closure[
+    def closure[
         simd_width: Int
     ](idx: Int) unified {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
@@ -94,7 +94,7 @@ fn any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
 # ===----------------------------------------------------------------------=== #
 
 
-fn all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
+def all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     """
     Test whether all array elements evaluate to True.
 
@@ -108,14 +108,14 @@ fn all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    fn closure[width: Int](i: Int) unified {mut res, read A}:
+    def closure[width: Int](i: Int) unified {mut res, read A}:
         res = (res & A._buf.ptr.load[width=width](i)).reduce_and()
 
     vectorize[width](A.size, closure)
     return res
 
 
-fn all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Test whether all array elements evaluate to True along axis.
     """
@@ -128,7 +128,7 @@ fn all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         for i in range(A.shape[0]):
 
             @parameter
-            fn cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) & A._load[width](i, j)
                 )
@@ -141,9 +141,9 @@ fn all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.ones[dtype](shape=(A.shape[0], 1))
 
         @parameter
-        fn cal_rows(i: Int):
+        def cal_rows(i: Int):
             @parameter
-            fn cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -159,7 +159,7 @@ fn all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
+def any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     """
     Test whether any array elements evaluate to True.
 
@@ -172,14 +172,14 @@ fn any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    fn cal_and[width: Int](i: Int) unified {mut res, read A}:
+    def cal_and[width: Int](i: Int) unified {mut res, read A}:
         res = res | A._buf.ptr.load[width=width](i).reduce_or()
 
     vectorize[width](A.size, cal_and)
     return res
 
 
-fn any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Test whether any array elements evaluate to True along axis.
     """
@@ -192,7 +192,7 @@ fn any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         for i in range(A.shape[0]):
 
             @parameter
-            fn cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) | A._load[width](i, j)
                 )
@@ -205,9 +205,9 @@ fn any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.zeros[dtype](shape=(A.shape[0], 1))
 
         @parameter
-        fn cal_rows(i: Int):
+        def cal_rows(i: Int):
             @parameter
-            fn cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store(
                     i,
                     0,

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -39,7 +39,7 @@ from numojo.core.indexing.utility import (
 # ===----------------------------------------------------------------------=== #
 
 
-fn copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
+def copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
     """
     Copies the array from src to dst.
 
@@ -75,7 +75,7 @@ fn copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
             dst._buf.ptr[dst_offset] = src._buf.ptr[src_offset]
 
 
-fn ndim[dtype: DType](array: NDArray[dtype]) -> Int:
+def ndim[dtype: DType](array: NDArray[dtype]) -> Int:
     """
     Returns the number of dimensions of the NDArray.
 
@@ -88,7 +88,7 @@ fn ndim[dtype: DType](array: NDArray[dtype]) -> Int:
     return array.ndim
 
 
-fn ndim[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> Int:
+def ndim[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> Int:
     """
     Returns the number of dimensions of the NDArray.
 
@@ -101,7 +101,7 @@ fn ndim[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> Int:
     return array.ndim
 
 
-fn shape[dtype: DType](array: NDArray[dtype]) -> NDArrayShape:
+def shape[dtype: DType](array: NDArray[dtype]) -> NDArrayShape:
     """
     Returns the shape of the NDArray.
 
@@ -114,7 +114,7 @@ fn shape[dtype: DType](array: NDArray[dtype]) -> NDArrayShape:
     return array.shape
 
 
-fn shape[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> NDArrayShape:
+def shape[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> NDArrayShape:
     """
     Returns the shape of the NDArray.
 
@@ -126,7 +126,7 @@ fn shape[cdtype: ComplexDType](array: ComplexNDArray[cdtype]) -> NDArrayShape:
     return array.shape
 
 
-fn size[dtype: DType](array: NDArray[dtype], axis: Int) raises -> Int:
+def size[dtype: DType](array: NDArray[dtype], axis: Int) raises -> Int:
     """
     Returns the size of the NDArray.
 
@@ -140,7 +140,7 @@ fn size[dtype: DType](array: NDArray[dtype], axis: Int) raises -> Int:
     return array.shape[axis]
 
 
-fn size[
+def size[
     cdtype: ComplexDType
 ](array: ComplexNDArray[cdtype], axis: Int) raises -> Int:
     """
@@ -161,7 +161,7 @@ fn size[
 # ===----------------------------------------------------------------------=== #
 
 
-fn reshape[
+def reshape[
     dtype: DType
 ](
     A: NDArray[dtype], shape: NDArrayShape, order: String = "C"
@@ -205,7 +205,7 @@ fn reshape[
     return B^
 
 
-fn ravel[
+def ravel[
     dtype: DType
 ](a: NDArray[dtype], order: String = "C") raises -> NDArray[dtype]:
     """
@@ -255,7 +255,7 @@ fn ravel[
 
 # TODO: Remove this one if the following function is working well:
 # `numojo.core.utility.TraverseMethods.traverse_buffer_according_to_shape_and_strides`
-fn _set_values_according_to_shape_and_strides(
+def _set_values_according_to_shape_and_strides(
     mut I: NDArray[DType.int],
     mut index: Int,
     current_dim: Int,
@@ -285,7 +285,7 @@ fn _set_values_according_to_shape_and_strides(
             )
 
 
-fn transpose[
+def transpose[
     dtype: DType
 ](A: NDArray[dtype], axes: List[Int]) raises -> NDArray[dtype]:
     """
@@ -351,7 +351,7 @@ fn transpose[
 
 
 # TODO: Make this operation in place to match numpy.
-fn transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
+def transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     (overload) Transpose the array when `axes` is not given.
     If `axes` is not given, it is equal to flipping the axes.
@@ -380,7 +380,7 @@ fn transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
         return transpose(A, axes=flipped_axes)
 
 
-fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Transpose of matrix.
     """
@@ -399,7 +399,7 @@ fn transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return B^
 
 
-fn reorder_layout[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
+def reorder_layout[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Create a new Matrix with the opposite layout from A:
     if A is C-contiguous, then create a new F-contiguous matrix of the same shape.
@@ -442,7 +442,7 @@ fn reorder_layout[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
 # ===----------------------------------------------------------------------=== #
 
 
-fn broadcast_to[
+def broadcast_to[
     dtype: DType
 ](a: NDArray[dtype], shape: NDArrayShape) raises -> NDArray[dtype]:
     if a.shape.ndim > shape.ndim:
@@ -503,7 +503,7 @@ fn broadcast_to[
     return b^
 
 
-fn broadcast_to[
+def broadcast_to[
     dtype: DType
 ](
     A: Matrix[dtype],
@@ -570,7 +570,7 @@ fn broadcast_to[
     return B^
 
 
-fn broadcast_to[
+def broadcast_to[
     dtype: DType
 ](A: Scalar[dtype], shape: Tuple[Int, Int], order: String) raises -> Matrix[
     dtype
@@ -583,7 +583,7 @@ fn broadcast_to[
     return B^
 
 
-fn _broadcast_back_to[
+def _broadcast_back_to[
     dtype: DType
 ](a: NDArray[dtype], shape: NDArrayShape, axis: Int) raises -> NDArray[dtype]:
     """
@@ -629,7 +629,7 @@ fn _broadcast_back_to[
 # ===----------------------------------------------------------------------=== #
 
 
-fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Returns flipped array and keep the shape.
 
@@ -651,7 +651,7 @@ fn flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return A^
 
 
-fn flip[
+def flip[
     dtype: DType
 ](array: NDArray[dtype], var axis: Int) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -21,7 +21,7 @@ from numojo.core.ndarray import NDArray
 # ===------------------------------------------------------------------------===#
 
 
-fn add[
+def add[
     dtype: DType,
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -43,7 +43,7 @@ fn add[
     return HostExecutor.apply_binary[dtype, SIMD.__add__](array1, array2)
 
 
-fn add[
+def add[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -62,7 +62,7 @@ fn add[
     return HostExecutor.apply_binary[dtype, SIMD.__add__](array, scalar)
 
 
-fn add[
+def add[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -81,7 +81,7 @@ fn add[
     return HostExecutor.apply_binary[dtype, SIMD.__add__](scalar, array)
 
 
-fn add[
+def add[
     dtype: DType,
 ](var *values: Variant[NDArray[dtype], Scalar[dtype]]) raises -> NDArray[dtype]:
     """
@@ -124,7 +124,7 @@ fn add[
 # ===------------------------------------------------------------------------===#
 
 
-fn sub[
+def sub[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -143,7 +143,7 @@ fn sub[
     return HostExecutor.apply_binary[dtype, SIMD.__sub__](array1, array2)
 
 
-fn sub[
+def sub[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -162,7 +162,7 @@ fn sub[
     return HostExecutor.apply_binary[dtype, SIMD.__sub__](array, scalar)
 
 
-fn sub[
+def sub[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -186,7 +186,7 @@ fn sub[
 # ===------------------------------------------------------------------------===#
 
 
-fn mod[
+def mod[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -205,7 +205,7 @@ fn mod[
     return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
 
 
-fn mod[
+def mod[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -224,7 +224,7 @@ fn mod[
     return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
 
 
-fn mod[
+def mod[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -248,7 +248,7 @@ fn mod[
 # ===------------------------------------------------------------------------===#
 
 
-fn mul[
+def mul[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -270,7 +270,7 @@ fn mul[
     return HostExecutor.apply_binary[dtype, SIMD.__mul__](array1, array2)
 
 
-fn mul[
+def mul[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -289,7 +289,7 @@ fn mul[
     return HostExecutor.apply_binary[dtype, SIMD.__mul__](array, scalar)
 
 
-fn mul[
+def mul[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -308,7 +308,7 @@ fn mul[
     return HostExecutor.apply_binary[dtype, SIMD.__mul__](scalar, array)
 
 
-fn mul[
+def mul[
     dtype: DType,
 ](var *values: Variant[NDArray[dtype], Scalar[dtype]]) raises -> NDArray[dtype]:
     """
@@ -351,7 +351,7 @@ fn mul[
 # ===------------------------------------------------------------------------===#
 
 
-fn div[
+def div[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -373,7 +373,7 @@ fn div[
     return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array1, array2)
 
 
-fn div[
+def div[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -392,7 +392,7 @@ fn div[
     return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array, scalar)
 
 
-fn div[
+def div[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -416,7 +416,7 @@ fn div[
 # ===------------------------------------------------------------------------===#
 
 
-fn floor_div[
+def floor_div[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -438,7 +438,7 @@ fn floor_div[
     return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array1, array2)
 
 
-fn floor_div[
+def floor_div[
     dtype: DType,
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -457,7 +457,7 @@ fn floor_div[
     return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array, scalar)
 
 
-fn floor_div[
+def floor_div[
     dtype: DType,
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -481,7 +481,7 @@ fn floor_div[
 # ===------------------------------------------------------------------------===#
 
 
-fn fma[
+def fma[
     dtype: DType
 ](
     array1: NDArray[dtype], array2: NDArray[dtype], array3: NDArray[dtype]
@@ -511,7 +511,7 @@ fn fma[
     )
 
 
-fn fma[
+def fma[
     dtype: DType
 ](
     array1: NDArray[dtype], array2: NDArray[dtype], simd: SIMD[dtype, 1]
@@ -543,7 +543,7 @@ fn fma[
 # ===------------------------------------------------------------------------===#
 
 
-fn remainder[
+def remainder[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -565,7 +565,7 @@ fn remainder[
     return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
 
 
-fn remainder[
+def remainder[
     dtype: DType
 ](array: NDArray[dtype], scalar: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -584,7 +584,7 @@ fn remainder[
     return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
 
 
-fn remainder[
+def remainder[
     dtype: DType
 ](scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/differences.mojo
+++ b/numojo/routines/math/differences.mojo
@@ -26,7 +26,7 @@ from numojo.core.dtype.utility import is_inttype, is_floattype
 # ===------------------------------------------------------------------------===#
 
 
-fn gradient[
+def gradient[
     dtype: DType = DType.float64
 ](x: NDArray[dtype], spacing: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -87,7 +87,7 @@ fn gradient[
 # ===------------------------------------------------------------------------===#
 
 
-fn diff[
+def diff[
     dtype: DType = DType.float64
 ](array: NDArray[dtype], n: Int = 1) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -23,7 +23,7 @@ from numojo.routines import HostExecutor
 # ===------------------------------------------------------------------------===#
 
 
-fn exp[
+def exp[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -52,7 +52,7 @@ fn exp[
     return HostExecutor.apply_unary[dtype, math.exp](array)
 
 
-fn exp[
+def exp[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -79,7 +79,7 @@ fn exp[
     return math.exp(value)
 
 
-fn exp2[
+def exp2[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -108,7 +108,7 @@ fn exp2[
     return HostExecutor.apply_unary[dtype, math.exp2](array)
 
 
-fn exp2[
+def exp2[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -135,7 +135,7 @@ fn exp2[
     return math.exp2(value)
 
 
-fn expm1[
+def expm1[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -163,7 +163,7 @@ fn expm1[
     return HostExecutor.apply_unary[dtype, math.expm1](array)
 
 
-fn expm1[
+def expm1[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -194,7 +194,7 @@ fn expm1[
 # ===------------------------------------------------------------------------===#
 
 
-fn log[
+def log[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -222,7 +222,7 @@ fn log[
     return HostExecutor.apply_unary[dtype, math.log](array)
 
 
-fn log[
+def log[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -248,7 +248,7 @@ fn log[
     return math.log(value)
 
 
-fn log2[
+def log2[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -277,7 +277,7 @@ fn log2[
     return HostExecutor.apply_unary[dtype, math.log2](array)
 
 
-fn log2[
+def log2[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -302,7 +302,7 @@ fn log2[
     return math.log2(value)
 
 
-fn log10[
+def log10[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -330,7 +330,7 @@ fn log10[
     return HostExecutor.apply_unary[dtype, math.log10](array)
 
 
-fn log10[
+def log10[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """
@@ -356,7 +356,7 @@ fn log10[
     return math.log10(value)
 
 
-fn log1p[
+def log1p[
     dtype: DType
 ](array: NDArray[dtype]) raises -> NDArray[
     dtype
@@ -385,7 +385,7 @@ fn log1p[
     return HostExecutor.apply_unary[dtype, math.log1p](array)
 
 
-fn log1p[
+def log1p[
     dtype: DType
 ](value: Scalar[dtype]) raises -> Scalar[dtype] where dtype.is_floating_point():
     """

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -32,7 +32,7 @@ from numojo.routines.manipulation import ravel
 # ===-----------------------------------------------------------------------===#
 
 
-fn extrema_1d[
+def extrema_1d[
     dtype: DType, //, is_max: Bool
 ](a: NDArray[dtype]) raises -> Scalar[dtype]:
     """
@@ -61,7 +61,7 @@ fn extrema_1d[
     comptime if is_max:
 
         @parameter
-        fn vectorize_max[
+        def vectorize_max[
             simd_width: Int
         ](offset: Int) unified {mut value, read a}:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
@@ -75,7 +75,7 @@ fn extrema_1d[
     else:
 
         @parameter
-        fn vectorize_min[
+        def vectorize_min[
             simd_width: Int
         ](offset: Int) unified {mut value, read a} -> None:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
@@ -87,7 +87,7 @@ fn extrema_1d[
         return value
 
 
-fn max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Find the max value of an array.
 
@@ -116,14 +116,14 @@ fn max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
         return extrema_1d[is_max=True](ravel(a))
 
 
-fn extrema_1d_max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def extrema_1d_max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Find the max value in a 1-D array.
     """
     return extrema_1d[is_max=True](a)
 
 
-fn max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+def max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Find the max value of an array along an axis.
 
@@ -162,7 +162,7 @@ fn max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     )
 
 
-fn min[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def min[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Find the min value of an array.
 
@@ -191,7 +191,7 @@ fn min[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
         return extrema_1d[is_max=False](ravel(a))
 
 
-fn min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+def min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Find the min value of an array along an axis.
 
@@ -236,7 +236,7 @@ fn min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
 
 
 @always_inline
-fn matrix_extrema[
+def matrix_extrema[
     dtype: DType, find_max: Bool
 ](A: Matrix[dtype]) raises -> Scalar[dtype]:
     """
@@ -260,7 +260,7 @@ fn matrix_extrema[
 
 
 @always_inline
-fn matrix_extrema_axis[
+def matrix_extrema_axis[
     dtype: DType, find_max: Bool
 ](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
@@ -309,7 +309,7 @@ fn matrix_extrema_axis[
     return B^
 
 
-fn max[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
+def max[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     """
     Find max item.
 
@@ -331,7 +331,7 @@ fn max[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     return matrix_extrema[dtype, True](A)
 
 
-fn max[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def max[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Find max item along the given axis.
 
@@ -354,7 +354,7 @@ fn max[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     return matrix_extrema_axis[dtype, True](A, axis)
 
 
-fn _max[
+def _max[
     dtype: DType
 ](A: Matrix[dtype], start: Int, end: Int) raises -> Tuple[
     Scalar[dtype], Scalar[DType.int]
@@ -408,7 +408,7 @@ fn _max[
     return (max_value, Scalar[DType.int](max_index))
 
 
-fn min[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
+def min[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     """
     Find min item.
 
@@ -430,7 +430,7 @@ fn min[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     return matrix_extrema[dtype, False](A)
 
 
-fn min[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def min[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Find min item along the given axis.
 
@@ -453,7 +453,7 @@ fn min[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     return matrix_extrema_axis[dtype, False](A, axis)
 
 
-fn _min[
+def _min[
     dtype: DType
 ](A: Matrix[dtype], start: Int, end: Int) raises -> Tuple[
     Scalar[dtype], Scalar[DType.int]
@@ -512,7 +512,7 @@ fn _min[
 # ===-----------------------------------------------------------------------===#
 
 
-fn minimum[
+def minimum[
     dtype: DType = DType.float64
 ](s1: SIMD[dtype, 1], s2: SIMD[dtype, 1]) -> SIMD[dtype, 1]:
     """
@@ -531,7 +531,7 @@ fn minimum[
     return builtin_min(s1, s2)
 
 
-fn maximum[
+def maximum[
     dtype: DType = DType.float64
 ](s1: SIMD[dtype, 1], s2: SIMD[dtype, 1]) -> SIMD[dtype, 1]:
     """
@@ -550,7 +550,7 @@ fn maximum[
     return builtin_max(s1, s2)
 
 
-fn minimum[
+def minimum[
     dtype: DType = DType.float64
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -579,7 +579,7 @@ fn minimum[
     return HostExecutor.apply_binary[dtype, builtin_min](array1, array2)
 
 
-fn maximum[
+def maximum[
     dtype: DType = DType.float64
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/floating.mojo
+++ b/numojo/routines/math/floating.mojo
@@ -20,7 +20,7 @@ from numojo.core.ndarray import NDArray
 # ===------------------------------------------------------------------------===#
 
 
-fn copysign[
+def copysign[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/hyper.mojo
+++ b/numojo/routines/math/hyper.mojo
@@ -24,7 +24,7 @@ from numojo.core.matrix.base import _arithmetic_func_matrix_to_matrix
 # ===------------------------------------------------------------------------===#
 
 
-fn acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse hyperbolic cosine.
 
@@ -40,7 +40,7 @@ fn acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.acosh](array)
 
 
-fn asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse hyperbolic sine.
 
@@ -56,7 +56,7 @@ fn asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.asinh](array)
 
 
-fn atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse hyperbolic tangent.
 
@@ -77,7 +77,7 @@ fn atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic cosine element-wise to a Matrix.
 
@@ -93,7 +93,7 @@ fn arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
 
 
-fn acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic cosine element-wise to a Matrix.
 
@@ -109,7 +109,7 @@ fn acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
 
 
-fn arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic sine element-wise to a Matrix.
 
@@ -125,7 +125,7 @@ fn arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
 
 
-fn asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic sine element-wise to a Matrix.
 
@@ -141,7 +141,7 @@ fn asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
 
 
-fn arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic tangent element-wise to a Matrix.
 
@@ -157,7 +157,7 @@ fn arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.atanh](A)
 
 
-fn atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse hyperbolic tangent element-wise to a Matrix.
 
@@ -178,7 +178,7 @@ fn atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply hyperbolic cosine.
 
@@ -194,7 +194,7 @@ fn cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.cosh](array)
 
 
-fn sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply hyperbolic sine.
 
@@ -210,7 +210,7 @@ fn sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.sinh](array)
 
 
-fn tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply hyperbolic tangent.
 
@@ -231,7 +231,7 @@ fn tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """Apply hyperbolic cosine.
 
     Parameters:
@@ -246,7 +246,7 @@ fn cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.cosh](A)
 
 
-fn sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """Apply hyperbolic sin.
 
     Parameters:
@@ -261,7 +261,7 @@ fn sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.sinh](A)
 
 
-fn tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """Apply hyperbolic tan.
 
     Parameters:

--- a/numojo/routines/math/misc.mojo
+++ b/numojo/routines/math/misc.mojo
@@ -20,7 +20,7 @@ from numojo.routines import HostExecutor
 
 
 # TODO: Implement same routines for Matrix.
-fn cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise cube root of a NDArray.
 
@@ -41,7 +41,7 @@ fn cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn clip[
+def clip[
     dtype: DType, //
 ](
     a: NDArray[dtype], a_min: Scalar[dtype], a_max: Scalar[dtype]
@@ -78,7 +78,7 @@ fn clip[
 # ===------------------------------------------------------------------------===#
 
 
-fn _mt_rsqrt[
+def _mt_rsqrt[
     dtype: DType, simd_width: Int
 ](value: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
     """
@@ -97,7 +97,7 @@ fn _mt_rsqrt[
     return stdlib_math.sqrt(SIMD.__truediv__(SIMD[dtype, simd_width](1), value))
 
 
-fn rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise reciprocal square root of NDArray.
 
@@ -113,7 +113,7 @@ fn rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, _mt_rsqrt](array)
 
 
-fn sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise square root of a NDArray.
 
@@ -134,7 +134,7 @@ fn sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn scalb[
+def scalb[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -21,7 +21,7 @@ from numojo.core.indexing import TraverseMethods
 from numojo.routines.creation import ones
 
 
-fn prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
+def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Returns products of all items in the array.
 
@@ -50,14 +50,14 @@ fn prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var res = Scalar[dtype](1)
 
     @parameter
-    fn cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
         res *= A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
     return res
 
 
-fn prod[
+def prod[
     dtype: DType
 ](A: NDArray[dtype], var axis: Int) raises -> NDArray[dtype]:
     """
@@ -97,7 +97,7 @@ fn prod[
     return result^
 
 
-fn prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
+def prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     """
     Product of all items in the Matrix.
 
@@ -110,14 +110,14 @@ fn prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    fn cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
         res = res * A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
     return res
 
 
-fn prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Product of items in a Matrix along the axis.
 
@@ -142,7 +142,7 @@ fn prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         for i in range(A.shape[0]):
 
             @parameter
-            fn cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) * A._load[width](i, j)
                 )
@@ -155,9 +155,9 @@ fn prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.ones[dtype](shape=(A.shape[0], 1))
 
         @parameter
-        fn cal_rows(i: Int):
+        def cal_rows(i: Int):
             @parameter
-            fn cal_vec[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec[width: Int](j: Int) unified {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -173,7 +173,7 @@ fn prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn cumprod[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
+def cumprod[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Returns cumprod of all items of an array.
     The array is flattened before cumprod.
@@ -198,7 +198,7 @@ fn cumprod[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
         return cumprod(A.flatten(), axis=-1)
 
 
-fn cumprod[
+def cumprod[
     dtype: DType
 ](A: NDArray[dtype], var axis: Int) raises -> NDArray[dtype]:
     """
@@ -240,7 +240,7 @@ fn cumprod[
     return B^
 
 
-fn cumprod[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
+def cumprod[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Cumprod of flattened matrix.
 
@@ -271,7 +271,7 @@ fn cumprod[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     return result^
 
 
-fn cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Cumprod of Matrix along the axis.
 
@@ -297,7 +297,7 @@ fn cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         for j in range(result.shape[1]):
 
             @parameter
-            fn copy_col[
+            def copy_col[
                 width: Int
             ](i: Int) unified {mut result, read A, read j}:
                 result._store[width](i, j, A._load[width](i, j))
@@ -309,7 +309,7 @@ fn cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for i in range(1, A.shape[0]):
 
                 @parameter
-                fn cal_vec_row[width: Int](j: Int) unified {mut result, read i}:
+                def cal_vec_row[width: Int](j: Int) unified {mut result, read i}:
                     result._store[width](
                         i,
                         j,
@@ -335,7 +335,7 @@ fn cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for j in range(1, A.shape[1]):
 
                 @parameter
-                fn cal_vec_column[
+                def cal_vec_column[
                     width: Int
                 ](i: Int) unified {mut result, read j}:
                     result._store[width](

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -309,7 +309,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for i in range(1, A.shape[0]):
 
                 @parameter
-                def cal_vec_row[width: Int](j: Int) unified {mut result, read i}:
+                def cal_vec_row[
+                    width: Int
+                ](j: Int) unified {mut result, read i}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -23,7 +23,7 @@ from numojo.routines import HostExecutor
 # ===------------------------------------------------------------------------===#
 
 
-fn round[dtype: DType](A: Matrix[dtype], decimals: Int = 0) -> Matrix[dtype]:
+def round[dtype: DType](A: Matrix[dtype], decimals: Int = 0) -> Matrix[dtype]:
     # FIXME
     # The built-in `round` function is not working now.
     # It will be fixed in future.
@@ -40,7 +40,7 @@ fn round[dtype: DType](A: Matrix[dtype], decimals: Int = 0) -> Matrix[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise absolute value of a NDArray.
 
@@ -61,7 +61,7 @@ fn tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise floor of a NDArray.
 
@@ -77,7 +77,7 @@ fn tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, SIMD.__floor__](array)
 
 
-fn tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise ceiling of a NDArray.
 
@@ -93,7 +93,7 @@ fn tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, SIMD.__ceil__](array)
 
 
-fn ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise truncation of a NDArray.
 
@@ -109,7 +109,7 @@ fn ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, SIMD.__trunc__](array)
 
 
-fn tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise rounding of a NDArray to a whole number.
 
@@ -125,7 +125,7 @@ fn tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
 
 
-fn roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise banker's rounding of a NDArray.
 
@@ -141,7 +141,7 @@ fn roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
 
 
-# fn round_half_down[
+# def round_half_down[
 #     dtype: DType
 # ](NDArray: NDArray[dtype]) -> NDArray[dtype]:
 #     """
@@ -162,7 +162,7 @@ fn roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 #     ](NDArray)
 
 
-# fn round_half_up[
+# def round_half_up[
 #     dtype: DType
 # ](NDArray: NDArray[dtype]) -> NDArray[dtype]:
 #     """
@@ -187,7 +187,7 @@ fn roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn nextafter[
+def nextafter[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[
     dtype

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -20,7 +20,7 @@ from numojo.core.indexing import TraverseMethods
 from numojo.routines.creation import zeros
 
 
-fn sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
+def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Returns sum of all items in the array.
 
@@ -48,14 +48,14 @@ fn sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var result: Scalar[dtype] = Scalar[dtype](0)
 
     @parameter
-    fn cal_vec[width: Int](i: Int) unified {mut result, read A}:
+    def cal_vec[width: Int](i: Int) unified {mut result, read A}:
         result += A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
     return result
 
 
-fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+def sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Returns sums of array elements over a given axis.
 
@@ -123,7 +123,7 @@ fn sum[dtype: DType](A: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     return result^
 
 
-fn sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
+def sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     """
     Sum up all items in the Matrix.
 
@@ -145,14 +145,14 @@ fn sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    fn cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
         res = res + A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
     return res
 
 
-fn sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Sum up the items in a Matrix along the axis.
 
@@ -179,9 +179,9 @@ fn sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if A.is_f_contiguous():
 
             @parameter
-            fn calc_columns(j: Int):
+            def calc_columns(j: Int):
                 @parameter
-                fn col_sum[width: Int](i: Int) unified {mut B, read j, read A}:
+                def col_sum[width: Int](i: Int) unified {mut B, read j, read A}:
                     B._store(
                         0,
                         j,
@@ -195,7 +195,7 @@ fn sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for i in range(A.shape[0]):
 
                 @parameter
-                fn cal_vec_sum[
+                def cal_vec_sum[
                     width: Int
                 ](j: Int) unified {mut B, read i, read A}:
                     B._store[width](
@@ -212,9 +212,9 @@ fn sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if A.is_c_contiguous():
 
             @parameter
-            fn cal_rows(i: Int):
+            def cal_rows(i: Int):
                 @parameter
-                fn cal_vec[width: Int](j: Int) unified {mut B, read i, read A}:
+                def cal_vec[width: Int](j: Int) unified {mut B, read i, read A}:
                     B._store(
                         i,
                         0,
@@ -235,7 +235,7 @@ fn sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn cumsum[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
+def cumsum[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Returns cumsum of all items of an array.
     The array is flattened before cumsum.
@@ -261,7 +261,7 @@ fn cumsum[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
 
 
 # Why do we do in inplace operation here?
-fn cumsum[
+def cumsum[
     dtype: DType
 ](A: NDArray[dtype], var axis: Int) raises -> NDArray[dtype]:
     """
@@ -305,7 +305,7 @@ fn cumsum[
     return B^
 
 
-fn cumsum[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
+def cumsum[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Cumsum of flattened matrix.
 
@@ -343,7 +343,7 @@ fn cumsum[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     return result^
 
 
-fn cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Cumsum of Matrix along the axis.
 
@@ -372,7 +372,7 @@ fn cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for i in range(1, A.shape[0]):
 
                 @parameter
-                fn cal_vec_sum_column[
+                def cal_vec_sum_column[
                     width: Int
                 ](j: Int) unified {mut result, read i}:
                     result._store[width](
@@ -400,7 +400,7 @@ fn cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             for j in range(1, A.shape[1]):
 
                 @parameter
-                fn cal_vec_sum_row[
+                def cal_vec_sum_row[
                     width: Int
                 ](i: Int) unified {mut result, read j}:
                     result._store[width](

--- a/numojo/routines/math/trig.mojo
+++ b/numojo/routines/math/trig.mojo
@@ -24,7 +24,7 @@ from numojo.routines.math.arithmetic import fma
 # ===------------------------------------------------------------------------===#
 
 
-fn acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse cosine.
 
@@ -40,7 +40,7 @@ fn acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.acos](array)
 
 
-fn asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse sine.
 
@@ -56,7 +56,7 @@ fn asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.asin](array)
 
 
-fn atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply inverse tangent.
 
@@ -72,7 +72,7 @@ fn atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.atan](array)
 
 
-fn atan2[
+def atan2[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -102,7 +102,7 @@ fn atan2[
 # ===------------------------------------------------------------------------===#
 
 
-fn arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse cosine.
 
@@ -118,7 +118,7 @@ fn arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
 
 
-fn acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse cosine.
 
@@ -134,7 +134,7 @@ fn acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
 
 
-fn arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse sine.
 
@@ -150,7 +150,7 @@ fn arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
 
 
-fn asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse sine.
 
@@ -166,7 +166,7 @@ fn asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
 
 
-fn arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse tangent.
 
@@ -182,7 +182,7 @@ fn arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.atan](A)
 
 
-fn atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply inverse tangent.
 
@@ -203,7 +203,7 @@ fn atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply cosine.
 
@@ -219,7 +219,7 @@ fn cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.cos](array)
 
 
-fn sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply sine.
 
@@ -235,7 +235,7 @@ fn sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     return HostExecutor.apply_unary[dtype, math.sin](array)
 
 
-fn tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
+def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Apply tangent.
 
@@ -256,7 +256,7 @@ fn tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply cosine.
 
@@ -272,7 +272,7 @@ fn cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.cos](A)
 
 
-fn sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply sine.
 
@@ -288,7 +288,7 @@ fn sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     return _arithmetic_func_matrix_to_matrix[dtype, math.sin](A)
 
 
-fn tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
+def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply tangent.
 
@@ -309,7 +309,7 @@ fn tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
 # ===------------------------------------------------------------------------===#
 
 
-fn hypot[
+def hypot[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -331,7 +331,7 @@ fn hypot[
     return HostExecutor.apply_binary[dtype, math.hypot](array1, array2)
 
 
-fn hypot_fma[
+def hypot_fma[
     dtype: DType
 ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
     """

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -31,11 +31,11 @@ struct HostExecutor:
     unary and binary functions to NDArrays, Scalars.
     """
 
-    fn __init__(out self):
+    def __init__(out self):
         pass
 
     @staticmethod
-    fn apply_unary[
+    def apply_unary[
         dtype: DType,
         simd_width: Int,
         kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
@@ -59,7 +59,7 @@ struct HostExecutor:
         return kernel[dtype, simd_width](scalar)
 
     @staticmethod
-    fn apply_binary[
+    def apply_binary[
         dtype: DType,
         simd_width: Int,
         kernel: fn[type: DType, simd_w: Int](
@@ -86,7 +86,7 @@ struct HostExecutor:
         return kernel[dtype, simd_width](simd1, simd2)
 
     @staticmethod
-    fn apply_unary_predicate[
+    def apply_unary_predicate[
         dtype: DType,
         simd_width: Int,
         kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
@@ -110,7 +110,7 @@ struct HostExecutor:
         return kernel[dtype, simd_width](simd)
 
     @staticmethod
-    fn apply_binary_predicate[
+    def apply_binary_predicate[
         dtype: DType,
         simd_width: Int,
         kernel: fn[type: DType, simd_w: Int](
@@ -137,7 +137,7 @@ struct HostExecutor:
         return kernel[dtype, simd_width](simd1, simd2)
 
     @staticmethod
-    fn apply_unary[
+    def apply_unary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
@@ -172,7 +172,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(i, kernel[dtype, simd_w](simd_data))
 
@@ -181,7 +181,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary[
+    def apply_binary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -227,7 +227,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
@@ -240,7 +240,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary[
+    def apply_binary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -274,7 +274,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
@@ -286,7 +286,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary[
+    def apply_binary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -321,7 +321,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
@@ -333,7 +333,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary[
+    def apply_binary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w], Int) -> SIMD[
             type, simd_w
@@ -361,7 +361,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array, read intval}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
@@ -374,7 +374,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary_predicate[
+    def apply_binary_predicate[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -427,7 +427,7 @@ struct HostExecutor:
         comptime width = simd_width_of[DType.bool]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
@@ -443,7 +443,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_binary_predicate[
+    def apply_binary_predicate[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
@@ -483,7 +483,7 @@ struct HostExecutor:
         comptime width = simd_width_of[DType.bool]()
 
         @parameter
-        fn closure[
+        def closure[
             simd_w: Int
         ](i: Int) unified {mut result_array, read array1, read scalar}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
@@ -498,7 +498,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_unary_predicate[
+    def apply_unary_predicate[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
@@ -525,7 +525,7 @@ struct HostExecutor:
         comptime width = simd_width_of[DType.bool]()
 
         @parameter
-        fn closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             bool_simd_store[simd_w](
                 result_array._buf.ptr,
@@ -537,7 +537,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_ternary[
+    def apply_ternary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
@@ -591,7 +591,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simdwidth: Int
         ](i: Int) unified {
             mut result_array, read array1, read array2, read array3
@@ -607,7 +607,7 @@ struct HostExecutor:
         return result_array^
 
     @staticmethod
-    fn apply_ternary[
+    def apply_ternary[
         dtype: DType,
         kernel: fn[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
@@ -653,7 +653,7 @@ struct HostExecutor:
         comptime width = simd_width_of[dtype]()
 
         @parameter
-        fn closure[
+        def closure[
             simdwidth: Int
         ](i: Int) unified {
             mut result_array, read array1, read array2, read scalar
@@ -669,7 +669,7 @@ struct HostExecutor:
 
 
 # This provides a way to bypass bitpacking issues with Bool
-fn bool_simd_store[
+def bool_simd_store[
     ptr_origin: MutOrigin,
     //,
     simd_width: Int,

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -25,7 +25,7 @@ from numojo.core.ndarray import NDArray
 # ===----------------------------------------------------------------------=== #
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
@@ -67,7 +67,7 @@ fn rand[
     return result^
 
 
-fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
+def rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     """
     Overloads the function `rand(shape: NDArrayShape)`.
     Creates an array of the given shape and populate it with random samples from
@@ -76,7 +76,7 @@ fn rand[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     return rand[dtype](NDArrayShape(shape))
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](shape: List[Int]) raises -> NDArray[dtype]:
     """
@@ -87,7 +87,7 @@ fn rand[
     return rand[dtype](NDArrayShape(shape))
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](shape: VariadicList[Int, _]) raises -> NDArray[dtype]:
     """
@@ -98,7 +98,7 @@ fn rand[
     return rand[dtype](NDArrayShape(shape))
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](
     shape: NDArrayShape, min: Scalar[dtype], max: Scalar[dtype]
@@ -148,7 +148,7 @@ fn rand[
     return result^
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](*shape: Int, min: Scalar[dtype], max: Scalar[dtype]) raises -> NDArray[dtype]:
     """
@@ -160,7 +160,7 @@ fn rand[
     return rand[dtype](NDArrayShape(shape), min=min, max=max)
 
 
-fn rand[
+def rand[
     dtype: DType = DType.float64
 ](shape: List[Int], min: Scalar[dtype], max: Scalar[dtype]) raises -> NDArray[
     dtype
@@ -179,7 +179,7 @@ fn rand[
 # ===----------------------------------------------------------------------=== #
 
 
-fn randint[
+def randint[
     dtype: DType = DType.int64
 ](shape: NDArrayShape, low: Int, high: Int) raises -> NDArray[
     dtype
@@ -220,7 +220,7 @@ fn randint[
     return result^
 
 
-fn randint[
+def randint[
     dtype: DType = DType.int64
 ](*shape: Int, low: Int, high: Int) raises -> NDArray[
     dtype
@@ -235,7 +235,7 @@ fn randint[
     return randint[dtype](NDArrayShape(shape), low=low, high=high)
 
 
-fn randint[
+def randint[
     dtype: DType = DType.int64
 ](shape: NDArrayShape, high: Int) raises -> NDArray[
     dtype
@@ -270,7 +270,7 @@ fn randint[
     return result^
 
 
-fn randint[
+def randint[
     dtype: DType = DType.int64
 ](*shape: Int, high: Int) raises -> NDArray[dtype] where dtype.is_integral():
     """
@@ -286,7 +286,7 @@ fn randint[
 # ===----------------------------------------------------------------------=== #
 
 
-fn randn[
+def randn[
     dtype: DType = DType.float64
 ](shape: NDArrayShape) raises -> NDArray[dtype]:
     """
@@ -316,7 +316,7 @@ fn randn[
     return result^
 
 
-fn randn[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
+def randn[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     """
     Overloads the function `randn(shape: NDArrayShape)`.
     Creates an array of the given shape and populate it with random samples from
@@ -325,7 +325,7 @@ fn randn[dtype: DType = DType.float64](*shape: Int) raises -> NDArray[dtype]:
     return randn[dtype](NDArrayShape(shape))
 
 
-fn randn[
+def randn[
     dtype: DType = DType.float64
 ](
     shape: NDArrayShape, mean: Scalar[dtype], variance: Scalar[dtype]
@@ -350,7 +350,7 @@ fn randn[
     return randn[dtype](shape) * mt.sqrt(variance) + mean
 
 
-fn randn[
+def randn[
     dtype: DType = DType.float64
 ](*shape: Int, mean: Scalar[dtype], variance: Scalar[dtype]) raises -> NDArray[
     dtype
@@ -363,7 +363,7 @@ fn randn[
     return randn[dtype](NDArrayShape(shape), mean=mean, variance=variance)
 
 
-fn randn[
+def randn[
     dtype: DType = DType.float64
 ](
     shape: List[Int], mean: Scalar[dtype], variance: Scalar[dtype]
@@ -381,7 +381,7 @@ fn randn[
 # ===----------------------------------------------------------------------=== #
 
 
-fn exponential[
+def exponential[
     dtype: DType = DType.float64
 ](shape: NDArrayShape, scale: Scalar[dtype] = 1.0) raises -> NDArray[
     dtype
@@ -423,7 +423,7 @@ fn exponential[
     return result^
 
 
-fn exponential[
+def exponential[
     dtype: DType = DType.float64
 ](*shape: Int, scale: Scalar[dtype] = 1.0) raises -> NDArray[
     dtype
@@ -437,7 +437,7 @@ fn exponential[
     return exponential[dtype](NDArrayShape(shape), scale=scale)
 
 
-fn exponential[
+def exponential[
     dtype: DType = DType.float64
 ](shape: List[Int], scale: Scalar[dtype] = 1.0) raises -> NDArray[
     dtype
@@ -457,7 +457,7 @@ fn exponential[
 
 
 @parameter
-fn _int_rand_func[
+def _int_rand_func[
     dtype: DType
 ](
     mut result: NDArray[dtype], min: Scalar[dtype], max: Scalar[dtype]
@@ -482,7 +482,7 @@ fn _int_rand_func[
 
 
 @parameter
-fn _float_rand_func[
+def _float_rand_func[
     dtype: DType
 ](mut result: NDArray[dtype], min: Scalar[dtype], max: Scalar[dtype]):
     """

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -25,7 +25,7 @@ from numojo.routines.math.extrema import _max, _min
 from numojo.routines.functional import apply_along_axis_reduce_to_int
 
 
-fn argmax_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmax_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     """Returns the index of the maximum value in the buffer.
     Regardless of the shape of input, it is treated as a 1-d array.
 
@@ -55,7 +55,7 @@ fn argmax_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     return Scalar[DType.int](result)
 
 
-fn argmin_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmin_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     """Returns the index of the minimum value in the buffer.
     Regardless of the shape of input, it is treated as a 1-d array.
 
@@ -85,7 +85,7 @@ fn argmin_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     return Scalar[DType.int](result)
 
 
-fn argmax[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmax[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     """Returns the indices of the maximum values of the array along an axis.
     When no axis is specified, the array is flattened.
 
@@ -110,7 +110,7 @@ fn argmax[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
         return argmax_1d(ravel(a))
 
 
-fn argmax[
+def argmax[
     dtype: DType, //
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """Returns the indices of the maximum values of the array along an axis.
@@ -137,7 +137,7 @@ fn argmax[
     from numojo.prelude import *
     from python import Python
 
-    fn main() raises:
+    def main() raises:
         var np = Python.import_module("numpy")
         # Test with argmax to get maximum values
         var a = nm.random.randint(5, 4, low=0, high=10)
@@ -175,7 +175,7 @@ fn argmax[
 
 
 @always_inline
-fn find_extrema_index[
+def find_extrema_index[
     dtype: DType, find_max: Bool
 ](A: Matrix[dtype]) raises -> Scalar[DType.int]:
     """Find index of min/max value, either in whole matrix or along an axis."""
@@ -201,7 +201,7 @@ fn find_extrema_index[
 
 
 @always_inline
-fn find_extrema_index[
+def find_extrema_index[
     dtype: DType, find_max: Bool
 ](A: Matrix[dtype], axis: Optional[Int]) raises -> Matrix[DType.int]:
     """Find index of min/max value, either in whole matrix or along an axis."""
@@ -253,19 +253,19 @@ fn find_extrema_index[
     return B^
 
 
-fn argmax[dtype: DType](A: Matrix[dtype]) raises -> Scalar[DType.int]:
+def argmax[dtype: DType](A: Matrix[dtype]) raises -> Scalar[DType.int]:
     """Find index of max value in a flattened matrix."""
     return find_extrema_index[dtype, True](A)
 
 
-fn argmax[
+def argmax[
     dtype: DType
 ](A: Matrix[dtype], axis: Int) raises -> Matrix[DType.int]:
     """Find indices of max values along the given axis."""
     return find_extrema_index[dtype, True](A, axis)
 
 
-fn argmin[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmin[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     """Returns the indices of the minimum values of the array along an axis.
     When no axis is specified, the array is flattened.
 
@@ -290,7 +290,7 @@ fn argmin[dtype: DType, //](a: NDArray[dtype]) raises -> Scalar[DType.int]:
         return argmin_1d(ravel(a))
 
 
-fn argmin[
+def argmin[
     dtype: DType, //
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """Returns the indices of the minimum values of the array along an axis.
@@ -327,14 +327,14 @@ fn argmin[
     )
 
 
-fn argmin[dtype: DType](A: Matrix[dtype]) raises -> Scalar[DType.int]:
+def argmin[dtype: DType](A: Matrix[dtype]) raises -> Scalar[DType.int]:
     """
     Index of the min. It is first flattened before sorting.
     """
     return find_extrema_index[dtype, False](A)
 
 
-fn argmin[
+def argmin[
     dtype: DType
 ](A: Matrix[dtype], axis: Int) raises -> Matrix[DType.int]:
     """

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -43,7 +43,7 @@ from numojo.routines.functional import (
 
 
 # Below are overrides for NDArray type
-fn sort[
+def sort[
     dtype: DType
 ](a: NDArray[dtype], stable: Bool = False) raises -> NDArray[dtype]:
     """
@@ -64,7 +64,7 @@ fn sort[
         return quick_sort_1d(a)
 
 
-fn sort[
+def sort[
     dtype: DType
 ](a: NDArray[dtype], axis: Int, stable: Bool = False) raises -> NDArray[dtype]:
     """
@@ -107,7 +107,7 @@ fn sort[
         )
 
 
-fn sort_inplace[
+def sort_inplace[
     dtype: DType
 ](mut a: NDArray[dtype], axis: Int, stable: Bool = False) raises:
     """
@@ -152,7 +152,7 @@ fn sort_inplace[
 # Below are overrides for Matrix type
 
 
-fn sort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
+def sort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Sort the Matrix. It is first flattened before sorting.
     """
@@ -163,7 +163,7 @@ fn sort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     return B^
 
 
-fn sort[dtype: DType](var A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def sort[dtype: DType](var A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Sort the Matrix along the given axis.
     """
@@ -210,7 +210,7 @@ fn sort[dtype: DType](var A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn argsort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[DType.int]:
+def argsort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[DType.int]:
     """
     Returns the indices that would sort an array.
     It is not guaranteed to be unstable.
@@ -238,7 +238,7 @@ fn argsort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[DType.int]:
     return indices^
 
 
-fn argsort[
+def argsort[
     dtype: DType
 ](mut a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """
@@ -279,7 +279,7 @@ fn argsort[
     )
 
 
-fn argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.int]:
+def argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.int]:
     """
     Argsort the Matrix. It is first flattened before sorting.
     """
@@ -296,7 +296,7 @@ fn argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.int]:
     return I^
 
 
-fn argsort[
+def argsort[
     dtype: DType
 ](A: Matrix[dtype], axis: Int) raises -> Matrix[DType.int]:
     """
@@ -353,7 +353,7 @@ fn argsort[
 ###############
 
 
-fn binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
+def binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     var result: NDArray[dtype] = a.contiguous()
     for end in range(result.size, 1, -1):
         for i in range(1, end):
@@ -364,7 +364,7 @@ fn binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     return result^
 
 
-fn binary_sort[
+def binary_sort[
     dtype: DType = DType.float64
 ](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -409,7 +409,7 @@ fn binary_sort[
 ###############
 
 
-fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
+def bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Bubble sort the NDArray.
     Average complexity: O(n^2) comparisons, O(n^2) swaps.
@@ -453,7 +453,7 @@ fn bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 ##############
 
 
-fn quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
+def quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Sort array using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -477,7 +477,7 @@ fn quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     return result^
 
 
-fn quick_sort_stable_1d[
+def quick_sort_stable_1d[
     dtype: DType
 ](a: NDArray[dtype]) raises -> NDArray[dtype]:
     """
@@ -502,7 +502,7 @@ fn quick_sort_stable_1d[
     return result^
 
 
-fn quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
+def quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     """
     Sort array in-place using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -523,7 +523,7 @@ fn quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     return
 
 
-fn quick_sort_stable_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
+def quick_sort_stable_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     """
     Sort array in-place using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -546,7 +546,7 @@ fn quick_sort_stable_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     return
 
 
-fn argsort_quick_sort_1d[
+def argsort_quick_sort_1d[
     dtype: DType
 ](a: NDArray[dtype]) raises -> NDArray[DType.int]:
     """
@@ -570,7 +570,7 @@ fn argsort_quick_sort_1d[
     return indices^
 
 
-fn _partition_in_range(
+def _partition_in_range(
     mut A: NDArray,
     left: Int,
     right: Int,
@@ -615,7 +615,7 @@ fn _partition_in_range(
     return store_index
 
 
-fn _partition_in_range(
+def _partition_in_range(
     mut A: NDArray,
     mut I: NDArray,
     left: Int,
@@ -675,7 +675,7 @@ fn _partition_in_range(
     return store_index
 
 
-fn _quick_sort_partition(
+def _quick_sort_partition(
     mut A: Matrix, mut I: Matrix, left: Int, right: Int, pivot_index: Int
 ) raises -> Int:
     """
@@ -738,7 +738,7 @@ fn _quick_sort_partition(
     return store_index
 
 
-fn _quick_sort_in_range(mut A: NDArray, left: Int, right: Int) raises:
+def _quick_sort_in_range(mut A: NDArray, left: Int, right: Int) raises:
     """
     Sort in-place of the data buffer (quick-sort) within give range.
     It is not guaranteed to be stable.
@@ -756,7 +756,7 @@ fn _quick_sort_in_range(mut A: NDArray, left: Int, right: Int) raises:
         _quick_sort_in_range(A, pivot_new_index + 1, right)
 
 
-fn _quick_sort_in_range(
+def _quick_sort_in_range(
     mut A: NDArray, mut I: NDArray, left: Int, right: Int
 ) raises:
     """
@@ -780,7 +780,7 @@ fn _quick_sort_in_range(
         _quick_sort_in_range(A, I, pivot_new_index + 1, right)
 
 
-fn _quick_sort_inplace(
+def _quick_sort_inplace(
     mut A: Matrix, mut I: Matrix, left: Int, right: Int
 ) raises:
     """
@@ -804,7 +804,7 @@ fn _quick_sort_inplace(
         _quick_sort_inplace(A, I, pivot_new_index + 1, right)
 
 
-fn _quick_sort_inplace[dtype: DType](mut A: NDArray[dtype]) raises:
+def _quick_sort_inplace[dtype: DType](mut A: NDArray[dtype]) raises:
     """
     Sort in-place array's buffer using quick sort method.
     It is not guaranteed to be unstable.
@@ -835,7 +835,7 @@ fn _quick_sort_inplace[dtype: DType](mut A: NDArray[dtype]) raises:
     )
 
 
-fn _quick_sort_inplace[
+def _quick_sort_inplace[
     dtype: DType
 ](mut A: NDArray[dtype], mut I: NDArray[DType.int]) raises:
     """
@@ -871,7 +871,7 @@ fn _quick_sort_inplace[
     )
 
 
-fn _quick_sort_stable_inplace[
+def _quick_sort_stable_inplace[
     dtype: DType, //
 ](mut a: NDArray[dtype], size: Int) raises:
     """

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -29,7 +29,7 @@ from numojo.routines.functional import (
 
 
 # not sure what's the side effect of using a returned dtype and casting to it. There could be some precision loss?
-fn mean_1d[
+def mean_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
@@ -51,7 +51,7 @@ fn mean_1d[
     return sum(a).cast[returned_dtype]() / Scalar[returned_dtype](a.size)
 
 
-fn mean[
+def mean[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
@@ -70,7 +70,7 @@ fn mean[
     return mean_1d[returned_dtype](a)
 
 
-fn mean[
+def mean[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[returned_dtype]:
     """
@@ -103,7 +103,7 @@ fn mean[
     ](a=a, axis=normalized_axis)
 
 
-fn mean[
+def mean[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: Matrix[dtype]) -> Scalar[returned_dtype]:
     """
@@ -123,7 +123,7 @@ fn mean[
     return sum(a).cast[returned_dtype]() / Scalar[returned_dtype](a.size)
 
 
-fn mean[
+def mean[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: Matrix[dtype], axis: Int) raises -> Matrix[returned_dtype]:
     """
@@ -153,7 +153,7 @@ fn mean[
         raise Error(String("The axis can either be 1 or 0!"))
 
 
-fn median_1d[
+def median_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
@@ -181,7 +181,7 @@ fn median_1d[
         ).cast[returned_dtype]() / 2
 
 
-fn median[
+def median[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
     """
@@ -201,7 +201,7 @@ fn median[
     return median_1d[returned_dtype](a)
 
 
-fn median[
+def median[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[returned_dtype]:
     """
@@ -232,7 +232,7 @@ fn median[
     ](a=a, axis=normalized_axis)
 
 
-fn mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     """
     Returns mode of all items of an array.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -267,7 +267,7 @@ fn mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     return mode_value
 
 
-fn mode[dtype: DType](array: NDArray[dtype]) raises -> Scalar[dtype]:
+def mode[dtype: DType](array: NDArray[dtype]) raises -> Scalar[dtype]:
     """Mode of all items of an array.
 
     Parameters:
@@ -283,7 +283,7 @@ fn mode[dtype: DType](array: NDArray[dtype]) raises -> Scalar[dtype]:
     return mode_1d(ravel(array))
 
 
-fn mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+def mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Returns mode of the array elements along the given axis.
 
@@ -313,7 +313,7 @@ fn mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     )
 
 
-fn std[
+def std[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -338,7 +338,7 @@ fn std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-fn std[
+def std[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], axis: Int, ddof: Int = 0) raises -> NDArray[
     returned_dtype
@@ -380,7 +380,7 @@ fn std[
     return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** 0.5
 
 
-fn std[
+def std[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -405,7 +405,7 @@ fn std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-fn std[
+def std[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
     """
@@ -424,7 +424,7 @@ fn std[
     return variance[returned_dtype](A, axis, ddof=ddof) ** 0.5
 
 
-fn variance[
+def variance[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -452,7 +452,7 @@ fn variance[
     ) / Scalar[returned_dtype](A.size - ddof)
 
 
-fn variance[
+def variance[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], axis: Int, ddof: Int = 0) raises -> NDArray[
     returned_dtype
@@ -512,7 +512,7 @@ fn variance[
     ) / Scalar[returned_dtype](A.shape[normalized_axis] - ddof)
 
 
-fn variance[
+def variance[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -540,7 +540,7 @@ fn variance[
     ) / Scalar[returned_dtype](A.size - ddof)
 
 
-fn variance[
+def variance[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
     """

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -5,7 +5,7 @@ from std.testing import TestSuite
 # TODO: Added getter and setter tests
 
 
-fn test_complex_array_init() raises:
+def test_complex_array_init() raises:
     """Test initialization of ComplexArray."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
     c1.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
@@ -16,7 +16,7 @@ fn test_complex_array_init() raises:
     assert_almost_equal(c1.item(0).im, 2.0, "init failed")
 
 
-fn test_complex_array_add() raises:
+def test_complex_array_add() raises:
     """Test addition of ComplexArray numbers."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
     var c2 = ComplexNDArray[cf32](Shape(2, 2))
@@ -41,7 +41,7 @@ fn test_complex_array_add() raises:
     assert_almost_equal(sum.item(3).im, 16.0, "add failed")
 
 
-fn test_complex_array_sub() raises:
+def test_complex_array_sub() raises:
     """Test subtraction of ComplexArray numbers."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
     var c2 = ComplexNDArray[cf32](Shape(2, 2))
@@ -67,7 +67,7 @@ fn test_complex_array_sub() raises:
     assert_almost_equal(diff.item(3).im, -2.0, "sub failed")
 
 
-fn test_complex_array_mul() raises:
+def test_complex_array_mul() raises:
     """Test multiplication of ComplexArray numbers."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
     var c2 = ComplexNDArray[cf32](Shape(2, 2))
@@ -87,7 +87,7 @@ fn test_complex_array_mul() raises:
     assert_almost_equal(prod.item(0).im, 4.0, "mul failed")
 
 
-fn test_complex_array_div() raises:
+def test_complex_array_div() raises:
     """Test division of ComplexArray numbers."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
     var c2 = ComplexNDArray[cf32](Shape(2, 2))

--- a/tests/core/test_complexSIMD.mojo
+++ b/tests/core/test_complexSIMD.mojo
@@ -4,7 +4,7 @@ from std.testing import TestSuite
 from numojo import *
 
 
-fn test_complex_init() raises:
+def test_complex_init() raises:
     """Test initialization of ComplexSIMD."""
     var c1 = ComplexSIMD[cf32](1.0, 2.0)
     assert_equal(c1.re, 1.0, "init failed")
@@ -19,7 +19,7 @@ fn test_complex_init() raises:
     assert_equal(c3.im[0], 1.0, "init failed")
 
 
-fn test_complex_add() raises:
+def test_complex_add() raises:
     """Test addition of ComplexSIMD numbers."""
     var c1 = ComplexSIMD[cf32](1.0, 2.0)
     var c2 = ComplexSIMD[cf32](3.0, 4.0)
@@ -34,7 +34,7 @@ fn test_complex_add() raises:
     assert_equal(c3.im, 6.0, "addition failed")
 
 
-fn test_complex_sub() raises:
+def test_complex_sub() raises:
     """Test subtraction of ComplexSIMD numbers."""
     var c1 = ComplexSIMD[cf32](3.0, 4.0)
     var c2 = ComplexSIMD[cf32](1.0, 2.0)
@@ -49,7 +49,7 @@ fn test_complex_sub() raises:
     assert_equal(c3.im, 2.0, "subtraction failed")
 
 
-fn test_complex_mul() raises:
+def test_complex_mul() raises:
     """Test multiplication of ComplexSIMD numbers."""
     var c1 = ComplexSIMD[cf32](1.0, 2.0)
     var c2 = ComplexSIMD[cf32](3.0, 4.0)
@@ -65,7 +65,7 @@ fn test_complex_mul() raises:
     assert_equal(c3.im, 10.0, "multiplication failed")
 
 
-fn test_complex_div() raises:
+def test_complex_div() raises:
     """Test division of ComplexSIMD numbers."""
     var c1 = ComplexSIMD[cf32](1.0, 2.0)
     var c2 = ComplexSIMD[cf32](3.0, 4.0)

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -15,14 +15,14 @@ comptime order: String = String("F") if is_defined[
 # ===-----------------------------------------------------------------------===#
 
 
-fn check_matrices_equal[
+def check_matrices_equal[
     dtype: DType
 ](matrix: Matrix[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.equal(np.matrix(matrix.to_numpy()), np_sol)), st)
 
 
-fn check_matrices_close[
+def check_matrices_close[
     dtype: DType
 ](matrix: Matrix[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -36,7 +36,7 @@ fn check_matrices_close[
     )
 
 
-fn check_values_close[
+def check_values_close[
     dtype: DType
 ](value: Scalar[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -22,14 +22,14 @@ from std.testing import TestSuite
 # ===-----------------------------------------------------------------------===#
 
 
-fn check_array[
+def check_array[
     dtype: DType
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)
 
 
-fn check_array_close[
+def check_array_close[
     dtype: DType
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -39,14 +39,14 @@ fn check_array_close[
     )
 
 
-fn check_scalar_close[
+def check_scalar_close[
     dtype: DType
 ](value: Scalar[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.isclose(value, np_sol, atol=PythonObject(0.001)), st)
 
 
-fn check_matrix_close[
+def check_matrix_close[
     dtype: DType
 ](matrix: Matrix[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -60,14 +60,14 @@ fn check_matrix_close[
     )
 
 
-fn check_matrix_equal[
+def check_matrix_equal[
     dtype: DType
 ](matrix: Matrix[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.equal(np.matrix(matrix.to_numpy()), np_sol)), st)
 
 
-fn check_value_close[
+def check_value_close[
     dtype: DType
 ](value: Scalar[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -79,7 +79,7 @@ fn check_value_close[
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_sums_products_view() raises:
+def test_ndarray_sums_products_view() raises:
     """Test sum, prod, cumsum, cumprod on F-order (non C-contiguous) NDArrays.
     """
     var np = Python.import_module("numpy")
@@ -145,7 +145,7 @@ fn test_ndarray_sums_products_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_extrema_view() raises:
+def test_ndarray_extrema_view() raises:
     """Test max, min, minimum, maximum on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -191,7 +191,7 @@ fn test_ndarray_extrema_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_searching_view() raises:
+def test_ndarray_searching_view() raises:
     """Test argmax_1d, argmin_1d on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -217,7 +217,7 @@ fn test_ndarray_searching_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_sorting_view() raises:
+def test_ndarray_sorting_view() raises:
     """Test sort, argsort on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -253,7 +253,7 @@ fn test_ndarray_sorting_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_linalg_view() raises:
+def test_ndarray_linalg_view() raises:
     """Test matmul, dot, trace, diagonal on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -307,7 +307,7 @@ fn test_ndarray_linalg_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_creation_view() raises:
+def test_ndarray_creation_view() raises:
     """Test diag on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -336,7 +336,7 @@ fn test_ndarray_creation_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_indexing_view() raises:
+def test_ndarray_indexing_view() raises:
     """Test compress on NDArrays with F-order condition."""
     var np = Python.import_module("numpy")
 
@@ -357,7 +357,7 @@ fn test_ndarray_indexing_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_pow_view() raises:
+def test_ndarray_pow_view() raises:
     """Test __pow__ on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -387,7 +387,7 @@ fn test_ndarray_pow_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_matrix_sums_products_view() raises:
+def test_matrix_sums_products_view() raises:
     """Test sum, prod, cumsum on F-order Matrices."""
     var np = Python.import_module("numpy")
 
@@ -438,7 +438,7 @@ fn test_matrix_sums_products_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_matrix_logic_view() raises:
+def test_matrix_logic_view() raises:
     """Test all, any on F-order Matrices."""
     var np = Python.import_module("numpy")
 
@@ -468,7 +468,7 @@ fn test_matrix_logic_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_matrix_pow_view() raises:
+def test_matrix_pow_view() raises:
     """Test __pow__ on F-order Matrices."""
     var np = Python.import_module("numpy")
 
@@ -495,7 +495,7 @@ fn test_matrix_pow_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_matrix_conversion_view() raises:
+def test_matrix_conversion_view() raises:
     """Test astype, flatten, to_ndarray on F-order Matrices."""
     var np = Python.import_module("numpy")
 
@@ -543,7 +543,7 @@ fn test_matrix_conversion_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_matrix_rounding_view() raises:
+def test_matrix_rounding_view() raises:
     """Test round on F-order Matrices."""
     var np = Python.import_module("numpy")
 
@@ -568,7 +568,7 @@ fn test_matrix_rounding_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_sort_does_not_mutate_original() raises:
+def test_sort_does_not_mutate_original() raises:
     """Test that sorting a view does not mutate the original array."""
     var np = Python.import_module("numpy")
 
@@ -599,7 +599,7 @@ fn test_sort_does_not_mutate_original() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_solve_view() raises:
+def test_ndarray_solve_view() raises:
     """Test linalg.solve on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -630,7 +630,7 @@ fn test_ndarray_solve_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_trig_view() raises:
+def test_ndarray_trig_view() raises:
     """Test trigonometric functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -661,7 +661,7 @@ fn test_ndarray_trig_view() raises:
     )
 
 
-fn test_ndarray_hyper_view() raises:
+def test_ndarray_hyper_view() raises:
     """Test hyperbolic functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -685,7 +685,7 @@ fn test_ndarray_hyper_view() raises:
     check_array_close(nm.acosh(C), np.arccosh(Cnp), "`acosh` on F-order broken")
 
 
-fn test_ndarray_exp_log_view() raises:
+def test_ndarray_exp_log_view() raises:
     """Test exp/log functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -704,7 +704,7 @@ fn test_ndarray_exp_log_view() raises:
     check_array_close(nm.log1p(A), np.log1p(Anp), "`log1p` on F-order broken")
 
 
-fn test_ndarray_arithmetic_view() raises:
+def test_ndarray_arithmetic_view() raises:
     """Test arithmetic functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -734,7 +734,7 @@ fn test_ndarray_arithmetic_view() raises:
     )
 
 
-fn test_ndarray_rounding_view() raises:
+def test_ndarray_rounding_view() raises:
     """Test rounding functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -751,7 +751,7 @@ fn test_ndarray_rounding_view() raises:
     check_array_close(nm.tround(A), np.round(Anp), "`tround` on F-order broken")
 
 
-fn test_ndarray_misc_math_view() raises:
+def test_ndarray_misc_math_view() raises:
     """Test misc math functions (clip, sqrt, cbrt, rsqrt) on F-order arrays."""
     var np = Python.import_module("numpy")
 
@@ -777,7 +777,7 @@ fn test_ndarray_misc_math_view() raises:
     )
 
 
-fn test_ndarray_comparison_view() raises:
+def test_ndarray_comparison_view() raises:
     """Test comparison and logic functions on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -806,7 +806,7 @@ fn test_ndarray_comparison_view() raises:
     )
 
 
-fn test_ndarray_copysign_view() raises:
+def test_ndarray_copysign_view() raises:
     """Test copysign and nextafter on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -831,7 +831,7 @@ fn test_ndarray_copysign_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_differences_view() raises:
+def test_ndarray_differences_view() raises:
     """Test gradient and trapz on F-order (non C-contiguous) NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -857,7 +857,7 @@ fn test_ndarray_differences_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_reshape_view() raises:
+def test_ndarray_reshape_view() raises:
     """Test reshape on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -876,7 +876,7 @@ fn test_ndarray_reshape_view() raises:
     check_array_close(flat, flat_np, "`reshape` to 1D on F-order broken")
 
 
-fn test_ndarray_ravel_view() raises:
+def test_ndarray_ravel_view() raises:
     """Test ravel on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -889,7 +889,7 @@ fn test_ndarray_ravel_view() raises:
     check_array_close(raveled, raveled_np, "`ravel` on F-order broken")
 
 
-fn test_ndarray_transpose_view() raises:
+def test_ndarray_transpose_view() raises:
     """Test transpose on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -912,7 +912,7 @@ fn test_ndarray_transpose_view() raises:
     check_array_close(T2, T2np, "`transpose(axes)` on F-order broken")
 
 
-fn test_ndarray_flip_view() raises:
+def test_ndarray_flip_view() raises:
     """Test flip on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -936,7 +936,7 @@ fn test_ndarray_flip_view() raises:
     check_array_close(flipped1, flipped1_np, "`flip(axis=1)` on F-order broken")
 
 
-fn test_ndarray_broadcast_to_view() raises:
+def test_ndarray_broadcast_to_view() raises:
     """Test broadcast_to on F-order NDArrays."""
     var np = Python.import_module("numpy")
 
@@ -955,7 +955,7 @@ fn test_ndarray_broadcast_to_view() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_ndarray_sliced_view_math() raises:
+def test_ndarray_sliced_view_math() raises:
     """Test math on non-contiguous views created via F-order reshape."""
     var np = Python.import_module("numpy")
 
@@ -999,7 +999,7 @@ fn test_ndarray_sliced_view_math() raises:
     )
 
 
-fn test_ndarray_sliced_view_manipulation() raises:
+def test_ndarray_sliced_view_manipulation() raises:
     """Test manipulation functions on 3D F-order arrays."""
     var np = Python.import_module("numpy")
 
@@ -1045,7 +1045,7 @@ fn test_ndarray_sliced_view_manipulation() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn _make_1d_offset_view(
+def _make_1d_offset_view(
     parent: nm.NDArray[nm.f64], offset: Int, size: Int
 ) raises -> nm.NDArray[nm.f64]:
     """Create a 1-D view into `parent` starting at `offset` with `size` elems.
@@ -1059,7 +1059,7 @@ fn _make_1d_offset_view(
     return view^
 
 
-fn _make_2d_offset_view(
+def _make_2d_offset_view(
     parent: nm.NDArray[nm.f64],
     offset: Int,
     rows: Int,
@@ -1077,7 +1077,7 @@ fn _make_2d_offset_view(
     return view^
 
 
-fn test_offset_view_load_store() raises:
+def test_offset_view_load_store() raises:
     """Test load/store/unsafe_load/unsafe_store on 1-D offset views."""
     # parent = [0, 1, 2, ..., 11]
     var parent = nm.arange[nm.f64](0, 12)
@@ -1102,7 +1102,7 @@ fn test_offset_view_load_store() raises:
     assert_true(parent.load(5) == 88.0, "unsafe_store reflected in parent")
 
 
-fn test_offset_view_item_and_itemset() raises:
+def test_offset_view_item_and_itemset() raises:
     """Test item() and itemset() on offset views."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=4, size=8)
@@ -1124,7 +1124,7 @@ fn test_offset_view_item_and_itemset() raises:
     assert_true(parent.load(7) == 66.0, "itemset(List) reflected in parent")
 
 
-fn test_offset_view_getitem_setitem_item() raises:
+def test_offset_view_getitem_setitem_item() raises:
     """Test __getitem__(Item) and __setitem__(Item, Scalar) on offset views."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=3, size=9)
@@ -1139,7 +1139,7 @@ fn test_offset_view_getitem_setitem_item() raises:
     assert_true(parent.load(4) == 42.0, "__setitem__(Item) in parent")
 
 
-fn test_offset_view_getitem_int() raises:
+def test_offset_view_getitem_int() raises:
     """Test __getitem__(idx: Int) which returns 0-D for 1-D arrays."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=2, size=10)
@@ -1152,7 +1152,7 @@ fn test_offset_view_getitem_int() raises:
     assert_true(s4.item() == 6.0, "view[4] → 0-D = parent[6]")
 
 
-fn test_offset_view_2d_getitem_int() raises:
+def test_offset_view_2d_getitem_int() raises:
     """Test __getitem__(idx: Int) on a 2-D offset view (returns a row)."""
     # parent = [0, 1, ..., 23], reshaped to 4x6, then view rows 2-3
     var parent = nm.arange[nm.f64](0, 24)
@@ -1172,7 +1172,7 @@ fn test_offset_view_2d_getitem_int() raises:
     assert_true(row1.item(5) == 23.0, "2D view[1] last elem")
 
 
-fn test_offset_view_setitem_int() raises:
+def test_offset_view_setitem_int() raises:
     """Test __setitem__(idx: Int, val: Self) on a 2-D offset view."""
     var parent = nm.arange[nm.f64](0, 24)
     var view = _make_2d_offset_view(
@@ -1194,7 +1194,7 @@ fn test_offset_view_setitem_int() raises:
     assert_true(parent.load(18) == 18.0, "setitem(int) parent[18] unchanged")
 
 
-fn test_offset_view_load_variadic() raises:
+def test_offset_view_load_variadic() raises:
     """Test load[width](*indices) and store[width](*indices) on 2-D view."""
     var parent = nm.arange[nm.f64](0, 24)
     var view = _make_2d_offset_view(
@@ -1211,7 +1211,7 @@ fn test_offset_view_load_variadic() raises:
     assert_true(parent.load(8) == 55.0, "store(0,2) reflected in parent")
 
 
-fn test_offset_view_mask_getter() raises:
+def test_offset_view_mask_getter() raises:
     """Test __getitem__(mask) on an offset view."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=4, size=8)
@@ -1237,7 +1237,7 @@ fn test_offset_view_mask_getter() raises:
     assert_true(result.item(2) == 11.0, "mask getter third")
 
 
-fn test_offset_view_mask_setter() raises:
+def test_offset_view_mask_setter() raises:
     """Test __setitem__(mask, Scalar) on an offset view."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=4, size=8)
@@ -1268,7 +1268,7 @@ fn test_offset_view_mask_setter() raises:
     assert_true(view.item(5) == 9.0, "mask setter view[5] unchanged")
 
 
-fn test_offset_view_write_to_0d() raises:
+def test_offset_view_write_to_0d() raises:
     """Test that printing a 1-D offset view shows the correct values."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=4, size=4)
@@ -1279,7 +1279,7 @@ fn test_offset_view_write_to_0d() raises:
     assert_true("7.0" in s, "offset view print contains last elem")
 
 
-fn test_offset_view_setitem_item_unsafe() raises:
+def test_offset_view_setitem_item_unsafe() raises:
     """Test _setitem (internal unsafe setter) on offset view."""
     var parent = nm.arange[nm.f64](0, 12)
     var view = _make_1d_offset_view(parent, offset=3, size=9)
@@ -1290,7 +1290,7 @@ fn test_offset_view_setitem_item_unsafe() raises:
     )
 
 
-fn test_offset_view_slice_getitem() raises:
+def test_offset_view_slice_getitem() raises:
     """Test __getitem__(slices) on a 2-D offset view."""
     var parent = nm.arange[nm.f64](0, 24)
     var view = _make_2d_offset_view(
@@ -1309,7 +1309,7 @@ fn test_offset_view_slice_getitem() raises:
     assert_true(sliced.item(3) == 13.0, "slice [1,0]")
 
 
-fn test_offset_view_slice_setitem() raises:
+def test_offset_view_slice_setitem() raises:
     """Test __setitem__(slices, val) on a 2-D offset view."""
     var parent = nm.arange[nm.f64](0, 24)
     var view = _make_2d_offset_view(
@@ -1337,7 +1337,7 @@ fn test_offset_view_slice_setitem() raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn test_inplace_iadd_scalar_view() raises:
+def test_inplace_iadd_scalar_view() raises:
     """Test += scalar on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 10)
     var view = _make_1d_offset_view(parent, offset=3, size=4)  # [3,4,5,6]
@@ -1353,7 +1353,7 @@ fn test_inplace_iadd_scalar_view() raises:
     assert_true(parent.load(7) == 7.0, "iadd parent[7] unchanged")
 
 
-fn test_inplace_isub_scalar_view() raises:
+def test_inplace_isub_scalar_view() raises:
     """Test -= scalar on a C-contiguous view with offset."""
     var parent = nm.full[nm.f64](Shape(10), fill_value=50.0)
     var view = _make_1d_offset_view(parent, offset=2, size=3)
@@ -1366,7 +1366,7 @@ fn test_inplace_isub_scalar_view() raises:
     assert_true(parent.load(5) == 50.0, "isub parent[5] unchanged")
 
 
-fn test_inplace_imul_scalar_view() raises:
+def test_inplace_imul_scalar_view() raises:
     """Test *= scalar on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](1, 9)  # [1,2,3,4,5,6,7,8]
     var view = _make_1d_offset_view(parent, offset=4, size=4)  # [5,6,7,8]
@@ -1379,7 +1379,7 @@ fn test_inplace_imul_scalar_view() raises:
     assert_true(parent.load(7) == 80.0, "imul parent[7]")
 
 
-fn test_inplace_itruediv_scalar_view() raises:
+def test_inplace_itruediv_scalar_view() raises:
     """Test /= scalar on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 8)  # [0,1,2,3,4,5,6,7]
     var view = _make_1d_offset_view(parent, offset=2, size=4)  # [2,3,4,5]
@@ -1393,7 +1393,7 @@ fn test_inplace_itruediv_scalar_view() raises:
     assert_true(parent.load(6) == 6.0, "itruediv parent[6] unchanged")
 
 
-fn test_inplace_iadd_array_view() raises:
+def test_inplace_iadd_array_view() raises:
     """Test += array on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 10)
     var view = _make_1d_offset_view(parent, offset=3, size=4)  # [3,4,5,6]
@@ -1408,7 +1408,7 @@ fn test_inplace_iadd_array_view() raises:
     assert_true(parent.load(7) == 7.0, "iadd arr parent[7] unchanged")
 
 
-fn test_inplace_ipow_view() raises:
+def test_inplace_ipow_view() raises:
     """Test **= int on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 8)  # [0,1,2,3,4,5,6,7]
     var view = _make_1d_offset_view(parent, offset=2, size=3)  # [2,3,4]
@@ -1421,7 +1421,7 @@ fn test_inplace_ipow_view() raises:
     assert_true(parent.load(5) == 5.0, "ipow parent[5] unchanged")
 
 
-fn test_inplace_ifloordiv_scalar_view() raises:
+def test_inplace_ifloordiv_scalar_view() raises:
     """Test //= scalar on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 8)  # [0,1,2,3,4,5,6,7]
     var view = _make_1d_offset_view(parent, offset=4, size=3)  # [4,5,6]
@@ -1434,7 +1434,7 @@ fn test_inplace_ifloordiv_scalar_view() raises:
     assert_true(parent.load(7) == 7.0, "ifloordiv parent[7] unchanged")
 
 
-fn test_inplace_imod_scalar_view() raises:
+def test_inplace_imod_scalar_view() raises:
     """Test %= scalar on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 8)  # [0,1,2,3,4,5,6,7]
     var view = _make_1d_offset_view(parent, offset=3, size=3)  # [3,4,5]
@@ -1447,7 +1447,7 @@ fn test_inplace_imod_scalar_view() raises:
     assert_true(parent.load(6) == 6.0, "imod parent[6] unchanged")
 
 
-fn test_matrix_view_fill() raises:
+def test_matrix_view_fill() raises:
     """Test Matrix.fill on a view with offset."""
     var parent = Matrix[nm.f64](shape=(3, 4), order="C")
     for i in range(3):
@@ -1470,7 +1470,7 @@ fn test_matrix_view_fill() raises:
     assert_true(parent[2, 0] == 8.0, "matrix fill parent[2,0] unchanged")
 
 
-fn test_matrix_view_getset() raises:
+def test_matrix_view_getset() raises:
     """Test Matrix __getitem__/__setitem__(x,y) respect offset."""
     var parent = Matrix[nm.f64](shape=(3, 4), order="C")
     for i in range(3):
@@ -1490,7 +1490,7 @@ fn test_matrix_view_getset() raises:
     assert_true(parent[2, 2] == 999.0, "matrix view set parent[2,2]")
 
 
-fn test_matrix_view_iadd() raises:
+def test_matrix_view_iadd() raises:
     """Test Matrix += on a row view with offset."""
     var parent = Matrix[nm.f64](shape=(3, 4), order="C")
     for i in range(3):
@@ -1512,7 +1512,7 @@ fn test_matrix_view_iadd() raises:
     assert_true(parent[2, 0] == 8.0, "matrix iadd parent[2,0] unchanged")
 
 
-fn test_matrix_view_load_store() raises:
+def test_matrix_view_load_store() raises:
     """Test Matrix load/store with offset."""
     var parent = Matrix[nm.f64](shape=(2, 4), order="C")
     for i in range(2):
@@ -1531,7 +1531,7 @@ fn test_matrix_view_load_store() raises:
     assert_true(parent[1, 1] == 555.0, "matrix store parent[1,1]")
 
 
-fn test_matrix_view_reshape() raises:
+def test_matrix_view_reshape() raises:
     """Test Matrix reshape on a view with offset."""
     var parent = Matrix[nm.f64](shape=(3, 4), order="C")
     for i in range(3):
@@ -1549,7 +1549,7 @@ fn test_matrix_view_reshape() raises:
     assert_true(reshaped[3, 1] == 11.0, "matrix reshape [3,1]")
 
 
-fn test_ndarray_ravel_offset_view() raises:
+def test_ndarray_ravel_offset_view() raises:
     """Test ravel on a C-contiguous view with offset."""
     var parent = nm.arange[nm.f64](0, 24)
     var view = _make_2d_offset_view(
@@ -1567,7 +1567,7 @@ fn test_ndarray_ravel_offset_view() raises:
     assert_true(flat.item(5) == 11.0, "ravel [5]")
 
 
-fn test_where_on_offset_view() raises:
+def test_where_on_offset_view() raises:
     """Test where() modifies an offset view's parent buffer."""
     var parent = nm.full[nm.f64](Shape(10), fill_value=0.0)
     var view = _make_1d_offset_view(parent, offset=3, size=4)  # [0,0,0,0]

--- a/tests/routines/test_functional.mojo
+++ b/tests/routines/test_functional.mojo
@@ -23,7 +23,7 @@ from numojo.routines.functional import (
 )
 
 
-fn test_apply_along_axis() raises:
+def test_apply_along_axis() raises:
     var np = Python.import_module("numpy")
     var a = nm.random.randn(Shape(4, 8, 16))
     var anp = a.to_numpy()

--- a/tests/routines/test_indexing.mojo
+++ b/tests/routines/test_indexing.mojo
@@ -15,7 +15,7 @@ from std.testing import TestSuite
 from numojo.prelude import *
 
 
-fn test_compress() raises:
+def test_compress() raises:
     var np = Python.import_module("numpy")
     var a = nm.arange[i8](24).reshape(Shape(2, 3, 4))
     var anp = a.to_numpy()
@@ -68,7 +68,7 @@ fn test_compress() raises:
     )
 
 
-fn test_take_along_axis() raises:
+def test_take_along_axis() raises:
     var np = Python.import_module("numpy")
 
     # Test 1-D array
@@ -220,7 +220,7 @@ fn test_take_along_axis() raises:
     )
 
 
-fn test_take_along_axis_fortran_order() raises:
+def test_take_along_axis_fortran_order() raises:
     var np = Python.import_module("numpy")
 
     # Create 3-D F-order array

--- a/tests/routines/test_io.mojo
+++ b/tests/routines/test_io.mojo
@@ -5,7 +5,7 @@ from std import os
 from std.testing import TestSuite
 
 
-fn test_save_and_load() raises:
+def test_save_and_load() raises:
     var np = Python.import_module("numpy")
     var arr = ones[numojo.f32](numojo.Shape(10, 15))
     var fname = "test_save_load.npy"
@@ -20,7 +20,7 @@ fn test_save_and_load() raises:
     os.remove(fname)
 
 
-fn test_savetxt_and_loadtxt() raises:
+def test_savetxt_and_loadtxt() raises:
     var np = Python.import_module("numpy")
     var arr = full[numojo.f32](numojo.Shape(10, 15), fill_value=5.0)
     var fname = "test_savetxt_loadtxt.txt"

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -6,7 +6,7 @@ from std.python import Python, PythonObject
 from std.testing import TestSuite
 
 
-fn test_arr_manipulation() raises:
+def test_arr_manipulation() raises:
     var np = Python.import_module("numpy")
 
     # Test arange

--- a/tests/routines/test_math.mojo
+++ b/tests/routines/test_math.mojo
@@ -378,7 +378,7 @@ def test_sin() raises:
     )
 
 
-fn test_extrema() raises:
+def test_extrema() raises:
     var np = Python.import_module("numpy")
     var a = nm.random.randn(10)
     var anp = a.to_numpy()
@@ -404,7 +404,7 @@ fn test_extrema() raises:
         )
 
 
-fn test_misc() raises:
+def test_misc() raises:
     var np = Python.import_module("numpy")
     var a = nm.random.randn(10)
     var anp = a.to_numpy()

--- a/tests/routines/test_searching.mojo
+++ b/tests/routines/test_searching.mojo
@@ -4,7 +4,7 @@ from utils_for_test import check, check_is_close, check_values_close
 from std.testing import TestSuite
 
 
-fn test_argmax() raises:
+def test_argmax() raises:
     var np = Python.import_module("numpy")
 
     # Test 1D array
@@ -94,7 +94,7 @@ fn test_argmax() raises:
         )
 
 
-fn test_argmin() raises:
+def test_argmin() raises:
     var np = Python.import_module("numpy")
 
     # Test 1D array
@@ -184,7 +184,7 @@ fn test_argmin() raises:
         )
 
 
-fn test_take_along_axis_with_argmax_argmin() raises:
+def test_take_along_axis_with_argmax_argmin() raises:
     var np = Python.import_module("numpy")
 
     # Test with argmax to get maximum values

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -4,7 +4,7 @@ from utils_for_test import check, check_is_close
 from std.testing import TestSuite
 
 
-fn test_sort() raises:
+def test_sort() raises:
     var np = Python.import_module("numpy")
     var A = nm.random.randn(10)
     var B = nm.random.randn(2, 3)
@@ -37,7 +37,7 @@ fn test_sort() raises:
         )
 
 
-fn test_argsort() raises:
+def test_argsort() raises:
     var np = Python.import_module("numpy")
     var A = nm.random.randn(10)
     var B = nm.random.randn(2, 3)
@@ -91,7 +91,7 @@ fn test_argsort() raises:
         )
 
 
-fn test_inplace_sort() raises:
+def test_inplace_sort() raises:
     var np = Python.import_module("numpy")
     var C = nm.random.randn(2, 3, 4)
     for i in range(3):
@@ -107,7 +107,7 @@ fn test_inplace_sort() raises:
         )
 
 
-fn test_sort_stable() raises:
+def test_sort_stable() raises:
     var np = Python.import_module("numpy")
     var A = nm.random.randn(10)
     var B = nm.random.randn(2, 3)

--- a/tests/utils_for_test.mojo
+++ b/tests/utils_for_test.mojo
@@ -3,14 +3,14 @@ from std.testing.testing import assert_true
 import numojo as nm
 
 
-fn check[
+def check[
     dtype: DType, //
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
     assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)
 
 
-fn check_with_dtype[
+def check_with_dtype[
     dtype: DType
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -18,7 +18,7 @@ fn check_with_dtype[
     assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)
 
 
-fn check_is_close[
+def check_is_close[
     dtype: DType
 ](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")
@@ -27,7 +27,7 @@ fn check_is_close[
     )
 
 
-fn check_values_close[
+def check_values_close[
     dtype: DType
 ](value: Scalar[dtype], np_sol: PythonObject, st: String) raises:
     var np = Python.import_module("numpy")


### PR DESCRIPTION
This PR deprecates `fn` keyword in favor of `def` (Mojo v0.26.2).