### PR TITLE
[NDArray] Improve NDArray getter & setter methods

### DIFF
--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3647,6 +3647,27 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return ComplexSIMD[Self.cdtype](prod_re, prod_im)
 
+    def prod(self, axis: Int) raises -> Self:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = Self(out_shape)
+        for o in range(outer):
+            var acc_re = Scalar[Self.dtype](1)
+            var acc_im = Scalar[Self.dtype](0)
+            var base = o * axis_len
+            for k in range(axis_len):
+                var a = transposed._flat_load(base + k)
+                var new_re = acc_re * a.re - acc_im * a.im
+                var new_im = acc_re * a.im + acc_im * a.re
+                acc_re = new_re
+                acc_im = new_im
+            result._flat_store(o, ComplexSIMD[Self.cdtype](acc_re, acc_im))
+        return result^
+
     def mean(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Mean (average) of all complex array elements.
@@ -3911,6 +3932,29 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
             result._flat_store(i, cum)
         return result^
+
+    def cumprod(self, axis: Int) raises -> Self:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var inv_axes = self._inverse_permutation(axes)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var transposed_result = Self(transposed.shape)
+        for o in range(outer):
+            var base = o * axis_len
+            var acc_re = Scalar[Self.dtype](1)
+            var acc_im = Scalar[Self.dtype](0)
+            for k in range(axis_len):
+                var a = transposed._flat_load(base + k)
+                var new_re = acc_re * a.re - acc_im * a.im
+                var new_im = acc_re * a.im + acc_im * a.re
+                acc_re = new_re
+                acc_im = new_im
+                transposed_result._flat_store(
+                    base + k, ComplexSIMD[Self.cdtype](acc_re, acc_im)
+                )
+        return transposed_result.T(inv_axes)
 
     # ===-------------------------------------------------------------------===#
     # Array Manipulation Methods

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -32,8 +32,8 @@ import std.builtin.bool as builtin_bool
 import std.math as builtin_math
 from std.collections.optional import Optional
 from std.math import log10, sqrt
-from std.memory import memset_zero, memcpy
-from std.python import PythonObject
+from std.memory import memset_zero, memcpy, UnsafePointer
+from std.python import Python, PythonObject
 from std.sys import simd_width_of
 from std.utils import Variant
 
@@ -253,6 +253,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             precision=2, edge_items=2, line_width=100, formatted_width=6
         )
 
+    # TODO: Remove VariadicList versions.
     @always_inline("nodebug")
     def __init__(
         out self,
@@ -269,7 +270,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         Example:
             ```mojo
             from numojo.prelude import *
-            var A = nm.ComplexNDArray[cf32](VariadicList(2,3,4))
+            var A = nm.ComplexNDArray[cf32](2,3,4)
             ```
 
         Notes:

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -854,12 +854,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             return result^
         else:
             # F layout
-            self[Self.dtype]._re._copy_first_axis_slice(
-                self._re, norm, result._re
-            )
-            self[Self.dtype]._im._copy_first_axis_slice(
-                self._im, norm, result._im
-            )
+            self._re._copy_first_axis_slice(self._re, norm, result._re)
+            self._im._copy_first_axis_slice(self._im, norm, result._im)
             return result^
 
     def __getitem__(self, var *slices: Slice) raises -> Self:
@@ -1853,8 +1849,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             return
 
         # F order
-        self[Self.dtype]._re._write_first_axis_slice(self._re, norm, val._re)
-        self[Self.dtype]._im._write_first_axis_slice(self._im, norm, val._im)
+        self._re._write_first_axis_slice(self._re, norm, val._re)
+        self._im._write_first_axis_slice(self._im, norm, val._im)
 
     def __setitem__(
         mut self, var index: Item, val: ComplexSIMD[Self.cdtype]
@@ -1916,9 +1912,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._im._buf.ptr.store(idx, val.im)
 
     def __setitem__(
-        mut self,
-        mask: ComplexNDArray[Self.cdtype],
-        value: ComplexSIMD[Self.cdtype],
+        mut self, mask: NDArray[DType.bool], value: ComplexSIMD[Self.cdtype]
     ) raises:
         """
         Set the value of the array at the indices where the mask is true.
@@ -1937,11 +1931,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-        for i in range(mask.size):
-            if mask._re._buf.ptr.load[width=1](i):
-                self._re._buf.ptr.store(i, value.re)
-            if mask._im._buf.ptr.load[width=1](i):
-                self._im._buf.ptr.store(i, value.im)
+        var mask_c = mask.contiguous()
+        for i in range(mask_c.size):
+            if mask_c._buf.ptr.load[width=1](i):
+                self.itemset(i, value)
 
     def __setitem__(
         mut self, var *slices: Slice, val: ComplexNDArray[Self.cdtype]
@@ -2069,7 +2062,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
     ## compiler doesn't accept this.
     def __setitem__(
-        self, var *slices: Variant[Slice, Int], val: ComplexNDArray[Self.cdtype]
+        mut self,
+        var *slices: Variant[Slice, Int],
+        val: ComplexNDArray[Self.cdtype],
     ) raises:
         """
         Get items by a series of either slices or integers.
@@ -2109,7 +2104,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         # self.__setitem__(slices=slice_list, val=val)
         self[slice_list^] = val
 
-    def __setitem__(self, index: NDArray[DType.int], val: Self) raises:
+    def __setitem__(mut self, index: NDArray[DType.int], val: Self) raises:
         """
         Returns the items of the ComplexNDArray from an array of indices.
 
@@ -2126,9 +2121,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
     # TODO: implement itemset().
     def __setitem__(
-        mut self,
-        mask: ComplexNDArray[Self.cdtype],
-        val: ComplexNDArray[Self.cdtype],
+        mut self, mask: NDArray[DType.bool], val: ComplexNDArray[Self.cdtype]
     ) raises:
         """
         Set the value of the ComplexNDArray at the indices where the mask is true.
@@ -2141,11 +2134,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
             raise Error(message)
 
-        for i in range(mask.size):
-            if mask._re._buf.ptr.load(i):
-                self._re._buf.ptr.store(i, val._re._buf.ptr.load(i))
-            if mask._im._buf.ptr.load(i):
-                self._im._buf.ptr.store(i, val._im._buf.ptr.load(i))
+        var mask_c = mask.contiguous()
+        for i in range(mask_c.size):
+            if mask_c._buf.ptr.load[width=1](i):
+                self.itemset(i, val.item(i))
 
     def __pos__(self) raises -> Self:
         """

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -70,6 +70,7 @@ from numojo.routines.io.formatting import (
     PrintOptions,
 )
 import numojo.routines.logic.comparison as comparison
+import numojo.routines.logic.logical_ops as logical_ops
 
 # ===----------------------------------------------------------------------===#
 # === numojo routines (math / bitwise / searching) ===
@@ -2430,9 +2431,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         Itemwise equivalence.
         """
-        return comparison.equal[Self.dtype](
-            self._re, other._re
-        ) and comparison.equal[Self.dtype](self._im, other._im)
+        return logical_ops.logical_and(
+            comparison.equal[Self.dtype](self._re, other._re),
+            comparison.equal[Self.dtype](self._im, other._im),
+        )
 
     @always_inline("nodebug")
     def __eq__(
@@ -2441,18 +2443,20 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         Itemwise equivalence between scalar and ComplexNDArray.
         """
-        return comparison.equal[Self.dtype](
-            self._re, other.re
-        ) and comparison.equal[Self.dtype](self._im, other.im)
+        return logical_ops.logical_and(
+            comparison.equal[Self.dtype](self._re, other.re),
+            comparison.equal[Self.dtype](self._im, other.im),
+        )
 
     @always_inline("nodebug")
     def __ne__(self, other: Self) raises -> NDArray[DType.bool]:
         """
         Itemwise non-equivalence.
         """
-        return comparison.not_equal[Self.dtype](
-            self._re, other._re
-        ) or comparison.not_equal[Self.dtype](self._im, other._im)
+        return logical_ops.logical_or(
+            comparison.not_equal[Self.dtype](self._re, other._re),
+            comparison.not_equal[Self.dtype](self._im, other._im),
+        )
 
     @always_inline("nodebug")
     def __ne__(
@@ -2461,9 +2465,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         Itemwise non-equivalence between scalar and ComplexNDArray.
         """
-        return comparison.not_equal[Self.dtype](
-            self._re, other.re
-        ) or comparison.not_equal[Self.dtype](self._im, other.im)
+        return logical_ops.logical_or(
+            comparison.not_equal[Self.dtype](self._re, other.re),
+            comparison.not_equal[Self.dtype](self._im, other.im),
+        )
 
     @always_inline("nodebug")
     def __lt__(self, other: Self) raises -> NDArray[DType.bool]:
@@ -2473,7 +2478,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other._re)
         var re_eq = comparison.equal[Self.dtype](self._re, other._re)
         var im_lt = comparison.less[Self.dtype](self._im, other._im)
-        var result = re_lt^ or (re_eq^ and im_lt^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_lt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2483,7 +2490,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other.re)
         var re_eq = comparison.equal[Self.dtype](self._re, other.re)
         var im_lt = comparison.less[Self.dtype](self._im, other.im)
-        var result = re_lt^ or (re_eq^ and im_lt^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_lt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2491,7 +2500,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other)
         var re_eq = comparison.equal[Self.dtype](self._re, other)
         var im_lt = comparison.less[Self.dtype](self._im, 0)
-        var result = re_lt^ or (re_eq^ and im_lt^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_lt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2499,7 +2510,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other._re)
         var re_eq = comparison.equal[Self.dtype](self._re, other._re)
         var im_le = comparison.less_equal[Self.dtype](self._im, other._im)
-        var result = re_lt^ or (re_eq^ and im_le^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_le^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2509,7 +2522,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other.re)
         var re_eq = comparison.equal[Self.dtype](self._re, other.re)
         var im_le = comparison.less_equal[Self.dtype](self._im, other.im)
-        var result = re_lt^ or (re_eq^ and im_le^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_le^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2517,7 +2532,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_lt = comparison.less[Self.dtype](self._re, other)
         var re_eq = comparison.equal[Self.dtype](self._re, other)
         var im_le = comparison.less_equal[Self.dtype](self._im, 0)
-        var result = re_lt^ or (re_eq^ and im_le^)
+        var result = logical_ops.logical_or(
+            re_lt^, logical_ops.logical_and(re_eq^, im_le^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2525,7 +2542,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other._re)
         var re_eq = comparison.equal[Self.dtype](self._re, other._re)
         var im_gt = comparison.greater[Self.dtype](self._im, other._im)
-        var result = re_gt^ or (re_eq^ and im_gt^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_gt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2535,7 +2554,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other.re)
         var re_eq = comparison.equal[Self.dtype](self._re, other.re)
         var im_gt = comparison.greater[Self.dtype](self._im, other.im)
-        var result = re_gt^ or (re_eq^ and im_gt^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_gt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2543,7 +2564,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other)
         var re_eq = comparison.equal[Self.dtype](self._re, other)
         var im_gt = comparison.greater[Self.dtype](self._im, 0)
-        var result = re_gt^ or (re_eq^ and im_gt^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_gt^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2551,7 +2574,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other._re)
         var re_eq = comparison.equal[Self.dtype](self._re, other._re)
         var im_ge = comparison.greater_equal[Self.dtype](self._im, other._im)
-        var result = re_gt^ or (re_eq^ and im_ge^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_ge^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2561,7 +2586,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other.re)
         var re_eq = comparison.equal[Self.dtype](self._re, other.re)
         var im_ge = comparison.greater_equal[Self.dtype](self._im, other.im)
-        var result = re_gt^ or (re_eq^ and im_ge^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_ge^)
+        )
         return result^
 
     @always_inline("nodebug")
@@ -2569,7 +2596,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var re_gt = comparison.greater[Self.dtype](self._re, other)
         var re_eq = comparison.equal[Self.dtype](self._re, other)
         var im_ge = comparison.greater_equal[Self.dtype](self._im, 0)
-        var result = re_gt^ or (re_eq^ and im_ge^)
+        var result = logical_ops.logical_or(
+            re_gt^, logical_ops.logical_and(re_eq^, im_ge^)
+        )
         return result^
 
     # ===------------------------------------------------------------------=== #

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -448,6 +448,24 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.flags = take.flags
         self.print_options = take.print_options
 
+    def view(mut self) raises -> Self:
+        """
+        Create a non-owning view of the current ComplexNDArray.
+        Returns:
+            A new ComplexNDArray instance that shares the data buffers with
+            `self` and does not allocate new memory.
+        Example:
+            ```mojo
+            import numojo as nm
+            var arr = nm.ComplexNDArray[nm.cf32](nm.Shape(3, 4))
+            var v = arr.view()  # Create a view into arr
+            ```
+        """
+        return ComplexNDArray[Self.cdtype](
+            re=self._re.view(),
+            im=self._im.view(),
+        )
+        
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing
     # Getter dunders and other getter methods
@@ -3406,7 +3424,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                         "Index {} is out of bounds for array of size {}. Use an"
                         " index in [0, {})."
                     ).format(index, self.size, self.size),
-                    location="ComplexNDArray.itemset(index: Int, item: ComplexSIMD)",
+                    location=(
+                        "ComplexNDArray.itemset(index: Int, item: ComplexSIMD)"
+                    ),
                 )
             )
 

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3343,95 +3343,151 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             dimension=0,
         )
 
-    def itemset(
-        mut self,
-        index: Variant[Int, List[Int]],
-        item: ComplexSIMD[Self.cdtype],
-    ) raises:
-        """Set the scalar at the coordinates.
+    def itemset(mut self, index: Int, item: ComplexSIMD[Self.cdtype]) raises:
+        """Sets the scalar at the given coordinate.
 
         Args:
-            index: The coordinates of the item.
-                Can either be `Int` or `List[Int]`.
-                If `Int` is passed, it is the index of i-th item of the whole array.
-                If `List[Int]` is passed, it is the coordinate of the item.
-            item: The scalar to be set.
+            index: The linear index of the i-th item of the whole array.
+            item: The complex scalar to be set.
+
+        Raises:
+            Error: If the index is out of bounds.
+            Error: If the length of index does not match the number of
+                dimensions.
+
+        Examples:
+
+        ```
+        import numojo as nm
+        def main() raises:
+            var A = nm.zeros[nm.cf16](nm.Shape(3, 3))
+            print(A)
+            A.itemset(5, nm.ComplexSIMD[nm.f16](1.0, 2.0))
+            print(A)
+        ```
+        ```console
+        [[      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]]
+        2-D array  Shape: [3, 3]  DType: complex16
+        [[      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (1.0, 2.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]]
+        2-D array  Shape: [3, 3]  DType: complex16
+        ```.
         """
-
-        # If one index is given
-        if index.isa[Int]():
-            var idx: Int = index[Int]
-            if idx < self.size:
-                if self.flags[
-                    "F_CONTIGUOUS"
-                ]:  # column-major should be converted to row-major
-                    # The following code can be taken out as a function that
-                    # convert any index to coordinates according to the order
-                    var c_stride = NDArrayStrides(shape=self.shape)
-                    var c_coordinates = List[Int]()
-                    for i in range(c_stride.ndim):
-                        var coordinate = idx // c_stride[i]
-                        idx = idx - c_stride[i] * coordinate
-                        c_coordinates.append(coordinate)
-                    self._re._buf.ptr.store(
-                        IndexMethods.get_1d_index(c_coordinates, self.strides),
-                        item.re,
-                    )
-                    self._im._buf.ptr.store(
-                        IndexMethods.get_1d_index(c_coordinates, self.strides),
-                        item.im,
-                    )
-                else:
-                    self._re._buf.ptr.store(idx, item.re)
-                    self._im._buf.ptr.store(idx, item.im)
+        var norm_idx = self.normalize(index, self.size)
+        if norm_idx < self.size:
+            if self.flags.F_CONTIGUOUS:
+                var c_stride = NDArrayStrides(shape=self.shape)
+                var c_coordinates = List[Int]()
+                for i in range(c_stride.ndim):
+                    var coordinate = norm_idx // c_stride[i]
+                    norm_idx = norm_idx - c_stride[i] * coordinate
+                    c_coordinates.append(coordinate)
+                self._re._buf.ptr.store(
+                    self._re.offset
+                    + IndexMethods.get_1d_index(c_coordinates, self.strides),
+                    item.re,
+                )
+                self._im._buf.ptr.store(
+                    self._im.offset
+                    + IndexMethods.get_1d_index(c_coordinates, self.strides),
+                    item.im,
+                )
             else:
-                raise Error(
-                    NumojoError(
-                        category="index",
-                        message=String(
-                            "Linear index {} out of range for size {}. Valid"
-                            " linear indices: 0..{}."
-                        ).format(idx, self.size, self.size - 1),
-                        location="ComplexNDArray.itemset(Int)",
-                    )
+                self._re._buf.ptr.store(self._re.offset + norm_idx, item.re)
+                self._im._buf.ptr.store(self._im.offset + norm_idx, item.im)
+        else:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Index {} is out of bounds for array of size {}. Use an"
+                        " index in [0, {})."
+                    ).format(index, self.size, self.size),
+                    location="ComplexNDArray.itemset(index: Int, item: ComplexSIMD)",
                 )
+            )
 
-        elif index.isa[List[Int]]():
-            var indices: List[Int] = index[List[Int]].copy()
-            if indices.__len__() != self.ndim:
+    def itemset(
+        mut self, var indices: List[Int], item: ComplexSIMD[Self.cdtype]
+    ) raises:
+        """Sets the scalar at the given coordinates.
+
+        Args:
+            indices: The coordinates of the item.
+            item: The complex scalar to be set.
+
+        Raises:
+            Error: If the index is out of bounds.
+            Error: If the length of index does not match the number of
+                dimensions.
+
+        Notes:
+            This is similar to `numpy.ndarray.itemset`. The difference is that
+            we take `List[Int]`, but NumPy takes a tuple.
+
+        Examples:
+
+        ```
+        import numojo as nm
+        def main() raises:
+            var A = nm.zeros[nm.cf16](nm.Shape(3, 3))
+            print(A)
+            A.itemset(nm.List(1, 1), nm.ComplexSIMD[nm.f16](1.0, 2.0))
+            print(A)
+        ```
+        ```console
+        [[      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]]
+        2-D array  Shape: [3, 3]  DType: complex16
+        [[      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (1.0, 2.0)    (0.0, 0.0)    ]
+        [      (0.0, 0.0)    (0.0, 0.0)    (0.0, 0.0)    ]]
+        2-D array  Shape: [3, 3]  DType: complex16
+        ```.
+        """
+        if len(indices) != self.ndim:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Invalid index length: expected {} but got {}. Pass"
+                        " exactly {} indices (one per dimension)."
+                    ).format(self.ndim, indices.__len__(), self.ndim),
+                    location=(
+                        "ComplexNDArray.itemset(indices: List[Int], item:"
+                        " ComplexSIMD)"
+                    ),
+                )
+            )
+        for i in range(len(indices)):
+            var norm_idx = self.normalize(indices[i], self.shape[i])
+            if norm_idx >= self.shape[i]:
                 raise Error(
                     NumojoError(
                         category="index",
                         message=String(
-                            "Expected {} indices (ndim) but received {}."
-                            " Provide one index per dimension; shape {} has {}"
-                            " dimensions."
-                        ).format(
-                            self.ndim, indices.__len__(), self.shape, self.ndim
+                            "Index out of range at dim {}: got {}; valid"
+                            " range is (-{}..{})."
+                        ).format(i, indices[i], self.shape[i], self.shape[i]),
+                        location=(
+                            "ComplexNDArray.itemset(indices: List[Int],"
+                            " item: ComplexSIMD)"
                         ),
-                        location="ComplexNDArray.itemset(List[Int])",
                     )
                 )
-            for i in range(indices.__len__()):
-                if indices[i] >= self.shape[i]:
-                    raise Error(
-                        NumojoError(
-                            category="index",
-                            message=String(
-                                "Index {} out of range for dim {} (size {})."
-                                " Valid range: [0, {})."
-                            ).format(
-                                indices[i], i, self.shape[i], self.shape[i]
-                            ),
-                            location="ComplexNDArray.itemset(List[Int])",
-                        )
-                    )
-            self._re._buf.ptr.store(
-                IndexMethods.get_1d_index(indices, self.strides), item.re
-            )
-            self._im._buf.ptr.store(
-                IndexMethods.get_1d_index(indices, self.strides), item.im
-            )
+            indices[i] = norm_idx
+        self._re._buf.ptr.store(
+            self._re.offset + IndexMethods.get_1d_index(indices, self.strides),
+            item.re,
+        )
+        self._im._buf.ptr.store(
+            self._im.offset + IndexMethods.get_1d_index(indices, self.strides),
+            item.im,
+        )
 
     def conj(self) raises -> Self:
         """

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3274,8 +3274,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             Array of the same data with a new shape.
         """
         var result: Self = ComplexNDArray[Self.cdtype](
-            re=numojo.reshape(self._re.copy(), shape=shape, order=order),
-            im=numojo.reshape(self._im.copy(), shape=shape, order=order),
+            re=numojo.reshape(self._re, shape=shape, order=order),
+            im=numojo.reshape(self._im, shape=shape, order=order),
         )
         result._re.flags = self._re.flags
         result._im.flags = self._im.flags

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3618,6 +3618,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return ComplexSIMD[Self.cdtype](sum_re, sum_im)
 
+    def sum(self, axis: Int) raises -> Self:
+        return Self(self._re.sum(axis), self._im.sum(axis))
+
     def prod(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Product of all complex array elements.
@@ -3662,6 +3665,16 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var n = Scalar[Self.dtype](self.size)
         return ComplexSIMD[Self.cdtype](total.re / n, total.im / n)
 
+    def mean(self, axis: Int) raises -> Self:
+        var s = self.sum(axis)
+        var normalized_axis = axis
+        if normalized_axis < 0:
+            normalized_axis += self.ndim
+        if (normalized_axis < 0) or (normalized_axis >= self.ndim):
+            raise Error("Axis out of range in ComplexNDArray.mean(axis)")
+        var n = Scalar[Self.dtype](self.shape[normalized_axis])
+        return Self(s._re / n, s._im / n)
+
     def max(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Find the complex element with maximum magnitude.
@@ -3689,6 +3702,24 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 best = z
         return best
 
+    def max(self, axis: Int) raises -> Self:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = Self(out_shape)
+        for o in range(outer):
+            var base = o * axis_len
+            var best = transposed._flat_load(base)
+            for k in range(1, axis_len):
+                var z = transposed._flat_load(base + k)
+                if self._lex_greater(z, best):
+                    best = z
+            result._flat_store(o, best)
+        return result^
+
     def min(self) raises -> ComplexSIMD[Self.cdtype]:
         """
         Find the complex element with minimum magnitude.
@@ -3715,6 +3746,24 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             if self._lex_less(z, best):
                 best = z
         return best
+
+    def min(self, axis: Int) raises -> Self:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = Self(out_shape)
+        for o in range(outer):
+            var base = o * axis_len
+            var best = transposed._flat_load(base)
+            for k in range(1, axis_len):
+                var z = transposed._flat_load(base + k)
+                if self._lex_less(z, best):
+                    best = z
+            result._flat_store(o, best)
+        return result^
 
     def argmax(self) raises -> Int:
         """
@@ -3744,6 +3793,27 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return max_idx
 
+    def argmax(self, axis: Int) raises -> NDArray[DType.int]:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = NDArray[DType.int](out_shape)
+        for o in range(outer):
+            var base = o * axis_len
+            var best_rel = 0
+            var best = transposed._flat_load(base)
+            for k in range(1, axis_len):
+                var z = transposed._flat_load(base + k)
+                if self._lex_greater(z, best):
+                    best = z
+                    best_rel = k
+            result._buf.ptr[o] = Scalar[DType.int](best_rel)
+            # result.itemset(o, Scalar[DType.int](best_rel))
+        return result^
+
     def argmin(self) raises -> Int:
         """
         Return the index of the element with minimum magnitude.
@@ -3772,6 +3842,27 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         return min_idx
 
+    def argmin(self, axis: Int) raises -> NDArray[DType.int]:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = NDArray[DType.int](out_shape)
+        for o in range(outer):
+            var base = o * axis_len
+            var best_rel = 0
+            var best = transposed._flat_load(base)
+            for k in range(1, axis_len):
+                var z = transposed._flat_load(base + k)
+                if self._lex_less(z, best):
+                    best = z
+                    best_rel = k
+            result._buf.ptr[o] = Scalar[DType.int](best_rel)
+            # result.itemset(o, Scalar[DType.int](best_rel))
+        return result^
+
     def cumsum(self) raises -> Self:
         """
         Cumulative sum of complex array elements.
@@ -3790,6 +3881,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             For array [a, b, c, d], returns [a, a+b, a+b+c, a+b+c+d].
         """
         return Self(self._re.cumsum(), self._im.cumsum())
+
+    def cumsum(self, axis: Int) raises -> Self:
+        return Self(self._re.cumsum(axis), self._im.cumsum(axis))
 
     def cumprod(self) raises -> Self:
         """

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -4030,13 +4030,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-        var width: Int = self.shape[1]
-        var result = Self(Shape(width))
-        for i in range(width):
-            var idx = i + id * width
-            result._re._buf.ptr.store(i, self._re._buf.ptr.load(idx))
-            result._im._buf.ptr.store(i, self._im._buf.ptr.load(idx))
-        return result^
+        return Self(self._re.row(id), self._im.row(id))
 
     def col(self, id: Int) raises -> Self:
         """
@@ -4070,14 +4064,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-        var width: Int = self.shape[1]
-        var height: Int = self.shape[0]
-        var result = Self(Shape(height))
-        for i in range(height):
-            var idx = id + i * width
-            result._re._buf.ptr.store(i, self._re._buf.ptr.load(idx))
-            result._im._buf.ptr.store(i, self._im._buf.ptr.load(idx))
-        return result^
+        return Self(self._re.col(id), self._im.col(id))
 
     def clip(
         self, a_min: Scalar[Self.dtype], a_max: Scalar[Self.dtype]
@@ -4223,8 +4210,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-        var diag_re = self[Self.dtype]._re.diagonal(offset)
-        var diag_im = self[Self.dtype]._im.diagonal(offset)
+        var diag_re = self._re.diagonal(offset)
+        var diag_im = self._im.diagonal(offset)
         return Self(diag_re^, diag_im^)
 
     def trace(self) raises -> ComplexSIMD[Self.cdtype]:
@@ -4265,6 +4252,58 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         for i in range(self.size):
             result.append(self._flat_load(i))
         return result^
+
+    def astype[target: ComplexDType](self) raises -> ComplexNDArray[target]:
+        """Casts this complex array to another complex dtype."""
+        return creation.astype[target](self)
+
+    def compress(
+        self, condition: NDArray[DType.bool], axis: Int
+    ) raises -> Self:
+        return Self(
+            self._re.compress(condition, axis),
+            self._im.compress(condition, axis),
+        )
+
+    def compress(self, condition: NDArray[DType.bool]) raises -> Self:
+        return Self(self._re.compress(condition), self._im.compress(condition))
+
+    def contiguous(self) raises -> Self:
+        return Self(self._re.contiguous(), self._im.contiguous())
+
+    def is_c_contiguous(self) -> Bool:
+        return self._re.is_c_contiguous()
+
+    def is_f_contiguous(self) -> Bool:
+        return self._re.is_f_contiguous()
+
+    def is_row_contiguous(self) -> Bool:
+        return self._re.is_row_contiguous()
+
+    def is_col_contiguous(self) -> Bool:
+        return self._re.is_col_contiguous()
+
+    def unsafe_load[
+        width: Int = 1
+    ](self, index: Int) -> ComplexSIMD[Self.cdtype, width]:
+        return ComplexSIMD[Self.cdtype, width](
+            self._re.unsafe_load[width=width](index),
+            self._im.unsafe_load[width=width](index),
+        )
+
+    def unsafe_store[
+        width: Int = 1
+    ](mut self, index: Int, val: ComplexSIMD[Self.cdtype, width]):
+        self._re.unsafe_store[width=width](index, val.re)
+        self._im.unsafe_store[width=width](index, val.im)
+
+    def to_numpy(self) raises -> PythonObject:
+        var np = Python.import_module("numpy")
+        var builtins = Python.import_module("builtins")
+        var re_np = self._re.to_numpy()
+        var im_np = self._im.to_numpy()
+        var imag_unit = builtins.complex(0, 1)
+        return re_np + im_np * imag_unit
 
     def argsort(self) raises -> NDArray[DType.int]:
         return self.argsort(axis=-1)

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3560,8 +3560,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ```
         """
         for i in range(self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
+            var z = self._flat_load(i)
+            var re_val = z.re
+            var im_val = z.im
             if (re_val == 0.0) and (im_val == 0.0):
                 return False
         return True
@@ -3585,8 +3586,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         ```
         """
         for i in range(self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
+            var z = self._flat_load(i)
+            var re_val = z.re
+            var im_val = z.im
             if (re_val != 0.0) or (im_val != 0.0):
                 return True
         return False
@@ -3608,9 +3610,11 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var sum_re = Scalar[Self.dtype](0)
         var sum_im = Scalar[Self.dtype](0)
 
+        # TODO: could vectorize this!
         for i in range(self.size):
-            sum_re += self._re._buf.ptr.load(i)
-            sum_im += self._im._buf.ptr.load(i)
+            var z = self._flat_load(i)
+            sum_re += z.re
+            sum_im += z.im
 
         return ComplexSIMD[Self.cdtype](sum_re, sum_im)
 
@@ -3632,10 +3636,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var prod_im = Scalar[Self.dtype](0)
 
         for i in range(self.size):
-            var a_re = self._re._buf.ptr.load(i)
-            var a_im = self._im._buf.ptr.load(i)
-            var new_re = prod_re * a_re - prod_im * a_im
-            var new_im = prod_re * a_im + prod_im * a_re
+            var a = self._flat_load(i)
+            var new_re = prod_re * a.re - prod_im * a.im
+            var new_im = prod_re * a.im + prod_im * a.re
             prod_re = new_re
             prod_im = new_im
 
@@ -3679,22 +3682,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.size == 0:
             raise Error("Cannot find max of empty array")
 
-        var max_mag_sq = self._re._buf.ptr.load(0) * self._re._buf.ptr.load(
-            0
-        ) + self._im._buf.ptr.load(0) * self._im._buf.ptr.load(0)
-        var max_idx = 0
-
+        var best = self._flat_load(0)
         for i in range(1, self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
-            var mag_sq = re_val * re_val + im_val * im_val
-            if mag_sq > max_mag_sq:
-                max_mag_sq = mag_sq
-                max_idx = i
-
-        return ComplexSIMD[Self.cdtype](
-            self._re._buf.ptr.load(max_idx), self._im._buf.ptr.load(max_idx)
-        )
+            var z = self._flat_load(i)
+            if self._lex_greater(z, best):
+                best = z
+        return best
 
     def min(self) raises -> ComplexSIMD[Self.cdtype]:
         """
@@ -3716,22 +3709,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.size == 0:
             raise Error("Cannot find min of empty array")
 
-        var min_mag_sq = self._re._buf.ptr.load(0) * self._re._buf.ptr.load(
-            0
-        ) + self._im._buf.ptr.load(0) * self._im._buf.ptr.load(0)
-        var min_idx = 0
-
+        var best = self._flat_load(0)
         for i in range(1, self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
-            var mag_sq = re_val * re_val + im_val * im_val
-            if mag_sq < min_mag_sq:
-                min_mag_sq = mag_sq
-                min_idx = i
-
-        return ComplexSIMD[Self.cdtype](
-            self._re._buf.ptr.load(min_idx), self._im._buf.ptr.load(min_idx)
-        )
+            var z = self._flat_load(i)
+            if self._lex_less(z, best):
+                best = z
+        return best
 
     def argmax(self) raises -> Int:
         """
@@ -3753,17 +3736,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.size == 0:
             raise Error("Cannot find argmax of empty array")
 
-        var max_mag_sq = self._re._buf.ptr.load(0) * self._re._buf.ptr.load(
-            0
-        ) + self._im._buf.ptr.load(0) * self._im._buf.ptr.load(0)
         var max_idx = 0
 
         for i in range(1, self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
-            var mag_sq = re_val * re_val + im_val * im_val
-            if mag_sq > max_mag_sq:
-                max_mag_sq = mag_sq
+            if self._lex_greater(self._flat_load(i), self._flat_load(max_idx)):
                 max_idx = i
 
         return max_idx
@@ -3788,17 +3764,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.size == 0:
             raise Error("Cannot find argmin of empty array")
 
-        var min_mag_sq = self._re._buf.ptr.load(0) * self._re._buf.ptr.load(
-            0
-        ) + self._im._buf.ptr.load(0) * self._im._buf.ptr.load(0)
         var min_idx = 0
 
         for i in range(1, self.size):
-            var re_val = self._re._buf.ptr.load(i)
-            var im_val = self._im._buf.ptr.load(i)
-            var mag_sq = re_val * re_val + im_val * im_val
-            if mag_sq < min_mag_sq:
-                min_mag_sq = mag_sq
+            if self._lex_less(self._flat_load(i), self._flat_load(min_idx)):
                 min_idx = i
 
         return min_idx
@@ -3820,17 +3789,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         Notes:
             For array [a, b, c, d], returns [a, a+b, a+b+c, a+b+c+d].
         """
-        var result = Self(self.shape)
-        var cum_re = Scalar[Self.dtype](0)
-        var cum_im = Scalar[Self.dtype](0)
-
-        for i in range(self.size):
-            cum_re += self._re._buf.ptr.load(i)
-            cum_im += self._im._buf.ptr.load(i)
-            result._re._buf.ptr.store(i, cum_re)
-            result._im._buf.ptr.store(i, cum_im)
-
-        return result^
+        return Self(self._re.cumsum(), self._im.cumsum())
 
     def cumprod(self) raises -> Self:
         """
@@ -3850,19 +3809,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             For array [a, b, c, d], returns [a, a*b, a*b*c, a*b*c*d].
         """
         var result = Self(self.shape)
-        var cum_re = Scalar[Self.dtype](1)
-        var cum_im = Scalar[Self.dtype](0)
-
+        var cum = ComplexSIMD[Self.cdtype](1, 0)
         for i in range(self.size):
-            var a_re = self._re._buf.ptr.load(i)
-            var a_im = self._im._buf.ptr.load(i)
-            var new_re = cum_re * a_re - cum_im * a_im
-            var new_im = cum_re * a_im + cum_im * a_re
-            cum_re = new_re
-            cum_im = new_im
-            result._re._buf.ptr.store(i, cum_re)
-            result._im._buf.ptr.store(i, cum_im)
-
+            var a = self._flat_load(i)
+            cum = ComplexSIMD[Self.cdtype](
+                cum.re * a.re - cum.im * a.im, cum.re * a.im + cum.im * a.re
+            )
+            result._flat_store(i, cum)
         return result^
 
     # ===-------------------------------------------------------------------===#
@@ -4172,11 +4125,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         var result = List[ComplexSIMD[Self.cdtype]](capacity=self.size)
         for i in range(self.size):
-            result.append(
-                ComplexSIMD[Self.cdtype](
-                    self._re._buf.ptr.load(i), self._im._buf.ptr.load(i)
-                )
-            )
+            result.append(self._flat_load(i))
         return result^
 
     def num_elements(self) -> Int:

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -451,21 +451,23 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     def view(mut self) raises -> Self:
         """
         Create a non-owning view of the current ComplexNDArray.
+
         Returns:
             A new ComplexNDArray instance that shares the data buffers with
-            `self` and does not allocate new memory.
-        Example:
+            `self` and does not allocate new memory
+
+        Examples:
             ```mojo
             import numojo as nm
             var arr = nm.ComplexNDArray[nm.cf32](nm.Shape(3, 4))
-            var v = arr.view()  # Create a view into arr
+            var v = arr.view()  # Create a view into arr.
             ```
         """
         return ComplexNDArray[Self.cdtype](
             re=self._re.view(),
             im=self._im.view(),
         )
-        
+
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing
     # Getter dunders and other getter methods
@@ -3339,7 +3341,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
 
         return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
-            self,
+            Pointer(to=self),
             dimension=0,
         )
 
@@ -3357,7 +3359,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
 
         return _ComplexNDArrayIter[origin_of(self), Self.cdtype, forward=False](
-            self,
+            Pointer(to=self),
             dimension=0,
         )
 
@@ -4272,7 +4274,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
 
 struct _ComplexNDArrayIter[
-    origin: MutOrigin,
+    is_mutable: Bool,
+    //,
+    origin: Origin[mut=is_mutable],
     cdtype: ComplexDType,
     forward: Bool = True,
 ](Copyable, Movable):
@@ -4286,6 +4290,7 @@ struct _ComplexNDArrayIter[
     It trys to create a view where possible.
 
     Parameters:
+        is_mutable: Whether the iterator allows mutation of the underlying data.
         origin: The lifetime of the underlying NDArray data.
         cdtype: The complex data type of the item.
         forward: The iteration direction. `False` is backwards.
@@ -4295,8 +4300,10 @@ struct _ComplexNDArrayIter[
 
     # FIELDS
     var index: Int
-    var re_ptr: UnsafePointer[Scalar[Self.dtype], origin=Self.origin]
-    var im_ptr: UnsafePointer[Scalar[Self.dtype], origin=Self.origin]
+    var _re_buf: DataContainer[Self.dtype]
+    var _im_buf: DataContainer[Self.dtype]
+    var offset: Int
+    """Offset of the first element in the data buffer."""
     var dimension: Int
     var length: Int
     var shape: NDArrayShape
@@ -4306,7 +4313,9 @@ struct _ComplexNDArrayIter[
     var size_of_item: Int
 
     def __init__(
-        out self, read a: ComplexNDArray[Self.cdtype], read dimension: Int
+        out self,
+        a: Pointer[ComplexNDArray[Self.cdtype], Self.origin],
+        dimension: Int,
     ) raises:
         """
         Initialize the iterator.
@@ -4316,7 +4325,7 @@ struct _ComplexNDArrayIter[
             dimension: Dimension to iterate over.
         """
 
-        if dimension < 0 or dimension >= a.ndim:
+        if dimension < 0 or dimension >= a[].ndim:
             raise Error(
                 NumojoError(
                     category="index",
@@ -4324,22 +4333,27 @@ struct _ComplexNDArrayIter[
                         "Axis {} out of valid range [0, {}). Valid axes: 0..{}."
                         " Use {} for last axis of shape {}."
                     ).format(
-                        dimension, a.ndim, a.ndim - 1, a.ndim - 1, a.shape
+                        dimension,
+                        a[].ndim,
+                        a[].ndim - 1,
+                        a[].ndim - 1,
+                        a[].shape,
                     ),
                     location="_ComplexNDArrayIter.__init__",
                 )
             )
 
-        self.re_ptr = a._re.unsafe_ptr().unsafe_origin_cast[Self.origin]()
-        self.im_ptr = a._im.unsafe_ptr().unsafe_origin_cast[Self.origin]()
+        self._re_buf = a[]._re._buf.copy()
+        self._im_buf = a[]._im._buf.copy()
+        self.offset = a[]._re.offset
         self.dimension = dimension
-        self.shape = a.shape
-        self.strides = a.strides
-        self.ndim = a.ndim
-        self.length = a.shape[dimension]
-        self.size_of_item = a.size // a.shape[dimension]
+        self.shape = a[].shape
+        self.strides = a[].strides
+        self.ndim = a[].ndim
+        self.length = a[].shape[dimension]
+        self.size_of_item = a[].size // a[].shape[dimension]
         # Status of the iterator
-        self.index = 0 if Self.forward else a.shape[dimension] - 1
+        self.index = 0 if Self.forward else a[].shape[dimension] - 1
 
     def __iter__(self) -> Self:
         return self.copy()
@@ -4368,12 +4382,11 @@ struct _ComplexNDArrayIter[
                         Scalar[DType.int](current_index)
                     )
 
-            (result._re._buf.ptr + offset).init_pointee_copy(
-                self.re_ptr[IndexMethods.get_1d_index(item, self.strides)]
+            var idx = self.offset + IndexMethods.get_1d_index(
+                item, self.strides
             )
-            (result._im._buf.ptr + offset).init_pointee_copy(
-                self.im_ptr[IndexMethods.get_1d_index(item, self.strides)]
-            )
+            result._re._buf.ptr[offset] = self._re_buf[idx]
+            result._im._buf.ptr[offset] = self._im_buf[idx]
         return result^
 
     @always_inline
@@ -4432,16 +4445,18 @@ struct _ComplexNDArrayIter[
                             Scalar[DType.int](index)
                         )
 
-                (result._re._buf.ptr + offset).init_pointee_copy(
-                    self.re_ptr[IndexMethods.get_1d_index(item, self.strides)]
+                var idx = self.offset + IndexMethods.get_1d_index(
+                    item, self.strides
                 )
-                (result._im._buf.ptr + offset).init_pointee_copy(
-                    self.im_ptr[IndexMethods.get_1d_index(item, self.strides)]
-                )
+                result._re._buf.ptr[offset] = self._re_buf[idx]
+                result._im._buf.ptr[offset] = self._im_buf[idx]
             return result^
 
         else:  # 0-D array
             var result = numojo.creation._0darray[Self.cdtype](
-                ComplexSIMD[Self.cdtype](self.re_ptr[index], self.im_ptr[index])
+                ComplexSIMD[Self.cdtype](
+                    self._re_buf.ptr[self.offset + index],
+                    self._im_buf.ptr[self.offset + index],
+                )
             )
             return result^

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -2452,7 +2452,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         return comparison.not_equal[Self.dtype](
             self._re, other._re
-        ) and comparison.not_equal[Self.dtype](self._im, other._im)
+        ) or comparison.not_equal[Self.dtype](self._im, other._im)
 
     @always_inline("nodebug")
     def __ne__(
@@ -2463,244 +2463,114 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         return comparison.not_equal[Self.dtype](
             self._re, other.re
-        ) and comparison.not_equal[Self.dtype](self._im, other.im)
+        ) or comparison.not_equal[Self.dtype](self._im, other.im)
 
     @always_inline("nodebug")
     def __lt__(self, other: Self) raises -> NDArray[DType.bool]:
         """
-        Itemwise less than comparison by magnitude.
-
-        For complex numbers, compares the magnitudes: |self| < |other|.
-        This provides a natural ordering for complex numbers.
-
-        Args:
-            other: The other ComplexNDArray to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| < |other|.
-
-        Examples:
-        ```mojo
-        import numojo as nm
-        var A = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var B = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var result = A < B  # Compare by magnitude
-        ```
-
-        Notes:
-            Complex number ordering is not naturally defined. This implementation
-            compares by magnitude (absolute value) to provide a consistent ordering.
+        NumPy-style lexicographic ordering: compare real part first, then imaginary part.
         """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other._re * other._re + other._im * other._im
-        return comparison.less[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other._re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other._re)
+        var im_lt = comparison.less[Self.dtype](self._im, other._im)
+        var result = re_lt^ or (re_eq^ and im_lt^)
+        return result^
 
     @always_inline("nodebug")
     def __lt__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
-        """
-        Itemwise less than comparison with scalar by magnitude.
-
-        Args:
-            other: The ComplexSIMD scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| < |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other.re * other.re + other.im * other.im
-        return comparison.less[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other.re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other.re)
+        var im_lt = comparison.less[Self.dtype](self._im, other.im)
+        var result = re_lt^ or (re_eq^ and im_lt^)
+        return result^
 
     @always_inline("nodebug")
     def __lt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
-        """
-        Itemwise less than comparison with real scalar by magnitude.
-
-        Args:
-            other: The real scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| < |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other * other
-        return comparison.less[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other)
+        var re_eq = comparison.equal[Self.dtype](self._re, other)
+        var im_lt = comparison.less[Self.dtype](self._im, 0)
+        var result = re_lt^ or (re_eq^ and im_lt^)
+        return result^
 
     @always_inline("nodebug")
     def __le__(self, other: Self) raises -> NDArray[DType.bool]:
-        """
-        Itemwise less than or equal comparison by magnitude.
-
-        For complex numbers, compares the magnitudes: |self| <= |other|.
-
-        Args:
-            other: The other ComplexNDArray to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| <= |other|.
-
-        Examples:
-        ```mojo
-        import numojo as nm
-        var A = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var B = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var result = A <= B  # Compare by magnitude
-        ```
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other._re * other._re + other._im * other._im
-        return comparison.less_equal[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other._re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other._re)
+        var im_le = comparison.less_equal[Self.dtype](self._im, other._im)
+        var result = re_lt^ or (re_eq^ and im_le^)
+        return result^
 
     @always_inline("nodebug")
     def __le__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
-        """
-        Itemwise less than or equal comparison with scalar by magnitude.
-
-        Args:
-            other: The ComplexSIMD scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| <= |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other.re * other.re + other.im * other.im
-        return comparison.less_equal[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other.re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other.re)
+        var im_le = comparison.less_equal[Self.dtype](self._im, other.im)
+        var result = re_lt^ or (re_eq^ and im_le^)
+        return result^
 
     @always_inline("nodebug")
     def __le__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
-        """
-        Itemwise less than or equal comparison with real scalar by magnitude.
-
-        Args:
-            other: The real scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| <= |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other * other
-        return comparison.less_equal[Self.dtype](self_mag, other_mag)
+        var re_lt = comparison.less[Self.dtype](self._re, other)
+        var re_eq = comparison.equal[Self.dtype](self._re, other)
+        var im_le = comparison.less_equal[Self.dtype](self._im, 0)
+        var result = re_lt^ or (re_eq^ and im_le^)
+        return result^
 
     @always_inline("nodebug")
     def __gt__(self, other: Self) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than comparison by magnitude.
-
-        For complex numbers, compares the magnitudes: |self| > |other|.
-
-        Args:
-            other: The other ComplexNDArray to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| > |other|.
-
-        Examples:
-        ```mojo
-        import numojo as nm
-        var A = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var B = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var result = A > B  # Compare by magnitude
-        ```
-
-        Notes:
-            Complex number ordering is not naturally defined. This implementation
-            compares by magnitude (absolute value) to provide a consistent ordering.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other._re * other._re + other._im * other._im
-        return comparison.greater[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other._re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other._re)
+        var im_gt = comparison.greater[Self.dtype](self._im, other._im)
+        var result = re_gt^ or (re_eq^ and im_gt^)
+        return result^
 
     @always_inline("nodebug")
     def __gt__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than comparison with scalar by magnitude.
-
-        Args:
-            other: The ComplexSIMD scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| > |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other.re * other.re + other.im * other.im
-        return comparison.greater[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other.re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other.re)
+        var im_gt = comparison.greater[Self.dtype](self._im, other.im)
+        var result = re_gt^ or (re_eq^ and im_gt^)
+        return result^
 
     @always_inline("nodebug")
     def __gt__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than comparison with real scalar by magnitude.
-
-        Args:
-            other: The real scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| > |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other * other
-        return comparison.greater[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other)
+        var re_eq = comparison.equal[Self.dtype](self._re, other)
+        var im_gt = comparison.greater[Self.dtype](self._im, 0)
+        var result = re_gt^ or (re_eq^ and im_gt^)
+        return result^
 
     @always_inline("nodebug")
     def __ge__(self, other: Self) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than or equal comparison by magnitude.
-
-        For complex numbers, compares the magnitudes: |self| >= |other|.
-
-        Args:
-            other: The other ComplexNDArray to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| >= |other|.
-
-        Examples:
-        ```mojo
-        import numojo as nm
-        var A = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var B = nm.ComplexNDArray[nm.cf64](nm.Shape(2, 2))
-        var result = A >= B  # Compare by magnitude
-        ```
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other._re * other._re + other._im * other._im
-        return comparison.greater_equal[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other._re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other._re)
+        var im_ge = comparison.greater_equal[Self.dtype](self._im, other._im)
+        var result = re_gt^ or (re_eq^ and im_ge^)
+        return result^
 
     @always_inline("nodebug")
     def __ge__(
         self, other: ComplexSIMD[Self.cdtype]
     ) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than or equal comparison with scalar by magnitude.
-
-        Args:
-            other: The ComplexSIMD scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| >= |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other.re * other.re + other.im * other.im
-        return comparison.greater_equal[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other.re)
+        var re_eq = comparison.equal[Self.dtype](self._re, other.re)
+        var im_ge = comparison.greater_equal[Self.dtype](self._im, other.im)
+        var result = re_gt^ or (re_eq^ and im_ge^)
+        return result^
 
     @always_inline("nodebug")
     def __ge__(self, other: Scalar[Self.dtype]) raises -> NDArray[DType.bool]:
-        """
-        Itemwise greater than or equal comparison with real scalar by magnitude.
-
-        Args:
-            other: The real scalar to compare with.
-
-        Returns:
-            An array of boolean values indicating where |self| >= |other|.
-        """
-        var self_mag = self._re * self._re + self._im * self._im
-        var other_mag = other * other
-        return comparison.greater_equal[Self.dtype](self_mag, other_mag)
+        var re_gt = comparison.greater[Self.dtype](self._re, other)
+        var re_eq = comparison.equal[Self.dtype](self._re, other)
+        var im_ge = comparison.greater_equal[Self.dtype](self._im, 0)
+        var result = re_gt^ or (re_eq^ and im_ge^)
+        return result^
 
     # ===------------------------------------------------------------------=== #
     # ARITHMETIC OPERATIONS

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3281,39 +3281,39 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         result._im.flags = self._im.flags
         return result^
 
-    #     def __iter__(
-    #         mut self,
-    #     ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
-    #         """
-    #         Iterates over elements of the ComplexNDArray and return sub-arrays as view.
-    #
-    #         Returns:
-    #             An iterator of ComplexNDArray elements.
-    #         """
-    #
-    #         return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
-    #             Pointer(to=self),
-    #             dimension=0,
-    #         )
-    #
-    #     def __reversed__(
-    #         mut self,
-    #     ) raises -> _ComplexNDArrayIter[
-    #         origin_of(self), Self.cdtype, forward=False
-    #     ]:
-    #         """
-    #         Iterates backwards over elements of the ComplexNDArray, returning
-    #         copied value.
-    #
-    #         Returns:
-    #             A reversed iterator of NDArray elements.
-    #         """
-    #
-    #         return _ComplexNDArrayIter[origin_of(self), Self.cdtype, forward=False](
-    #             Pointer(to=self),
-    #             dimension=0,
-    #         )
-    #
+    # def __iter__(
+    #     mut self,
+    # ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
+    #     """
+    #     Iterates over elements of the ComplexNDArray and return sub-arrays as view.
+
+    #     Returns:
+    #         An iterator of ComplexNDArray elements.
+    #     """
+
+    #     return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
+    #         Pointer(to=self),
+    #         dimension=0,
+    #     )
+
+    # def __reversed__(
+    #     mut self,
+    # ) raises -> _ComplexNDArrayIter[
+    #     origin_of(self), Self.cdtype, forward=False
+    # ]:
+    #     """
+    #     Iterates backwards over elements of the ComplexNDArray, returning
+    #     copied value.
+
+    #     Returns:
+    #         A reversed iterator of NDArray elements.
+    #     """
+
+    #     return _ComplexNDArrayIter[origin_of(self), Self.cdtype, forward=False](
+    #         Pointer(to=self),
+    #         dimension=0,
+    #     )
+
     def itemset(mut self, index: Int, item: ComplexSIMD[Self.cdtype]) raises:
         """Sets the scalar at the given coordinate.
 
@@ -4297,6 +4297,16 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self._re.unsafe_store[width=width](index, val.re)
         self._im.unsafe_store[width=width](index, val.im)
 
+    # def unsafe_ptr(
+    #     ref self, part: String = "re"
+    # ) raises -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
+    #     if part == "re":
+    #         return self._re.unsafe_ptr()
+    #     elif part == "im":
+    #         return self._im.unsafe_ptr()
+    #     else:
+    #         raise Error("part must be either 're' or 'im' in unsafe_ptr")
+
     def to_numpy(self) raises -> PythonObject:
         var np = Python.import_module("numpy")
         var builtins = Python.import_module("builtins")
@@ -4304,6 +4314,35 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var im_np = self._im.to_numpy()
         var imag_unit = builtins.complex(0, 1)
         return re_np + im_np * imag_unit
+
+    # def iter_over_dimension(
+    #     read self, dimension: Int = 0
+    # ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
+    #     var normalized_dim = dimension
+    #     if normalized_dim < 0:
+    #         normalized_dim += self.ndim
+    #     if (normalized_dim >= self.ndim) or (normalized_dim < 0):
+    #         raise Error(
+    #             String(
+    #                 "\nError in `ComplexNDArray.iter_over_dimension()`: "
+    #                 "Axis ({}) is not in valid range [{}, {})."
+    #             ).format(dimension, -self.ndim, self.ndim)
+    #         )
+    #     return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
+    #         a=Pointer(to=self), dimension=normalized_dim
+    #     )
+
+    # def iter_along_axis(
+    #     read self, axis: Int = 0
+    # ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
+    #     return self.iter_over_dimension(axis)
+
+    # def nditer(
+    #     read self,
+    # ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
+    #     if self.ndim == 0:
+    #         raise Error("nditer is undefined for 0D ComplexNDArray.")
+    #     return self.iter_over_dimension(0)
 
     def argsort(self) raises -> NDArray[DType.int]:
         return self.argsort(axis=-1)
@@ -4412,6 +4451,102 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     ),
                 )
         return result^
+
+    # def std[
+    #     returned_dtype: DType = DType.float64
+    # ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
+    #     var v = self.variance[returned_dtype](ddof=ddof)
+    #     return sqrt(Scalar[returned_dtype](v))
+
+    # def std[
+    #     returned_dtype: DType = DType.float64
+    # ](self, axis: Int, ddof: Int = 0) raises -> NDArray[returned_dtype]:
+    #     return misc.sqrt[returned_dtype](
+    #         self.variance[returned_dtype](axis, ddof)
+    #     )
+
+    # def variance[
+    #     returned_dtype: DType = DType.float64
+    # ](self, ddof: Int = 0) raises -> Scalar[returned_dtype]:
+    #     if self.size == 0:
+    #         raise Error("variance is undefined for an empty ComplexNDArray.")
+    #     if ddof < 0:
+    #         raise Error("ddof must be non-negative in ComplexNDArray.variance.")
+    #     var denom = self.size - ddof
+    #     if denom <= 0:
+    #         raise Error(
+    #             String(
+    #                 "ddof={} is too large for size {}. Need size - ddof > 0."
+    #             ).format(ddof, self.size)
+    #         )
+
+    #     var sum_re = Scalar[returned_dtype](0)
+    #     var sum_im = Scalar[returned_dtype](0)
+    #     for i in range(self.size):
+    #         var z = self._flat_load(i)
+    #         sum_re += Scalar[returned_dtype](z.re)
+    #         sum_im += Scalar[returned_dtype](z.im)
+
+    #     var n = Scalar[returned_dtype](self.size)
+    #     var mean_re = sum_re / n
+    #     var mean_im = sum_im / n
+
+    #     var acc = Scalar[returned_dtype](0)
+    #     for i in range(self.size):
+    #         var z = self._flat_load(i)
+    #         var dr = Scalar[returned_dtype](z.re) - mean_re
+    #         var di = Scalar[returned_dtype](z.im) - mean_im
+    #         acc += dr * dr + di * di
+
+    #     return acc / Scalar[returned_dtype](denom)
+
+    # def variance[
+    #     returned_dtype: DType = DType.float64
+    # ](self, axis: Int, ddof: Int = 0) raises -> NDArray[returned_dtype]:
+    #     if ddof < 0:
+    #         raise Error("ddof must be non-negative in ComplexNDArray.variance.")
+
+    #     var normalized_axis = self._normalize_axis(axis)
+    #     var axes = self._permute_axis_to_last(normalized_axis)
+    #     var transposed = self.T(axes)
+    #     var axis_len = self.shape[normalized_axis]
+    #     var denom = axis_len - ddof
+    #     if denom <= 0:
+    #         raise Error(
+    #             String(
+    #                 "ddof={} is too large for axis length {}. Need n - ddof"
+    #                 " > 0."
+    #             ).format(ddof, axis_len)
+    #         )
+
+    #     var outer = self.size // axis_len
+    #     var out_shape = self.shape.pop(normalized_axis)
+    #     var result = NDArray[returned_dtype](out_shape)
+
+    #     for o in range(outer):
+    #         var base = o * axis_len
+    #         var sum_re = Scalar[returned_dtype](0)
+    #         var sum_im = Scalar[returned_dtype](0)
+
+    #         for k in range(axis_len):
+    #             var z = transposed._flat_load(base + k)
+    #             sum_re += Scalar[returned_dtype](z.re)
+    #             sum_im += Scalar[returned_dtype](z.im)
+
+    #         var n = Scalar[returned_dtype](axis_len)
+    #         var mean_re = sum_re / n
+    #         var mean_im = sum_im / n
+
+    #         var acc = Scalar[returned_dtype](0)
+    #         for k in range(axis_len):
+    #             var z = transposed._flat_load(base + k)
+    #             var dr = Scalar[returned_dtype](z.re) - mean_re
+    #             var di = Scalar[returned_dtype](z.im) - mean_im
+    #             acc += dr * dr + di * di
+
+    #         result._buf.ptr[o] = acc / Scalar[returned_dtype](denom)
+
+    #     return result^
 
     def num_elements(self) -> Int:
         """

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -449,13 +449,28 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.flags = take.flags
         self.print_options = take.print_options
 
+    @always_inline("nodebug")
+    def __del__(deinit self):
+        """Destroys array buffers."""
+        _ = self._re^
+        _ = self._im^
+
+    def deep_copy(self) raises -> Self:
+        """
+        Create a deep copy of this ComplexNDArray.
+        """
+        return Self(
+            re=self._re.deep_copy(),
+            im=self._im.deep_copy(),
+        )
+
     def view(mut self) raises -> Self:
         """
         Create a non-owning view of the current ComplexNDArray.
 
         Returns:
             A new ComplexNDArray instance that shares the data buffers with
-            `self` and does not allocate new memory
+            `self` and does not allocate new memory.
 
         Examples:
             ```mojo
@@ -468,6 +483,79 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             re=self._re.view(),
             im=self._im.view(),
         )
+
+    @always_inline("nodebug")
+    def _flat_offset(self, flat_index: Int) -> Int:
+        """
+        Return backing-buffer offset for logical C-order flat index.
+        """
+        var remainder = flat_index
+        var offset = self._re.offset
+        for dim in range(self.ndim - 1, -1, -1):
+            var dim_size = Int(self.shape.unsafe_load(dim))
+            var coord = remainder % dim_size
+            remainder = remainder // dim_size
+            offset += coord * Int(self.strides.unsafe_load(dim))
+        return offset
+
+    @always_inline("nodebug")
+    def _flat_load(self, flat_index: Int) -> ComplexSIMD[Self.cdtype]:
+        """Stride-safe logical flat load."""
+        var off = self._flat_offset(flat_index)
+        return ComplexSIMD[Self.cdtype](
+            self._re._buf.ptr[off], self._im._buf.ptr[off]
+        )
+
+    @always_inline("nodebug")
+    def _flat_store(mut self, flat_index: Int, value: ComplexSIMD[Self.cdtype]):
+        """Stride-safe logical flat store."""
+        var off = self._flat_offset(flat_index)
+        self._re._buf.ptr[off] = value.re
+        self._im._buf.ptr[off] = value.im
+
+    @always_inline("nodebug")
+    def _lex_less(
+        self, a: ComplexSIMD[Self.cdtype], b: ComplexSIMD[Self.cdtype]
+    ) -> Bool:
+        return (a.re < b.re) or ((a.re == b.re) and (a.im < b.im))
+
+    @always_inline("nodebug")
+    def _lex_greater(
+        self, a: ComplexSIMD[Self.cdtype], b: ComplexSIMD[Self.cdtype]
+    ) -> Bool:
+        return (a.re > b.re) or ((a.re == b.re) and (a.im > b.im))
+
+    @always_inline("nodebug")
+    def _normalize_axis(self, axis: Int) raises -> Int:
+        var normalized_axis = axis
+        if normalized_axis < 0:
+            normalized_axis += self.ndim
+        if (normalized_axis < 0) or (normalized_axis >= self.ndim):
+            raise Error(
+                String("Axis {} is out of bounds for ndim {}.").format(
+                    axis, self.ndim
+                )
+            )
+        return normalized_axis
+
+    def _permute_axis_to_last(self, axis: Int) raises -> List[Int]:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = List[Int](capacity=self.ndim)
+        for i in range(self.ndim):
+            if i != normalized_axis:
+                axes.append(i)
+        axes.append(normalized_axis)
+        return axes^
+
+    def _inverse_permutation(self, axes: List[Int]) raises -> List[Int]:
+        if len(axes) != self.ndim:
+            raise Error("Invalid permutation length.")
+        var inv = List[Int](capacity=self.ndim)
+        for _ in range(self.ndim):
+            inv.append(0)
+        for i in range(self.ndim):
+            inv[axes[i]] = i
+        return inv^
 
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -4266,6 +4266,114 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             result.append(self._flat_load(i))
         return result^
 
+    def argsort(self) raises -> NDArray[DType.int]:
+        return self.argsort(axis=-1)
+
+    def argsort(self, axis: Int) raises -> NDArray[DType.int]:
+        if self.ndim == 0:
+            var out = NDArray[DType.int](Shape())
+            out._buf.ptr[] = 0
+            return out^
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var inv_axes = self._inverse_permutation(axes)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var idx_t = NDArray[DType.int](transposed.shape)
+
+        for o in range(outer):
+            var base = o * axis_len
+            var idxs = List[Int](capacity=axis_len)
+            for k in range(axis_len):
+                idxs.append(k)
+            for i in range(1, axis_len):
+                var key = idxs[i]
+                var j = i - 1
+                while j >= 0 and self._lex_greater(
+                    transposed._flat_load(base + idxs[j]),
+                    transposed._flat_load(base + key),
+                ):
+                    idxs[j + 1] = idxs[j]
+                    j -= 1
+                idxs[j + 1] = key
+            for k in range(axis_len):
+                # idx_t._buf.ptr[base + k] = idxs[k]
+                idx_t.itemset(base + k, Scalar[DType.int](idxs[k]))
+
+        return idx_t.T(inv_axes)
+
+    def sort(mut self, axis: Int = -1, stable: Bool = False) raises:
+        _ = stable
+        if self.ndim == 0:
+            return
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var inv_axes = self._inverse_permutation(axes)
+        var transposed = self.T(axes)
+        var idx_t = self.argsort(normalized_axis).T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var sorted_t = Self(transposed.shape)
+
+        for o in range(outer):
+            var base = o * axis_len
+            for k in range(axis_len):
+                var src_rel = Int(idx_t.load(base + k))
+                sorted_t._flat_store(
+                    base + k, transposed._flat_load(base + src_rel)
+                )
+
+        var sorted = sorted_t.T(inv_axes)
+        self = sorted^
+
+    def median(self) raises -> ComplexSIMD[Self.cdtype]:
+        if self.size == 0:
+            raise Error("Cannot compute median of empty ComplexNDArray.")
+        var a = self.flatten("C")
+        a.sort(axis=0)
+        if self.size % 2 == 1:
+            return a._flat_load(self.size // 2)
+        var left = a._flat_load(self.size // 2 - 1)
+        var right = a._flat_load(self.size // 2)
+        return ComplexSIMD[Self.cdtype](
+            (left.re + right.re) / 2, (left.im + right.im) / 2
+        )
+
+    def median(self, axis: Int) raises -> Self:
+        var normalized_axis = self._normalize_axis(axis)
+        var axes = self._permute_axis_to_last(normalized_axis)
+        var transposed = self.T(axes)
+        var axis_len = self.shape[normalized_axis]
+        var outer = self.size // axis_len
+        var out_shape = self.shape.pop(normalized_axis)
+        var result = Self(out_shape)
+
+        for o in range(outer):
+            var base = o * axis_len
+            var vals = List[ComplexSIMD[Self.cdtype]](capacity=axis_len)
+            for k in range(axis_len):
+                vals.append(transposed._flat_load(base + k))
+            for i in range(1, axis_len):
+                var key = vals[i]
+                var j = i - 1
+                while j >= 0 and self._lex_greater(vals[j], key):
+                    vals[j + 1] = vals[j]
+                    j -= 1
+                vals[j + 1] = key
+            if axis_len % 2 == 1:
+                result._flat_store(o, vals[axis_len // 2])
+            else:
+                var left = vals[axis_len // 2 - 1]
+                var right = vals[axis_len // 2]
+                result._flat_store(
+                    o,
+                    ComplexSIMD[Self.cdtype](
+                        (left.re + right.re) / 2, (left.im + right.im) / 2
+                    ),
+                )
+        return result^
+
     def num_elements(self) -> Int:
         """
         Return the total number of elements in the array.

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -3281,39 +3281,39 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         result._im.flags = self._im.flags
         return result^
 
-    def __iter__(
-        mut self,
-    ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
-        """
-        Iterates over elements of the ComplexNDArray and return sub-arrays as view.
-
-        Returns:
-            An iterator of ComplexNDArray elements.
-        """
-
-        return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
-            Pointer(to=self),
-            dimension=0,
-        )
-
-    def __reversed__(
-        mut self,
-    ) raises -> _ComplexNDArrayIter[
-        origin_of(self), Self.cdtype, forward=False
-    ]:
-        """
-        Iterates backwards over elements of the ComplexNDArray, returning
-        copied value.
-
-        Returns:
-            A reversed iterator of NDArray elements.
-        """
-
-        return _ComplexNDArrayIter[origin_of(self), Self.cdtype, forward=False](
-            Pointer(to=self),
-            dimension=0,
-        )
-
+    #     def __iter__(
+    #         mut self,
+    #     ) raises -> _ComplexNDArrayIter[origin_of(self), Self.cdtype]:
+    #         """
+    #         Iterates over elements of the ComplexNDArray and return sub-arrays as view.
+    #
+    #         Returns:
+    #             An iterator of ComplexNDArray elements.
+    #         """
+    #
+    #         return _ComplexNDArrayIter[origin_of(self), Self.cdtype](
+    #             Pointer(to=self),
+    #             dimension=0,
+    #         )
+    #
+    #     def __reversed__(
+    #         mut self,
+    #     ) raises -> _ComplexNDArrayIter[
+    #         origin_of(self), Self.cdtype, forward=False
+    #     ]:
+    #         """
+    #         Iterates backwards over elements of the ComplexNDArray, returning
+    #         copied value.
+    #
+    #         Returns:
+    #             A reversed iterator of NDArray elements.
+    #         """
+    #
+    #         return _ComplexNDArrayIter[origin_of(self), Self.cdtype, forward=False](
+    #             Pointer(to=self),
+    #             dimension=0,
+    #         )
+    #
     def itemset(mut self, index: Int, item: ComplexSIMD[Self.cdtype]) raises:
         """Sets the scalar at the given coordinate.
 
@@ -4458,190 +4458,190 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.strides = NDArrayStrides(shape, order=order)
 
 
-struct _ComplexNDArrayIter[
-    is_mutable: Bool,
-    //,
-    origin: Origin[mut=is_mutable],
-    cdtype: ComplexDType,
-    forward: Bool = True,
-](Copyable, Movable):
-    # TODO:
-    # Return a view instead of copy where possible
-    # (when Bufferable is supported).
-    """
-    An iterator yielding `ndim-1` array slices over the given dimension.
-    It is the default iterator of the `ComplexNDArray.__iter__() method and for loops.
-    It can also be constructed using the `ComplexNDArray.iter_over_dimension()` method.
-    It trys to create a view where possible.
-
-    Parameters:
-        is_mutable: Whether the iterator allows mutation of the underlying data.
-        origin: The lifetime of the underlying NDArray data.
-        cdtype: The complex data type of the item.
-        forward: The iteration direction. `False` is backwards.
-    """
-    comptime dtype: DType = Self.cdtype.dtype
-    """The equivalent DType of the ComplexDType."""
-
-    # FIELDS
-    var index: Int
-    var _re_buf: DataContainer[Self.dtype]
-    var _im_buf: DataContainer[Self.dtype]
-    var offset: Int
-    """Offset of the first element in the data buffer."""
-    var dimension: Int
-    var length: Int
-    var shape: NDArrayShape
-    var strides: NDArrayStrides
-    """Strides of array or view. It is not necessarily compatible with shape."""
-    var ndim: Int
-    var size_of_item: Int
-
-    def __init__(
-        out self,
-        a: Pointer[ComplexNDArray[Self.cdtype], Self.origin],
-        dimension: Int,
-    ) raises:
-        """
-        Initialize the iterator.
-
-        Args:
-            a: The array
-            dimension: Dimension to iterate over.
-        """
-
-        if dimension < 0 or dimension >= a[].ndim:
-            raise Error(
-                NumojoError(
-                    category="index",
-                    message=String(
-                        "Axis {} out of valid range [0, {}). Valid axes: 0..{}."
-                        " Use {} for last axis of shape {}."
-                    ).format(
-                        dimension,
-                        a[].ndim,
-                        a[].ndim - 1,
-                        a[].ndim - 1,
-                        a[].shape,
-                    ),
-                    location="_ComplexNDArrayIter.__init__",
-                )
-            )
-
-        self._re_buf = a[]._re._buf.copy()
-        self._im_buf = a[]._im._buf.copy()
-        self.offset = a[]._re.offset
-        self.dimension = dimension
-        self.shape = a[].shape
-        self.strides = a[].strides
-        self.ndim = a[].ndim
-        self.length = a[].shape[dimension]
-        self.size_of_item = a[].size // a[].shape[dimension]
-        # Status of the iterator
-        self.index = 0 if Self.forward else a[].shape[dimension] - 1
-
-    def __iter__(self) -> Self:
-        return self.copy()
-
-    def __next__(mut self) raises -> ComplexNDArray[Self.cdtype]:
-        var result = ComplexNDArray[Self.cdtype](self.shape.pop(self.dimension))
-        var current_index = self.index
-
-        comptime if Self.forward:
-            self.index += 1
-        else:
-            self.index -= 1
-
-        for offset in range(self.size_of_item):
-            var remainder = offset
-            var item: Item = Item(ndim=self.ndim)
-
-            for i in range(self.ndim - 1, -1, -1):
-                if i != self.dimension:
-                    (item._buf.ptr + i).init_pointee_copy(
-                        Scalar[DType.int](remainder % self.shape[i])
-                    )
-                    remainder = remainder // self.shape[i]
-                else:
-                    (item._buf.ptr + self.dimension).init_pointee_copy(
-                        Scalar[DType.int](current_index)
-                    )
-
-            var idx = self.offset + IndexMethods.get_1d_index(
-                item, self.strides
-            )
-            result._re._buf.ptr[offset] = self._re_buf[idx]
-            result._im._buf.ptr[offset] = self._im_buf[idx]
-        return result^
-
-    @always_inline
-    def __has_next__(self) -> Bool:
-        comptime if Self.forward:
-            return self.index < self.length
-        else:
-            return self.index >= 0
-
-    def __len__(self) -> Int:
-        comptime if Self.forward:
-            return self.length - self.index
-        else:
-            return self.index
-
-    def ith(self, index: Int) raises -> ComplexNDArray[Self.cdtype]:
-        """
-        Gets the i-th array of the iterator.
-
-        Args:
-            index: The index of the item. It must be non-negative.
-
-        Returns:
-            The i-th `ndim-1`-D array of the iterator.
-        """
-
-        if (index >= self.length) or (index < 0):
-            raise Error(
-                NumojoError(
-                    category="index",
-                    message=String(
-                        "Iterator index {} out of range [0, {}). Use ith(i)"
-                        " with 0 <= i < {} or iterate via for-loop."
-                    ).format(index, self.length, self.length),
-                    location="_ComplexNDArrayIter.ith",
-                )
-            )
-
-        if self.ndim > 1:
-            var result = ComplexNDArray[Self.cdtype](
-                self.shape.pop(self.dimension)
-            )
-
-            for offset in range(self.size_of_item):
-                var remainder = offset
-                var item: Item = Item(ndim=self.ndim)
-
-                for i in range(self.ndim - 1, -1, -1):
-                    if i != self.dimension:
-                        (item._buf.ptr + i).init_pointee_copy(
-                            Scalar[DType.int](remainder % self.shape[i])
-                        )
-                        remainder = remainder // self.shape[i]
-                    else:
-                        (item._buf.ptr + self.dimension).init_pointee_copy(
-                            Scalar[DType.int](index)
-                        )
-
-                var idx = self.offset + IndexMethods.get_1d_index(
-                    item, self.strides
-                )
-                result._re._buf.ptr[offset] = self._re_buf[idx]
-                result._im._buf.ptr[offset] = self._im_buf[idx]
-            return result^
-
-        else:  # 0-D array
-            var result = numojo.creation._0darray[Self.cdtype](
-                ComplexSIMD[Self.cdtype](
-                    self._re_buf.ptr[self.offset + index],
-                    self._im_buf.ptr[self.offset + index],
-                )
-            )
-            return result^
+# struct _ComplexNDArrayIter[
+#     is_mutable: Bool,
+#     //,
+#     origin: Origin[mut=is_mutable],
+#     cdtype: ComplexDType,
+#     forward: Bool = True,
+# ](Copyable, Movable):
+#     # TODO:
+#     # Return a view instead of copy where possible
+#     # (when Bufferable is supported).
+#     """
+#     An iterator yielding `ndim-1` array slices over the given dimension.
+#     It is the default iterator of the `ComplexNDArray.__iter__() method and for loops.
+#     It can also be constructed using the `ComplexNDArray.iter_over_dimension()` method.
+#     It trys to create a view where possible.
+#
+#     Parameters:
+#         is_mutable: Whether the iterator allows mutation of the underlying data.
+#         origin: The lifetime of the underlying NDArray data.
+#         cdtype: The complex data type of the item.
+#         forward: The iteration direction. `False` is backwards.
+#     """
+#     comptime dtype: DType = Self.cdtype.dtype
+#     """The equivalent DType of the ComplexDType."""
+#
+#     # FIELDS
+#     var index: Int
+#     var _re_buf: DataContainer[Self.dtype]
+#     var _im_buf: DataContainer[Self.dtype]
+#     var offset: Int
+#     """Offset of the first element in the data buffer."""
+#     var dimension: Int
+#     var length: Int
+#     var shape: NDArrayShape
+#     var strides: NDArrayStrides
+#     """Strides of array or view. It is not necessarily compatible with shape."""
+#     var ndim: Int
+#     var size_of_item: Int
+#
+#     def __init__(
+#         out self,
+#         a: Pointer[ComplexNDArray[Self.cdtype], Self.origin],
+#         dimension: Int,
+#     ) raises:
+#         """
+#         Initialize the iterator.
+#
+#         Args:
+#             a: The array
+#             dimension: Dimension to iterate over.
+#         """
+#
+#         if dimension < 0 or dimension >= a[].ndim:
+#             raise Error(
+#                 NumojoError(
+#                     category="index",
+#                     message=String(
+#                         "Axis {} out of valid range [0, {}). Valid axes: 0..{}."
+#                         " Use {} for last axis of shape {}."
+#                     ).format(
+#                         dimension,
+#                         a[].ndim,
+#                         a[].ndim - 1,
+#                         a[].ndim - 1,
+#                         a[].shape,
+#                     ),
+#                     location="_ComplexNDArrayIter.__init__",
+#                 )
+#             )
+#
+#         self._re_buf = a[]._re._buf.copy()
+#         self._im_buf = a[]._im._buf.copy()
+#         self.offset = a[]._re.offset
+#         self.dimension = dimension
+#         self.shape = a[].shape
+#         self.strides = a[].strides
+#         self.ndim = a[].ndim
+#         self.length = a[].shape[dimension]
+#         self.size_of_item = a[].size // a[].shape[dimension]
+#         # Status of the iterator
+#         self.index = 0 if Self.forward else a[].shape[dimension] - 1
+#
+#     def __iter__(self) -> Self:
+#         return self.copy()
+#
+#     def __next__(mut self) raises -> ComplexNDArray[Self.cdtype]:
+#         var result = ComplexNDArray[Self.cdtype](self.shape.pop(self.dimension))
+#         var current_index = self.index
+#
+#         comptime if Self.forward:
+#             self.index += 1
+#         else:
+#             self.index -= 1
+#
+#         for offset in range(self.size_of_item):
+#             var remainder = offset
+#             var item: Item = Item(ndim=self.ndim)
+#
+#             for i in range(self.ndim - 1, -1, -1):
+#                 if i != self.dimension:
+#                     (item._buf.ptr + i).init_pointee_copy(
+#                         Scalar[DType.int](remainder % self.shape[i])
+#                     )
+#                     remainder = remainder // self.shape[i]
+#                 else:
+#                     (item._buf.ptr + self.dimension).init_pointee_copy(
+#                         Scalar[DType.int](current_index)
+#                     )
+#
+#             var idx = self.offset + IndexMethods.get_1d_index(
+#                 item, self.strides
+#             )
+#             result._re._buf.ptr[offset] = self._re_buf[idx]
+#             result._im._buf.ptr[offset] = self._im_buf[idx]
+#         return result^
+#
+#     @always_inline
+#     def __has_next__(self) -> Bool:
+#         comptime if Self.forward:
+#             return self.index < self.length
+#         else:
+#             return self.index >= 0
+#
+#     def __len__(self) -> Int:
+#         comptime if Self.forward:
+#             return self.length - self.index
+#         else:
+#             return self.index
+#
+#     def ith(self, index: Int) raises -> ComplexNDArray[Self.cdtype]:
+#         """
+#         Gets the i-th array of the iterator.
+#
+#         Args:
+#             index: The index of the item. It must be non-negative.
+#
+#         Returns:
+#             The i-th `ndim-1`-D array of the iterator.
+#         """
+#
+#         if (index >= self.length) or (index < 0):
+#             raise Error(
+#                 NumojoError(
+#                     category="index",
+#                     message=String(
+#                         "Iterator index {} out of range [0, {}). Use ith(i)"
+#                         " with 0 <= i < {} or iterate via for-loop."
+#                     ).format(index, self.length, self.length),
+#                     location="_ComplexNDArrayIter.ith",
+#                 )
+#             )
+#
+#         if self.ndim > 1:
+#             var result = ComplexNDArray[Self.cdtype](
+#                 self.shape.pop(self.dimension)
+#             )
+#
+#             for offset in range(self.size_of_item):
+#                 var remainder = offset
+#                 var item: Item = Item(ndim=self.ndim)
+#
+#                 for i in range(self.ndim - 1, -1, -1):
+#                     if i != self.dimension:
+#                         (item._buf.ptr + i).init_pointee_copy(
+#                             Scalar[DType.int](remainder % self.shape[i])
+#                         )
+#                         remainder = remainder // self.shape[i]
+#                     else:
+#                         (item._buf.ptr + self.dimension).init_pointee_copy(
+#                             Scalar[DType.int](index)
+#                         )
+#
+#                 var idx = self.offset + IndexMethods.get_1d_index(
+#                     item, self.strides
+#                 )
+#                 result._re._buf.ptr[offset] = self._re_buf[idx]
+#                 result._im._buf.ptr[offset] = self._im_buf[idx]
+#             return result^
+#
+#         else:  # 0-D array
+#             var result = numojo.creation._0darray[Self.cdtype](
+#                 ComplexSIMD[Self.cdtype](
+#                     self._re_buf.ptr[self.offset + index],
+#                     self._im_buf.ptr[self.offset + index],
+#                 )
+#             )
+#             return result^

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2501,7 +2501,6 @@ struct NDArray[dtype: DType = DType.float64](
 
         self.__setitem__(slices=slice_list, val=val)
 
-    # TODO: fix this setter, add bound checks. Not sure about it's use case.
     def __setitem__(
         mut self, index: NDArray[DType.int], val: NDArray[Self.dtype]
     ) raises:
@@ -2547,22 +2546,29 @@ struct NDArray[dtype: DType = DType.float64](
             if val.size == 1:
                 var scalar_val = val.item(0)
                 for i in range(index_c.size):
-                    var idx = Int(index_c._buf.ptr[i])
-                    idx = self.normalize(idx, self.shape[0])
-                    if idx < 0 or idx >= self.shape[0]:
+                    var raw_idx = Int(index_c._buf.ptr[i])
+                    if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                         raise Error(
                             NumojoError(
                                 category="index",
                                 message=String(
-                                    "Index out of range at position {}: got {};"
-                                    " valid range is [{}, {})."
-                                ).format(i, idx, -self.shape[0], self.shape[0]),
+                                    "Index out of range at position {}: got"
+                                    " {}; valid range is [{}, {})."
+                                ).format(
+                                    i,
+                                    raw_idx,
+                                    -self.shape[0],
+                                    self.shape[0],
+                                ),
                                 location=(
                                     "NDArray.__setitem__(index: NDArray, val:"
                                     " NDArray)"
                                 ),
                             )
                         )
+                    var idx = raw_idx
+                    if idx < 0:
+                        idx += self.shape[0]
                     self.itemset(idx, scalar_val)
                 return
 
@@ -2582,22 +2588,24 @@ struct NDArray[dtype: DType = DType.float64](
 
             var val_c = val.contiguous()
             for i in range(index_c.size):
-                var idx = Int(index_c._buf.ptr[i])
-                idx = self.normalize(idx, self.shape[0])
-                if idx < 0 or idx >= self.shape[0]:
+                var raw_idx = Int(index_c._buf.ptr[i])
+                if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                     raise Error(
                         NumojoError(
                             category="index",
                             message=String(
                                 "Index out of range at position {}: got {};"
                                 " valid range is [{}, {})."
-                            ).format(i, idx, -self.shape[0], self.shape[0]),
+                            ).format(i, raw_idx, -self.shape[0], self.shape[0]),
                             location=(
                                 "NDArray.__setitem__(index: NDArray, val:"
                                 " NDArray)"
                             ),
                         )
                     )
+                var idx = raw_idx
+                if idx < 0:
+                    idx += self.shape[0]
                 self.itemset(idx, val_c._buf.ptr[i])
             return
 
@@ -2625,7 +2633,11 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        var val_c_for_slices = val.contiguous()
+        # Only materialize a contiguous copy of `val` when we need to slice
+        # per-index rows out of it.
+        var val_c_for_slices = (
+            val.contiguous() if val_is_per_index else val.copy()
+        )
 
         for i in range(index_c.size):
             var idx = Int(index_c._buf.ptr[i])
@@ -2656,9 +2668,6 @@ struct NDArray[dtype: DType = DType.float64](
                     count=per_slice_size,
                 )
                 self.__setitem__(idx=idx, val=slice)
-
-        # for i in range(len(index)):
-        # self.store(Int(index.load(i)), rebind[Scalar[dtype]](val.load(i)))
 
     def __setitem__(
         mut self, mask: NDArray[DType.bool], val: NDArray[Self.dtype]
@@ -2700,11 +2709,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         var mask_c = mask.contiguous()
         var val_c = val.contiguous()
-        var true_count = 0
-        for i in range(mask_c.size):
-            if mask_c._buf.ptr.load[width=1](i):
-                true_count += 1
 
+        # Elementwise (val matches self) and scalar broadcast paths do not
+        # need to count selected elements; only the compact 1-D path does.
         if val_c.shape == self.shape:
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
@@ -2717,6 +2724,11 @@ struct NDArray[dtype: DType = DType.float64](
                 if mask_c._buf.ptr.load[width=1](i):
                     self.itemset(i, scalar_val)
             return
+
+        var true_count = 0
+        for i in range(mask_c.size):
+            if mask_c._buf.ptr.load[width=1](i):
+                true_count += 1
 
         if val_c.ndim == 1 and val_c.size == true_count:
             var j = 0

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1383,37 +1383,45 @@ struct NDArray[dtype: DType = DType.float64](
         ```.
         """
 
-        # Get the shape of resulted array
-        # var shape = indices.shape.join(self.shape._pop(0))
         var shape = indices.shape.join(self.shape.pop(0))
-
         var result: NDArray[Self.dtype] = NDArray[Self.dtype](shape)
         var size_per_item: Int = self.size // self.shape[0]
+        var indices_c = indices.contiguous()
 
-        # Fill in the values
-        for i in range(indices.size):
-            if indices.item(i) >= Scalar[DType.int](self.shape[0]):
+        # Fill in the values (advanced indexing on axis 0).
+        for i in range(indices_c.size):
+            var raw_idx = Int(indices_c._buf.ptr[i])
+            if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                 raise Error(
                     NumojoError(
                         category="index",
                         message=String(
                             "Index out of range at position {}: got {}; valid"
-                            " range for the first dimension is [0, {})."
-                            " Validate indices against the first dimension size"
-                            " ({})."
-                        ).format(
-                            i, indices.item(i), self.shape[0], self.shape[0]
-                        ),
+                            " range for axis 0 is [{}, {})."
+                        ).format(i, raw_idx, -self.shape[0], self.shape[0]),
                         location="NDArray.__getitem__(indices: NDArray[dtype])",
                     )
                 )
-            memcpy(
-                dest=result._buf.ptr + i * size_per_item,
-                src=self._buf.ptr
-                + self.offset
-                + Int(indices.item(i)) * size_per_item,
-                count=size_per_item,
-            )
+
+            var normalized_idx = raw_idx
+            if normalized_idx < 0:
+                normalized_idx += self.shape[0]
+
+            if self.is_c_contiguous():
+                memcpy(
+                    dest=result._buf.ptr + i * size_per_item,
+                    src=self._buf.ptr
+                    + self.offset
+                    + normalized_idx * size_per_item,
+                    count=size_per_item,
+                )
+            else:
+                var selected = self[normalized_idx].contiguous()
+                memcpy(
+                    dest=result._buf.ptr + i * size_per_item,
+                    src=selected._buf.ptr + selected.offset,
+                    count=size_per_item,
+                )
 
         return result^
 
@@ -2461,8 +2469,30 @@ struct NDArray[dtype: DType = DType.float64](
                 slice_list.append(slices[i][Slice])
             elif slices[i].isa[Int]():
                 count_int += 1
-                var int: Int = slices[i][Int]
-                slice_list.append(Slice(int, int + 1, 1))
+                var idx: Int = slices[i][Int]
+                if idx >= self.shape[i] or idx < -self.shape[i]:
+                    raise Error(
+                        NumojoError(
+                            category="index",
+                            message=String(
+                                "Integer index {} out of bounds for axis {}"
+                                " (size {}). Valid range is [{}, {})."
+                            ).format(
+                                idx,
+                                i,
+                                self.shape[i],
+                                -self.shape[i],
+                                self.shape[i],
+                            ),
+                            location=(
+                                "NDArray.__setitem__(*slices: Variant[Slice,"
+                                " Int], val: NDArray)"
+                            ),
+                        )
+                    )
+                if idx < 0:
+                    idx += self.shape[i]
+                slice_list.append(Slice(idx, idx + 1, 1))
 
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
@@ -2511,53 +2541,115 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        if index.size > self.shape[0]:
+        var index_c = index.contiguous()
+
+        if self.ndim == 1:
+            if val.size == 1:
+                var scalar_val = val.item(0)
+                for i in range(index_c.size):
+                    var idx = Int(index_c._buf.ptr[i])
+                    idx = self.normalize(idx, self.shape[0])
+                    if idx < 0 or idx >= self.shape[0]:
+                        raise Error(
+                            NumojoError(
+                                category="index",
+                                message=String(
+                                    "Index out of range at position {}: got {};"
+                                    " valid range is [{}, {})."
+                                ).format(i, idx, -self.shape[0], self.shape[0]),
+                                location=(
+                                    "NDArray.__setitem__(index: NDArray, val:"
+                                    " NDArray)"
+                                ),
+                            )
+                        )
+                    self.itemset(idx, scalar_val)
+                return
+
+            if val.ndim != 1 or val.size != index_c.size:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "For 1-D indexed assignment, value must have size"
+                            " 1 or exactly {} elements; got shape {}."
+                        ).format(index_c.size, val.shape),
+                        location="NDArray.__setitem__(index: NDArray, val: NDArray)",
+                    )
+                )
+
+            var val_c = val.contiguous()
+            for i in range(index_c.size):
+                var idx = Int(index_c._buf.ptr[i])
+                idx = self.normalize(idx, self.shape[0])
+                if idx < 0 or idx >= self.shape[0]:
+                    raise Error(
+                        NumojoError(
+                            category="index",
+                            message=String(
+                                "Index out of range at position {}: got {};"
+                                " valid range is [{}, {})."
+                            ).format(i, idx, -self.shape[0], self.shape[0]),
+                            location=(
+                                "NDArray.__setitem__(index: NDArray, val:"
+                                " NDArray)"
+                            ),
+                        )
+                    )
+                self.itemset(idx, val_c._buf.ptr[i])
+            return
+
+        var tail_shape = self.shape.pop(0)
+        var per_slice_size = self.size // self.shape[0]
+        var val_is_single_slice = val.shape == tail_shape
+        var val_is_per_index = (
+            val.ndim == self.ndim
+            and val.shape[0] == index_c.size
+            and val.shape.pop(0) == tail_shape
+        )
+
+        if not val_is_single_slice and not val_is_per_index:
             raise Error(
                 NumojoError(
-                    category="index",
+                    category="shape",
                     message=String(
-                        "Index array has {} elements; first dimension size is"
-                        " {}. Truncate or reshape the index array to fit within"
-                        " the first dimension ({})."
-                    ).format(index.size, self.shape[0], self.shape[0]),
-                    location=(
-                        "NDArray.__setitem__(index: NDArray, val: NDArray)"
-                    ),
+                        "Invalid value shape {} for indexed assignment. Expected"
+                        " either {} (single slice broadcast) or [{}, ...] with"
+                        " tail shape {}."
+                    ).format(val.shape, tail_shape, index_c.size, tail_shape),
+                    location="NDArray.__setitem__(index: NDArray, val: NDArray)",
                 )
             )
 
-        # var output_shape_list: List[Int] = List[Int]()
-        # output_shape_list.append(index.size)
-        # for i in range(1, self.ndim):
-        #     output_shape_list.append(self.shape[i])
+        var val_c_for_slices = val.contiguous()
 
-        # var output_shape: NDArrayShape = NDArrayShape(output_shape_list)
-        # print("output_shape\n", output_shape.__str__())
-
-        for i in range(index.size):
-            if (
-                index.item(i) >= Scalar[DType.int](self.shape[0])
-                or index.item(i) < 0
-            ):
+        for i in range(index_c.size):
+            var idx = Int(index_c._buf.ptr[i])
+            if idx < -self.shape[0] or idx >= self.shape[0]:
                 raise Error(
                     NumojoError(
                         category="index",
                         message=String(
                             "Index out of range at position {}: got {}; valid"
-                            " range is [0, {}). Validate indices against the"
-                            " first dimension size ({})."
-                        ).format(
-                            i, index.item(i), self.shape[0], self.shape[0]
-                        ),
-                        location=(
-                            "NDArray.__setitem__(index: NDArray, val: NDArray)"
-                        ),
+                            " range is [{}, {})."
+                        ).format(i, idx, -self.shape[0], self.shape[0]),
+                        location="NDArray.__setitem__(index: NDArray, val: NDArray)",
                     )
                 )
+            if idx < 0:
+                idx += self.shape[0]
 
-        # var new_arr: NDArray[dtype] = NDArray[dtype](output_shape)
-        for i in range(index.size):
-            self.__setitem__(idx=Int(index.item(i)), val=val)
+            if val_is_single_slice:
+                self.__setitem__(idx=idx, val=val)
+            else:
+                var src_offset = val_c_for_slices.offset + i * per_slice_size
+                var slice = NDArray[Self.dtype](tail_shape)
+                memcpy(
+                    dest=slice._buf.ptr + slice.offset,
+                    src=val_c_for_slices._buf.ptr + src_offset,
+                    count=per_slice_size,
+                )
+                self.__setitem__(idx=idx, val=slice)
 
         # for i in range(len(index)):
         # self.store(Int(index.load(i)), rebind[Scalar[dtype]](val.load(i)))
@@ -2602,9 +2694,46 @@ struct NDArray[dtype: DType = DType.float64](
 
         var mask_c = mask.contiguous()
         var val_c = val.contiguous()
+        var true_count = 0
         for i in range(mask_c.size):
-            if mask_c._buf.ptr.load(i):
-                self.itemset(i, val_c._buf.ptr.load(i))
+            if mask_c._buf.ptr.load[width=1](i):
+                true_count += 1
+
+        if val_c.shape == self.shape:
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    self.itemset(i, val_c._buf.ptr.load[width=1](i))
+            return
+
+        if val_c.size == 1:
+            var scalar_val = val_c._buf.ptr.load[width=1](val_c.offset)
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    self.itemset(i, scalar_val)
+            return
+
+        if val_c.ndim == 1 and val_c.size == true_count:
+            var j = 0
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    self.itemset(i, val_c._buf.ptr.load[width=1](j))
+                    j += 1
+            return
+
+        raise Error(
+            NumojoError(
+                category="shape",
+                message=String(
+                    "Invalid value shape {} for boolean mask assignment with"
+                    " {} selected elements. Expected value shape {} (elementwise),"
+                    " a scalar/size-1 array, or 1-D shape [{}]."
+                ).format(val.shape, true_count, self.shape, true_count),
+                location=(
+                    "NDArray.__setitem__(mask: NDArray[DType.bool], val:"
+                    " NDArray)"
+                ),
+            )
+        )
 
     def itemset(mut self, index: Int, item: Scalar[Self.dtype]) raises:
         """Sets the scalar at the given coordinate.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2574,7 +2574,9 @@ struct NDArray[dtype: DType = DType.float64](
                             "For 1-D indexed assignment, value must have size"
                             " 1 or exactly {} elements; got shape {}."
                         ).format(index_c.size, val.shape),
-                        location="NDArray.__setitem__(index: NDArray, val: NDArray)",
+                        location=(
+                            "NDArray.__setitem__(index: NDArray, val: NDArray)"
+                        ),
                     )
                 )
 
@@ -2613,11 +2615,13 @@ struct NDArray[dtype: DType = DType.float64](
                 NumojoError(
                     category="shape",
                     message=String(
-                        "Invalid value shape {} for indexed assignment. Expected"
-                        " either {} (single slice broadcast) or [{}, ...] with"
-                        " tail shape {}."
+                        "Invalid value shape {} for indexed assignment."
+                        " Expected either {} (single slice broadcast) or [{},"
+                        " ...] with tail shape {}."
                     ).format(val.shape, tail_shape, index_c.size, tail_shape),
-                    location="NDArray.__setitem__(index: NDArray, val: NDArray)",
+                    location=(
+                        "NDArray.__setitem__(index: NDArray, val: NDArray)"
+                    ),
                 )
             )
 
@@ -2633,7 +2637,9 @@ struct NDArray[dtype: DType = DType.float64](
                             "Index out of range at position {}: got {}; valid"
                             " range is [{}, {})."
                         ).format(i, idx, -self.shape[0], self.shape[0]),
-                        location="NDArray.__setitem__(index: NDArray, val: NDArray)",
+                        location=(
+                            "NDArray.__setitem__(index: NDArray, val: NDArray)"
+                        ),
                     )
                 )
             if idx < 0:
@@ -2724,8 +2730,8 @@ struct NDArray[dtype: DType = DType.float64](
             NumojoError(
                 category="shape",
                 message=String(
-                    "Invalid value shape {} for boolean mask assignment with"
-                    " {} selected elements. Expected value shape {} (elementwise),"
+                    "Invalid value shape {} for boolean mask assignment with {}"
+                    " selected elements. Expected value shape {} (elementwise),"
                     " a scalar/size-1 array, or 1-D shape [{}]."
                 ).format(val.shape, true_count, self.shape, true_count),
                 location=(

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -85,6 +85,9 @@ comptime IndexTypes = Variant[Int, NewAxis, EllipsisType, Slice]
 """IndexTypes is used to represent the different kinds of indices that can be used for indexing and slicing operations on the NDArray.
 """
 
+# TODO: MutAnyOrigin in unsafe_ptr() will lead to double free errors! gotta fix this!
+# TODO: Make internal fields (shape, strides, print_opts) private and add getters/setters as needed.
+
 
 struct NDArray[dtype: DType = DType.float64](
     Absable,

--- a/pixi.lock
+++ b/pixi.lock
@@ -15,11 +15,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
@@ -51,16 +47,11 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
@@ -72,14 +63,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -92,17 +81,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
@@ -130,16 +113,11 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
@@ -151,26 +129,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
-=======
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
-<<<<<<< HEAD
-=======
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -242,28 +214,16 @@ packages:
   license: BSD-3-Clause
   size: 100048
   timestamp: 1777219902525
-<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   noarch: generic
   sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
   md5: 3a8a8b87e72f95b54689fb588e154ec9
-=======
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
-  noarch: generic
-  sha256: 40dc224f2b718e5f034efd2332bc315a719063235f63673468d26a24770094ee
-  md5: f111d4cfaf1fe9496f386bc98ae94452
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi * *_cp313
   license: Python-2.0
-<<<<<<< HEAD
   size: 48530
   timestamp: 1775613723457
-=======
-  size: 49809
-  timestamp: 1775614256655
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -874,7 +834,6 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-<<<<<<< HEAD
   size: 8857056
   timestamp: 1773839226294
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
@@ -883,39 +842,18 @@ packages:
   depends:
   - python
   - python 3.13.* *_cp313
-=======
-  size: 8927860
-  timestamp: 1773839233468
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
-  sha256: c269916245aa84d923b6607fce877a069403714c65f6207d6bec70a333c32331
-  md5: d8dd63deccebc802a8fe5a5e6c255cd6
-  depends:
-  - python
-  - libcxx >=19
-  - python 3.14.* *_cp314t
->>>>>>> daf1aaf (move to using mojo instead of modular)
   - __osx >=11.0
   - libcxx >=19
   - liblapack >=3.9.0,<4.0a0
-<<<<<<< HEAD
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - python_abi 3.13.* *_cp313
-=======
-  - libcblas >=3.9.0,<4.0a0
-  - python_abi 3.14.* *_cp314t
->>>>>>> daf1aaf (move to using mojo instead of modular)
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-<<<<<<< HEAD
   size: 6924384
   timestamp: 1773839167287
-=======
-  size: 7062457
-  timestamp: 1773839188614
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   md5: da1b85b6a87e141f5140bb9924cecab0
@@ -965,17 +903,10 @@ packages:
   license_family: MIT
   size: 25862
   timestamp: 1775741140609
-<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   build_number: 100
   sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
   md5: 05051be49267378d2fcd12931e319ac3
-=======
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
-  build_number: 100
-  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
-  md5: a443f87920815d41bfe611296e507995
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -990,16 +921,11 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
-<<<<<<< HEAD
   - python_abi 3.13.* *_cp313
-=======
-  - python_abi 3.14.* *_cp314
->>>>>>> daf1aaf (move to using mojo instead of modular)
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   license: Python-2.0
-<<<<<<< HEAD
   size: 37358322
   timestamp: 1775614712638
   python_site_packages_path: lib/python3.13/site-packages
@@ -1007,14 +933,6 @@ packages:
   build_number: 100
   sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
   md5: 9991a930e81d3873eba7a299ba783ec4
-=======
-  size: 36705460
-  timestamp: 1775614357822
-  python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
-  sha256: e825c7f56d811f63995be4482442398909000ce71137ce6c9e5bab80ca74997b
-  md5: fe2e332924c098feefba3b806a9951b5
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
@@ -1035,14 +953,9 @@ packages:
   size: 12966447
   timestamp: 1775615694085
   python_site_packages_path: lib/python3.13/site-packages
-=======
-  - python_abi 3.14.* *_cp314t
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - zstd >=1.5.7,<1.6.0a0
-  track_features:
-  - py_freethreading
   license: Python-2.0
   size: 13978318
   timestamp: 1775615456198
@@ -1070,13 +983,9 @@ packages:
   size: 48536
   timestamp: 1775613791711
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-=======
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-  sha256: 36ff7984e4565c85149e64f8206303d412a0652e55cf806dcb856903fa056314
-  md5: e4e60721757979d01d3964122f674959
   depends:
-  - cpython 3.14.4.*
-  - python_abi * *_cp314
+  - cpython 3.13.13.*
+  - python_abi * *_cp313
   license: Python-2.0
   size: 49806
   timestamp: 1775614307464
@@ -1089,23 +998,8 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-<<<<<<< HEAD
   size: 7002
   timestamp: 1752805902938
-=======
-  size: 6989
-  timestamp: 1752805904792
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
-  build_number: 8
-  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
-  md5: 3251796e09870c978e0f69fa05e38fb6
-  constrains:
-  - python 3.14.* *_cp314t
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7020
-  timestamp: 1752805919426
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -1122,25 +1016,21 @@ packages:
   license_family: BSD
   size: 211567
   timestamp: 1771716961404
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
-  sha256: 7be013c4ccbc1581cbfa94d4979eb1f2113f7eeb76a40e2589155a694733d0e1
-  md5: 4a45b46523c1b5733a867692ad1ed64f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
+  noarch: python
+  sha256: 2f31f799a46ed75518fae0be75ecc8a1b84360dbfd55096bc2fe8bd9c797e772
+  md5: 2f6b79700452ef1e91f45a99ab8ffe5a
   depends:
   - python
-  - python 3.14.* *_cp314t
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.12
   - zeromq >=4.3.5,<4.4.0a0
-  - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
-<<<<<<< HEAD
   size: 191641
   timestamp: 1771717073430
-=======
-  size: 374574
-  timestamp: 1771717083205
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -1162,15 +1052,9 @@ packages:
   license_family: GPL
   size: 313930
   timestamp: 1765813902568
-<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
   sha256: fdd92a119a2a5f89d6e549a326adcb008f5046ea5034a9af409e97b7e20e6f06
   md5: ec81bc03787968decae6765c7f61b7cf
-=======
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
-  sha256: 1ae427836d7979779c9005388a05993a3addabcc66c4422694639a4272d7d972
-  md5: d0510124f87c75403090e220db1e9d41
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -1187,19 +1071,11 @@ packages:
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-<<<<<<< HEAD
   size: 17121940
   timestamp: 1771880708672
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
   sha256: d22bf4791d1fc96b35374de0dd904745c3b54282ba23c3d435a994b4ff384719
   md5: 6f3a898962bdea87c076108bc336df2e
-=======
-  size: 17225275
-  timestamp: 1771880751368
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
-  sha256: 204de892c41cf702f456833c97dc7e2ef2fbb835ccc320e5c1614e78e7cf8c31
-  md5: 5e58062849f471f014feac2ffad301eb
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -1211,7 +1087,6 @@ packages:
   - numpy <2.7
   - numpy >=1.23,<3
   - numpy >=1.25.2
-<<<<<<< HEAD
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
@@ -1219,15 +1094,6 @@ packages:
   license_family: BSD
   size: 14038926
   timestamp: 1771880554132
-=======
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314t
-  - python_abi 3.14.* *_cp314t
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14358162
-  timestamp: 1771880795641
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -1271,15 +1137,9 @@ packages:
   license_family: MIT
   size: 21561
   timestamp: 1774492402955
-<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
   sha256: 9e8497e1ecca77d03c6be2d3b5f901dfe0ab99686af4fb94ab418b7d449ac547
   md5: 6c0b0ae017b5bfd9c8d718217efd8f14
-=======
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
-  sha256: ed8d06093ff530a2dae9ed1e51eb6f908fbfd171e8b62f4eae782d67b420be5a
-  md5: dc1ff1e915ab35a06b6fa61efae73ab5
->>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -1302,17 +1162,11 @@ packages:
   license_family: Apache
   size: 883472
   timestamp: 1774358832451
-=======
-  size: 912476
-  timestamp: 1774358032579
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
-  sha256: f747246aab4ca6b15523aa8b40805995a1019450bd2382c906d0a074f1e9d876
-  md5: d33bcf373760d2958e6defa1fe1b0192
   depends:
   - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314t
-  - python_abi 3.14.* *_cp314t
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
   size: 909663

--- a/pixi.lock
+++ b/pixi.lock
@@ -46,7 +46,7 @@ environments:
       - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
@@ -63,17 +63,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
@@ -112,7 +101,7 @@ environments:
       - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
@@ -129,16 +118,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
@@ -212,6 +191,7 @@ packages:
   - python
   - python >=3.10
   license: BSD-3-Clause
+  license_family: BSD
   size: 100048
   timestamp: 1777219902525
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
@@ -801,23 +781,23 @@ packages:
   license_family: MIT
   size: 11766
   timestamp: 1745776666688
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-  sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
-  md5: 47e340acb35de30501a76c7c799c41d7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
+  - libgcc >=14
   license: X11 AND BSD-3-Clause
-  size: 891641
-  timestamp: 1738195959188
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-  sha256: 2827ada40e8d9ca69a153a45f7fd14f32b2ead7045d3bbb5d10964898fe65733
-  md5: 068d497125e4bf8a66bf707254fff5ae
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
-  size: 797030
-  timestamp: 1738196177597
+  size: 805509
+  timestamp: 1777423252320
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
   sha256: bcf75998ea3ae133df3580fb427d1054b006b093799430f499fd7ce8207d34c7
   md5: c4a9d2e77eb9fee983a70cf5f047c202
@@ -891,6 +871,7 @@ packages:
   depends:
   - python >=3.10
   license: MPL-2.0
+  license_family: MOZILLA
   size: 56559
   timestamp: 1777271601895
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
@@ -944,7 +925,6 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
-<<<<<<< HEAD
   - python_abi 3.13.* *_cp313
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -953,14 +933,6 @@ packages:
   size: 12966447
   timestamp: 1775615694085
   python_site_packages_path: lib/python3.13/site-packages
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  license: Python-2.0
-  size: 13978318
-  timestamp: 1775615456198
-  python_site_packages_path: lib/python3.14t/site-packages
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -972,7 +944,6 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
-<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
   sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
   md5: fd00e4b24ea88093c93f5c9bad27b52f
@@ -983,14 +954,6 @@ packages:
   size: 48536
   timestamp: 1775613791711
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-  depends:
-  - cpython 3.13.13.*
-  - python_abi * *_cp313
-  license: Python-2.0
-  size: 49806
-  timestamp: 1775614307464
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
->>>>>>> daf1aaf (move to using mojo instead of modular)
   build_number: 8
   sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
   md5: 94305520c52a4aa3f6c2b1ff6008d9f8
@@ -1147,7 +1110,6 @@ packages:
   - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
-<<<<<<< HEAD
   size: 882996
   timestamp: 1774358035145
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
@@ -1162,16 +1124,6 @@ packages:
   license_family: Apache
   size: 883472
   timestamp: 1774358832451
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 909663
-  timestamp: 1774358650588
->>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed

--- a/pixi.lock
+++ b/pixi.lock
@@ -15,7 +15,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
@@ -47,11 +51,16 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
@@ -63,6 +72,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
@@ -70,11 +92,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
@@ -102,11 +130,16 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+<<<<<<< HEAD
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
@@ -118,10 +151,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
+=======
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+<<<<<<< HEAD
+=======
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -193,16 +242,28 @@ packages:
   license: BSD-3-Clause
   size: 100048
   timestamp: 1777219902525
+<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   noarch: generic
   sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
   md5: 3a8a8b87e72f95b54689fb588e154ec9
+=======
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+  noarch: generic
+  sha256: 40dc224f2b718e5f034efd2332bc315a719063235f63673468d26a24770094ee
+  md5: f111d4cfaf1fe9496f386bc98ae94452
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi * *_cp313
   license: Python-2.0
+<<<<<<< HEAD
   size: 48530
   timestamp: 1775613723457
+=======
+  size: 49809
+  timestamp: 1775614256655
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -813,6 +874,7 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
+<<<<<<< HEAD
   size: 8857056
   timestamp: 1773839226294
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
@@ -821,18 +883,39 @@ packages:
   depends:
   - python
   - python 3.13.* *_cp313
+=======
+  size: 8927860
+  timestamp: 1773839233468
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
+  sha256: c269916245aa84d923b6607fce877a069403714c65f6207d6bec70a333c32331
+  md5: d8dd63deccebc802a8fe5a5e6c255cd6
+  depends:
+  - python
+  - libcxx >=19
+  - python 3.14.* *_cp314t
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   - __osx >=11.0
   - libcxx >=19
   - liblapack >=3.9.0,<4.0a0
+<<<<<<< HEAD
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - python_abi 3.13.* *_cp313
+=======
+  - libcblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314t
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
+<<<<<<< HEAD
   size: 6924384
   timestamp: 1773839167287
+=======
+  size: 7062457
+  timestamp: 1773839188614
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   md5: da1b85b6a87e141f5140bb9924cecab0
@@ -882,10 +965,17 @@ packages:
   license_family: MIT
   size: 25862
   timestamp: 1775741140609
+<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   build_number: 100
   sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
   md5: 05051be49267378d2fcd12931e319ac3
+=======
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
+  md5: a443f87920815d41bfe611296e507995
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -900,11 +990,16 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
+<<<<<<< HEAD
   - python_abi 3.13.* *_cp313
+=======
+  - python_abi 3.14.* *_cp314
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   license: Python-2.0
+<<<<<<< HEAD
   size: 37358322
   timestamp: 1775614712638
   python_site_packages_path: lib/python3.13/site-packages
@@ -912,6 +1007,14 @@ packages:
   build_number: 100
   sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
   md5: 9991a930e81d3873eba7a299ba783ec4
+=======
+  size: 36705460
+  timestamp: 1775614357822
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
+  sha256: e825c7f56d811f63995be4482442398909000ce71137ce6c9e5bab80ca74997b
+  md5: fe2e332924c098feefba3b806a9951b5
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
@@ -923,6 +1026,7 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
+<<<<<<< HEAD
   - python_abi 3.13.* *_cp313
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -931,6 +1035,19 @@ packages:
   size: 12966447
   timestamp: 1775615694085
   python_site_packages_path: lib/python3.13/site-packages
+=======
+  - python_abi 3.14.* *_cp314t
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  track_features:
+  - py_freethreading
+  license: Python-2.0
+  size: 13978318
+  timestamp: 1775615456198
+  python_site_packages_path: lib/python3.14t/site-packages
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -942,6 +1059,7 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
+<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
   sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
   md5: fd00e4b24ea88093c93f5c9bad27b52f
@@ -952,6 +1070,18 @@ packages:
   size: 48536
   timestamp: 1775613791711
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+=======
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
+  sha256: 36ff7984e4565c85149e64f8206303d412a0652e55cf806dcb856903fa056314
+  md5: e4e60721757979d01d3964122f674959
+  depends:
+  - cpython 3.14.4.*
+  - python_abi * *_cp314
+  license: Python-2.0
+  size: 49806
+  timestamp: 1775614307464
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   build_number: 8
   sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
   md5: 94305520c52a4aa3f6c2b1ff6008d9f8
@@ -959,8 +1089,23 @@ packages:
   - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+<<<<<<< HEAD
   size: 7002
   timestamp: 1752805902938
+=======
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+  build_number: 8
+  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
+  md5: 3251796e09870c978e0f69fa05e38fb6
+  constrains:
+  - python 3.14.* *_cp314t
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7020
+  timestamp: 1752805919426
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -977,21 +1122,25 @@ packages:
   license_family: BSD
   size: 211567
   timestamp: 1771716961404
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
-  noarch: python
-  sha256: 2f31f799a46ed75518fae0be75ecc8a1b84360dbfd55096bc2fe8bd9c797e772
-  md5: 2f6b79700452ef1e91f45a99ab8ffe5a
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
+  sha256: 7be013c4ccbc1581cbfa94d4979eb1f2113f7eeb76a40e2589155a694733d0e1
+  md5: 4a45b46523c1b5733a867692ad1ed64f
   depends:
   - python
-  - libcxx >=19
+  - python 3.14.* *_cp314t
   - __osx >=11.0
-  - _python_abi3_support 1.*
-  - cpython >=3.12
+  - libcxx >=19
   - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
+<<<<<<< HEAD
   size: 191641
   timestamp: 1771717073430
+=======
+  size: 374574
+  timestamp: 1771717083205
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -1013,9 +1162,15 @@ packages:
   license_family: GPL
   size: 313930
   timestamp: 1765813902568
+<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
   sha256: fdd92a119a2a5f89d6e549a326adcb008f5046ea5034a9af409e97b7e20e6f06
   md5: ec81bc03787968decae6765c7f61b7cf
+=======
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
+  sha256: 1ae427836d7979779c9005388a05993a3addabcc66c4422694639a4272d7d972
+  md5: d0510124f87c75403090e220db1e9d41
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -1032,11 +1187,19 @@ packages:
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
+<<<<<<< HEAD
   size: 17121940
   timestamp: 1771880708672
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
   sha256: d22bf4791d1fc96b35374de0dd904745c3b54282ba23c3d435a994b4ff384719
   md5: 6f3a898962bdea87c076108bc336df2e
+=======
+  size: 17225275
+  timestamp: 1771880751368
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
+  sha256: 204de892c41cf702f456833c97dc7e2ef2fbb835ccc320e5c1614e78e7cf8c31
+  md5: 5e58062849f471f014feac2ffad301eb
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -1048,6 +1211,7 @@ packages:
   - numpy <2.7
   - numpy >=1.23,<3
   - numpy >=1.25.2
+<<<<<<< HEAD
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
@@ -1055,6 +1219,15 @@ packages:
   license_family: BSD
   size: 14038926
   timestamp: 1771880554132
+=======
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314t
+  - python_abi 3.14.* *_cp314t
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14358162
+  timestamp: 1771880795641
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -1098,9 +1271,15 @@ packages:
   license_family: MIT
   size: 21561
   timestamp: 1774492402955
+<<<<<<< HEAD
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
   sha256: 9e8497e1ecca77d03c6be2d3b5f901dfe0ab99686af4fb94ab418b7d449ac547
   md5: 6c0b0ae017b5bfd9c8d718217efd8f14
+=======
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
+  sha256: ed8d06093ff530a2dae9ed1e51eb6f908fbfd171e8b62f4eae782d67b420be5a
+  md5: dc1ff1e915ab35a06b6fa61efae73ab5
+>>>>>>> daf1aaf (move to using mojo instead of modular)
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -1108,6 +1287,7 @@ packages:
   - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
+<<<<<<< HEAD
   size: 882996
   timestamp: 1774358035145
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
@@ -1122,6 +1302,22 @@ packages:
   license_family: Apache
   size: 883472
   timestamp: 1774358832451
+=======
+  size: 912476
+  timestamp: 1774358032579
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
+  sha256: f747246aab4ca6b15523aa8b40805995a1019450bd2382c906d0a074f1e9d876
+  md5: d33bcf373760d2958e6defa1fe1b0192
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314t
+  - python_abi 3.14.* *_cp314t
+  license: Apache-2.0
+  license_family: Apache
+  size: 909663
+  timestamp: 1774358650588
+>>>>>>> daf1aaf (move to using mojo instead of modular)
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed

--- a/pixi.lock
+++ b/pixi.lock
@@ -15,7 +15,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
@@ -47,22 +47,22 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
@@ -70,9 +70,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
@@ -100,26 +102,26 @@ environments:
       - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -191,16 +193,16 @@ packages:
   license: BSD-3-Clause
   size: 100048
   timestamp: 1777219902525
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.13-py313hd8ed1ab_100.conda
   noarch: generic
-  sha256: 40dc224f2b718e5f034efd2332bc315a719063235f63673468d26a24770094ee
-  md5: f111d4cfaf1fe9496f386bc98ae94452
+  sha256: 836b92c209d4b6b9fb28bd51bd788b22a0c5492ae95eec2724e65a15ed4ab2e1
+  md5: 3a8a8b87e72f95b54689fb588e154ec9
   depends:
-  - python >=3.14,<3.15.0a0
-  - python_abi * *_cp314
+  - python >=3.13,<3.14.0a0
+  - python_abi * *_cp313
   license: Python-2.0
-  size: 49809
-  timestamp: 1775614256655
+  size: 48530
+  timestamp: 1775613723457
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -795,15 +797,15 @@ packages:
   license: X11 AND BSD-3-Clause
   size: 797030
   timestamp: 1738196177597
-- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
-  sha256: f2ba8cb0d86a6461a6bcf0d315c80c7076083f72c6733c9290086640723f79ec
-  md5: 36f5b7eb328bdc204954a2225cf908e2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
+  sha256: bcf75998ea3ae133df3580fb427d1054b006b093799430f499fd7ce8207d34c7
+  md5: c4a9d2e77eb9fee983a70cf5f047c202
   depends:
   - python
   - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.14.* *_cp314
+  - python_abi 3.13.* *_cp313
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - libblas >=3.9.0,<4.0a0
@@ -811,26 +813,26 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 8927860
-  timestamp: 1773839233468
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
-  sha256: c269916245aa84d923b6607fce877a069403714c65f6207d6bec70a333c32331
-  md5: d8dd63deccebc802a8fe5a5e6c255cd6
+  size: 8857056
+  timestamp: 1773839226294
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
+  sha256: d55c3f4b13486bf8e3cadaf731a5d9b67aa9deb51f7c30e381b948a9ada20ef0
+  md5: 03b99caf1270c27febfcceb4f1090af7
   depends:
   - python
-  - libcxx >=19
-  - python 3.14.* *_cp314t
+  - python 3.13.* *_cp313
   - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
+  - libcxx >=19
   - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - python_abi 3.14.* *_cp314t
+  - python_abi 3.13.* *_cp313
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7062457
-  timestamp: 1773839188614
+  size: 6924384
+  timestamp: 1773839167287
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
   sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
   md5: da1b85b6a87e141f5140bb9924cecab0
@@ -880,10 +882,10 @@ packages:
   license_family: MIT
   size: 25862
   timestamp: 1775741140609
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.13-h6add32d_100_cp313.conda
   build_number: 100
-  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
-  md5: a443f87920815d41bfe611296e507995
+  sha256: 7f77eb57648f545c1f58e10035d0d9d66b0a0efb7c4b58d3ed89ec7269afdde1
+  md5: 05051be49267378d2fcd12931e319ac3
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -898,18 +900,18 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
-  - python_abi 3.14.* *_cp314
+  - python_abi 3.13.* *_cp313
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 36705460
-  timestamp: 1775614357822
-  python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
-  sha256: e825c7f56d811f63995be4482442398909000ce71137ce6c9e5bab80ca74997b
-  md5: fe2e332924c098feefba3b806a9951b5
+  size: 37358322
+  timestamp: 1775614712638
+  python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.13-h20e6be0_100_cp313.conda
+  build_number: 100
+  sha256: d0fffc5fde21d1ae350da545dfb9e115a8c53bed8a9c5761f9efd4a5581853c1
+  md5: 9991a930e81d3873eba7a299ba783ec4
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
@@ -921,17 +923,14 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.6,<4.0a0
-  - python_abi 3.14.* *_cp314t
+  - python_abi 3.13.* *_cp313
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
-  - zstd >=1.5.7,<1.6.0a0
-  track_features:
-  - py_freethreading
   license: Python-2.0
-  size: 13978318
-  timestamp: 1775615456198
-  python_site_packages_path: lib/python3.14t/site-packages
+  size: 12966447
+  timestamp: 1775615694085
+  python_site_packages_path: lib/python3.13/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -943,35 +942,25 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
-  sha256: 36ff7984e4565c85149e64f8206303d412a0652e55cf806dcb856903fa056314
-  md5: e4e60721757979d01d3964122f674959
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.13-h4df99d1_100.conda
+  sha256: b2e51d83e5ebeb7e9fde1cde822a60e8564cc9dabd786ad853056afbf708a466
+  md5: fd00e4b24ea88093c93f5c9bad27b52f
   depends:
-  - cpython 3.14.4.*
-  - python_abi * *_cp314
+  - cpython 3.13.13.*
+  - python_abi * *_cp313
   license: Python-2.0
-  size: 49806
-  timestamp: 1775614307464
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  size: 48536
+  timestamp: 1775613791711
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
   build_number: 8
-  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
-  md5: 0539938c55b6b1a59b560e843ad864a4
+  sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
+  md5: 94305520c52a4aa3f6c2b1ff6008d9f8
   constrains:
-  - python 3.14.* *_cp314
+  - python 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 6989
-  timestamp: 1752805904792
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
-  build_number: 8
-  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
-  md5: 3251796e09870c978e0f69fa05e38fb6
-  constrains:
-  - python 3.14.* *_cp314t
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7020
-  timestamp: 1752805919426
+  size: 7002
+  timestamp: 1752805902938
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -988,20 +977,21 @@ packages:
   license_family: BSD
   size: 211567
   timestamp: 1771716961404
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
-  sha256: 7be013c4ccbc1581cbfa94d4979eb1f2113f7eeb76a40e2589155a694733d0e1
-  md5: 4a45b46523c1b5733a867692ad1ed64f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
+  noarch: python
+  sha256: 2f31f799a46ed75518fae0be75ecc8a1b84360dbfd55096bc2fe8bd9c797e772
+  md5: 2f6b79700452ef1e91f45a99ab8ffe5a
   depends:
   - python
-  - python 3.14.* *_cp314t
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.12
   - zeromq >=4.3.5,<4.4.0a0
-  - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
-  size: 374574
-  timestamp: 1771717083205
+  size: 191641
+  timestamp: 1771717073430
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -1023,9 +1013,9 @@ packages:
   license_family: GPL
   size: 313930
   timestamp: 1765813902568
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
-  sha256: 1ae427836d7979779c9005388a05993a3addabcc66c4422694639a4272d7d972
-  md5: d0510124f87c75403090e220db1e9d41
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_0.conda
+  sha256: fdd92a119a2a5f89d6e549a326adcb008f5046ea5034a9af409e97b7e20e6f06
+  md5: ec81bc03787968decae6765c7f61b7cf
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -1038,15 +1028,15 @@ packages:
   - numpy <2.7
   - numpy >=1.23,<3
   - numpy >=1.25.2
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 17225275
-  timestamp: 1771880751368
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
-  sha256: 204de892c41cf702f456833c97dc7e2ef2fbb835ccc320e5c1614e78e7cf8c31
-  md5: 5e58062849f471f014feac2ffad301eb
+  size: 17121940
+  timestamp: 1771880708672
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py313hc753a45_0.conda
+  sha256: d22bf4791d1fc96b35374de0dd904745c3b54282ba23c3d435a994b4ff384719
+  md5: 6f3a898962bdea87c076108bc336df2e
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -1058,13 +1048,13 @@ packages:
   - numpy <2.7
   - numpy >=1.23,<3
   - numpy >=1.25.2
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314t
-  - python_abi 3.14.* *_cp314t
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
-  size: 14358162
-  timestamp: 1771880795641
+  size: 14038926
+  timestamp: 1771880554132
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -1108,30 +1098,30 @@ packages:
   license_family: MIT
   size: 21561
   timestamp: 1774492402955
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
-  sha256: ed8d06093ff530a2dae9ed1e51eb6f908fbfd171e8b62f4eae782d67b420be5a
-  md5: dc1ff1e915ab35a06b6fa61efae73ab5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py313h07c4f96_0.conda
+  sha256: 9e8497e1ecca77d03c6be2d3b5f901dfe0ab99686af4fb94ab418b7d449ac547
+  md5: 6c0b0ae017b5bfd9c8d718217efd8f14
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
-  size: 912476
-  timestamp: 1774358032579
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
-  sha256: f747246aab4ca6b15523aa8b40805995a1019450bd2382c906d0a074f1e9d876
-  md5: d33bcf373760d2958e6defa1fe1b0192
+  size: 882996
+  timestamp: 1774358035145
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py313h0997733_0.conda
+  sha256: c5b0ee042d8a0b88a3823226dc95b794c042c498aee330aa9b4d78bfad01d099
+  md5: 303333dd882dfeb303cc8bfac178464b
   depends:
   - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314t
-  - python_abi 3.14.* *_cp314t
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
   license: Apache-2.0
   license_family: Apache
-  size: 909663
-  timestamp: 1774358650588
+  size: 883472
+  timestamp: 1774358832451
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
@@ -1192,13 +1182,3 @@ packages:
   license_family: BSD
   size: 601375
   timestamp: 1764777111296
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
-  md5: ab136e4c34e97f34fb621d2592a393d8
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 433413
-  timestamp: 1764777166076

--- a/pixi.lock
+++ b/pixi.lock
@@ -2,9 +2,9 @@ version: 6
 environments:
   default:
     channels:
-    - url: https://conda.modular.com/max-nightly/
-    - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.modular.com/max/
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.modular.com/max-nightly/
     - url: https://repo.prefix.dev/modular-community/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
@@ -12,522 +12,113 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.11.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/av-17.0.0-py314hb413b2f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.135.2-hc25896d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.135.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gguf-0.17.1-pyhc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.73.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.78.1-py314h5885658_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-transfer-0.1.9-py314h922f143_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.4.2-py310hb823017_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py314h5bd0f2a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.36.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.2.1-h432359f_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/llguidance-1.7.0-py310hc9716df_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-26.2.0-3.14release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/max-core-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-pipelines-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.2.0-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/modular-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.2.0-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.20.0-py314h5bd0f2a_2.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py314h2b28147_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-prometheus-0.56b0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.56b0-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py314h61e7c5f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyinstrument-5.1.2-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.22-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.2.28-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.7-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.7.0-py314ha5689aa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.2-hdeec2a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.2.1-h8997910_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.2.1-py314hb175150_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-spm-0.2.1-h432359f_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/taskgroup-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py314h67fec18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py314h98f1220_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/transformers-4.57.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.42.0-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.42.0-h76e4700_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py314h5bd0f2a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py314ha5689aa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py314h0f05182_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py314h5bd0f2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.11.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/av-17.0.0-py314h1af1617_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dbus-1.16.2-h3ff7a7c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.135.2-hc25896d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.135.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_ha5d8480_114.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.5-h4e57454_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/gguf-0.17.1-pyhc364b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glslang-16.2.0-h7cb4797_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.73.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.78.1-py314h63f87bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-13.2.1-h3103d1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-transfer-0.1.9-py314h57a929c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-xet-1.4.2-py310he76dbf2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.7.1-py314h0612a62_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.36.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.18-hdfa7624_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-6_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-6_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.4-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.86.4-he378b5c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.2-default_ha3cc4f2_1000.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.3.0-h48b13b8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.2-hc919400_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.2-h913acd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.0.0-h3e6d54f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.0.0-h3e6d54f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.0.0-h2406d2e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.0.0-h2406d2e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.0.0-h85cbfa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.0.0-h85cbfa6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.0.0-h41365f2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.0.0-h41365f2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.0.0-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.0.0-hc295da0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.0.0-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.6.1-h1a92334_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.55-h132b30e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.1-he8aa2a2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsentencepiece-0.2.1-h9466b84_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h81086ad_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.15.2-ha759d40_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.2-h5ef1a60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.2-h8d039ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llguidance-1.7.0-py310h3a138ce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.1-hc7d1edf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-26.2.0-3.14release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/max-pipelines-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.2.0-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/modular-26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.2.0-release.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.20.0-py314h6c2aa35_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.4-hc7d1edf_0.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314h1569ea8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.6.0-hb5b2745_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-prometheus-0.56b0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.35.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.56b0-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-6.33.5-py314he407d35_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.15-hd3d436d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py314haad56a0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyinstrument-5.1.2-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.22-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.2.28-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.7-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/safetensors-0.7.0-py314h8d4a433_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314hfc1f868_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl3-3.4.2-h6fa9c73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-0.2.1-h1f5ecb9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-python-0.2.1-py314h761924b_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-spm-0.2.1-h9466b84_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shaderc-2025.5-hf31e910_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spirv-tools-2026.1-h4ddebb9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.3.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/taskgroup-0.2.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.3.0-h4ddebb9_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiktoken-0.12.0-py314h84b920e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tokenizers-0.22.2-py314h84b920e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/transformers-4.57.6-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.42.0-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.42.0-h76e4700_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvloop-0.22.1-py314h0612a62_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-1.1.1-py314h8d4a433_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-16.0-py314ha14b1ff_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.1.2-py314h6c2aa35_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -563,174 +154,6 @@ packages:
   license_family: MIT
   size: 8191
   timestamp: 1744137672556
-- conda: https://conda.anaconda.org/conda-forge/noarch/aiofiles-25.1.0-pyhcf101f3_1.conda
-  sha256: f37288164cf28b916b184b0a5e89225e17af0e0c9bcd4d0dc39e5a597fcfeed1
-  md5: a6435dc39a8031d33d6d52859913e939
-  depends:
-  - python >=3.10
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 24824
-  timestamp: 1767290524894
-- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
-  md5: dcdc58c15961dbf17a0621312b01f5cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  license_family: GPL
-  size: 584660
-  timestamp: 1768327524772
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
-  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
-  md5: 52be5139047efadaeeb19c6a5103f92a
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 14222
-  timestamp: 1762868213144
-- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
-  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
-  md5: 2934f256a8acfe48f6ebb4fce6cde29c
-  depends:
-  - python >=3.9
-  - typing-extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  size: 18074
-  timestamp: 1733247158254
-- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
-  sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
-  md5: af2df4b9108808da3dc76710fe50eae2
-  depends:
-  - exceptiongroup >=1.0.2
-  - idna >=2.8
-  - python >=3.10
-  - typing_extensions >=4.5
-  - python
-  constrains:
-  - trio >=0.32.0
-  - uvloop >=0.22.1
-  - winloop >=0.2.3
-  license: MIT
-  license_family: MIT
-  size: 146764
-  timestamp: 1774359453364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
-  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
-  md5: 346722a0be40f6edc53f12640d301338
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2706396
-  timestamp: 1718551242397
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.9.1-h7bae524_0.conda
-  sha256: ec238f18ce8140485645252351a0eca9ef4f7a1c568a420f240a585229bc12ef
-  md5: 7adba36492a1bb22d98ffffe4f6fc6de
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2235747
-  timestamp: 1718551382432
-- conda: https://conda.anaconda.org/conda-forge/noarch/asgiref-3.11.1-pyhcf101f3_0.conda
-  sha256: aaeeaf5129981ac0a50c7615458687a606cebfa259a0a94ed94096645ee0d61c
-  md5: 91781fff6c1b3775c47a06b5f5a8f4f1
-  depends:
-  - python >=3.10
-  - typing_extensions >=4
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28381
-  timestamp: 1770273198327
-- conda: https://conda.anaconda.org/conda-forge/linux-64/av-17.0.0-py314hb413b2f_0.conda
-  sha256: ed3005357ad928c3f02e8d6267e3e2c0f6596d6ea8bb060c33497351c779e22b
-  md5: 425bf1e2eee0e47e47926bca1333d67f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ffmpeg >=8.0.1,<9.0a0
-  - libgcc >=14
-  - numpy >=1.22
-  - numpy >=1.23,<3
-  - pillow
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1306351
-  timestamp: 1773532439363
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/av-17.0.0-py314h1af1617_0.conda
-  sha256: eb351c353d364d7f6d3c2f5dee7ad37fe4dd1743e0ceb7759a1f76021cdd25ec
-  md5: cb26982139410632acc017c9d7698962
-  depends:
-  - __osx >=11.0
-  - ffmpeg >=8.0.1,<9.0a0
-  - numpy >=1.22
-  - numpy >=1.23,<3
-  - pillow
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1192581
-  timestamp: 1773532805601
-- conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
-  sha256: f334115c6b0c6c2cd0d28595365f205ec7eaa60bcc5ff91a75d7245f728be820
-  md5: a38b801f2bcc12af80c2e02a9e4ce7d9
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 18816
-  timestamp: 1733771192649
-- conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
-  noarch: generic
-  sha256: c31ab719d256bc6f89926131e88ecd0f0c5d003fe8481852c6424f4ec6c7eb29
-  md5: a2ac7763a9ac75055b68f325d3255265
-  depends:
-  - python >=3.14
-  license: BSD-3-Clause AND MIT AND EPL-2.0
-  size: 7514
-  timestamp: 1767044983590
-- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
-  sha256: 3ad3500bff54a781c29f16ce1b288b36606e2189d0b0ef2f67036554f47f12b0
-  md5: 8910d2c46f7e7b519129f486e0fe927a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - libbrotlicommon 1.2.0 hb03c661_1
-  license: MIT
-  license_family: MIT
-  size: 367376
-  timestamp: 1764017265553
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
-  sha256: 5c2e471fd262fcc3c5a9d5ea4dae5917b885e0e9b02763dbd0f0d9635ed4cb99
-  md5: f9501812fe7c66b6548c7fcaa1c1f252
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - libbrotlicommon 1.2.0 hc919400_1
-  license: MIT
-  license_family: MIT
-  size: 359854
-  timestamp: 1764018178608
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -750,856 +173,34 @@ packages:
   license_family: BSD
   size: 124834
   timestamp: 1771350416561
-- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-  sha256: cc9accf72fa028d31c2a038460787751127317dcfa991f8d1f1babf216bb454e
-  md5: 920bb03579f15389b9e512095ad995b7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 207882
-  timestamp: 1765214722852
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-  sha256: 2995f2aed4e53725e5efbc28199b46bf311c3cab2648fc4f10c2227d6d5fa196
-  md5: bcb3cba70cf1eec964a03b4ba7775f01
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 180327
-  timestamp: 1765215064054
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
-  sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
-  md5: 4492fd26db29495f0ba23f146cd5638d
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
+  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
   depends:
   - __unix
   license: ISC
-  size: 147413
-  timestamp: 1772006283803
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
-  md5: bb6c4808bfa69d6f7f6b07e5846ced37
+  size: 131039
+  timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.3-pyhc90fa1f_0.conda
+  sha256: 37a5d8b10ea3516e2c42f870c9c351b9f7b31ff48c66d83490039f417e1e5228
+  md5: 2266262ce8a425ecb6523d765f79b303
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - icu >=78.1,<79.0a0
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libglib >=2.86.3,<3.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.46.4,<1.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  - xorg-libsm >=1.2.6,<2.0a0
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: LGPL-2.1-only or MPL-1.1
-  size: 989514
-  timestamp: 1766415934926
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
-  sha256: cde9b79ee206fe3ba6ca2dc5906593fb7a1350515f85b2a1135a4ce8ec1539e3
-  md5: 36200ecfbbfbcb82063c87725434161f
-  depends:
-  - __osx >=11.0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - icu >=78.1,<79.0a0
-  - libcxx >=19
-  - libexpat >=2.7.3,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libglib >=2.86.3,<3.0a0
-  - libpng >=1.6.53,<1.7.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pixman >=0.46.4,<1.0a0
-  license: LGPL-2.1-only or MPL-1.1
-  size: 900035
-  timestamp: 1766416416791
-- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
-  sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
-  md5: 765c4d97e877cdbbb88ff33152b86125
-  depends:
-  - python >=3.10
-  license: ISC
-  size: 151445
-  timestamp: 1772001170301
-- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-  sha256: d86dfd428b2e3c364fa90e07437c8405d635aa4ef54b25ab51d9c712be4112a5
-  md5: 49ee13eb9b8f44d63879c69b8a40a74b
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 58510
-  timestamp: 1773660086450
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-  sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
-  md5: ea8a6c3256897cc31263de9f455e25d9
-  depends:
-  - python >=3.10
   - __unix
   - python
+  - python >=3.10
   license: BSD-3-Clause
-  license_family: BSD
-  size: 97676
-  timestamp: 1764518652276
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
+  size: 100048
+  timestamp: 1777219902525
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
   noarch: generic
-  sha256: 91b06300879df746214f7363d6c27c2489c80732e46a369eb2afc234bcafb44c
-  md5: 3bb89e4f795e5414addaa531d6b1500a
+  sha256: 40dc224f2b718e5f034efd2332bc315a719063235f63673468d26a24770094ee
+  md5: f111d4cfaf1fe9496f386bc98ae94452
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi * *_cp314
   license: Python-2.0
-  size: 50078
-  timestamp: 1770674447292
-- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  md5: 418c6ca5929a611cbd69204907a83995
-  depends:
-  - libgcc-ng >=12
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 760229
-  timestamp: 1685695754230
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
-  sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
-  md5: 5a74cdee497e6b65173e10d94582fae6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 316394
-  timestamp: 1685695959391
-- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
-  md5: ce96f2f470d39bd96ce03945af92e280
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - libglib >=2.86.2,<3.0a0
-  - libexpat >=2.7.3,<3.0a0
-  license: AFL-2.1 OR GPL-2.0-or-later
-  size: 447649
-  timestamp: 1764536047944
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/dbus-1.16.2-h3ff7a7c_1.conda
-  sha256: a8207751ed261764061866880da38e4d3063e167178bfe85b6db9501432462ba
-  md5: 5a3506971d2d53023c1c4450e908a8da
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - libglib >=2.86.2,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
-  license: AFL-2.1 OR GPL-2.0-or-later
-  size: 393811
-  timestamp: 1764536084131
-- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
-  sha256: 7d57a7b8266043ffb99d092ebc25e89a0a2490bed4146b9432c83c2c476fa94d
-  md5: 5498feb783ab29db6ca8845f68fa0f03
-  depends:
-  - python >=3.10
-  - wrapt <3,>=1.10
-  license: MIT
-  license_family: MIT
-  size: 15896
-  timestamp: 1768934186726
-- conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
-  sha256: ef1e7b8405997ed3d6e2b6722bd7088d4a8adf215e7c88335582e65651fb4e05
-  md5: d73fdc05f10693b518f52c994d748c19
-  depends:
-  - python >=3.10,<4.0.0
-  - sniffio
-  - python
-  constrains:
-  - aioquic >=1.2.0
-  - cryptography >=45
-  - httpcore >=1.0.0
-  - httpx >=0.28.0
-  - h2 >=4.2.0
-  - idna >=3.10
-  - trio >=0.30
-  - wmi >=1.5.1
-  license: ISC
-  size: 196500
-  timestamp: 1757292856922
-- conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
-  sha256: c37320864c35ef996b0e02e289df6ee89582d6c8e233e18dc9983375803c46bb
-  md5: 3bc0ac31178387e8ed34094d9481bfe8
-  depends:
-  - dnspython >=2.0.0
-  - idna >=2.0.0
-  - python >=3.10
-  license: Unlicense
-  size: 46767
-  timestamp: 1756221480106
-- conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
-  sha256: 6a518e00d040fcad016fb2dde29672aa3476cd9ae33ea5b7b257222e66037d89
-  md5: 2452e434747a6b742adc5045f2182a8e
-  depends:
-  - email-validator >=2.3.0,<2.3.1.0a0
-  license: Unlicense
-  size: 7077
-  timestamp: 1756221480651
-- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
-  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
-  md5: 8e662bd460bda79b1ea39194e3c4c9ab
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.6.0
-  license: MIT and PSF-2.0
-  size: 21333
-  timestamp: 1763918099466
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.135.2-hc25896d_0.conda
-  sha256: a9daf52c37baed7b6f6280411d89ec035bbeea9d580734e1c5f9e54eacfd7288
-  md5: d8f65c6808d64f9259c30d5e45076c4d
-  depends:
-  - fastapi-core ==0.135.2 pyhcf101f3_0
-  - email_validator
-  - fastapi-cli
-  - httpx
-  - jinja2
-  - pydantic-settings
-  - pydantic-extra-types
-  - python-multipart
-  - uvicorn-standard
-  license: MIT
-  license_family: MIT
-  size: 4817
-  timestamp: 1774290725801
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.23-pyhcf101f3_0.conda
-  sha256: cb60fc8c96dcd2a6335914d4d6d7d5f5549c9e1ff4533be28ba699e648babf37
-  md5: 442ec6511754418c87a84bc1dc0c5384
-  depends:
-  - python >=3.10
-  - rich-toolkit >=0.14.8
-  - tomli >=2.0.0
-  - typer >=0.15.1
-  - uvicorn-standard >=0.15.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 18920
-  timestamp: 1771293215825
-- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.135.2-pyhcf101f3_0.conda
-  sha256: 849c179ffd86f3c1045a15bf6af1b3bbce39f8c67eb48769fc5fa5620a25b307
-  md5: 81998811f3e68132d4718be59d6cef94
-  depends:
-  - python >=3.10
-  - annotated-doc >=0.0.2
-  - starlette >=0.46.0
-  - typing_extensions >=4.8.0
-  - typing-inspection >=0.4.2
-  - pydantic >=2.9.0
-  - python
-  constrains:
-  - email_validator >=2.0.0
-  - fastapi-cli >=0.0.8
-  - httpx >=0.23.0,<1.0.0
-  - jinja2 >=3.1.5
-  - pydantic-extra-types >=2.0.0
-  - pydantic-settings >=2.0.0
-  - python-multipart >=0.0.18
-  - uvicorn-standard >=0.12.0
-  license: MIT
-  license_family: MIT
-  size: 95598
-  timestamp: 1774290725801
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_hcddb375_914.conda
-  sha256: 0d465b145eb7166d6a3989f0befe790789624604945f53de767b169b1832c088
-  md5: f0e9f1452786e2b32907e8d9a6b3c752
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.15.3,<1.3.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=12.3.2
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.4,<0.17.5.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libopenvino >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-cpu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-gpu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-intel-npu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopus >=1.6.1,<2.0a0
-  - librsvg >=2.60.2,<3.0a0
-  - libstdcxx >=14
-  - libva >=2.23.0,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpl >=2.16.0,<2.17.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.5,<4.0a0
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=4.0.1,<4.0.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  constrains:
-  - __cuda  >=12.8
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 12485347
-  timestamp: 1773008832077
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-8.0.1-gpl_ha5d8480_114.conda
-  sha256: 5ad931d8ae03ad6a76104dc79189ba0838eed15b814cb12ae94aed0f139e7e66
-  md5: c61afe756ee72cdb873b4a500a674975
-  depends:
-  - __osx >=11.0
-  - aom >=3.9.1,<3.10.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gmp >=6.3.0,<7.0a0
-  - harfbuzz >=12.3.2
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.4,<0.17.5.0a0
-  - libcxx >=19
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libiconv >=1.18,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libopenvino >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-arm-cpu-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-batch-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-auto-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-hetero-plugin >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-ir-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-onnx-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-paddle-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-pytorch-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopenvino-tensorflow-lite-frontend >=2026.0.0,<2026.0.1.0a0
-  - libopus >=1.6.1,<2.0a0
-  - librsvg >=2.60.0,<3.0a0
-  - libvorbis >=1.3.7,<1.4.0a0
-  - libvpx >=1.15.2,<1.16.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libzlib >=1.3.1,<2.0a0
-  - openh264 >=2.6.0,<2.6.1.0a0
-  - openssl >=3.5.5,<4.0a0
-  - sdl2 >=2.32.56,<3.0a0
-  - shaderc >=2025.5,<2025.6.0a0
-  - svt-av1 >=4.0.1,<4.0.2.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9562305
-  timestamp: 1773009604760
-- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.25.2-pyhd8ed1ab_0.conda
-  sha256: dddea9ec53d5e179de82c24569d41198f98db93314f0adae6b15195085d5567f
-  md5: f58064cec97b12a7136ebb8a6f8a129b
-  depends:
-  - python >=3.10
-  license: Unlicense
-  size: 25845
-  timestamp: 1773314012590
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  md5: 0c96522c6bdaed4b1566d11387caaf45
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 397370
-  timestamp: 1566932522327
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  md5: 34893075a5c9e55cdafac56607368fc6
-  license: OFL-1.1
-  license_family: Other
-  size: 96530
-  timestamp: 1620479909603
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  md5: 4d59c254e01d9cde7957100457e2d5fb
-  license: OFL-1.1
-  license_family: Other
-  size: 700814
-  timestamp: 1620479612257
-- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  md5: 49023d73832ef61042f6a237cb2687e7
-  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
-  license_family: Other
-  size: 1620504
-  timestamp: 1727511233259
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.17.1-h27c8c51_0.conda
-  sha256: aa4a44dba97151221100a637c7f4bde619567afade9c0265f8e1c8eed8d7bd8c
-  md5: 867127763fbe935bab59815b6e0b7b5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libgcc >=14
-  - libuuid >=2.41.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 270705
-  timestamp: 1771382710863
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.17.1-h2b252f5_0.conda
-  sha256: 851e9c778bfc54645dcab7038c0383445cbebf16f6bb2d3f62ce422b1605385a
-  md5: d06ae1a11b46cc4c74177ecd28de7c7a
-  depends:
-  - __osx >=11.0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 237308
-  timestamp: 1771382999247
-- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  md5: fee5683a3f04bd15cbd8318b096a27ab
-  depends:
-  - fonts-conda-forge
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3667
-  timestamp: 1566974674465
-- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
-  md5: a7970cd949a077b7cb9696379d338681
-  depends:
-  - font-ttf-ubuntu
-  - font-ttf-inconsolata
-  - font-ttf-dejavu-sans-mono
-  - font-ttf-source-code-pro
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4059
-  timestamp: 1762351264405
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
-  sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
-  md5: f9f81ea472684d75b9dd8d0b328cf655
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 61244
-  timestamp: 1757438574066
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.16-hc919400_0.conda
-  sha256: d856dc6744ecfba78c5f7df3378f03a75c911aadac803fa2b41a583667b4b600
-  md5: 04bdce8d93a4ed181d1d726163c2d447
-  depends:
-  - __osx >=11.0
-  license: LGPL-2.1-or-later
-  size: 59391
-  timestamp: 1757438897523
-- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.2.0-pyhd8ed1ab_0.conda
-  sha256: 239b67edf1c5e5caed52cf36e9bed47cb21b37721779828c130e6b3fd9793c1b
-  md5: 496c6c9411a6284addf55c898d6ed8d7
-  depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 148757
-  timestamp: 1770387898414
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_1.conda
-  sha256: b2a6fb56b8f2d576a3ae5e6c57b2dbab91d52d1f1658bf1b258747ae25bb9fde
-  md5: 7eb4977dd6f60b3aaab0715a0ea76f11
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 575109
-  timestamp: 1771530561157
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.44.5-h4e57454_1.conda
-  sha256: ed637a29deb9afb77c51a0e8b3961eb725fcbf7d6d84dadb0983a457f24dba24
-  md5: 444c1d08dc4c0303ae08fa7cd14497a4
-  depends:
-  - __osx >=11.0
-  - libglib >=2.86.4,<3.0a0
-  - libintl >=0.25.1,<1.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 549384
-  timestamp: 1771530540200
-- conda: https://conda.anaconda.org/conda-forge/noarch/gguf-0.17.1-pyhc364b38_1.conda
-  sha256: db9153390627023f88c83e8fca87825a67bde3080dca91554be83b8db369e75e
-  md5: 99d5d8bfe8def56f3514c82bfe840315
-  depends:
-  - python >=3.8
-  - numpy >=1.17
-  - tqdm >=4.27
-  - pyyaml >=5.1
-  - python
-  license: MIT
-  license_family: MIT
-  size: 92302
-  timestamp: 1770223049607
-- conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
-  sha256: 88a5ad3571948bde22957d08ab01328b8a7eb04fdee66268b3125cc322dbde8b
-  md5: ba5b655d827f263090ad2dc514810328
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - spirv-tools >=2026,<2027.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1353008
-  timestamp: 1770195199411
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/glslang-16.2.0-h7cb4797_1.conda
-  sha256: c37ff244957b26ea30ca358870a3dcebdc00380cf503934d15ed9a2d9a0974a6
-  md5: 078b7bfbdcab987a291814439d3e4383
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - spirv-tools >=2026,<2027.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 865639
-  timestamp: 1770195584496
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
-  md5: c94a5994ef49749880a8139cf9afcbe1
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 460055
-  timestamp: 1718980856608
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
-  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
-  md5: eed7278dfbab727b56f2c0b64330814b
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  license: GPL-2.0-or-later OR LGPL-3.0-or-later
-  size: 365188
-  timestamp: 1718981343258
-- conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.73.0-pyhcf101f3_0.conda
-  sha256: b228ef6e9a7aa4cbdff42df1ddc7ab305266268bbfaf2cf946a56da66818c7b7
-  md5: 07531f1f9bb98acde68747f69127ccc1
-  depends:
-  - python >=3.10
-  - protobuf >=3.20.2,<7.0.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 146811
-  timestamp: 1772881883607
-- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
-  md5: 2cd94587f3a401ae05e03a6caf09539d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 99596
-  timestamp: 1755102025473
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
-  sha256: c507ae9989dbea7024aa6feaebb16cbf271faac67ac3f0342ef1ab747c20475d
-  md5: 0fc46fee39e88bbcf5835f71a9d9a209
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 81202
-  timestamp: 1755102333712
-- conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.78.1-py314h5885658_0.conda
-  sha256: b788fe890209ad6da16aff17684a080055ebea0014e004299e5311e3894fd1c6
-  md5: 6715c7d2b0e20d0e59fa72997ed759c5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libgrpc 1.78.1 h1d1128b_0
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 900313
-  timestamp: 1774020522415
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.78.1-py314h63f87bf_0.conda
-  sha256: 1a93667a727c80f991fc246bfffa2b1251eedb6352af51936acc98931d20327d
-  md5: 254ed802b3dbb276a748c9839b82f5df
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libgrpc 1.78.1 h3e3f78d_0
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  - typing-extensions >=4.12,<5
-  license: Apache-2.0
-  license_family: APACHE
-  size: 784062
-  timestamp: 1774013533665
-- conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
-  sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
-  md5: b8993c19b0c32a2f7b66cbb58ca27069
-  depends:
-  - python >=3.10
-  - typing_extensions
-  - python
-  license: MIT
-  license_family: MIT
-  size: 39069
-  timestamp: 1767729720872
-- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
-  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
-  depends:
-  - python >=3.10
-  - hyperframe >=6.1,<7
-  - hpack >=4.1,<5
-  - python
-  license: MIT
-  license_family: MIT
-  size: 95967
-  timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
-  sha256: 477f2c553f72165020d3c56740ba354be916c2f0b76fd9f535e83d698277d5ec
-  md5: 14470902326beee192e33719a2e8bb7f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.3,<79.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libstdcxx >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 2384060
-  timestamp: 1774276284520
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-13.2.1-h3103d1b_0.conda
-  sha256: 7bfb3037cc73dabf755b4308eb4ac885e40806df824838928904758ef1bc92c9
-  md5: 07313476933d7bf01bfe9a0ae9a5ca4d
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.4,<2.0a0
-  - graphite2 >=1.3.14,<2.0a0
-  - icu >=78.3,<79.0a0
-  - libcxx >=19
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libglib >=2.86.4,<3.0a0
-  - libzlib >=1.3.2,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 1649886
-  timestamp: 1774277167588
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-transfer-0.1.9-py314h922f143_2.conda
-  sha256: 27c84c4b9e4179696c37b9f5787a0ab60de2f867a480aca8542ad4b2386af4d3
-  md5: d7dfce3c787dc5b84254a2a54aebe079
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.14.* *_cp314
-  - openssl >=3.5.2,<4.0a0
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1304128
-  timestamp: 1756624832097
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-transfer-0.1.9-py314h57a929c_2.conda
-  sha256: 5851eba2dbcea7670015dd96cdf0f19ff508cc4d7397724b3daad079666ea8f6
-  md5: f186b44e09452d390ee56ef214d08a76
-  depends:
-  - python
-  - python 3.14.* *_cp314
-  - __osx >=11.0
-  - openssl >=3.5.2,<4.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1190299
-  timestamp: 1756624925269
-- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.4.2-py310hb823017_0.conda
-  noarch: python
-  sha256: 58f25aa8320c45bdc9c7fc9fffa6ef16adf44d774ddd8417692018c77f65f045
-  md5: 3e564715ea4c03e3d19b8c8343cebaeb
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3372988
-  timestamp: 1773430452044
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/hf-xet-1.4.2-py310he76dbf2_0.conda
-  noarch: python
-  sha256: c33bfa6c8cd398ac1e45027fef928615fedf60140d96599c60039ad7f06d014d
-  md5: 3b217dc11941496037703c7cf9e3dd08
-  depends:
-  - python
-  - __osx >=11.0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  - openssl >=3.5.5,<4.0a0
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 3161873
-  timestamp: 1773430720023
-- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
-  sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
-  md5: 0a802cb9888dd14eeefc611f05c40b6e
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 30731
-  timestamp: 1737618390337
-- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
-  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
-  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
-  depends:
-  - python >=3.9
-  - h11 >=0.16
-  - h2 >=3,<5
-  - sniffio 1.*
-  - anyio >=4.0,<5.0
-  - certifi
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 49483
-  timestamp: 1745602916758
-- conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py314h5bd0f2a_1.conda
-  sha256: 91bfdf1dad0fa57efc2404ca00f5fee8745ad9b56ec1d0df298fd2882ad39806
-  md5: 067a52c66f453b97771650bbb131e2b5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: MIT
-  license_family: MIT
-  size: 99037
-  timestamp: 1762504051423
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/httptools-0.7.1-py314h0612a62_1.conda
-  sha256: 042343211aafabab79120d0deda73358ddd3cb61b9ad55307108a275976fccfa
-  md5: 0ca03669a236fee8ce414e166d0bbf23
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: MIT
-  license_family: MIT
-  size: 90384
-  timestamp: 1762504632522
-- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
-  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
-  md5: d6989ead454181f4f9bc987d3dc4e285
-  depends:
-  - anyio
-  - certifi
-  - httpcore 1.*
-  - idna
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 63082
-  timestamp: 1733663449209
-- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.36.0-pyhd8ed1ab_0.conda
-  sha256: 7ba53c55530b8bbbd64805b5820a9f4dd35b3d749cdd57092b09f07f71447da6
-  md5: 39e591c87bc60fcf0944f5b878ed3e27
-  depends:
-  - filelock
-  - fsspec >=2023.5.0
-  - hf-xet >=1.1.3,<2.0.0
-  - packaging >=20.9
-  - python >=3.10
-  - pyyaml >=5.1
-  - requests
-  - tqdm >=4.42.1
-  - typing-extensions >=3.7.4.3
-  - typing_extensions >=3.7.4.3
-  license: Apache-2.0
-  license_family: APACHE
-  size: 338701
-  timestamp: 1761225975526
-- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-  sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
-  md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 17397
-  timestamp: 1737618427549
+  size: 49809
+  timestamp: 1775614256655
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -1611,70 +212,17 @@ packages:
   license_family: MIT
   size: 12723451
   timestamp: 1773822285671
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
-  md5: f1182c91c0de31a7abd40cedf6a5ebef
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 12361647
-  timestamp: 1773822915649
-- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
-  sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
-  md5: 53abe63df7e10a6ba605dc5f9f961d36
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+  sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
+  md5: 080594bf4493e6bae2607e65390c520a
   depends:
   - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50721
-  timestamp: 1760286526795
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
-  md5: 63ccfdc3a3ce25b027b8767eb722fca8
-  depends:
-  - python >=3.9
   - zipp >=3.20
   - python
   license: Apache-2.0
   license_family: APACHE
-  size: 34641
-  timestamp: 1747934053147
-- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
-  sha256: bc231d69eb6663db0e09738fb916c5e5507147cf1ac60f364f964004e0b29bab
-  md5: 10909406c1b0e4b57f9f4f0eb0999af8
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 1013714
-  timestamp: 1774422680665
-- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.5-hecca717_0.conda
-  sha256: 11392c7e965a68548754f17b0e358f54590c233da6cbcdac1096c2a39ff0f6da
-  md5: 6124ffce32e909624a446aa5c419faec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - intel-gmmlib >=22.9.0,<23.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libva >=2.23.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 8786646
-  timestamp: 1774266925285
-- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
-  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
-  md5: 04558c96691bed63104678757beb4f8d
-  depends:
-  - markupsafe >=2.0
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 120685
-  timestamp: 1764517220861
+  size: 34387
+  timestamp: 1773931568510
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
   md5: 4ebae00eae9705b0c3d6d1018a81d047
@@ -1743,45 +291,6 @@ packages:
   license_family: MIT
   size: 1160828
   timestamp: 1769770119811
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
-  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
-  md5: a8832b479f93521a9e7b5b743803be51
-  depends:
-  - libgcc-ng >=12
-  license: LGPL-2.0-only
-  license_family: LGPL
-  size: 508258
-  timestamp: 1664996250081
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
-  sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
-  md5: bff0e851d66725f78dc2fd8b032ddb7e
-  license: LGPL-2.0-only
-  license_family: LGPL
-  size: 528805
-  timestamp: 1664996399305
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.18-h0c24ade_0.conda
-  sha256: 836ec4b895352110335b9fdcfa83a8dcdbe6c5fb7c06c4929130600caea91c0a
-  md5: 6f2e2c8f58160147c4d1c6f4c14cbac4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  size: 249959
-  timestamp: 1768184673131
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.18-hdfa7624_0.conda
-  sha256: d768da024ab74a4b30642401877fa914a68bdc238667f16b1ec2e0e98b2451a6
-  md5: 6631a7bd2335bb9699b1dbc234b19784
-  depends:
-  - __osx >=11.0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  license: MIT
-  license_family: MIT
-  size: 211756
-  timestamp: 1768184994800
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -1794,270 +303,77 @@ packages:
   license_family: GPL
   size: 728002
   timestamp: 1774197446916
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
-  sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
-  md5: a752488c68f2e7c456bcbd8f16eec275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h4a7cf45_openblas.conda
+  build_number: 6
+  sha256: 7bfe936dbb5db04820cf300a9cc1f5ee8d5302fc896c2d66e30f1ee2f20fbfd6
+  md5: 6d6d225559bfa6e2f3c90ee9c03d4e2e
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 261513
-  timestamp: 1773113328888
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
-  sha256: 66e5ffd301a44da696f3efc2f25d6d94f42a9adc0db06c44ad753ab844148c51
-  md5: 095e5749868adab9cae42d4b460e5443
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: Apache-2.0
-  license_family: Apache
-  size: 164222
-  timestamp: 1773114244984
-- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.2-hb700be7_0.conda
-  sha256: 5384380213daffbd7fe4d568b2cf2ab9f2476f7a5f228a3d70280e98333eaf0f
-  md5: 4323e07abff8366503b97a0f17924b76
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 858387
-  timestamp: 1772045965844
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-  sha256: a7a4481a4d217a3eadea0ec489826a69070fcc3153f00443aa491ed21527d239
-  md5: 6f7b4302263347698fd24565fbf11310
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
+  - libopenblas >=0.3.32,<0.3.33.0a0
+  - libopenblas >=0.3.32,<1.0a0
   constrains:
-  - libabseil-static =20260107.1=cxx17*
-  - abseil-cpp =20260107.1
-  license: Apache-2.0
-  license_family: Apache
-  size: 1384817
-  timestamp: 1770863194876
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-  sha256: 756611fbb8d2957a5b4635d9772bd8432cb6ddac05580a6284cca6fdc9b07fca
-  md5: bb65152e0d7c7178c0f1ee25692c9fd1
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  constrains:
-  - abseil-cpp =20260107.1
-  - libabseil-static =20260107.1=cxx17*
-  license: Apache-2.0
-  license_family: Apache
-  size: 1229639
-  timestamp: 1770863511331
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
-  sha256: 035eb8b54e03e72e42ef707420f9979c7427776ea99e0f1e3c969f92eb573f19
-  md5: d3be7b2870bf7aff45b12ea53165babd
-  depends:
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
-  - fribidi >=1.0.10,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - harfbuzz >=11.0.1
-  license: ISC
-  size: 152179
-  timestamp: 1749328931930
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.4-hcbd7ca7_0.conda
-  sha256: 079f5fdf7aace970a0db91cd2cc493c754dfdc4520d422ecec43d2561021167a
-  md5: 0977f4a79496437ff3a2c97d13c4c223
-  depends:
-  - __osx >=11.0
-  - fontconfig >=2.15.0,<3.0a0
-  - fonts-conda-ecosystem
-  - libzlib >=1.3.1,<2.0a0
-  - fribidi >=1.0.10,<2.0a0
-  - libiconv >=1.18,<2.0a0
-  - harfbuzz >=11.0.1
-  - libfreetype >=2.13.3
-  - libfreetype6 >=2.13.3
-  license: ISC
-  size: 138339
-  timestamp: 1749328988096
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
-  build_number: 5
-  sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
-  md5: c160954f7418d7b6e87eaf05a8913fa9
-  depends:
-  - libopenblas >=0.3.30,<0.3.31.0a0
-  - libopenblas >=0.3.30,<1.0a0
-  constrains:
-  - mkl <2026
-  - liblapack  3.11.0   5*_openblas
-  - libcblas   3.11.0   5*_openblas
-  - blas 2.305   openblas
-  - liblapacke 3.11.0   5*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18213
-  timestamp: 1765818813880
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
-  build_number: 5
-  sha256: 620a6278f194dcabc7962277da6835b1e968e46ad0c8e757736255f5ddbfca8d
-  md5: bcc025e2bbaf8a92982d20863fe1fb69
-  depends:
-  - libopenblas >=0.3.30,<0.3.31.0a0
-  - libopenblas >=0.3.30,<1.0a0
-  constrains:
-  - libcblas   3.11.0   5*_openblas
-  - liblapack  3.11.0   5*_openblas
-  - liblapacke 3.11.0   5*_openblas
-  - blas 2.305   openblas
+  - blas 2.306   openblas
+  - liblapack  3.11.0   6*_openblas
+  - liblapacke 3.11.0   6*_openblas
+  - libcblas   3.11.0   6*_openblas
   - mkl <2026
   license: BSD-3-Clause
   license_family: BSD
-  size: 18546
-  timestamp: 1765819094137
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
-  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
-  md5: 72c8fd1af66bd67bf580645b426513ed
+  size: 18621
+  timestamp: 1774503034895
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-6_h51639a9_openblas.conda
+  build_number: 6
+  sha256: 979227fc03628925037ab2dfda008eb7b5592644d9c2c21dd285cefe8c42553d
+  md5: e551103471911260488a02155cef9c94
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 79965
-  timestamp: 1764017188531
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
-  sha256: a7cb9e660531cf6fbd4148cff608c85738d0b76f0975c5fc3e7d5e92840b7229
-  md5: 006e7ddd8a110771134fcc4e1e3a6ffa
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 79443
-  timestamp: 1764017945924
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
-  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
-  md5: 366b40a69f0ad6072561c1d09301c886
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 34632
-  timestamp: 1764017199083
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
-  sha256: 2eae444039826db0454b19b52a3390f63bfe24f6b3e63089778dd5a5bf48b6bf
-  md5: 079e88933963f3f149054eec2c487bc2
-  depends:
-  - __osx >=11.0
-  - libbrotlicommon 1.2.0 hc919400_1
-  license: MIT
-  license_family: MIT
-  size: 29452
-  timestamp: 1764017979099
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
-  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libbrotlicommon 1.2.0 hb03c661_1
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 298378
-  timestamp: 1764017210931
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-hc919400_1.conda
-  sha256: 01436c32bb41f9cb4bcf07dda647ce4e5deb8307abfc3abdc8da5317db8189d1
-  md5: b2b7c8288ca1a2d71ff97a8e6a1e8883
-  depends:
-  - __osx >=11.0
-  - libbrotlicommon 1.2.0 hc919400_1
-  license: MIT
-  license_family: MIT
-  size: 290754
-  timestamp: 1764018009077
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
-  sha256: 37c41b1024d0c75da76822e3c079aabaf121618a32fe05e53a897b35a88008fc
-  md5: 499cd8e2d4358986dbe3b30e8fe1bf6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 124432
-  timestamp: 1774333989027
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
-  build_number: 5
-  sha256: 0cbdcc67901e02dc17f1d19e1f9170610bd828100dc207de4d5b6b8ad1ae7ad8
-  md5: 6636a2b6f1a87572df2970d3ebc87cc0
-  depends:
-  - libblas 3.11.0 5_h4a7cf45_openblas
+  - libopenblas >=0.3.32,<0.3.33.0a0
+  - libopenblas >=0.3.32,<1.0a0
   constrains:
-  - liblapacke 3.11.0   5*_openblas
-  - blas 2.305   openblas
-  - liblapack  3.11.0   5*_openblas
+  - liblapacke 3.11.0   6*_openblas
+  - liblapack  3.11.0   6*_openblas
+  - blas 2.306   openblas
+  - libcblas   3.11.0   6*_openblas
+  - mkl <2026
   license: BSD-3-Clause
   license_family: BSD
-  size: 18194
-  timestamp: 1765818837135
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
-  build_number: 5
-  sha256: 38809c361bbd165ecf83f7f05fae9b791e1baa11e4447367f38ae1327f402fc0
-  md5: efd8bd15ca56e9d01748a3beab8404eb
+  size: 18859
+  timestamp: 1774504387211
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
+  build_number: 6
+  sha256: 57edafa7796f6fa3ebbd5367692dd4c7f552be42109c2dd1a7c89b55089bf374
+  md5: 36ae340a916635b97ac8a0655ace2a35
   depends:
-  - libblas 3.11.0 5_h51639a9_openblas
+  - libblas 3.11.0 6_h4a7cf45_openblas
   constrains:
-  - liblapacke 3.11.0   5*_openblas
-  - liblapack  3.11.0   5*_openblas
-  - blas 2.305   openblas
+  - blas 2.306   openblas
+  - liblapack  3.11.0   6*_openblas
+  - liblapacke 3.11.0   6*_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 18548
-  timestamp: 1765819108956
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.2-h55c6f16_0.conda
-  sha256: d1402087c8792461bfc081629e8aa97e6e577a31ae0b84e6b9cc144a18f48067
-  md5: 4280e0a7fd613b271e022e60dea0138c
+  size: 18622
+  timestamp: 1774503050205
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-6_hb0561ab_openblas.conda
+  build_number: 6
+  sha256: 2e6b3e9b1ab672133b70fc6730e42290e952793f132cb5e72eee22835463eba0
+  md5: 805c6d31c5621fd75e53dfcf21fb243a
+  depends:
+  - libblas 3.11.0 6_h51639a9_openblas
+  constrains:
+  - liblapacke 3.11.0   6*_openblas
+  - blas 2.306   openblas
+  - liblapack  3.11.0   6*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18863
+  timestamp: 1774504433388
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.4-h55c6f16_0.conda
+  sha256: 25a0d02148a39b665d9c2957676faf62a4d2a58494d53b201151199a197db4b0
+  md5: 448a1af83a9205655ee1cf48d3875ca3
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 568094
-  timestamp: 1774439202359
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
-  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
-  md5: 6c77a605a7a689d17d4819c0f8ac9a00
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 73490
-  timestamp: 1761979956660
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.25-hc11a715_0.conda
-  sha256: 5e0b6961be3304a5f027a8c00bd0967fc46ae162cffb7553ff45c70f51b8314c
-  md5: a6130c709305cd9828b4e1bd9ba0000c
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 55420
-  timestamp: 1761980066242
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
-  sha256: c076a213bd3676cc1ef22eeff91588826273513ccc6040d9bea68bccdc849501
-  md5: 9314bc5a1fe7d1044dc9dfd3ef400535
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpciaccess >=0.18,<0.19.0a0
-  license: MIT
-  license_family: MIT
-  size: 310785
-  timestamp: 1757212153962
+  size: 569927
+  timestamp: 1776816293111
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -2081,38 +397,29 @@ packages:
   license_family: BSD
   size: 107691
   timestamp: 1738479560845
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
-  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
-  md5: c151d5eb730e9b7480e6d48c0fc44048
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 44840
-  timestamp: 1731330973553
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
-  sha256: d78f1d3bea8c031d2f032b760f36676d87929b18146351c4464c66b0869df3f5
-  md5: e7f7ce06ec24cfcfb9e36d28cf82ba57
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.5-hecca717_0.conda
+  sha256: e8c2b57f6aacabdf2f1b0924bd4831ce5071ba080baa4a9e8c0d720588b6794c
+  md5: 49f570f3bc4c874a06ea69b7225753af
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - expat 2.7.4.*
+  - expat 2.7.5.*
   license: MIT
   license_family: MIT
-  size: 76798
-  timestamp: 1771259418166
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
-  sha256: 03887d8080d6a8fe02d75b80929271b39697ecca7628f0657d7afaea87761edf
-  md5: a92e310ae8dfc206ff449f362fc4217f
+  size: 76624
+  timestamp: 1774719175983
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.5-hf6b4638_0.conda
+  sha256: 06780dec91dd25770c8cf01e158e1062fbf7c576b1406427475ce69a8af75b7e
+  md5: a32123f93e168eaa4080d87b0fb5da8a
   depends:
   - __osx >=11.0
   constrains:
-  - expat 2.7.4.*
+  - expat 2.7.5.*
   license: MIT
   license_family: MIT
-  size: 68199
-  timestamp: 1771260020767
+  size: 68192
+  timestamp: 1774719211725
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -2132,60 +439,6 @@ packages:
   license_family: MIT
   size: 40979
   timestamp: 1769456747661
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
-  sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
-  md5: 47595b9d53054907a00d95e4d47af1d6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libogg >=1.3.5,<1.4.0a0
-  - libstdcxx >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 424563
-  timestamp: 1764526740626
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
-  sha256: 38f014a7129e644636e46064ecd6b1945e729c2140e21d75bb476af39e692db2
-  md5: e289f3d17880e44b633ba911d57a321b
-  depends:
-  - libfreetype6 >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 8049
-  timestamp: 1774298163029
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.14.3-hce30654_0.conda
-  sha256: a047a2f238362a37d484f9620e8cba29f513a933cd9eb68571ad4b270d6f8f3e
-  md5: f73b109d49568d5d1dda43bb147ae37f
-  depends:
-  - libfreetype6 >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 8091
-  timestamp: 1774298691258
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
-  sha256: 16f020f96da79db1863fcdd8f2b8f4f7d52f177dd4c58601e38e9182e91adf1d
-  md5: fb16b4b69e3f1dcfe79d80db8fd0c55d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  constrains:
-  - freetype >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 384575
-  timestamp: 1774298162622
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.14.3-hdfa99f5_0.conda
-  sha256: ff764608e1f2839e95e2cf9b243681475f8778c36af7a42b3f78f476fdbb1dd3
-  md5: e98ba7b5f09a5f450eca083d5a1c4649
-  depends:
-  - __osx >=11.0
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  constrains:
-  - freetype >=2.14.3
-  license: GPL-2.0-only OR FTL
-  size: 338085
-  timestamp: 1774298689297
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   sha256: faf7d2017b4d718951e3a59d081eb09759152f93038479b768e3d612688f83f5
   md5: 0aa00f03f9e39fb9876085dee11a85d4
@@ -2211,15 +464,6 @@ packages:
   license_family: GPL
   size: 401974
   timestamp: 1771378877463
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
-  md5: d5e96b1ed75ca01906b3d2469b4ce493
-  depends:
-  - libgcc 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27526
-  timestamp: 1771378224552
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
   sha256: d2c9fad338fd85e4487424865da8e74006ab2e2475bd788f624d7a39b2a72aee
   md5: 9063115da5bc35fdc3e1002e69b9ef6e
@@ -2265,64 +509,6 @@ packages:
   license_family: GPL
   size: 598634
   timestamp: 1771378886363
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
-  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
-  md5: 928b8be80851f5d8ffb016f9c81dae7a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - libglx 1.7.0 ha4b6fd6_2
-  license: LicenseRef-libglvnd
-  size: 134712
-  timestamp: 1731330998354
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
-  sha256: a27e44168a1240b15659888ce0d9b938ed4bdb49e9ea68a7c1ff27bcea8b55ce
-  md5: bb26456332b07f68bf3b7622ed71c0da
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  constrains:
-  - glib 2.86.4 *_1
-  license: LGPL-2.1-or-later
-  size: 4398701
-  timestamp: 1771863239578
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.86.4-he378b5c_1.conda
-  sha256: a4254a241a96198e019ced2e0d2967e4c0ef64fac32077a45c065b32dc2b15d2
-  md5: 673069f6725ed7b1073f9b96094294d1
-  depends:
-  - __osx >=11.0
-  - libffi >=3.5.2,<3.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libintl >=0.25.1,<1.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  constrains:
-  - glib 2.86.4 *_1
-  license: LGPL-2.1-or-later
-  size: 4108927
-  timestamp: 1771864169970
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
-  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
-  md5: 434ca7e50e40f4918ab701e3facd59a0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: LicenseRef-libglvnd
-  size: 132463
-  timestamp: 1731330968309
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
-  md5: c8013e438185f33b13814c5c488acd5c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libglvnd 1.7.0 ha4b6fd6_2
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: LicenseRef-libglvnd
-  size: 75504
-  timestamp: 1731330988898
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   md5: 239c5e9546c38a1e884d69effcf4c882
@@ -2332,214 +518,55 @@ packages:
   license_family: GPL
   size: 603262
   timestamp: 1771378117851
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
-  sha256: 5bb935188999fd70f67996746fd2dca85ec6204289e11695c316772e19451eb8
-  md5: b5fb6d6c83f63d83ef2721dca6ff7091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
+  build_number: 6
+  sha256: 371f517eb7010b21c6cc882c7606daccebb943307cb9a3bf2c70456a5c024f7d
+  md5: 881d801569b201c2e753f03c84b85e15
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - c-ares >=1.34.6,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - re2
+  - libblas 3.11.0 6_h4a7cf45_openblas
   constrains:
-  - grpc-cpp =1.78.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 7021360
-  timestamp: 1774020290672
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
-  sha256: a6e01573795484c2200e499ddffb825d24184888be6a596d4beaceebe6f8f525
-  md5: 17b9e07ba9b46754a6953999a948dcf7
-  depends:
-  - __osx >=11.0
-  - c-ares >=1.34.6,<2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libre2-11 >=2025.11.5
-  - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.5.5,<4.0a0
-  - re2
-  constrains:
-  - grpc-cpp =1.78.1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4820402
-  timestamp: 1774012715207
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
-  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
-  md5: 0ed3aa3e3e6bc85050d38881673a692f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - blas 2.306   openblas
+  - liblapacke 3.11.0   6*_openblas
+  - libcblas   3.11.0   6*_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 2449916
-  timestamp: 1765103845133
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.12.2-default_ha3cc4f2_1000.conda
-  sha256: 4d03bb9bc0a813cf5e24f07e6adec3c42df2c9c36e226b71cb1dc6c7868c7d90
-  md5: 38b8aa4ea25d313ad951bcb7d3cd0ad3
+  size: 18624
+  timestamp: 1774503065378
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-6_hd9741b5_openblas.conda
+  build_number: 6
+  sha256: 21606b7346810559e259807497b86f438950cf19e71838e44ebaf4bd2b35b549
+  md5: ee33d2d05a7c5ea1f67653b37eb74db1
   depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - libblas 3.11.0 6_h51639a9_openblas
+  constrains:
+  - liblapacke 3.11.0   6*_openblas
+  - libcblas   3.11.0   6*_openblas
+  - blas 2.306   openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 2356224
-  timestamp: 1765104113197
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
-  sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
-  md5: c2a0c1d0120520e979685034e0b79859
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0 OR BSD-3-Clause
-  size: 1448617
-  timestamp: 1758894401402
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.3.0-h48b13b8_1.conda
-  sha256: 837fe775ba8ec9f08655bb924e28dba390d917423350333a75fd5eeac0776174
-  md5: 6375717f5fcd756de929a06d0e40fab0
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: Apache-2.0 OR BSD-3-Clause
-  size: 581579
-  timestamp: 1758894814983
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
-  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
-  md5: 915f5995e94f60e9a4826e0b0920ee88
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: LGPL-2.1-only
-  size: 790176
-  timestamp: 1754908768807
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
-  sha256: de0336e800b2af9a40bdd694b03870ac4a848161b35c8a2325704f123f185f03
-  md5: 4d5a7445f0b25b6a3ddbb56e790f5251
-  depends:
-  - __osx >=11.0
-  license: LGPL-2.1-only
-  size: 750379
-  timestamp: 1754909073836
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.25.1-h493aca8_0.conda
-  sha256: 99d2cebcd8f84961b86784451b010f5f0a795ed1c08f1e7c76fbb3c22abf021a
-  md5: 5103f6a6b210a3912faf8d7db516918c
-  depends:
-  - __osx >=11.0
-  - libiconv >=1.18,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 90957
-  timestamp: 1751558394144
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
-  md5: 8397539e3a0bbd1695584fb4f927485a
+  size: 18863
+  timestamp: 1774504467905
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  size: 633710
-  timestamp: 1762094827865
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.2-hc919400_0.conda
-  sha256: 6c061c56058bb10374daaef50e81b39cf43e8aee21f0037022c0c39c4f31872f
-  md5: f0695fbecf1006f27f4395d64bd0c4b8
-  depends:
-  - __osx >=11.0
-  constrains:
-  - jpeg <0.0.0a
-  license: IJG AND BSD-3-Clause AND Zlib
-  size: 551197
-  timestamp: 1762095054358
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
-  sha256: 0c2399cef02953b719afe6591223fb11d287d5a108ef8bb9a02dd509a0f738d7
-  md5: 1df8c1b1d6665642107883685db6cf37
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libhwy >=1.3.0,<1.4.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1883476
-  timestamp: 1770801977654
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjxl-0.11.2-h913acd8_0.conda
-  sha256: 44fdcae8ab3958f371565198f82d0748714dccc8a897ca202e54e18bde096f0d
-  md5: bec365333f77af833f8e46f6de96e2a2
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libhwy >=1.3.0,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1032335
-  timestamp: 1770802059749
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
-  build_number: 5
-  sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
-  md5: b38076eb5c8e40d0106beda6f95d7609
-  depends:
-  - libblas 3.11.0 5_h4a7cf45_openblas
-  constrains:
-  - blas 2.305   openblas
-  - liblapacke 3.11.0   5*_openblas
-  - libcblas   3.11.0   5*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18200
-  timestamp: 1765818857876
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
-  build_number: 5
-  sha256: 735a6e6f7d7da6f718b6690b7c0a8ae4815afb89138aa5793abe78128e951dbb
-  md5: ca9d752201b7fa1225bca036ee300f2b
-  depends:
-  - libblas 3.11.0 5_h51639a9_openblas
-  constrains:
-  - libcblas   3.11.0   5*_openblas
-  - blas 2.305   openblas
-  - liblapacke 3.11.0   5*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18551
-  timestamp: 1765819121855
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
-  md5: c7c83eecbb72d88b940c249af56c8b17
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - xz 5.8.2.*
+  - xz 5.8.3.*
   license: 0BSD
-  size: 113207
-  timestamp: 1768752626120
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
-  sha256: 7bfc7ffb2d6a9629357a70d4eadeadb6f88fa26ebc28f606b1c1e5e5ed99dc7e
-  md5: 009f0d956d7bfb00de86901d16e486c7
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
   depends:
   - __osx >=11.0
   constrains:
-  - xz 5.8.2.*
+  - xz 5.8.3.*
   license: 0BSD
-  size: 92242
-  timestamp: 1768752982486
+  size: 92472
+  timestamp: 1775825802659
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
   sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
   md5: 2c21e66f50753a083cbe6b80f38268fa
@@ -2559,555 +586,34 @@ packages:
   license_family: BSD
   size: 73690
   timestamp: 1769482560514
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-  sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
-  md5: 68e52064ed3897463c0e958ab5c8f91b
-  depends:
-  - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 218500
-  timestamp: 1745825989535
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
-  sha256: 28bd1fe20fe43da105da41b95ac201e95a1616126f287985df8e86ddebd1c3d8
-  md5: 29b8b11f6d7e6bd0e76c029dcf9dd024
-  depends:
-  - __osx >=11.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216719
-  timestamp: 1745826006052
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-  sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
-  md5: be43915efc66345cccb3c310b6ed0374
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.32-pthreads_h94d23a6_0.conda
+  sha256: 6dc30b28f32737a1c52dada10c8f3a41bc9e021854215efca04a7f00487d09d9
+  md5: 89d61bc91d3f39fda0ca10fcd3c68594
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libgfortran
   - libgfortran5 >=14.3.0
   constrains:
-  - openblas >=0.3.30,<0.3.31.0a0
+  - openblas >=0.3.32,<0.3.33.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5927939
-  timestamp: 1763114673331
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
-  sha256: ebbbc089b70bcde87c4121a083c724330f02a690fb9d7c6cd18c30f1b12504fa
-  md5: a6f6d3a31bb29e48d37ce65de54e2df0
+  size: 5928890
+  timestamp: 1774471724897
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.32-openmp_he657e61_0.conda
+  sha256: 713e453bde3531c22a660577e59bf91ef578dcdfd5edb1253a399fa23514949a
+  md5: 3a1111a4b6626abebe8b978bb5a323bf
   depends:
   - __osx >=11.0
   - libgfortran
   - libgfortran5 >=14.3.0
   - llvm-openmp >=19.1.7
   constrains:
-  - openblas >=0.3.30,<0.3.31.0a0
+  - openblas >=0.3.32,<0.3.33.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 4284132
-  timestamp: 1768547079205
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.0.0-hb56ce9e_1.conda
-  sha256: a396a2d1aa267f21c98717ac097138b32e41e4c40ae501729bded3801476eeb5
-  md5: 9f0596e995efe372c470ff45c93131cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 6582302
-  timestamp: 1772727204779
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2026.0.0-h3e6d54f_1.conda
-  sha256: ffbd4a3c8540dfaddbdd68cf3073967a3c8faadd97d7df912f73734e53f9213e
-  md5: 8e140a6e2a1db294892a8da72c9afb0e
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4515660
-  timestamp: 1772716610278
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2026.0.0-h3e6d54f_1.conda
-  sha256: 352ebc24805cb756ef11afa5c9606b3e19da99e434afc35cddc356538b5ec49d
-  md5: 48f3117552be579619620f3b6768b52f
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 8759182
-  timestamp: 1772716648998
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.0.0-hd85de46_1.conda
-  sha256: 286de85805dc69ce0bd25367ae2a20c8096ddef35eb2483474eb246dacd5387e
-  md5: ee41df976413676f794af2785b291b0c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 114431
-  timestamp: 1772727230331
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2026.0.0-h2406d2e_1.conda
-  sha256: 1cbbf43149334ccf793f782bd0924e08e5952c667578ac33a33076a4ab54ad47
-  md5: 6012967b53bf790c2ad9160c2779d7bc
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 105710
-  timestamp: 1772716704250
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.0.0-hd85de46_1.conda
-  sha256: 9988ed6339a5eb044ae8d079e2b22f5a310c41e49a0cf716057f30b21ef9cec2
-  md5: ca025fa5c42ba94453636a2ae333de6b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 249056
-  timestamp: 1772727247597
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2026.0.0-h2406d2e_1.conda
-  sha256: fa6c01a897ccc92998cae1e75ac65c68f311ad0834182801d5d3139ac307309f
-  md5: 52839e682c6bde645a9f4cdcdfc33639
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 213574
-  timestamp: 1772716732087
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.0.0-hd41364c_1.conda
-  sha256: c7db498aeda5b0f36b347f4211b93b66ba108faaf54157a08bae8fa3c3af5f81
-  md5: 07a23e96db38f63d9763f666b2db66aa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 211582
-  timestamp: 1772727264950
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2026.0.0-h85cbfa6_1.conda
-  sha256: 18e6b6d061d27049e2a34fbd1a633209294eb700aa7eee7a3d2877ce4d45888b
-  md5: 77d314ff80fb262dbe061527dec60263
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 184975
-  timestamp: 1772716757394
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: 01a28c0bd1f205b3800e7759e30bc8e8a75836e0d5a73a745b4da42837bbb174
-  md5: b43b96578573ddbcc8d084ae6e44c964
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 13173323
-  timestamp: 1772727282718
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: 720b87e1d5f1a10c577e040d4bf425072a978e925c6dfab8b1551bc848007c94
-  md5: 26e8e92c90d1a22af6eac8e9507d9b8f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - ocl-icd >=2.3.3,<3.0a0
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 11402462
-  timestamp: 1772727323957
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.0.0-hb56ce9e_1.conda
-  sha256: df7eb2b23a1af38f2cd2281353309f2e2a04da1374ecedc7c6745c2a67ba617c
-  md5: 01ba8b179ac45b2b37fe2d4225dddcc7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - level-zero >=1.28.2,<2.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  - tbb >=2022.3.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1994640
-  timestamp: 1772727360780
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.0.0-hd41364c_1.conda
-  sha256: 8e7356b0b80b3f180615e264694d6811d388b210155d419553ff64e42f78ffa0
-  md5: aa002c4d343b01cdcc458c95cd071d1b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 192778
-  timestamp: 1772727380069
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2026.0.0-h85cbfa6_1.conda
-  sha256: 166792875fe62f90a528a4931f29ea18cf74694469870e98c8772460f92fc653
-  md5: c7f37a124ab9a53444d213a3db5f9747
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - pugixml >=1.15,<1.16.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 172169
-  timestamp: 1772716782643
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.0.0-h7a07914_1.conda
-  sha256: 35a68214201e807bd9a31f94e618cb6a5385198e89eef46dde6c122cff77da58
-  md5: 218084544c2e7e78e4b8877ec37b8cdb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1860687
-  timestamp: 1772727397981
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2026.0.0-h41365f2_1.conda
-  sha256: eb307ee1ad8eb47aa011d03d77995bfd1153b80893ab5880fd928093ad50cab4
-  md5: 8d32df9ac0c17ba2735e26be190399f6
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1425474
-  timestamp: 1772716809587
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.0.0-h7a07914_1.conda
-  sha256: cb37b717480207a66443a93d4342cf88210a74c0820fc0edd70e4fc791a64779
-  md5: 74915e5e271ef76a89f711eff5959a75
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 684224
-  timestamp: 1772727417276
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2026.0.0-h41365f2_1.conda
-  sha256: e3ca93158beac502b65256ae78736889e8b40184b0dc938a1b8136ae2a0c3a4d
-  md5: 6c821b72c8e5b0467f3d39a33e357064
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 434092
-  timestamp: 1772716839090
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.0.0-hecca717_1.conda
-  sha256: 086469e5cd8bfde48975fe8641a7d6924e3da00d75dd06c99e03a78df03a0568
-  md5: 559ef86008749861a53025f669004f18
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1185558
-  timestamp: 1772727435039
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2026.0.0-hf6b4638_1.conda
-  sha256: c694e5dc1bbb2ea876e65c8c33b148a24f56b5f7a60f8449ca62b159d9020709
-  md5: 7cd9c1d466e5be74f5cb32f545b1b887
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 823766
-  timestamp: 1772716865028
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.0.0-h78e8023_1.conda
-  sha256: 3a9a404bc9fd39e7395d49f4bd8facb58a01a31aeceabe8723a9d4f8eb5cc381
-  md5: fb20f4234bc0e29af1baa13d35e36785
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  - snappy >=1.2.2,<1.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1257870
-  timestamp: 1772727453738
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2026.0.0-hc295da0_1.conda
-  sha256: f680809aef09ca68d7446e3f1810ca3f3d9f744cbfe3a8d8ec9bd807f17d80fd
-  md5: 09d1d2b4e5648afd706e2252299087f4
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - snappy >=1.2.2,<1.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 910147
-  timestamp: 1772716892527
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.0.0-hecca717_1.conda
-  sha256: e7cee37c92ed0b62c0458c13937b6ad66319f1879f236a31c3a67391a999f429
-  md5: 0f0281435478b981f672a44d0029018c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libopenvino 2026.0.0 hb56ce9e_1
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 456585
-  timestamp: 1772727473378
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2026.0.0-hf6b4638_1.conda
-  sha256: 3079cdc940a7e0b84376845accefd084f9a01c37af5901083ae47cc02fd5723d
-  md5: 361b9eb57e71939cf3d35fa1145a6325
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libopenvino 2026.0.0 h3e6d54f_1
-  license: Apache-2.0
-  license_family: APACHE
-  size: 379126
-  timestamp: 1772716918802
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
-  sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
-  md5: 2446ac1fe030c2aa6141386c1f5a6aed
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 324993
-  timestamp: 1768497114401
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.6.1-h1a92334_0.conda
-  sha256: 5c95a5f7712f543c59083e62fc3a95efec8b7f3773fbf4542ad1fb87fbf51ff4
-  md5: 7f414dd3fd1cb7a76e51fec074a9c49e
-  depends:
-  - __osx >=11.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 308000
-  timestamp: 1768497248058
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-  sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
-  md5: 70e3400cbbfa03e96dcde7fc13e38c7b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 28424
-  timestamp: 1749901812541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
-  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
-  md5: 5f13ffc7d30ffec87864e678df9957b4
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 317669
-  timestamp: 1770691470744
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.55-h132b30e_0.conda
-  sha256: 7a4fd29a6ee2d7f7a6e610754dfdf7410ed08f40d8d8b488a27bc0f9981d5abb
-  md5: 871dc88b0192ac49b6a5509932c31377
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: zlib-acknowledgement
-  size: 288950
-  timestamp: 1770691485950
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
-  sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
-  md5: 11ac478fa72cf12c214199b8a96523f4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 3638698
-  timestamp: 1769749419271
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
-  sha256: 626852cd50690526c9eac216a9f467edd4cbb01060d0efe41b7def10b54bdb08
-  md5: b839e3295b66434f20969c8b940f056a
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=19
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2713660
-  timestamp: 1769748299578
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
-  sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
-  md5: ced7f10b6cfb4389385556f47c0ad949
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - re2 2025.11.05.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 213122
-  timestamp: 1768190028309
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
-  sha256: 1e2d23bbc1ffca54e4912365b7b59992b7ae5cbeb892779a6dcd9eca9f71c428
-  md5: 40d8ad21be4ccfff83a314076c3563f4
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=19
-  constrains:
-  - re2 2025.11.05.*
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 165851
-  timestamp: 1768190225157
-- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.1-h4c96295_0.conda
-  sha256: dc4698b32b2ca3fc0715d7d307476a71622bee0f2f708f9dadec8af21e1047c8
-  md5: a4b87f1fbcdbb8ad32e99c2611120f2e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gdk-pixbuf >=2.44.5,<3.0a0
-  - harfbuzz >=13.1.1
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libxml2-16 >=2.14.6
-  - pango >=1.56.4,<2.0a0
-  constrains:
-  - __glibc >=2.17
-  license: LGPL-2.1-or-later
-  size: 3474421
-  timestamp: 1773814909137
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.62.1-he8aa2a2_0.conda
-  sha256: 4d28ad0213fca6f93624c27f13493b986ce63e05386d2ff7a2ad723c4e7c7cec
-  md5: 4766fd69e64e477b500eb901dbe7bb6b
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - gdk-pixbuf >=2.44.5,<3.0a0
-  - harfbuzz >=13.1.1
-  - libglib >=2.86.4,<3.0a0
-  - libxml2-16 >=2.14.6
-  - pango >=1.56.4,<2.0a0
-  constrains:
-  - __osx >=11.0
-  license: LGPL-2.1-or-later
-  size: 2402915
-  timestamp: 1773816188394
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsentencepiece-0.2.1-h432359f_3.conda
-  sha256: 5a40fb6a8190a57c704f8dc7c23fbcee0eca400a70e1bcf8774aeae708575f4a
-  md5: ba0d4bf618ee90dd0d88780b0a925923
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 859187
-  timestamp: 1770167820403
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsentencepiece-0.2.1-h9466b84_3.conda
-  sha256: 742a3e63421909a743f38131bc7d3e497a3a983d1852253ef475921ddc8b8c3d
-  md5: 3825d2353a5b282c4c17831e4db00244
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=19
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 779133
-  timestamp: 1770168520556
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-  sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
-  md5: 067590f061c9f6ea7e61e3b2112ed6b3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - lame >=3.100,<3.101.0a0
-  - libflac >=1.5.0,<1.6.0a0
-  - libgcc >=14
-  - libogg >=1.3.5,<1.4.0a0
-  - libopus >=1.5.2,<2.0a0
-  - libstdcxx >=14
-  - libvorbis >=1.3.7,<1.4.0a0
-  - mpg123 >=1.32.9,<1.33.0a0
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 355619
-  timestamp: 1765181778282
+  size: 4308797
+  timestamp: 1774472508546
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
   sha256: 64e5c80cbce4680a2d25179949739a6def695d72c40ca28f010711764e372d97
   md5: 7af961ef4aa2c1136e11dd43ded245ab
@@ -3125,27 +631,26 @@ packages:
   license: ISC
   size: 248039
   timestamp: 1772479570912
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
-  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
-  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
+  sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
+  md5: 810d83373448da85c3f673fbcb7ad3a3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
+  - icu >=78.3,<79.0a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: blessing
-  size: 951405
-  timestamp: 1772818874251
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
-  sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
-  md5: f6233a3fddc35a2ec9f617f79d6f3d71
+  size: 958864
+  timestamp: 1775753750179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
+  sha256: 1a9d1e3e18dbb0b87cff3b40c3e42703730d7ac7ee9b9322c2682196a81ba0c3
+  md5: 8423c008105df35485e184066cad4566
   depends:
   - __osx >=11.0
-  - icu >=78.2,<79.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: blessing
-  size: 918420
-  timestamp: 1772819478684
+  size: 920039
+  timestamp: 1775754485962
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
   sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
   md5: 1b08cd684f34175e4514474793d44bcb
@@ -3158,368 +663,16 @@ packages:
   license_family: GPL
   size: 5852330
   timestamp: 1771378262446
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
-  md5: 6235adb93d064ecdf3d44faee6f468de
-  depends:
-  - libstdcxx 15.2.0 h934c35e_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27575
-  timestamp: 1771378314494
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
-  sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
-  md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 492799
-  timestamp: 1773797095649
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-  sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
-  md5: cd5a90476766d53e901500df9215e927
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libgcc >=14
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libstdcxx >=14
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: HPND
-  size: 435273
-  timestamp: 1762022005702
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
-  sha256: e9248077b3fa63db94caca42c8dbc6949c6f32f94d1cafad127f9005d9b1507f
-  md5: e2a72ab2fa54ecb6abab2b26cde93500
-  depends:
-  - __osx >=11.0
-  - lerc >=4.0.0,<5.0a0
-  - libcxx >=19
-  - libdeflate >=1.25,<1.26.0a0
-  - libjpeg-turbo >=3.1.0,<4.0a0
-  - liblzma >=5.8.1,<6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: HPND
-  size: 373892
-  timestamp: 1762022345545
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
-  sha256: 1a1e367c04d66030aa93b4d33905f7f6fbb59cfc292e816fe3e9c1e8b3f4d1e2
-  md5: 2c2270f93d6f9073cbf72d821dfc7d72
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libcap >=2.77,<2.78.0a0
-  - libgcc >=14
-  license: LGPL-2.1-or-later
-  size: 145087
-  timestamp: 1773797108513
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
-  sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
-  md5: e179a69edd30d75c0144d7a380b88f28
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 75995
-  timestamp: 1757032240102
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
-  sha256: 3d17b7aa90610afc65356e9e6149aeac0b2df19deda73a51f0a09cf04fd89286
-  md5: 56f65185b520e016d29d01657ac02c0d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 154203
-  timestamp: 1770566529700
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
-  sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
-  md5: d17e3fb595a9f24fa9e149239a33475d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libudev1 >=257.4
-  license: LGPL-2.1-or-later
-  size: 89551
-  timestamp: 1748856210075
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libusb-1.0.29-hbc156a2_0.conda
-  sha256: 5eee9a2bf359e474d4548874bcfc8d29ebad0d9ba015314439c256904e40aaad
-  md5: f6654e9e96e9d973981b3b2f898a5bfa
-  depends:
-  - __osx >=11.0
-  license: LGPL-2.1-or-later
-  size: 83849
-  timestamp: 1748856224950
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
-  sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
-  md5: db409b7c1720428638e7c0d509d3e1b5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
-  size: 40311
-  timestamp: 1766271528534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
-  sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
-  md5: 0f03292cc56bf91a077a134ea8747118
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 895108
-  timestamp: 1753948278280
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
-  sha256: 042c7488ad97a5629ec0a991a8b2a3345599401ecc75ad6a5af73b60e6db9689
-  md5: c0d87c3c8e075daf1daf6c31b53e8083
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 421195
-  timestamp: 1753948426421
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
-  sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
-  md5: 25813fe38b3e541fc40007592f12bae5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libgcc >=14
-  - libgl >=1.7.0,<2.0a0
-  - libglx >=1.7.0,<2.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - wayland >=1.24.0,<2.0a0
-  - wayland-protocols
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 221308
-  timestamp: 1765652453244
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
-  sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
-  md5: b4ecbefe517ed0157c37f8182768271c
-  depends:
-  - libogg
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libogg >=1.3.5,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 285894
-  timestamp: 1753879378005
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvorbis-1.3.7-h81086ad_2.conda
-  sha256: 95768e4eceaffb973081fd986d03da15d93aa10609ed202e6fd5ca1e490a3dce
-  md5: 719e7653178a09f5ca0aa05f349b41f7
-  depends:
-  - libogg
-  - libcxx >=19
-  - __osx >=11.0
-  - libogg >=1.3.5,<1.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 259122
-  timestamp: 1753879389702
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
-  sha256: 38850657dd6835613ef16b34895a54bea98bc7639db6a649c886b331635714fc
-  md5: 9f6b0090c3902b2c763a16f7dace7b6e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - intel-media-driver >=26.1.2,<26.2.0a0
-  - libva >=2.23.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 287992
-  timestamp: 1772980546550
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
-  sha256: 8e1119977f235b488ab32d540c018d3fd1eccefc3dd3859921a0ff555d8c10d2
-  md5: 10f5008f1c89a40b09711b5a9cdbd229
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1070048
-  timestamp: 1762010217363
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.15.2-ha759d40_0.conda
-  sha256: d21729b04fe101d1b2f8cdd607faacf1070abba3702db699787a3fe026eeaca6
-  md5: 0d2febd301e25a48e00447b300d68f9c
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1192913
-  timestamp: 1762010603501
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
-  sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
-  md5: 31ad065eda3c2d88f8215b1289df9c89
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxrandr >=1.5.5,<2.0a0
-  constrains:
-  - libvulkan-headers 1.4.341.0.*
-  license: Apache-2.0
-  license_family: APACHE
-  size: 199795
-  timestamp: 1770077125520
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvulkan-loader-1.4.341.0-h3feff0a_0.conda
-  sha256: d2790dafc9149b1acd45b9033d02cfa3f3e9ee5af97bd61e0a5718c414a0a135
-  md5: 6b4c9a5b130759136a0dde0c373cb0ea
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  constrains:
-  - libvulkan-headers 1.4.341.0.*
-  license: Apache-2.0
-  license_family: APACHE
-  size: 180304
-  timestamp: 1770077143460
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
-  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
-  md5: aea31d2e5b1091feca96fcfe945c3cf9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - libwebp 1.6.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 429011
-  timestamp: 1752159441324
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
-  sha256: a4de3f371bb7ada325e1f27a4ef7bcc81b2b6a330e46fac9c2f78ac0755ea3dd
-  md5: e5e7d467f80da752be17796b87fe6385
-  depends:
-  - __osx >=11.0
-  constrains:
-  - libwebp 1.6.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 294974
-  timestamp: 1752159906788
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
-  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
-  md5: 92ed62436b625154323d40d5f2f11dd7
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 395888
-  timestamp: 1727278577118
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
-  sha256: bd3816218924b1e43b275863e21a3e13a5db4a6da74cca8e60bc3c213eb62f71
-  md5: af523aae2eca6dfa1c8eec693f5b9a79
-  depends:
-  - __osx >=11.0
-  - pthread-stubs
-  - xorg-libxau >=1.0.11,<2.0a0
-  - xorg-libxdmcp
-  license: MIT
-  license_family: MIT
-  size: 323658
-  timestamp: 1727278733917
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
-  sha256: d2195b5fbcb0af1ff7b345efdf89290c279b8d1d74f325ae0ac98148c375863c
-  md5: 2bca1fbb221d9c3c8e3a155784bbc2e9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libxcb >=1.17.0,<2.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - xkeyboard-config
-  - xorg-libxau >=1.0.12,<2.0a0
-  license: MIT/X11 Derivative
-  license_family: MIT
-  size: 837922
-  timestamp: 1764794163823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
-  sha256: 275c324f87bda1a3b67d2f4fcc3555eeff9e228a37655aa001284a7ceb6b0392
-  md5: e49238a1609f9a4a844b09d9926f2c3d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libxml2-16 2.15.2 hca6bf5a_0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 45968
-  timestamp: 1772704614539
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.2-h8d039ee_0.conda
-  sha256: 99cb32dd06a2e58c12981b71a84b052293f27b5ab042e3f21d895f5d7ee13eff
-  md5: e476ba84e57f2bd2004a27381812ad4e
-  depends:
-  - __osx >=11.0
-  - icu >=78.2,<79.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libxml2-16 2.15.2 h5ef1a60_0
-  - libzlib >=1.3.1,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 41206
-  timestamp: 1772704982288
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
-  sha256: 08d2b34b49bec9613784f868209bb7c3bb8840d6cf835ff692e036b09745188c
-  md5: f3bc152cb4f86babe30f3a4bf0dbef69
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
-  - libgcc >=14
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.2
-  license: MIT
-  license_family: MIT
-  size: 557492
-  timestamp: 1772704601644
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.2-h5ef1a60_0.conda
-  sha256: 6432259204e78c8a8a815afae987fbf60bd722605fe2c4b022e65196b17d4537
-  md5: b284e2b02d53ef7981613839fb86beee
-  depends:
-  - __osx >=11.0
-  - icu >=78.2,<79.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.2,<6.0a0
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - libxml2 2.15.2
-  license: MIT
-  license_family: MIT
-  size: 466220
-  timestamp: 1772704950232
+  size: 40297
+  timestamp: 1775052476770
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
   sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
   md5: d87ff7921124eccd67248aa483c23fec
@@ -3542,181 +695,19 @@ packages:
   license_family: Other
   size: 47759
   timestamp: 1774072956767
-- conda: https://conda.anaconda.org/conda-forge/linux-64/llguidance-1.7.0-py310hc9716df_0.conda
-  noarch: python
-  sha256: 542f802478f65cd9fb6796e5ed8d93250f1c7b7fa9c141b61e56246379ca9ad6
-  md5: 28f3e8825c7a4daf72ecde2ec3f7bd3d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  - libgcc >=14
-  - python
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 2166297
-  timestamp: 1773873138695
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llguidance-1.7.0-py310h3a138ce_0.conda
-  noarch: python
-  sha256: 83f986fb688f0a4406bc94d12b2151eafc6b45e2566d729bdb1b5ee3ccc88826
-  md5: c17aea7c231ba8f0e394071a1edd96b2
-  depends:
-  - __osx >=11.0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  - python
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 1935734
-  timestamp: 1773874009282
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.1-hc7d1edf_0.conda
-  sha256: c6f67e928f47603aca7e4b83632d8f3e82bd698051c7c0b34fcce3796eb9b63c
-  md5: 5a44f53783d87427790fc8692542f1bb
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.4-hc7d1edf_0.conda
+  sha256: a269273ccf48be6ac582bb958713ba8373262b9157a0fc76b7e5475e8a1d2a78
+  md5: 46d04a647df7a4525e487d88068d19ef
   depends:
   - __osx >=11.0
   constrains:
+  - openmp 22.1.4|22.1.4.*
   - intel-openmp <0.0a0
-  - openmp 22.1.1|22.1.1.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 285912
-  timestamp: 1774349644882
-- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
-  sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
-  md5: 5b5203189eb668f042ac2b0826244964
-  depends:
-  - mdurl >=0.1,<1
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 64736
-  timestamp: 1754951288511
-- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-  sha256: c279be85b59a62d5c52f5dd9a4cd43ebd08933809a8416c22c3131595607d4cf
-  md5: 9a17c4307d23318476d7fbf0fedc0cde
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27424
-  timestamp: 1772445227915
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
-  sha256: 411153d14ee0d98be6e3751cf5cc0502db17bce2deebebb8779e33d29d0e525f
-  md5: d33c0a15882b70255abdd54711b06a45
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - jinja2 >=3.0.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27256
-  timestamp: 1772445397216
-- conda: https://conda.modular.com/max-nightly/linux-64/max-26.2.0-3.14release.conda
-  sha256: 58565c18bcf3600eb4cf19f967742cf3a94965554127fb5b043c840067f34c45
-  md5: 767bb92c9ee2dbef2e403a45524ad1e7
-  depends:
-  - numpy >=1.18
-  - typing-extensions >=4.12.2
-  - pyyaml >=6.0.1
-  - rich >=13.0.1
-  - python 3.14.*
-  - python-gil
-  - max-core ==26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 4293418
-  timestamp: 1773797339964
-- conda: https://conda.modular.com/max-nightly/osx-arm64/max-26.2.0-3.14release.conda
-  sha256: 64490969cad7a2210c30fcbd3b9976137b71ded7d9362bcba8717c697246973f
-  md5: 1a5a0594af0164ee690f4c15ea7c6704
-  depends:
-  - numpy >=1.18
-  - typing-extensions >=4.12.2
-  - pyyaml >=6.0.1
-  - rich >=13.0.1
-  - python 3.14.*
-  - python-gil
-  - max-core ==26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 7022574
-  timestamp: 1773797272132
-- conda: https://conda.modular.com/max-nightly/linux-64/max-core-26.2.0-release.conda
-  sha256: f2bd52e98af849955112def3de6577b64479d367874cd7edaaf0de7a1fadc9ba
-  md5: ba55bf4d820d5ad79a3751eb35919331
-  depends:
-  - mojo-compiler ==0.26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 139958668
-  timestamp: 1773797397280
-- conda: https://conda.modular.com/max-nightly/osx-arm64/max-core-26.2.0-release.conda
-  sha256: 96ab225cdba7893771bec6e4370f27b7c29aac79ff7c47abf2de361e19b40951
-  md5: 4403c061c99c288de94b1e3faef07c54
-  depends:
-  - mojo-compiler ==0.26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 93297448
-  timestamp: 1773797215730
-- conda: https://conda.modular.com/max-nightly/noarch/max-pipelines-26.2.0-release.conda
-  noarch: python
-  sha256: 6ec877cb7ba0ab2b606003e718098dd9b4b56a25d7f36ed539f84fcea0d23243
-  md5: 709e46691f843ed35db12a0ed8aa9c86
-  depends:
-  - av >=14.0.0
-  - click >=8.0.0
-  - exceptiongroup >=0.2.2
-  - gguf >=0.17.1
-  - hf-transfer >=0.1.9
-  - huggingface_hub >=0.28.0
-  - llguidance >=0.7.30
-  - jinja2 >=3.1.0
-  - pillow >=11.0.0
-  - psutil >=6.1.1
-  - pydantic-settings >=2.7.1
-  - pydantic
-  - pydantic-core
-  - requests >=2.32.3
-  - sentencepiece >=0.2.0
-  - taskgroup >=0.2.2
-  - tiktoken >=0.5.0
-  - tqdm >=4.67.1
-  - transformers >=4.57.0,<5.0.0
-  - uvicorn >=0.34.0
-  - uvloop >=0.21.0
-  - aiofiles >=24.1.0
-  - asgiref >=3.8.1
-  - fastapi >=0.115.3
-  - grpcio >=1.68.0
-  - httpx >=0.28.1,<0.29
-  - msgspec >=0.19.0
-  - opentelemetry-api >=1.29.0
-  - opentelemetry-exporter-otlp-proto-http >=1.27.0
-  - opentelemetry-exporter-prometheus >=0.50b0
-  - opentelemetry-sdk >=1.29.0,<1.36.0
-  - prometheus_client >=0.21.0
-  - protobuf >=6.33.5,<6.34.0
-  - pyinstrument >=5.0.1
-  - python-json-logger >=2.0.7
-  - pyzmq >=26.3.0
-  - regex >=2024.11.6
-  - scipy >=1.13.0
-  - sse-starlette >=2.1.2
-  - starlette >=0.47.2
-  - max ==26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 16735
-  timestamp: 1773780199134
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.2.0-release.conda
+  size: 286406
+  timestamp: 1776846235007
+- conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
   noarch: python
   sha256: 3c2fceb89cefca899dcd7c8f26a6202acacb2a073e4cb2ef365514a465d01dcd
   md5: dd13667299b9b66b8b314dc8d95b54a3
@@ -3731,26 +722,7 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 133798
   timestamp: 1773780198354
-- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
-  md5: 592132998493b3ff25fd7479396e8351
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 14465
-  timestamp: 1733255681319
-- conda: https://conda.modular.com/max-nightly/noarch/modular-26.2.0-release.conda
-  noarch: python
-  sha256: 6f8257a50e1e0ffc892f8c2a074548d4ff82c0ea3962f935530073d91aff59dd
-  md5: f026075592fb7959a1efc9502b212fa4
-  depends:
-  - max-pipelines ==26.2.0
-  - mojo ==0.26.2.0
-  license: LicenseRef-Modular-Proprietary
-  size: 16239
-  timestamp: 1773780198142
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.2.0-release.conda
+- conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
   sha256: 4d7047466c13d92b1c8eb19c6d203a8503afbd2b1ad63eb5289a8f4bbf4d2945
   md5: 61318988733a695066b39704f6e08bd2
   depends:
@@ -3761,7 +733,7 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 89753715
   timestamp: 1773797215278
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.2.0-release.conda
+- conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
   sha256: e35b8d34564b30189c5a985990466b4283f9e1d897baf23fe9ddbcbc9283459c
   md5: 12e4d8397c451b7c8a55ff5a759ce00b
   depends:
@@ -3772,7 +744,7 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 81534498
   timestamp: 1773797099755
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.2.0-release.conda
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
   sha256: e53f30d72a65e6b0a67745e6988f978d8f6ecc14531420631c9719eb9c7b9c2b
   md5: e3a673daa0ddf3ca6af297daee4ceab5
   depends:
@@ -3780,7 +752,7 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 89091679
   timestamp: 1773797216619
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
   sha256: e82cb7ce1a756876a233d364d5397adca5ad7e20fff5204c1c7e93aefe4549b5
   md5: 96e3ec50a2ea4abdb9fc4f3f89dc874b
   depends:
@@ -3788,7 +760,7 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 67499721
   timestamp: 1773797103208
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.2.0-release.conda
+- conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
   noarch: python
   sha256: 2d9e350cfe7a0ae5d96dea13c082b09f21aac8ac4caa3e5def6b075930348fa1
   md5: 67a4fc0d47e84d3a91c4f12cc912c7ac
@@ -3797,41 +769,6 @@ packages:
   license: LicenseRef-Modular-Proprietary
   size: 22936
   timestamp: 1773780198161
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-  sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
-  md5: c7f302fd11eeb0987a6a5e1f3aed6a21
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 491140
-  timestamp: 1730581373280
-- conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.20.0-py314h5bd0f2a_2.conda
-  sha256: d5bb34f3b81ad08fd46ee67a1f2ce5038b554505dfcd7ddfb06cf70f3b06e81a
-  md5: 2119bbd43f139c11cd83dbc7e4c7a3b1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 220071
-  timestamp: 1768737712629
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgspec-0.20.0-py314h6c2aa35_2.conda
-  sha256: 3c8d2336b78aa8fb1f411af6f4554a0fb059e74ee6543f19a060635f7c34c65e
-  md5: e817681f9a0104ad084ab0f94b49a56e
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 216905
-  timestamp: 1768738208294
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -3876,654 +813,125 @@ packages:
   license_family: BSD
   size: 8927860
   timestamp: 1773839233468
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314h1569ea8_0.conda
-  sha256: fe565b09011e8b8edb11bc20564ab130b107d4717590c2464d6d7c2a5a53c6da
-  md5: 0fab9cf4fc5163131387f36742b50c79
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py314ha4d8615_0.conda
+  sha256: c269916245aa84d923b6607fce877a069403714c65f6207d6bec70a333c32331
+  md5: d8dd63deccebc802a8fe5a5e6c255cd6
   depends:
   - python
   - libcxx >=19
-  - python 3.14.* *_cp314
+  - python 3.14.* *_cp314t
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - python_abi 3.14.* *_cp314
   - libcblas >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314t
   constrains:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6993182
-  timestamp: 1773839150339
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-  sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
-  md5: 56f8947aa9d5cf37b0b3d43b83f34192
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - opencl-headers >=2024.10.24
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 106742
-  timestamp: 1743700382939
-- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
-  sha256: 8de2f0cd8a659b01abf86e7fbb8cea4f28ada62fd288429a2bbc040db1b98dd0
-  md5: c930c8052d780caa41216af7de472226
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 55754
-  timestamp: 1773844383536
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
-  sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
-  md5: b28cf020fd2dead0ca6d113608683842
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 731471
-  timestamp: 1739400677213
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.6.0-hb5b2745_0.conda
-  sha256: fbea05722a8e8abfb41c989e2cec7ba6597eabe27cb6b88ff0b6443a5abb9069
-  md5: 6ff0890a94972aca7cc7f8f8ef1ff142
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 601538
-  timestamp: 1739400923874
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-  sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
-  md5: 11b3379b191f63139e29c0d19dee24cd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libpng >=1.6.50,<1.7.0a0
-  - libstdcxx >=14
-  - libtiff >=4.7.1,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 355400
-  timestamp: 1758489294972
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-  sha256: 60aca8b9f94d06b852b296c276b3cf0efba5a6eb9f25feb8708570d3a74f00e4
-  md5: 4b5d3a91320976eec71678fad1e3569b
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libpng >=1.6.55,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 319697
-  timestamp: 1772625397692
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
-  md5: f61eb8cd60ff9057122a3d338b99c00f
+  size: 7062457
+  timestamp: 1773839188614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
   - libgcc >=14
   license: Apache-2.0
   license_family: Apache
-  size: 3164551
-  timestamp: 1769555830639
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
-  sha256: 361f5c5e60052abc12bdd1b50d7a1a43e6a6653aab99a2263bf2288d709dcf67
-  md5: f4f6ad63f98f64191c3e77c5f5f29d76
+  size: 3167099
+  timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
+  md5: 25dcccd4f80f1638428613e0d7c9b4e1
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  size: 3104268
-  timestamp: 1769556384749
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-api-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 6228c870ad994ea843b78505c3df818dada38a6e9a8c658a02552898c8ddb218
-  md5: 241b102f0e44e7992f58c2419b84cf2e
-  depends:
-  - deprecated >=1.2.6
-  - importlib-metadata <8.8.0,>=6.0
-  - python >=3.9
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 45773
-  timestamp: 1752286891826
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-common-1.35.0-pyhd8ed1ab_0.conda
-  sha256: ff2776168c26365290ab480ac14f8f27392d4286c6f8fabd9c33884bd9fff094
-  md5: d98d06fedf338be8773b6c9bb023952d
-  depends:
-  - backoff >=1.10.0,<3.0.0
-  - opentelemetry-proto 1.35.0
-  - python >=3.9
-  license: Apache-2.0
-  license_family: APACHE
-  size: 19234
-  timestamp: 1752327590965
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-otlp-proto-http-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 41c96d6d309eedfd9c2ef49784e79ab0e228351fb9ef6ccbdb3839ac110fcb7c
-  md5: 2582574aa069164d1127c0b84e31bf47
-  depends:
-  - deprecated >=1.2.6
-  - googleapis-common-protos >=1.52,<2.dev0
-  - opentelemetry-api >=1.15,<2.dev0
-  - opentelemetry-exporter-otlp-proto-common 1.35.0
-  - opentelemetry-proto 1.35.0
-  - opentelemetry-sdk >=1.35.0,<1.36.dev0
-  - python >=3.9
-  - requests >=2.7,<3.dev0
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 18011
-  timestamp: 1752362461602
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-exporter-prometheus-0.56b0-pyhe01879c_1.conda
-  sha256: 145d87a756d2f6db6963d9105c26f09c04f79a24278b631f672d13adbb469c70
-  md5: 372d2c49b89dbb827ec2e85998a75095
-  depends:
-  - python >=3.9
-  - opentelemetry-api >=1.12,<2.dev0
-  - opentelemetry-sdk >=1.35.0,<1.36.dev0
-  - prometheus_client >=0.5.0,<1.0.0
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 22901
-  timestamp: 1754090360044
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-proto-1.35.0-pyhd8ed1ab_0.conda
-  sha256: 53f20256a65df56031b8d285dd76c5181fe987682efe8286dd02f5fee31e3ce9
-  md5: 67e3d4dd1e0ced032ef8fa99340e50c5
-  depends:
-  - protobuf <7.0,>=5.0
-  - python >=3.9
-  license: Apache-2.0
-  license_family: APACHE
-  size: 45741
-  timestamp: 1752308297180
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-sdk-1.35.0-pyhd8ed1ab_0.conda
-  sha256: f091363a1a0dd8d1c9b889f9ee433f28efb122edbc4222b8468790689fd106b1
-  md5: 226ec4d220a74e1fcc8c658f365bd3ef
-  depends:
-  - opentelemetry-api 1.35.0
-  - opentelemetry-semantic-conventions 0.56b0
-  - python >=3.9
-  - typing-extensions >=3.7.4
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 78751
-  timestamp: 1752299653515
-- conda: https://conda.anaconda.org/conda-forge/noarch/opentelemetry-semantic-conventions-0.56b0-pyh3cfb1c2_0.conda
-  sha256: 9d439ad39d33f3ea61553b5a48b4250fd06d8a4ad99ccb3bac6d8d1a273339ba
-  md5: 251c0dfb684e8f43a71d579091191580
-  depends:
-  - deprecated >=1.2.6
-  - opentelemetry-api 1.35.0
-  - python >=3.9
-  - typing_extensions >=4.5.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 107441
-  timestamp: 1752290820962
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
-  md5: b76541e68fea4d511b1ac46a28dcd2c6
+  size: 3106008
+  timestamp: 1775587972483
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+  md5: 4c06a92e74452cfa53623a81592e8934
   depends:
   - python >=3.8
   - python
   license: Apache-2.0
   license_family: APACHE
-  size: 72010
-  timestamp: 1769093650580
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
-  sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
-  md5: d53ffc0edc8eabf4253508008493c5bc
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.16,<2.0a0
-  - harfbuzz >=13.2.1
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libgcc >=14
-  - libglib >=2.86.4,<3.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 458036
-  timestamp: 1774281947855
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.56.4-hf80efc4_1.conda
-  sha256: b57c59cf5abb06d407b3a79017b990ca5bfb10c15a10c62fc29e113f2b12d9a9
-  md5: 4b433508ebb295c05dd3d03daf27f7bb
-  depends:
-  - __osx >=11.0
-  - cairo >=1.18.4,<2.0a0
-  - fontconfig >=2.17.1,<3.0a0
-  - fonts-conda-ecosystem
-  - fribidi >=1.0.16,<2.0a0
-  - harfbuzz >=13.2.1
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
-  - libglib >=2.86.4,<3.0a0
-  - libpng >=1.6.55,<1.7.0a0
-  - libzlib >=1.3.2,<2.0a0
-  license: LGPL-2.1-or-later
-  size: 425743
-  timestamp: 1774282709773
-- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-  sha256: 29ea20d0faf20374fcd61c25f6d32fb8e9a2c786a7f1473a0c3ead359470fbe1
-  md5: 2908273ac396d2cd210a8127f5f1c0d6
+  size: 91574
+  timestamp: 1777103621679
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+  sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
+  md5: 11adc78451c998c0fd162584abfa3559
   depends:
   - python >=3.10
   license: MPL-2.0
-  license_family: MOZILLA
-  size: 53739
-  timestamp: 1769677743677
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
-  md5: 7a3bff861a6583f1889021facefc08b1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 1222481
-  timestamp: 1763655398280
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
-  sha256: 5e2e443f796f2fd92adf7978286a525fb768c34e12b1ee9ded4000a41b2894ba
-  md5: 9b4190c4055435ca3502070186eba53a
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 850231
-  timestamp: 1763655726735
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py314h8ec4b1a_0.conda
-  sha256: 9e6ec8f3213e8b7d64b0ad45f84c51a2c9eba4398efda31e196c9a56186133ee
-  md5: 79678378ae235e24b3aa83cee1b38207
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - python_abi 3.14.* *_cp314
-  - tk >=8.6.13,<8.7.0a0
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - lcms2 >=2.18,<3.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  license: HPND
-  size: 1073026
-  timestamp: 1770794002408
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py314hab283cf_0.conda
-  sha256: 1659ff6e8ea6170a90fb8eb7291990d12bba270aab18176defa0717ed34ce186
-  md5: bcb38a8005e93a3b240a0dbcf28df87a
-  depends:
-  - python
-  - python 3.14.* *_cp314
-  - __osx >=11.0
-  - libxcb >=1.17.0,<2.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
-  - libjpeg-turbo >=3.1.2,<4.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - python_abi 3.14.* *_cp314
-  - lcms2 >=2.18,<3.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  license: HPND
-  size: 996187
-  timestamp: 1770794152243
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
-  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
-  md5: c01af13bdc553d1a8fbfff6e8db075f0
-  depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: MIT
-  license_family: MIT
-  size: 450960
-  timestamp: 1754665235234
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
-  sha256: 29c9b08a9b8b7810f9d4f159aecfd205fce051633169040005c0b7efad4bc718
-  md5: 17c3d745db6ea72ae2fce17e7338547f
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: MIT
-  license_family: MIT
-  size: 248045
-  timestamp: 1754665282033
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
-  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
-  md5: 82c1787f2a65c0155ef9652466ee98d6
+  size: 56559
+  timestamp: 1777271601895
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+  sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
+  md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 25646
-  timestamp: 1773199142345
-- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
-  sha256: 75b2589159d04b3fb92db16d9970b396b9124652c784ab05b66f584edc97f283
-  md5: 7526d20621b53440b0aae45d4797847e
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: Apache
-  size: 56634
-  timestamp: 1768476602855
-- conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-6.33.5-py314h61e7c5f_2.conda
-  sha256: ceed4e3b1d13b0f200afbf01f7e314111cce85e116b8db512ff940571ba64104
-  md5: 418826d23f3fa6354700b4f31c5b87ba
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 491842
-  timestamp: 1773265994654
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-6.33.5-py314he407d35_2.conda
-  sha256: 1c9dc0ad0ecb8b346b8321c6c6a57cd436a0a852d02e42ce05c1ec12964cb8dd
-  md5: a667bd9984b0d39ec5d6ea5bf7f052c4
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcxx >=19
-  - libzlib >=1.3.1,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - libprotobuf 6.33.5
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 473978
-  timestamp: 1773265431848
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
-  sha256: f15574ed6c8c8ed8c15a0c5a00102b1efe8b867c0bd286b498cd98d95bd69ae5
-  md5: 4f225a966cfee267a79c5cb6382bd121
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 231303
-  timestamp: 1769678156552
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
-  sha256: e0f31c053eb11803d63860c213b2b1b57db36734f5f84a3833606f7c91fedff9
-  md5: fc4c7ab223873eee32080d51600ce7e7
-  depends:
-  - python
-  - __osx >=11.0
-  - python 3.14.* *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 245502
-  timestamp: 1769678303655
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
-  md5: b3c17d95b5a10c6e64a21fa17573e70e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 8252
-  timestamp: 1726802366959
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
-  sha256: 8ed65e17fbb0ca944bfb8093b60086e3f9dd678c3448b5de212017394c247ee3
-  md5: 415816daf82e0b23a736a069a75e9da7
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 8381
-  timestamp: 1726802424786
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
-  sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
-  md5: b11a4c6bf6f6f44e5e143f759ffa2087
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  license: MIT
-  license_family: MIT
-  size: 118488
-  timestamp: 1736601364156
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.15-hd3d436d_0.conda
-  sha256: 5ad8d036040b095f85d23c70624d3e5e1e4c00bc5cea97831542f2dcae294ec9
-  md5: b9a4004e46de7aeb005304a13b35cb94
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  license: MIT
-  license_family: MIT
-  size: 91283
-  timestamp: 1736601509593
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
-  sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
-  md5: b8ea447fdf62e3597cb8d2fae4eb1a90
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - dbus >=1.16.2,<2.0a0
-  - libgcc >=14
-  - libglib >=2.86.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - libsndfile >=1.2.2,<1.3.0a0
-  - libsystemd0 >=257.10
-  - libxcb >=1.17.0,<2.0a0
-  constrains:
-  - pulseaudio 17.0 *_3
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 750785
-  timestamp: 1763148198088
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
-  sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
-  md5: c3946ed24acdb28db1b5d63321dbca7d
-  depends:
-  - typing-inspection >=0.4.2
-  - typing_extensions >=4.14.1
-  - python >=3.10
-  - typing-extensions >=4.6.1
-  - annotated-types >=0.6.0
-  - pydantic-core ==2.41.5
-  - python
-  license: MIT
-  license_family: MIT
-  size: 340482
-  timestamp: 1764434463101
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py314h2e6c369_1.conda
-  sha256: 7e0ae379796e28a429f8e48f2fe22a0f232979d65ec455e91f8dac689247d39f
-  md5: 432b0716a1dfac69b86aa38fdd59b7e6
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 1943088
-  timestamp: 1762988995556
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py314haad56a0_1.conda
-  sha256: dded9092d89f1d8c267d5ce8b5e21f935c51acb7a64330f507cdfb3b69a98116
-  md5: 420a4b8024e9b22880f1e03b612afa7d
-  depends:
-  - python
-  - typing-extensions >=4.6.0,!=4.7.0
-  - __osx >=11.0
-  - python 3.14.* *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 1784478
-  timestamp: 1762989019956
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
-  sha256: 385a900cf5d1d39dafab6088537c58a32d572fd237d7c4598def92c4c1120cb8
-  md5: 96513760035d70917819a2840155d23a
-  depends:
-  - python >=3.10
-  - pydantic >=2.5.2
-  - python
-  constrains:
-  - phonenumbers >=8,<9
-  - pycountry >=23
-  - semver >=3.0.2,<4
-  - python-ulid >=1,<4
-  - pendulum >=3.0.0,<4.0.0
-  - pytz >=2024.1
-  - tzdata >=2024a
-  license: MIT
-  license_family: MIT
-  size: 72040
-  timestamp: 1773664659868
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.13.1-pyhd8ed1ab_0.conda
-  sha256: 343988d65c08477a87268d4fbeba59d0295514143965d2755ac4519b73155479
-  md5: cc0da73801948100ae97383b8da12993
-  depends:
-  - pydantic >=2.7.0
-  - python >=3.10
-  - python-dotenv >=0.21.0
-  - typing-inspection >=0.4.0
-  license: MIT
-  license_family: MIT
-  size: 49319
-  timestamp: 1771527313149
-- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
-  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
-  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
-  depends:
-  - python >=3.9
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 889287
-  timestamp: 1750615908735
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyinstrument-5.1.2-py314h5bd0f2a_0.conda
-  sha256: a3651410868d483ee5b9c13f77e2dec0190d63a04d75b0bf787fec8cd7e22629
-  md5: 25cf8bf8f4755ad07613d1dafb66c0f9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 194459
-  timestamp: 1767565403103
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyinstrument-5.1.2-py314h6c2aa35_0.conda
-  sha256: 5a4731fa27d1a7fb37a6db18bdc2944cb46f419b84d4ccd871b7698aec21b3e8
-  md5: a398962395f78da42d2e0cf8f56b6185
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 193564
-  timestamp: 1767565658444
-- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-  sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
-  md5: 461219d1a5bd61342293efa2c0c90eac
-  depends:
-  - __unix
-  - python >=3.9
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 21085
-  timestamp: 1733217331982
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
-  build_number: 101
-  sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
-  md5: c014ad06e60441661737121d3eae8a60
+  size: 25862
+  timestamp: 1775741140609
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
+  md5: a443f87920815d41bfe611296e507995
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.7.3,<3.0a0
+  - libexpat >=2.7.5,<3.0a0
   - libffi >=3.5.2,<3.6.0a0
   - libgcc >=14
   - liblzma >=5.8.2,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libuuid >=2.41.3,<3.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - libuuid >=2.42,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 36702440
-  timestamp: 1770675584356
+  size: 36705460
+  timestamp: 1775614357822
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
-  build_number: 101
-  sha256: fccce2af62d11328d232df9f6bbf63464fd45f81f718c661757f9c628c4378ce
-  md5: 753c8d0447677acb7ddbcc6e03e82661
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.4-h6c44a53_0_cp314t.conda
+  sha256: e825c7f56d811f63995be4482442398909000ce71137ce6c9e5bab80ca74997b
+  md5: fe2e332924c098feefba3b806a9951b5
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.7.3,<3.0a0
+  - libexpat >=2.7.5,<3.0a0
   - libffi >=3.5.2,<3.6.0a0
   - liblzma >=5.8.2,<6.0a0
   - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.51.2,<4.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - ncurses >=6.5,<7.0a0
-  - openssl >=3.5.5,<4.0a0
-  - python_abi 3.14.* *_cp314
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314t
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - zstd >=1.5.7,<1.6.0a0
+  track_features:
+  - py_freethreading
   license: Python-2.0
-  size: 13522698
-  timestamp: 1770675365241
-  python_site_packages_path: lib/python3.14/site-packages
+  size: 13978318
+  timestamp: 1775615456198
+  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -4535,43 +943,15 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
-  sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
-  md5: 130584ad9f3a513cdd71b1fdc1244e9c
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.4-h4df99d1_100.conda
+  sha256: 36ff7984e4565c85149e64f8206303d412a0652e55cf806dcb856903fa056314
+  md5: e4e60721757979d01d3964122f674959
   depends:
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27848
-  timestamp: 1772388605021
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
-  sha256: 233aebd94c704ac112afefbb29cf4170b7bc606e22958906f2672081bc50638a
-  md5: 235765e4ea0d0301c75965985163b5a1
-  depends:
-  - cpython 3.14.3.*
+  - cpython 3.14.4.*
   - python_abi * *_cp314
   license: Python-2.0
-  size: 50062
-  timestamp: 1770674497152
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
-  sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
-  md5: a61bf9ec79426938ff785eb69dbb1960
-  depends:
-  - python >=3.6
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 13383
-  timestamp: 1677079727691
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.22-pyhcf101f3_0.conda
-  sha256: 8275c88b0f138dbd602c53bae9a11789126c6a2c97f7e89f679d3e7ccbb121ba
-  md5: 5a2610edf297cbd1cbc0e2c17bc47efc
-  depends:
-  - python >=3.10
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 30342
-  timestamp: 1769356329419
+  size: 49806
+  timestamp: 1775614307464
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8
   sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
@@ -4582,32 +962,16 @@ packages:
   license_family: BSD
   size: 6989
   timestamp: 1752805904792
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
-  sha256: b318fb070c7a1f89980ef124b80a0b5ccf3928143708a85e0053cde0169c699d
-  md5: 2035f68f96be30dc60a5dfd7452c7941
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 202391
-  timestamp: 1770223462836
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
-  sha256: 95f385f9606e30137cf0b5295f63855fd22223a4cf024d306cf9098ea1c4a252
-  md5: dcf51e564317816cb8d546891019b3ab
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  - yaml >=0.2.5,<0.3.0a0
-  license: MIT
-  license_family: MIT
-  size: 189475
-  timestamp: 1770223788648
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+  build_number: 8
+  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
+  md5: 3251796e09870c978e0f69fa05e38fb6
+  constrains:
+  - python 3.14.* *_cp314t
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7020
+  timestamp: 1752805919426
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -4624,39 +988,20 @@ packages:
   license_family: BSD
   size: 211567
   timestamp: 1771716961404
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
-  noarch: python
-  sha256: 2f31f799a46ed75518fae0be75ecc8a1b84360dbfd55096bc2fe8bd9c797e772
-  md5: 2f6b79700452ef1e91f45a99ab8ffe5a
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py314h87575ce_2.conda
+  sha256: 7be013c4ccbc1581cbfa94d4979eb1f2113f7eeb76a40e2589155a694733d0e1
+  md5: 4a45b46523c1b5733a867692ad1ed64f
   depends:
   - python
-  - libcxx >=19
+  - python 3.14.* *_cp314t
   - __osx >=11.0
-  - _python_abi3_support 1.*
-  - cpython >=3.12
+  - libcxx >=19
   - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
-  size: 191641
-  timestamp: 1771717073430
-- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
-  sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
-  md5: 66a715bc01c77d43aca1f9fcb13dde3c
-  depends:
-  - libre2-11 2025.11.05 h0dc7533_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27469
-  timestamp: 1768190052132
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
-  sha256: 5bab972e8f2bff1b5b3574ffec8ecb89f7937578bd107584ed3fde507ff132f9
-  md5: a1ff22f664b0affa3de712749ccfbf04
-  depends:
-  - libre2-11 2025.11.05 h4c27e2a_1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 27445
-  timestamp: 1768190259003
+  size: 374574
+  timestamp: 1771717083205
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -4678,99 +1023,6 @@ packages:
   license_family: GPL
   size: 313930
   timestamp: 1765813902568
-- conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.2.28-py314h5bd0f2a_0.conda
-  sha256: e085e336f1446f5263a3ec9747df8c719b6996753901181add50dc4fdd8bb2e8
-  md5: 3c8b6a8c4d0ff5a264e9831eac4941f4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: Apache-2.0 AND CNRI-Python
-  license_family: PSF
-  size: 411924
-  timestamp: 1772255161535
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.2.28-py314h6c2aa35_0.conda
-  sha256: 345ea06b0a48bd9178a00c375f65cb5359953566cbd152962c083e7c766cc0bb
-  md5: 2d9d9c8cb8990250eb938011606d78c1
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: Apache-2.0 AND CNRI-Python
-  license_family: PSF
-  size: 376504
-  timestamp: 1772255973560
-- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.0-pyhcf101f3_0.conda
-  sha256: fbc7183778e1f9976ae7d812986c227f9d43f841326ac03b5f43f1ac93fa8f3b
-  md5: bee5ed456361bfe8af502beaf5db82e2
-  depends:
-  - python >=3.10
-  - certifi >=2023.5.7
-  - charset-normalizer >=2,<4
-  - idna >=2.5,<4
-  - urllib3 >=1.26,<3
-  - python
-  constrains:
-  - chardet >=3.0.2,<6
-  license: Apache-2.0
-  size: 63788
-  timestamp: 1774462091279
-- conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.3-pyhcf101f3_0.conda
-  sha256: b06ce84d6a10c266811a7d3adbfa1c11f13393b91cc6f8a5b468277d90be9590
-  md5: 7a6289c50631d620652f5045a63eb573
-  depends:
-  - markdown-it-py >=2.2.0
-  - pygments >=2.13.0,<3.0.0
-  - python >=3.10
-  - typing_extensions >=4.0.0,<5.0.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 208472
-  timestamp: 1771572730357
-- conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.7-pyhcf101f3_0.conda
-  sha256: 9cf3b9a083ebdee70ef5a48fbe409d91d2a8c4eed3c581a7b33b4d5ca7c813be
-  md5: 8b1a4d854f9a4ea1e4abc93ccab0ded9
-  depends:
-  - python >=3.10
-  - rich >=13.7.1
-  - click >=8.1.7
-  - typing_extensions >=4.12.2
-  - python
-  license: MIT
-  license_family: MIT
-  size: 32484
-  timestamp: 1771977622605
-- conda: https://conda.anaconda.org/conda-forge/linux-64/safetensors-0.7.0-py314ha5689aa_0.conda
-  sha256: c426ea6d97904fa187ede5f329b0152b11d0a1cbc195e17341fe0403fc78f685
-  md5: a89e88bc4a311084a6393bffd5e69bab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 452508
-  timestamp: 1763569634991
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/safetensors-0.7.0-py314h8d4a433_0.conda
-  sha256: b4985ee189e8ea2e012206ee5196e37b0f9759cc3390d8a0a4cc6530e062d58e
-  md5: edc25331f7b299e2e777f8749b4599bc
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 396052
-  timestamp: 1763570163071
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_0.conda
   sha256: 1ae427836d7979779c9005388a05993a3addabcc66c4422694639a4272d7d972
   md5: d0510124f87c75403090e220db1e9d41
@@ -4792,9 +1044,9 @@ packages:
   license_family: BSD
   size: 17225275
   timestamp: 1771880751368
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314hfc1f868_0.conda
-  sha256: 6ca2abcaff2cd071aabaabd82b10a87fc7de3a4619f6c98820cc28e90cc2cb20
-  md5: 7806ce54b78b0b11517b465a3398e910
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py314heec9164_0.conda
+  sha256: 204de892c41cf702f456833c97dc7e2ef2fbb835ccc320e5c1614e78e7cf8c31
+  md5: 5e58062849f471f014feac2ffad301eb
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -4807,193 +1059,12 @@ packages:
   - numpy >=1.23,<3
   - numpy >=1.25.2
   - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
+  - python >=3.14,<3.15.0a0 *_cp314t
+  - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
-  size: 13986990
-  timestamp: 1771881110844
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
-  sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
-  md5: cdd138897d94dc07d99afe7113a07bec
-  depends:
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgl >=1.7.0,<2.0a0
-  - sdl3 >=3.2.22,<4.0a0
-  - libegl >=1.7.0,<2.0a0
-  license: Zlib
-  size: 589145
-  timestamp: 1757842881
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl2-2.32.56-h248ca61_0.conda
-  sha256: 704c5cae4bc839a18c70cbf3387d7789f1902828c79c6ddabcd34daf594f4103
-  md5: 092c5b693dc6adf5f409d12f33295a2a
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - sdl3 >=3.2.22,<4.0a0
-  license: Zlib
-  size: 542508
-  timestamp: 1757842919681
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.2-hdeec2a5_0.conda
-  sha256: 64b982664550e01c25f8f09333c0ee54d4764a80fe8636b8aaf881fe6e8a0dbe
-  md5: 88a69db027a8ff59dab972a09d69a1ab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - xorg-libxscrnsaver >=1.2.4,<2.0a0
-  - libdrm >=2.4.125,<2.5.0a0
-  - xorg-libxfixes >=6.0.2,<7.0a0
-  - libudev1 >=257.10
-  - pulseaudio-client >=17.0,<17.1.0a0
-  - xorg-libxtst >=1.2.5,<2.0a0
-  - libegl >=1.7.0,<2.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - xorg-libxcursor >=1.2.3,<2.0a0
-  - xorg-libx11 >=1.8.13,<2.0a0
-  - liburing >=2.14,<2.15.0a0
-  - libxkbcommon >=1.13.1,<2.0a0
-  - libunwind >=1.8.3,<1.9.0a0
-  - libusb >=1.0.29,<2.0a0
-  - dbus >=1.16.2,<2.0a0
-  - xorg-libxext >=1.3.7,<2.0a0
-  - libgl >=1.7.0,<2.0a0
-  - xorg-libxi >=1.8.2,<2.0a0
-  - wayland >=1.24.0,<2.0a0
-  license: Zlib
-  size: 2138749
-  timestamp: 1771668185803
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sdl3-3.4.2-h6fa9c73_0.conda
-  sha256: e0589f700a9e9c188ba54c7ba5482885dc2e025f01de30fab098896cd6fda0a3
-  md5: 5e999442b4391dcd702f6026ac1a23f2
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - libusb >=1.0.29,<2.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - dbus >=1.16.2,<2.0a0
-  license: Zlib
-  size: 1556104
-  timestamp: 1771668215375
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-0.2.1-h8997910_3.conda
-  sha256: 04c8a8865934c4012468fbbb58bbb43f7ab58aa2427a9023c3c82d08409817aa
-  md5: 214177e62f636da374df16d9b563a282
-  depends:
-  - libsentencepiece 0.2.1 h432359f_3
-  - python_abi 3.14.* *_cp314
-  - sentencepiece-python 0.2.1 py314hb175150_3
-  - sentencepiece-spm 0.2.1 h432359f_3
-  license: Apache-2.0
-  license_family: Apache
-  size: 19962
-  timestamp: 1770168263955
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-0.2.1-h1f5ecb9_3.conda
-  sha256: 72433ebac197a4867a80a5872103b34ce7a8b145f04ec0fe40043f6888d1c3ba
-  md5: 005f5584dfa1b1334f54f4976e848ccb
-  depends:
-  - libsentencepiece 0.2.1 h9466b84_3
-  - python_abi 3.14.* *_cp314
-  - sentencepiece-python 0.2.1 py314h761924b_3
-  - sentencepiece-spm 0.2.1 h9466b84_3
-  license: Apache-2.0
-  license_family: Apache
-  size: 20138
-  timestamp: 1770169299048
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-python-0.2.1-py314hb175150_3.conda
-  sha256: 3431d0d4f20f2a1c22c064864ef07e92494fd53f4805eb425f14278ce917ad98
-  md5: 383bd4f054b9920bd4b28e3126cf9ab5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h432359f_3
-  - libstdcxx >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: Apache-2.0
-  license_family: Apache
-  size: 3287395
-  timestamp: 1770167913255
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-python-0.2.1-py314h761924b_3.conda
-  sha256: b0537e6589edef09912ecb8273745bad1e3a0c03bd58468ad6f23b973627fcbe
-  md5: b71ed331ffab7ab3a21315e354048b26
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h9466b84_3
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: Apache-2.0
-  license_family: Apache
-  size: 3316818
-  timestamp: 1770168602720
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sentencepiece-spm-0.2.1-h432359f_3.conda
-  sha256: f6cec76b6bf9d2e6d35706be91aaf4072557e351fff40f7d1aea421c0777accb
-  md5: d6c303d1238b187b6d1e47d473a5cd87
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libgcc >=14
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h432359f_3
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 87674
-  timestamp: 1770168237369
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sentencepiece-spm-0.2.1-h9466b84_3.conda
-  sha256: 5f50b6bcbac6f8ba8d01ae9b87d90e00a2e5050d764472490459c0734f3227e8
-  md5: 96d38e92eac429c38f96c09f2de257d4
-  depends:
-  - __osx >=11.0
-  - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libcxx >=19
-  - libprotobuf >=6.33.5,<6.33.6.0a0
-  - libsentencepiece 0.2.1 h9466b84_3
-  license: Apache-2.0
-  license_family: Apache
-  size: 85881
-  timestamp: 1770169273364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
-  sha256: 0c2d6f24ee2b614ee1da4d7d99cc9944ea1ace65455a47d48d8c1f726317168a
-  md5: 8dc8dda113c4c568256bdd486b6e842e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - glslang >=16,<17.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - spirv-tools >=2026,<2027.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 113513
-  timestamp: 1770208767759
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/shaderc-2025.5-hf31e910_1.conda
-  sha256: d657df64dbf32c127ff788dc8b3b1017e9fd56ee5142690e2b0302f900437a4b
-  md5: c00668684040c717f1711a81ac1f18f0
-  depends:
-  - __osx >=11.0
-  - glslang >=16,<17.0a0
-  - libcxx >=19
-  - spirv-tools >=2026,<2027.0a0
-  license: Apache-2.0
-  license_family: Apache
-  size: 112531
-  timestamp: 1770209178534
-- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
-  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
-  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
-  depends:
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 15018
-  timestamp: 1762858315311
+  size: 14358162
+  timestamp: 1771880795641
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -5004,174 +1075,6 @@ packages:
   license_family: MIT
   size: 18455
   timestamp: 1753199211006
-- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
-  sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
-  md5: 98b6c9dc80eb87b2519b97bcf7e578dd
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 45829
-  timestamp: 1762948049098
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
-  sha256: cb9305ede19584115f43baecdf09a3866bfcd5bcca0d9e527bd76d9a1dbe2d8d
-  md5: fca4a2222994acd7f691e57f94b750c5
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 38883
-  timestamp: 1762948066818
-- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
-  sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
-  md5: 03fe290994c5e4ec17293cfb6bdce520
-  depends:
-  - python >=3.10
-  license: Apache-2.0
-  license_family: Apache
-  size: 15698
-  timestamp: 1762941572482
-- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
-  sha256: 003180b3a2e0c6490b1f3461cf9e0ed740b1bbf88ee4b73ee177b94bea0dc95d
-  md5: 8809e0bd5ec279bfe4bb6651c3ed2730
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  constrains:
-  - spirv-headers >=1.4.341.0,<1.4.341.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2296977
-  timestamp: 1770089626195
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/spirv-tools-2026.1-h4ddebb9_0.conda
-  sha256: 8c7b7b1f7a42f1a878f08e44ee94023285eb51ba8e5042f28d61dce305b10242
-  md5: 2e34a5f251c18163da9bfbb4733cc1d9
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  constrains:
-  - spirv-headers >=1.4.341.0,<1.4.341.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 1613001
-  timestamp: 1770089883327
-- conda: https://conda.anaconda.org/conda-forge/noarch/sse-starlette-3.3.3-pyhd8ed1ab_0.conda
-  sha256: 08897a79f7366193fdd779500bad1883df08ad4c5b950ed64464c023f52d30b7
-  md5: 9a6dae690702ee4c88c3cea3bd15dd13
-  depends:
-  - anyio >=4.7.0
-  - python >=3.10
-  - starlette >=0.49.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 19983
-  timestamp: 1773794166260
-- conda: https://conda.anaconda.org/conda-forge/noarch/starlette-1.0.0-pyhcf101f3_0.conda
-  sha256: 1a1dc376e95491f4b2003f4428e6f7caf4a3de0ef9869248b29dcc9704c34b39
-  md5: 8fbd5b6879350f1b5303c1a652d4b781
-  depends:
-  - anyio >=3.6.2,<5
-  - python >=3.10
-  - typing_extensions >=4.10.0
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 63717
-  timestamp: 1774215956101
-- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
-  sha256: 4a1d2005153b9454fc21c9bad1b539df189905be49e851ec62a6212c2e045381
-  md5: 2a2170a3e5c9a354d09e4be718c43235
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2619743
-  timestamp: 1769664536467
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
-  sha256: bdef3c1c4d2a396ad4f7dc64c5e9a02d4c5a21ff93ed07a33e49574de5d2d18d
-  md5: 8badc3bf16b62272aa2458f138223821
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1456245
-  timestamp: 1769664727051
-- conda: https://conda.anaconda.org/conda-forge/noarch/taskgroup-0.2.2-pyhd8ed1ab_0.conda
-  sha256: 6f8db6da8de445930de55b708e6a5d3ab5f076bc14a39578db0190b2a9b8e437
-  md5: 9fa69537fb68a095fbac139210575bad
-  depends:
-  - exceptiongroup
-  - python >=3.9
-  - typing_extensions >=4.12.2,<5
-  license: MIT
-  license_family: MIT
-  size: 17330
-  timestamp: 1736003478648
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
-  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
-  md5: 8f7278ca5f7456a974992a8b34284737
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libhwloc >=2.12.2,<2.12.3.0a0
-  - libstdcxx >=14
-  license: Apache-2.0
-  license_family: APACHE
-  size: 181329
-  timestamp: 1767886632911
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2022.3.0-h4ddebb9_2.conda
-  sha256: 54278e6bdf378b92cbec941d29e8f360796dabf72c9ad1f6e2a27ca91a9f804a
-  md5: 82395152e3ba2dea9ea6a3dc17553136
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libhwloc >=2.12.2,<2.12.3.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 120040
-  timestamp: 1767887181945
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py314h67fec18_3.conda
-  sha256: 7e395d67fd249d901beb1ae269057763c0d8c3ee5f7a348694bdb16d158a37d9
-  md5: d705f9d8a1185a2b01cced191177a028
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - regex >=2022.1.18
-  - requests >=2.26.0
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 939648
-  timestamp: 1764028306357
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiktoken-0.12.0-py314h84b920e_3.conda
-  sha256: 5da44d5df48cfd64b4d547916c174b300fe2e8207c0b73d8f8c5ba1e68a54f07
-  md5: beff809aa4e80a856d951e0a0b128a25
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  - regex >=2022.1.18
-  - requests >=2.26.0
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 822640
-  timestamp: 1764028597180
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -5195,49 +1098,16 @@ packages:
   license_family: BSD
   size: 3127137
   timestamp: 1769460817696
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py314h98f1220_0.conda
-  sha256: fe5f643b3a5b8b32fc23a86ee5b5be2091931978afc8cb4e83f05ff77af9476b
-  md5: 43daaff0563759050f17c8d81076edc5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - huggingface_hub >=0.16.4,<2.0
-  - libgcc >=14
-  - libstdcxx >=14
-  - openssl >=3.5.4,<4.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __glibc >=2.17
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2463535
-  timestamp: 1764695049274
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tokenizers-0.22.2-py314h84b920e_0.conda
-  sha256: b6b28e7ba6bad0a12bf466329f7cec6e5e9e3391ab2516fd7104c98b1cfae762
-  md5: 74cf6b7acb49ac938c70a5693506e905
-  depends:
-  - __osx >=11.0
-  - huggingface_hub >=0.16.4,<2.0
-  - libcxx >=19
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __osx >=11.0
-  license: Apache-2.0
-  license_family: APACHE
-  size: 2206342
-  timestamp: 1764695882354
-- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-  sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
-  md5: 72e780e9aa2d0a3295f59b1874e3768b
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 21453
-  timestamp: 1768146676791
+  size: 21561
+  timestamp: 1774492402955
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py314h5bd0f2a_0.conda
   sha256: ed8d06093ff530a2dae9ed1e51eb6f908fbfd171e8b62f4eae782d67b420be5a
   md5: dc1ff1e915ab35a06b6fa61efae73ab5
@@ -5250,28 +1120,18 @@ packages:
   license_family: Apache
   size: 912476
   timestamp: 1774358032579
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314h6c2aa35_0.conda
-  sha256: 4ccc4a20d676c0ba85adee9c99015bec7f5b685df0cf8006e34573f1d6c2ce75
-  md5: 3f81f8b2fe2c26a82c0abf57ab2b9610
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.5-py314ha0ac461_0.conda
+  sha256: f747246aab4ca6b15523aa8b40805995a1019450bd2382c906d0a074f1e9d876
+  md5: d33bcf373760d2958e6defa1fe1b0192
   depends:
   - __osx >=11.0
   - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
+  - python >=3.14,<3.15.0a0 *_cp314t
+  - python_abi 3.14.* *_cp314t
   license: Apache-2.0
   license_family: Apache
-  size: 910845
-  timestamp: 1774358965067
-- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
-  sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
-  md5: e5ce43272193b38c2e9037446c1d9206
-  depends:
-  - python >=3.10
-  - __unix
-  - python
-  license: MPL-2.0 and MIT
-  size: 94132
-  timestamp: 1770153424136
+  size: 909663
+  timestamp: 1774358650588
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
@@ -5281,472 +1141,12 @@ packages:
   license_family: BSD
   size: 110051
   timestamp: 1733367480074
-- conda: https://conda.anaconda.org/conda-forge/noarch/transformers-4.57.6-pyhd8ed1ab_1.conda
-  sha256: f9d90fd9ebf2005b3e38e51da57a43213dba4595d834fdeff438646ff8d8111e
-  md5: 38e994a6794f2904fd903956eca814fa
-  depends:
-  - filelock
-  - huggingface_hub >=0.34.0,<1.0
-  - numpy >=1.17
-  - packaging >=20.0
-  - python >=3.10
-  - pyyaml >=5.1
-  - regex !=2019.12.17
-  - requests
-  - safetensors >=0.4.1
-  - tokenizers >=0.22,<=0.23
-  - tqdm >=4.27
-  license: Apache-2.0
-  license_family: APACHE
-  size: 4400292
-  timestamp: 1770349724325
-- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
-  sha256: e1116d08e6a55b2b42a090130c268f75211ad8e6a8e7749e977924de3864d487
-  md5: 10870929f587540c5802cd9b071cba5c
-  depends:
-  - annotated-doc >=0.0.2
-  - click >=8.2.1
-  - python >=3.10
-  - rich >=12.3.0
-  - shellingham >=1.3.0
-  - python
-  license: MIT
-  license_family: MIT
-  size: 117860
-  timestamp: 1771292312899
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
-  sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
-  md5: edd329d7d3a4ab45dcf905899a7a6115
-  depends:
-  - typing_extensions ==4.15.0 pyhcf101f3_0
-  license: PSF-2.0
-  license_family: PSF
-  size: 91383
-  timestamp: 1756220668932
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
-  sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
-  md5: a0a4a3035667fc34f29bfbd5c190baa6
-  depends:
-  - python >=3.10
-  - typing_extensions >=4.12.0
-  license: MIT
-  license_family: MIT
-  size: 18923
-  timestamp: 1764158430324
-- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
-  md5: 0caa1af407ecff61170c9437a808404d
-  depends:
-  - python >=3.10
-  - python
-  license: PSF-2.0
-  license_family: PSF
-  size: 51692
-  timestamp: 1756220668932
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
   sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
   md5: ad659d0a2b3e47e38d829aa8cad2d610
   license: LicenseRef-Public-Domain
   size: 119135
   timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
-  md5: 9272daa869e03efe68833e3dc7a02130
-  depends:
-  - backports.zstd >=1.0.0
-  - brotli-python >=1.2.0
-  - h2 >=4,<5
-  - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.10
-  license: MIT
-  license_family: MIT
-  size: 103172
-  timestamp: 1767817860341
-- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.42.0-pyhc90fa1f_0.conda
-  sha256: f6522b921e7434775cd283c9b2382e5344db226e58bd36b294a1553700d0d1f9
-  md5: c6ad593e48d81ab822b7ac6b9b054a0d
-  depends:
-  - __unix
-  - click >=7.0
-  - h11 >=0.8
-  - python >=3.10
-  - typing_extensions >=4.0
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 54908
-  timestamp: 1773659868807
-- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.42.0-h76e4700_0.conda
-  sha256: 98f2619d66c477745272b8ec10dd4737055848372a007af3228bb9fb1547e894
-  md5: 6eb0881849490cee741779c698f68d45
-  depends:
-  - __unix
-  - uvicorn ==0.42.0 pyhc90fa1f_0
-  - websockets >=10.4
-  - httptools >=0.6.3
-  - watchfiles >=0.20
-  - python-dotenv >=0.13
-  - pyyaml >=5.1
-  - uvloop >=0.15.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4141
-  timestamp: 1773659868807
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py314h5bd0f2a_1.conda
-  sha256: ad3058ed67e1de5f9a73622a44a5c7a51af6a4527cf4881ae22b8bb6bd30bceb
-  md5: 41f06d5cb2a80011c7da5a835721acdd
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libuv >=1.51.0,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: MIT OR Apache-2.0
-  size: 593392
-  timestamp: 1762472837997
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvloop-0.22.1-py314h0612a62_1.conda
-  sha256: 7850dd9238beb14f9c7db1901229cc5d2ecd10d031cbdb712a95eba57a5d5992
-  md5: 74683034f513752be1467c9232480a13
-  depends:
-  - __osx >=11.0
-  - libuv >=1.51.0,<2.0a0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: MIT OR Apache-2.0
-  size: 492509
-  timestamp: 1762473163613
-- conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py314ha5689aa_0.conda
-  sha256: fcec93ca26320764c55042fc56b772a88533ed01f1c713553c985b379e174d09
-  md5: fb190bbf05b3b963bea7ab7c20624d5d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - anyio >=3.0.0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  size: 421969
-  timestamp: 1760456771978
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-1.1.1-py314h8d4a433_0.conda
-  sha256: b9446970047031e66edf76548fa427fe0ce7e81655208dc2e2a0b0bf94ebf7ba
-  md5: 33c8e4a66a7cb5d75ba8165a6075cd28
-  depends:
-  - __osx >=11.0
-  - anyio >=3.0.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 367150
-  timestamp: 1760457260426
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-  sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
-  md5: 996583ea9c796e5b915f7d7580b51ea6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libexpat >=2.7.4,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: MIT
-  license_family: MIT
-  size: 334139
-  timestamp: 1773959575393
-- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
-  sha256: 9ab2c12053ea8984228dd573114ffc6d63df42c501d59fda3bf3aeb1eaa1d23e
-  md5: 7da1571f560d4ba3343f7f4c48a79c76
-  license: MIT
-  license_family: MIT
-  size: 140476
-  timestamp: 1765821981856
-- conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py314h0f05182_1.conda
-  sha256: 15cf4ebe64022b71bcec9e3554c0b36f6cab4d7726018ccf768982bc3984198e
-  md5: 26fea8d00be28d4c6f6b49fe6b31cd1e
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 382988
-  timestamp: 1768087395103
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-16.0-py314ha14b1ff_1.conda
-  sha256: 2d708c6173773cc4883582c216f0ab1e776155aa74116ef6092b7084c879e92b
-  md5: 0cd5ebc7e220c79c6969ec15e82c741e
-  depends:
-  - python
-  - python 3.14.* *_cp314
-  - __osx >=11.0
-  - python_abi 3.14.* *_cp314
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 387183
-  timestamp: 1768087446876
-- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py314h5bd0f2a_0.conda
-  sha256: 9c6ed8b7322a62bea2f738191c374aeea34bf655d399124245f1bbd8e986b3f4
-  md5: ecb8efb80a3f80e096fdc95f524d54b5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 88335
-  timestamp: 1772794808717
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.1.2-py314h6c2aa35_0.conda
-  sha256: 01e523dd50b90981c3c62e3a0ec6115a8b93bf27a93811d682ca59cb2c633350
-  md5: 0ae7bae2e2fa519cd59681c7c1af83d6
-  depends:
-  - __osx >=11.0
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 85647
-  timestamp: 1772795720805
-- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
-  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
-  md5: 6c99772d483f566d59e25037fea2c4b1
-  depends:
-  - libgcc-ng >=12
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 897548
-  timestamp: 1660323080555
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
-  sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
-  md5: b1f6dccde5d3a1f911960b6e567113ff
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 717038
-  timestamp: 1660323292329
-- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
-  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
-  md5: e7f6ed84d4623d52ee581325c1587a6b
-  depends:
-  - libgcc-ng >=10.3.0
-  - libstdcxx-ng >=10.3.0
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 3357188
-  timestamp: 1646609687141
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-  sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
-  md5: b1f7f2780feffe310b068c021e8ff9b2
-  depends:
-  - libcxx >=12.0.1
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 1832744
-  timestamp: 1646609481185
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.47-hb03c661_0.conda
-  sha256: 19c2bb14bec84b0e995b56b752369775c75f1589314b43733948bb5f471a6915
-  md5: b56e0c8432b56decafae7e78c5f29ba5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.13,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 399291
-  timestamp: 1772021302485
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
-  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
-  md5: fb901ff28063514abb6046c9ec2c4a45
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: MIT
-  license_family: MIT
-  size: 58628
-  timestamp: 1734227592886
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
-  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
-  md5: 1c74ff8c35dcadf952a16f752ca5aa49
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libuuid >=2.38.1,<3.0a0
-  - xorg-libice >=1.1.2,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 27590
-  timestamp: 1741896361728
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
-  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
-  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libxcb >=1.17.0,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 839652
-  timestamp: 1770819209719
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
-  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
-  md5: b2895afaf55bf96a8c8282a2e47a5de0
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 15321
-  timestamp: 1762976464266
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
-  sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
-  md5: 78b548eed8227a689f93775d5d23ae09
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 14105
-  timestamp: 1762976976084
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
-  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
-  md5: 2ccd714aa2242315acaf0a67faea780b
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  - xorg-libxrender >=0.9.11,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  size: 32533
-  timestamp: 1730908305254
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
-  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
-  md5: 1dafce8548e38671bea82e3f5c6ce22f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 20591
-  timestamp: 1762976546182
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
-  sha256: f7fa0de519d8da589995a1fe78ef74556bb8bc4172079ae3a8d20c3c81354906
-  md5: 9d1299ace1924aa8f4e0bc8e71dd0cf7
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 19156
-  timestamp: 1762977035194
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
-  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
-  md5: 34e54f03dfea3e7a2dcf1453a85f1085
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 50326
-  timestamp: 1769445253162
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
-  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
-  md5: ba231da7fccf9ea1e768caf5c7099b84
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 20071
-  timestamp: 1759282564045
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
-  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
-  md5: 17dcc85db3c7886650b8908b183d6876
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxfixes >=6.0.1,<7.0a0
-  license: MIT
-  license_family: MIT
-  size: 47179
-  timestamp: 1727799254088
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
-  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
-  md5: e192019153591938acf7322b6459d36e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - xorg-libx11 >=1.8.12,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxrender >=0.9.12,<0.10.0a0
-  license: MIT
-  license_family: MIT
-  size: 30456
-  timestamp: 1769445263457
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
-  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
-  md5: 96d57aba173e878a2089d5638016dc5e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 33005
-  timestamp: 1734229037766
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
-  sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
-  md5: 303f7a0e9e0cd7d250bb6b952cecda90
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 14412
-  timestamp: 1727899730073
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
-  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
-  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - xorg-libx11 >=1.8.10,<2.0a0
-  - xorg-libxext >=1.3.6,<2.0a0
-  - xorg-libxi >=1.7.10,<2.0a0
-  license: MIT
-  license_family: MIT
-  size: 32808
-  timestamp: 1727964811275
-- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
-  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
-  md5: a77f85f77be52ff59391544bfe73390a
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: MIT
-  license_family: MIT
-  size: 85189
-  timestamp: 1753484064210
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
-  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 83386
-  timestamp: 1753484079473
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
   sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
   md5: 755b096086851e1193f3b10347415d7c
@@ -5772,37 +1172,16 @@ packages:
   license_family: MOZILLA
   size: 245246
   timestamp: 1772476886668
-- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
-  sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
-  md5: 30cd29cb87d819caead4d55184c1d115
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.1-pyhcf101f3_0.conda
+  sha256: 523616c0530d305d2216c2b4a8dfd3872628b60083255b89c5e0d8c42e738cca
+  md5: e1c36c6121a7c9c76f2f148f1e83b983
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 24194
-  timestamp: 1764460141901
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
-  sha256: ea4e50c465d70236408cb0bfe0115609fd14db1adcd8bd30d8918e0291f8a75f
-  md5: 2aadb0d17215603a82a2a6b0afd9a4cb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  license: Zlib
-  license_family: Other
-  size: 122618
-  timestamp: 1770167931827
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
-  sha256: a339606a6b224bb230ff3d711e801934f3b3844271df9720165e0353716580d4
-  md5: d99c2a23a31b0172e90f456f580b695e
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  license: Zlib
-  license_family: Other
-  size: 94375
-  timestamp: 1770168363685
+  size: 24461
+  timestamp: 1776131454755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
   md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,9 +8,9 @@ authors = [
   "durnwalder <>",
 ]
 channels = [
-  "https://conda.modular.com/max-nightly/",
-  "conda-forge",
   "https://conda.modular.com/max",
+  "conda-forge",
+  "https://conda.modular.com/max-nightly/",
   "https://repo.prefix.dev/modular-community",
 ]
 description = "NuMojo is a library for numerical computing written in Mojo 🔥"
@@ -69,7 +69,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
-modular = "26.2.*"
 numpy = ">=2.4.2,<3"
 python = ">=3.14.3,<3.15"
 scipy = ">=1.17.0,<2"
+mojo = ">=0.26.2.0,<0.27"

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,13 +34,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-modular = "26.2.*"
+mojo = "26.2.*"
 
 [package.build-dependencies]
-modular = "26.2.*"
+mojo = "26.2.*"
 
 [package.run-dependencies]
-modular = "26.2.*"
+mojo = "26.2.*"
 
 [tasks]
 # compile the package and copy it to the tests folder
@@ -70,6 +70,6 @@ release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
 numpy = ">=2.4.2,<3"
-python = ">=3.14.3,<3.15"
+python = ">=3.13,<3.14"
 scipy = ">=1.17.0,<2"
 mojo = ">=0.26.2.0,<0.27"

--- a/tests/core/test_array_indexing_and_slicing.mojo
+++ b/tests/core/test_array_indexing_and_slicing.mojo
@@ -288,11 +288,14 @@ def test_getitem_index_array_negative_indices() raises:
     var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
     var anp = np.arange(12, dtype=np.int32).reshape(3, 4)
     var idx = nm.array[int]("[2, -1, 0, -2]")
-    check(a[idx], anp[[2, -1, 0, -2]], "index-array getter with negatives failed")
+    check(
+        a[idx], anp[[2, -1, 0, -2]], "index-array getter with negatives failed"
+    )
 
 
 def test_setitem_index_array_per_index_rows() raises:
-    """Integer-array setitem assigns row-by-row when val has leading index dim."""
+    """Integer-array setitem assigns row-by-row when val has leading index dim.
+    """
     var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
     var idx = nm.array[int]("[2, 0]")
     var repl = nm.array[nm.i32]("[[100, 101, 102, 103], [200, 201, 202, 203]]")
@@ -325,7 +328,8 @@ def test_setitem_index_array_broadcast_single_row() raises:
 
 
 def test_mask_setitem_compact_values() raises:
-    """Boolean-mask assignment supports compact 1-D values of true-count size."""
+    """Boolean-mask assignment supports compact 1-D values of true-count size.
+    """
     var a = nm.arange[nm.i32](0, 6, step=1).reshape(Shape(2, 3))
     var mask = nm.array[boolean]("[[1,0,1],[0,1,0]]")
     var vals = nm.array[nm.i32]("[50, 60, 70]")

--- a/tests/core/test_array_indexing_and_slicing.mojo
+++ b/tests/core/test_array_indexing_and_slicing.mojo
@@ -1,9 +1,10 @@
+from std.python import Python, PythonObject
+from std.testing import TestSuite
+
 import numojo as nm
 from numojo.prelude import *
 from std.testing.testing import assert_true, assert_almost_equal, assert_equal
 from utils_for_test import check, check_is_close
-from std.python import Python, PythonObject
-from std.testing import TestSuite
 
 
 def test_getitem_scalar() raises:

--- a/tests/core/test_array_indexing_and_slicing.mojo
+++ b/tests/core/test_array_indexing_and_slicing.mojo
@@ -282,6 +282,65 @@ def test_setitem_single_axis_index_oob_error() raises:
     assert_true(raised, "__setitem__(idx: Int, val) did not raise on OOB index")
 
 
+def test_getitem_index_array_negative_indices() raises:
+    """Integer-array getitem supports negative indices on axis 0."""
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
+    var anp = np.arange(12, dtype=np.int32).reshape(3, 4)
+    var idx = nm.array[int]("[2, -1, 0, -2]")
+    check(a[idx], anp[[2, -1, 0, -2]], "index-array getter with negatives failed")
+
+
+def test_setitem_index_array_per_index_rows() raises:
+    """Integer-array setitem assigns row-by-row when val has leading index dim."""
+    var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
+    var idx = nm.array[int]("[2, 0]")
+    var repl = nm.array[nm.i32]("[[100, 101, 102, 103], [200, 201, 202, 203]]")
+    a[idx] = repl
+
+    # row 2 replaced by repl[0], row 0 replaced by repl[1]
+    assert_equal(Int(a[2].load(0)), 100)
+    assert_equal(Int(a[2].load(3)), 103)
+    assert_equal(Int(a[0].load(0)), 200)
+    assert_equal(Int(a[0].load(3)), 203)
+    # untouched row
+    assert_equal(Int(a[1].load(0)), 4)
+    assert_equal(Int(a[1].load(3)), 7)
+
+
+def test_setitem_index_array_broadcast_single_row() raises:
+    """Integer-array setitem broadcasts one row to every selected row."""
+    var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
+    var idx = nm.array[int]("[1, 2]")
+    var row = nm.array[nm.i32]("[9, 9, 9, 9]")
+    a[idx] = row
+
+    assert_equal(Int(a[1].load(0)), 9)
+    assert_equal(Int(a[1].load(3)), 9)
+    assert_equal(Int(a[2].load(0)), 9)
+    assert_equal(Int(a[2].load(3)), 9)
+    # untouched row
+    assert_equal(Int(a[0].load(0)), 0)
+    assert_equal(Int(a[0].load(3)), 3)
+
+
+def test_mask_setitem_compact_values() raises:
+    """Boolean-mask assignment supports compact 1-D values of true-count size."""
+    var a = nm.arange[nm.i32](0, 6, step=1).reshape(Shape(2, 3))
+    var mask = nm.array[boolean]("[[1,0,1],[0,1,0]]")
+    var vals = nm.array[nm.i32]("[50, 60, 70]")
+    a[mask] = vals
+
+    # True positions in row-major order: (0,0), (0,2), (1,1)
+    assert_equal(Int(a.item(0, 0)), 50)
+    assert_equal(Int(a.item(0, 2)), 60)
+    assert_equal(Int(a.item(1, 1)), 70)
+    # False positions unchanged
+    assert_equal(Int(a.item(0, 1)), 1)
+    assert_equal(Int(a.item(1, 0)), 3)
+    assert_equal(Int(a.item(1, 2)), 5)
+
+
 # ===== F-order integer indexing =====
 # TODO: Fix "F" order issue in NDArray
 # def test_getitem_single_axis_f_order():

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -38,6 +38,7 @@ def test_complex_array_view() raises:
     assert_almost_equal(v.item(0).re, 1.0, "view failed")
     assert_almost_equal(v.item(0).im, 2.0, "view failed")
 
+
 def test_complex_array_view() raises:
     """Test view() method."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -176,24 +176,28 @@ def test_complex_array_setitem_bool_mask_scalar() raises:
     assert_almost_equal(c.item(5).im, -9.0, "mask scalar write failed")
 
 
-# TODO: Re-enable once ComplexNDArray comparison dunders avoid NDArray truth-value ambiguity.
-# def test_complex_array_lexicographic_comparisons() raises:
-#     var a = ComplexNDArray[cf32](Shape(3))
-#     a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
-#     a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-#     a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
-#
-#     var b = ComplexNDArray[cf32](Shape(3))
-#     b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
-#     b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-#     b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
-#
-#     var lt = a < b
-#     var gt = a > b
-#
-#     assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
-#     assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
-#     assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+def test_complex_array_lexicographic_comparisons() raises:
+    var a = ComplexNDArray[cf32](Shape(3))
+    a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+    a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
+
+    var b = ComplexNDArray[cf32](Shape(3))
+    b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
+    b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
+
+    var lt = a < b
+    var gt = a > b
+    var ne = a != b
+    var eq = a == b
+
+    assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
+    assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
+    assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+    assert_equal(Int(ne.load(0)), 1, "!= failed at 0")
+    assert_equal(Int(ne.load(1)), 0, "!= failed at 1")
+    assert_equal(Int(eq.load(1)), 1, "== failed at 1")
 
 
 def test_complex_array_axis_reductions() raises:

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -184,24 +184,28 @@ def test_complex_array_setitem_bool_mask_scalar() raises:
     assert_almost_equal(c.item(5).im, -9.0, "mask scalar write failed")
 
 
-# TODO: Re-enable once ComplexNDArray comparison dunders avoid NDArray truth-value ambiguity.
-# def test_complex_array_lexicographic_comparisons() raises:
-#     var a = ComplexNDArray[cf32](Shape(3))
-#     a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
-#     a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-#     a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
-#
-#     var b = ComplexNDArray[cf32](Shape(3))
-#     b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
-#     b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-#     b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
-#
-#     var lt = a < b
-#     var gt = a > b
-#
-#     assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
-#     assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
-#     assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+def test_complex_array_lexicographic_comparisons() raises:
+    var a = ComplexNDArray[cf32](Shape(3))
+    a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+    a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
+
+    var b = ComplexNDArray[cf32](Shape(3))
+    b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
+    b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
+
+    var lt = a < b
+    var gt = a > b
+    var ne = a != b
+    var eq = a == b
+
+    assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
+    assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
+    assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+    assert_equal(Int(ne.load(0)), 1, "!= failed at 0")
+    assert_equal(Int(ne.load(1)), 0, "!= failed at 1")
+    assert_equal(Int(eq.load(1)), 1, "== failed at 1")
 
 
 def test_complex_array_axis_reductions() raises:

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -16,6 +16,31 @@ def test_complex_array_init() raises:
     assert_almost_equal(c1.item(0).im, 2.0, "init failed")
 
 
+def test_complex_array_itemset_list() raises:
+    """Test itemset with List[Int] coordinates."""
+    var c1 = ComplexNDArray[cf32](Shape(3, 3))
+    c1.itemset(List(0, 0), ComplexSIMD[cf32](1.0, 2.0))
+    c1.itemset(List(1, 1), ComplexSIMD[cf32](3.0, 4.0))
+    c1.itemset(List(2, 2), ComplexSIMD[cf32](5.0, 6.0))
+    assert_almost_equal(c1.item(0, 0).re, 1.0, "itemset List failed")
+    assert_almost_equal(c1.item(0, 0).im, 2.0, "itemset List failed")
+    assert_almost_equal(c1.item(1, 1).re, 3.0, "itemset List failed")
+    assert_almost_equal(c1.item(1, 1).im, 4.0, "itemset List failed")
+    assert_almost_equal(c1.item(2, 2).re, 5.0, "itemset List failed")
+    assert_almost_equal(c1.item(2, 2).im, 6.0, "itemset List failed")
+
+
+def test_complex_array_itemset_negative_index() raises:
+    """Test itemset with negative indices."""
+    var c1 = ComplexNDArray[cf32](Shape(3, 3))
+    c1.itemset(-1, ComplexSIMD[cf32](7.0, 8.0))
+    c1.itemset(List(-1, -1), ComplexSIMD[cf32](9.0, 10.0))
+    assert_almost_equal(c1.item(2, 2).re, 7.0, "negative index failed")
+    assert_almost_equal(c1.item(2, 2).im, 8.0, "negative index failed")
+    assert_almost_equal(c1.item(2, 2).re, 9.0, "negative index List failed")
+    assert_almost_equal(c1.item(2, 2).im, 10.0, "negative index List failed")
+
+
 def test_complex_array_add() raises:
     """Test addition of ComplexArray numbers."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -141,5 +141,146 @@ def test_complex_array_div() raises:
     assert_almost_equal(quot.item(0).im, 0.08, "div failed")
 
 
+def _make_complex_2x3() raises -> ComplexNDArray[cf32]:
+    var c = ComplexNDArray[cf32](Shape(2, 3))
+    # Row 0
+    c.itemset(0, ComplexSIMD[cf32](1.0, 0.0))
+    c.itemset(1, ComplexSIMD[cf32](2.0, 1.0))
+    c.itemset(2, ComplexSIMD[cf32](3.0, -1.0))
+    # Row 1
+    c.itemset(3, ComplexSIMD[cf32](0.0, 2.0))
+    c.itemset(4, ComplexSIMD[cf32](2.0, -3.0))
+    c.itemset(5, ComplexSIMD[cf32](5.0, 4.0))
+    return c^
+
+
+def test_complex_array_deep_copy_independent() raises:
+    var c = _make_complex_2x3()
+    var d = c.deep_copy()
+    d.itemset(0, ComplexSIMD[cf32](99.0, 88.0))
+    assert_almost_equal(c.item(0).re, 1.0, "deep_copy modified source")
+    assert_almost_equal(c.item(0).im, 0.0, "deep_copy modified source")
+    assert_almost_equal(d.item(0).re, 99.0, "deep_copy write failed")
+    assert_almost_equal(d.item(0).im, 88.0, "deep_copy write failed")
+
+
+def test_complex_array_setitem_bool_mask_scalar() raises:
+    var c = _make_complex_2x3()
+    var idx = arange[i32](0, 6, step=1).reshape(Shape(2, 3))
+    var mask = idx > 2
+    var rhs = ComplexNDArray[cf32](Shape(2, 3))
+    rhs.fill(ComplexSIMD[cf32](9.0, -9.0))
+    c[mask] = rhs
+    assert_almost_equal(c.item(0).re, 1.0, "mask scalar write incorrect")
+    assert_almost_equal(c.item(3).re, 9.0, "mask scalar write failed")
+    assert_almost_equal(c.item(5).im, -9.0, "mask scalar write failed")
+
+
+def test_complex_array_lexicographic_comparisons() raises:
+    var a = ComplexNDArray[cf32](Shape(3))
+    a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+    a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
+
+    var b = ComplexNDArray[cf32](Shape(3))
+    b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
+    b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+    b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
+
+    var lt = a < b
+    var gt = a > b
+
+    assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
+    assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
+    assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+
+
+def test_complex_array_axis_reductions() raises:
+    var c = _make_complex_2x3()
+
+    var s0 = c.sum(axis=0)
+    assert_almost_equal(s0.item(0).re, 1.0, "sum(axis=0) re[0] failed")
+    assert_almost_equal(s0.item(0).im, 2.0, "sum(axis=0) im[0] failed")
+    assert_almost_equal(s0.item(1).re, 4.0, "sum(axis=0) re[1] failed")
+    assert_almost_equal(s0.item(1).im, -2.0, "sum(axis=0) im[1] failed")
+
+    var s1 = c.sum(axis=1)
+    assert_almost_equal(s1.item(0).re, 6.0, "sum(axis=1) re[0] failed")
+    assert_almost_equal(s1.item(0).im, 0.0, "sum(axis=1) im[0] failed")
+    assert_almost_equal(s1.item(1).re, 7.0, "sum(axis=1) re[1] failed")
+    assert_almost_equal(s1.item(1).im, 3.0, "sum(axis=1) im[1] failed")
+
+    var m1 = c.mean(axis=1)
+    assert_almost_equal(m1.item(0).re, 2.0, "mean(axis=1) re[0] failed")
+    assert_almost_equal(m1.item(0).im, 0.0, "mean(axis=1) im[0] failed")
+
+
+def test_complex_array_axis_prod_and_cumprod() raises:
+    var c = _make_complex_2x3()
+
+    var p1 = c.prod(axis=1)
+    # (1+0i)*(2+1i)*(3-1i) = 7+1i
+    assert_almost_equal(p1.item(0).re, 7.0, "prod(axis=1) row0 re failed")
+    assert_almost_equal(p1.item(0).im, 1.0, "prod(axis=1) row0 im failed")
+
+    var cp1 = c.cumprod(axis=1)
+    # Row 0 cumulative: [1+0i, 2+1i, 7+1i]
+    assert_almost_equal(cp1.item(0, 0).re, 1.0, "cumprod(axis=1) [0,0] re")
+    assert_almost_equal(cp1.item(0, 1).im, 1.0, "cumprod(axis=1) [0,1] im")
+    assert_almost_equal(cp1.item(0, 2).re, 7.0, "cumprod(axis=1) [0,2] re")
+    assert_almost_equal(cp1.item(0, 2).im, 1.0, "cumprod(axis=1) [0,2] im")
+
+
+def test_complex_array_axis_arg_and_extrema() raises:
+    var c = _make_complex_2x3()
+
+    var am1 = c.argmax(axis=1)
+    var an1 = c.argmin(axis=1)
+    assert_equal(Int(am1.load(0)), 2, "argmax(axis=1) row0 failed")
+    assert_equal(Int(am1.load(1)), 2, "argmax(axis=1) row1 failed")
+    assert_equal(Int(an1.load(0)), 0, "argmin(axis=1) row0 failed")
+    assert_equal(Int(an1.load(1)), 0, "argmin(axis=1) row1 failed")
+
+    var mx0 = c.max(axis=0)
+    var mn0 = c.min(axis=0)
+    assert_almost_equal(mx0.item(0).re, 1.0, "max(axis=0) col0 re failed")
+    assert_almost_equal(mn0.item(0).re, 0.0, "min(axis=0) col0 re failed")
+
+
+def test_complex_array_argsort_sort_median() raises:
+    var c = ComplexNDArray[cf32](Shape(4))
+    c.itemset(0, ComplexSIMD[cf32](2.0, 1.0))
+    c.itemset(1, ComplexSIMD[cf32](1.0, 9.0))
+    c.itemset(2, ComplexSIMD[cf32](2.0, -3.0))
+    c.itemset(3, ComplexSIMD[cf32](0.0, 4.0))
+
+    var idx = c.argsort(axis=0)
+    assert_equal(Int(idx.load(0)), 3, "argsort index 0 failed")
+    assert_equal(Int(idx.load(1)), 1, "argsort index 1 failed")
+    assert_equal(Int(idx.load(2)), 2, "argsort index 2 failed")
+    assert_equal(Int(idx.load(3)), 0, "argsort index 3 failed")
+
+    c.sort(axis=0)
+    assert_almost_equal(c.item(0).re, 0.0, "sort first re failed")
+    assert_almost_equal(c.item(1).re, 1.0, "sort second re failed")
+    assert_almost_equal(c.item(2).im, -3.0, "sort third im failed")
+
+    var med = c.median()
+    # middle two are (1+9i) and (2-3i) -> (1.5+3i)
+    assert_almost_equal(med.re, 1.5, "median re failed")
+    assert_almost_equal(med.im, 3.0, "median im failed")
+
+
+def test_complex_array_tolist_respects_view_order() raises:
+    var c = _make_complex_2x3()
+    var t = c.T([1, 0])
+    var vals = t.tolist()
+    # transposed first column should be original [0,0], [1,0]
+    assert_almost_equal(vals[0].re, 1.0, "tolist transposed value[0] re")
+    assert_almost_equal(vals[0].im, 0.0, "tolist transposed value[0] im")
+    assert_almost_equal(vals[1].re, 0.0, "tolist transposed value[1] re")
+    assert_almost_equal(vals[1].im, 2.0, "tolist transposed value[1] im")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -29,6 +29,7 @@ def test_complex_array_itemset() raises:
     assert_almost_equal(c1.item(2, 2).re, 5.0, "itemset List failed")
     assert_almost_equal(c1.item(2, 2).im, 6.0, "itemset List failed")
 
+
 def test_complex_array_view() raises:
     """Test view() method."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -16,12 +16,12 @@ def test_complex_array_init() raises:
     assert_almost_equal(c1.item(0).im, 2.0, "init failed")
 
 
-def test_complex_array_itemset_list() raises:
+def test_complex_array_itemset() raises:
     """Test itemset with List[Int] coordinates."""
     var c1 = ComplexNDArray[cf32](Shape(3, 3))
-    c1.itemset(List(0, 0), ComplexSIMD[cf32](1.0, 2.0))
-    c1.itemset(List(1, 1), ComplexSIMD[cf32](3.0, 4.0))
-    c1.itemset(List(2, 2), ComplexSIMD[cf32](5.0, 6.0))
+    c1.itemset([0, 0], ComplexSIMD[cf32](1.0, 2.0))
+    c1.itemset([1, 1], ComplexSIMD[cf32](3.0, 4.0))
+    c1.itemset([2, 2], ComplexSIMD[cf32](5.0, 6.0))
     assert_almost_equal(c1.item(0, 0).re, 1.0, "itemset List failed")
     assert_almost_equal(c1.item(0, 0).im, 2.0, "itemset List failed")
     assert_almost_equal(c1.item(1, 1).re, 3.0, "itemset List failed")
@@ -43,7 +43,7 @@ def test_complex_array_itemset_negative_index() raises:
     """Test itemset with negative indices."""
     var c1 = ComplexNDArray[cf32](Shape(3, 3))
     c1.itemset(-1, ComplexSIMD[cf32](7.0, 8.0))
-    c1.itemset(List(-1, -1), ComplexSIMD[cf32](9.0, 10.0))
+    c1.itemset([-1, -1], ComplexSIMD[cf32](9.0, 10.0))
     assert_almost_equal(c1.item(2, 2).re, 7.0, "negative index failed")
     assert_almost_equal(c1.item(2, 2).im, 8.0, "negative index failed")
     assert_almost_equal(c1.item(2, 2).re, 9.0, "negative index List failed")

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -38,6 +38,7 @@ def test_complex_array_view() raises:
     assert_almost_equal(v.item(0).re, 1.0, "view failed")
     assert_almost_equal(v.item(0).im, 2.0, "view failed")
 
+
 def test_complex_array_itemset_negative_index() raises:
     """Test itemset with negative indices."""
     var c1 = ComplexNDArray[cf32](Shape(3, 3))

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -29,6 +29,13 @@ def test_complex_array_itemset() raises:
     assert_almost_equal(c1.item(2, 2).re, 5.0, "itemset List failed")
     assert_almost_equal(c1.item(2, 2).im, 6.0, "itemset List failed")
 
+def test_complex_array_view() raises:
+    """Test view() method."""
+    var c1 = ComplexNDArray[cf32](Shape(2, 2))
+    c1.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+    var v = c1.view()
+    assert_almost_equal(v.item(0).re, 1.0, "view failed")
+    assert_almost_equal(v.item(0).im, 2.0, "view failed")
 
 def test_complex_array_view() raises:
     """Test view() method."""

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -43,9 +43,9 @@ def test_complex_array_itemset_negative_index() raises:
     """Test itemset with negative indices."""
     var c1 = ComplexNDArray[cf32](Shape(3, 3))
     c1.itemset(-1, ComplexSIMD[cf32](7.0, 8.0))
-    c1.itemset([-1, -1], ComplexSIMD[cf32](9.0, 10.0))
     assert_almost_equal(c1.item(2, 2).re, 7.0, "negative index failed")
     assert_almost_equal(c1.item(2, 2).im, 8.0, "negative index failed")
+    c1.itemset([-1, -1], ComplexSIMD[cf32](9.0, 10.0))
     assert_almost_equal(c1.item(2, 2).re, 9.0, "negative index List failed")
     assert_almost_equal(c1.item(2, 2).im, 10.0, "negative index List failed")
 

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -29,6 +29,7 @@ def test_complex_array_itemset_list() raises:
     assert_almost_equal(c1.item(2, 2).re, 5.0, "itemset List failed")
     assert_almost_equal(c1.item(2, 2).im, 6.0, "itemset List failed")
 
+
 def test_complex_array_view() raises:
     """Test view() method."""
     var c1 = ComplexNDArray[cf32](Shape(2, 2))
@@ -36,6 +37,7 @@ def test_complex_array_view() raises:
     var v = c1.view()
     assert_almost_equal(v.item(0).re, 1.0, "view failed")
     assert_almost_equal(v.item(0).im, 2.0, "view failed")
+
 
 def test_complex_array_itemset_negative_index() raises:
     """Test itemset with negative indices."""

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -176,23 +176,24 @@ def test_complex_array_setitem_bool_mask_scalar() raises:
     assert_almost_equal(c.item(5).im, -9.0, "mask scalar write failed")
 
 
-def test_complex_array_lexicographic_comparisons() raises:
-    var a = ComplexNDArray[cf32](Shape(3))
-    a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
-    a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-    a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
-
-    var b = ComplexNDArray[cf32](Shape(3))
-    b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
-    b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
-    b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
-
-    var lt = a < b
-    var gt = a > b
-
-    assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
-    assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
-    assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
+# TODO: Re-enable once ComplexNDArray comparison dunders avoid NDArray truth-value ambiguity.
+# def test_complex_array_lexicographic_comparisons() raises:
+#     var a = ComplexNDArray[cf32](Shape(3))
+#     a.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+#     a.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+#     a.itemset(2, ComplexSIMD[cf32](2.0, 3.0))
+#
+#     var b = ComplexNDArray[cf32](Shape(3))
+#     b.itemset(0, ComplexSIMD[cf32](1.0, 3.0))
+#     b.itemset(1, ComplexSIMD[cf32](2.0, -1.0))
+#     b.itemset(2, ComplexSIMD[cf32](1.0, 9.0))
+#
+#     var lt = a < b
+#     var gt = a > b
+#
+#     assert_equal(Int(lt.load(0)), 1, "lexicographic < failed at 0")
+#     assert_equal(Int(lt.load(1)), 0, "lexicographic < failed at 1")
+#     assert_equal(Int(gt.load(2)), 1, "lexicographic > failed at 2")
 
 
 def test_complex_array_axis_reductions() raises:

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -29,6 +29,13 @@ def test_complex_array_itemset_list() raises:
     assert_almost_equal(c1.item(2, 2).re, 5.0, "itemset List failed")
     assert_almost_equal(c1.item(2, 2).im, 6.0, "itemset List failed")
 
+def test_complex_array_view() raises:
+    """Test view() method."""
+    var c1 = ComplexNDArray[cf32](Shape(2, 2))
+    c1.itemset(0, ComplexSIMD[cf32](1.0, 2.0))
+    var v = c1.view()
+    assert_almost_equal(v.item(0).re, 1.0, "view failed")
+    assert_almost_equal(v.item(0).im, 2.0, "view failed")
 
 def test_complex_array_itemset_negative_index() raises:
     """Test itemset with negative indices."""


### PR DESCRIPTION
This PR improves advanced indexing on `NDArray`:

- `__getitem__(indices)`: supports negative indices, validates `[-N, N)`, stride-aware fallback for non-contiguous `self`.
- `__setitem__(*slices)`: bounds-checks and normalizes integer slots.
- `__setitem__(index, val)`: full rewrite supporting scalar broadcast, per-element 1-D, single-slice broadcast, and per-index rows, with raw-index bounds errors.
- `__setitem__(mask, val)`: adds scalar/size-1 broadcast and compact 1-D `val` (length = true-count).
 
Also fixes `ComplexNDArray` comparison dunders to use `logical_and`/`logical_or` instead of Python and/or (truth-value ambiguity on `NDArray`).

