### PR TITLE
[Routines] Add column_stack, concatenate, hstack, vstack, and row_stack

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -270,6 +270,11 @@ from numojo.routines.manipulation import (
     transpose,
     broadcast_to,
     flip,
+    concatenate,
+    column_stack,
+    row_stack,
+    hstack,
+    vstack,
 )
 
 from numojo.routines import random

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -171,6 +171,11 @@ from .manipulation import (
     transpose,
     broadcast_to,
     flip,
+    concatenate,
+    column_stack,
+    row_stack,
+    hstack,
+    vstack,
 )
 
 from .sorting import sort, argsort

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -691,3 +691,363 @@ def flip[
             A._buf.ptr[I._buf.ptr[i + A.shape[axis] - 1 - j]] = temp
 
     return A^
+
+
+# ===----------------------------------------------------------------------=== #
+# Joining arrays
+# ===----------------------------------------------------------------------=== #
+
+
+def _concatenate_list[
+    dtype: DType
+](arrays: List[NDArray[dtype]], axis: Int = 0) raises -> NDArray[dtype]:
+    """Internal: Join a list of arrays along an existing axis."""
+    if len(arrays) == 0:
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Need at least one array to concatenate.",
+                location="concatenate()",
+            )
+        )
+
+    if len(arrays) == 1:
+        return arrays[0].contiguous()
+
+    ref first = arrays[0]
+    var ndims = first.ndim
+
+    var ax = axis
+    if ax < 0:
+        ax += ndims
+    if ax < 0 or ax >= ndims:
+        raise Error(
+            NumojoError(
+                category="value",
+                message=String(
+                    "axis {} is out of bounds for array of dimension {}."
+                ).format(axis, ndims),
+                location="concatenate()",
+            )
+        )
+
+    # Validate shapes and compute the total size along the concat axis.
+    var total_along_axis: Int = first.shape[ax]
+    for i in range(1, len(arrays)):
+        ref arr = arrays[i]
+        if arr.ndim != ndims:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=String(
+                        "All arrays must have the same number of dimensions."
+                        " Array 0 has {} dims, array {} has {} dims."
+                    ).format(ndims, i, arr.ndim),
+                    location="concatenate()",
+                )
+            )
+        for d in range(ndims):
+            if d != ax and arr.shape[d] != first.shape[d]:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "All array dimensions except for the"
+                            " concatenation axis must match. Dimension {}"
+                            " of array {} has size {} but expected {}."
+                        ).format(d, i, arr.shape[d], first.shape[d]),
+                        location="concatenate()",
+                    )
+                )
+        total_along_axis += arr.shape[ax]
+
+    # Build the output shape.
+    var out_shape_list = List[Int]()
+    for d in range(ndims):
+        if d == ax:
+            out_shape_list.append(total_along_axis)
+        else:
+            out_shape_list.append(first.shape[d])
+    var out_shape = NDArrayShape(out_shape_list)
+    var result = NDArray[dtype](out_shape)
+
+    # Copy data array by array.
+    # We iterate over the output in C-order and figure out which source
+    # array each element comes from.
+    #
+    # Strategy: walk the output linearly, convert flat index to
+    # multi-dimensional index, map the concat-axis coordinate back to the
+    # source array, read from the (contiguous) source.
+
+    # Pre-compute the boundary offsets along the concat axis for each array.
+    var boundaries = List[Int]()
+    var running: Int = 0
+    for i in range(len(arrays)):
+        boundaries.append(running)
+        running += arrays[i].shape[ax]
+
+    # For each element in the result, determine the source array and index.
+    for flat_idx in range(result.size):
+        # Convert flat_idx to nd-index (C-order).
+        var remainder = flat_idx
+        var nd_index = List[Int]()
+        for _ in range(ndims):
+            nd_index.append(0)
+        for d in range(ndims):
+            nd_index[d] = remainder // result.strides[d]
+            remainder = remainder % result.strides[d]
+
+        # Determine which source array this element comes from.
+        var coord_along_axis = nd_index[ax]
+        var src_idx: Int = len(arrays) - 1
+        for i in range(len(arrays) - 1, -1, -1):
+            if coord_along_axis >= boundaries[i]:
+                src_idx = i
+                break
+
+        # Adjust the coordinate along the concat axis to be local.
+        nd_index[ax] = coord_along_axis - boundaries[src_idx]
+
+        result._buf.ptr[flat_idx] = arrays[src_idx]._getitem(nd_index)
+
+    return result^
+
+
+def concatenate[
+    dtype: DType
+](*arrays: NDArray[dtype], axis: Int = 0) raises -> NDArray[dtype]:
+    """Join a sequence of arrays along an existing axis.
+
+    Parameters:
+        dtype: The data type of the arrays.
+
+    Args:
+        arrays: The arrays to concatenate. All arrays must have the same
+            shape except in the dimension corresponding to `axis`.
+        axis: The axis along which the arrays will be joined. Default is 0.
+
+    Returns:
+        The concatenated array.
+
+    Raises:
+        Error: If the list of arrays is empty.
+        Error: If the arrays do not have the same number of dimensions.
+        Error: If the array shapes are incompatible along non-concatenation axes.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        var a = nm.arange[nm.f64](0, 6, 1)
+        var a2d = nm.reshape(a, nm.Shape(2, 3))
+        var b = nm.arange[nm.f64](6, 12, 1)
+        var b2d = nm.reshape(b, nm.Shape(2, 3))
+        var c = nm.concatenate(a2d, b2d, axis=0)  # Shape (4, 3)
+        var d = nm.concatenate(a2d, b2d, axis=1)  # Shape (2, 6)
+        ```
+    """
+    var arr_list = List[NDArray[dtype]]()
+    for i in range(len(arrays)):
+        arr_list.append(arrays[i].copy())
+    return _concatenate_list(arr_list, axis)
+
+
+def column_stack[
+    dtype: DType
+](*arrays: NDArray[dtype]) raises -> NDArray[dtype]:
+    """Stack 1-D arrays as columns into a 2-D array, or concatenate
+    2-D+ arrays along the second axis (like `numpy.column_stack`).
+
+    Parameters:
+        dtype: The data type of the arrays.
+
+    Args:
+        arrays: The arrays to stack. 1-D arrays are treated as column
+            vectors. All arrays must have the same number of rows
+            (first dimension).
+
+    Returns:
+        The 2-D (or higher) array formed by stacking the inputs as columns.
+
+    Raises:
+        Error: If the list of arrays is empty.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        var a = nm.arange[nm.f64](0, 3, 1)   # Shape (3,)
+        var b = nm.arange[nm.f64](3, 6, 1)   # Shape (3,)
+        var c = nm.column_stack(a, b)         # Shape (3, 2)
+        ```
+    """
+    if len(arrays) == 0:
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Need at least one array to column_stack.",
+                location="column_stack()",
+            )
+        )
+
+    # Transform 1-D arrays into 2-D column vectors.
+    var transformed = List[NDArray[dtype]]()
+    for i in range(len(arrays)):
+        if arrays[i].ndim == 1:
+            # Reshape (N,) -> (N, 1)
+            transformed.append(
+                reshape(
+                    arrays[i].copy(),
+                    NDArrayShape(arrays[i].shape[0], 1),
+                )
+            )
+        else:
+            transformed.append(arrays[i].copy())
+
+    return _concatenate_list(transformed, axis=1)
+
+
+def row_stack[dtype: DType](*arrays: NDArray[dtype]) raises -> NDArray[dtype]:
+    """Stack arrays vertically (row-wise), equivalent to
+    `numpy.row_stack` / `numpy.vstack`.
+
+    Parameters:
+        dtype: The data type of the arrays.
+
+    Args:
+        arrays: The arrays to stack. 1-D arrays of shape `(N,)` are
+            reshaped to `(1, N)` before concatenation.
+
+    Returns:
+        The array formed by stacking the inputs vertically.
+
+    Raises:
+        Error: If the list of arrays is empty.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        var a = nm.arange[nm.f64](0, 3, 1)  # Shape (3,)
+        var b = nm.arange[nm.f64](3, 6, 1)  # Shape (3,)
+        var c = nm.row_stack(a, b)           # Shape (2, 3)
+        ```
+    """
+    if len(arrays) == 0:
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Need at least one array to row_stack.",
+                location="row_stack()",
+            )
+        )
+
+    var transformed = List[NDArray[dtype]]()
+    for i in range(len(arrays)):
+        if arrays[i].ndim == 1:
+            # Reshape (N,) -> (1, N)
+            transformed.append(
+                reshape(
+                    arrays[i].copy(),
+                    NDArrayShape(1, arrays[i].shape[0]),
+                )
+            )
+        else:
+            transformed.append(arrays[i].copy())
+
+    return _concatenate_list(transformed, axis=0)
+
+
+def hstack[dtype: DType](*arrays: NDArray[dtype]) raises -> NDArray[dtype]:
+    """Stack arrays in sequence horizontally (column-wise),
+    equivalent to `numpy.hstack`.
+
+    For 1-D arrays, this concatenates along axis 0.
+    For 2-D+ arrays, this concatenates along axis 1.
+
+    Parameters:
+        dtype: The data type of the arrays.
+
+    Args:
+        arrays: The arrays to stack.
+
+    Returns:
+        The array formed by stacking the inputs horizontally.
+
+    Raises:
+        Error: If the list of arrays is empty.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        var a = nm.arange[nm.f64](0, 3, 1)  # Shape (3,)
+        var b = nm.arange[nm.f64](3, 6, 1)  # Shape (3,)
+        var c = nm.hstack(a, b)              # Shape (6,)
+        ```
+    """
+    if len(arrays) == 0:
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Need at least one array to hstack.",
+                location="hstack()",
+            )
+        )
+
+    var arr_list = List[NDArray[dtype]]()
+    for i in range(len(arrays)):
+        arr_list.append(arrays[i].copy())
+
+    # For 1-D arrays, concatenate along axis 0.
+    if arr_list[0].ndim == 1:
+        return _concatenate_list(arr_list, axis=0)
+
+    return _concatenate_list(arr_list, axis=1)
+
+
+def vstack[dtype: DType](*arrays: NDArray[dtype]) raises -> NDArray[dtype]:
+    """Stack arrays in sequence vertically (row-wise),
+    equivalent to `numpy.vstack`.
+
+    For 1-D arrays of shape `(N,)`, they are reshaped to `(1, N)` first.
+    Then concatenated along axis 0.
+
+    Parameters:
+        dtype: The data type of the arrays.
+
+    Args:
+        arrays: The arrays to stack.
+
+    Returns:
+        The array formed by stacking the inputs vertically.
+
+    Raises:
+        Error: If the list of arrays is empty.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        var a = nm.arange[nm.f64](0, 3, 1)  # Shape (3,)
+        var b = nm.arange[nm.f64](3, 6, 1)  # Shape (3,)
+        var c = nm.vstack(a, b)              # Shape (2, 3)
+        ```
+    """
+    if len(arrays) == 0:
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Need at least one array to vstack.",
+                location="vstack()",
+            )
+        )
+
+    var transformed = List[NDArray[dtype]]()
+    for i in range(len(arrays)):
+        if arrays[i].ndim == 1:
+            transformed.append(
+                reshape(
+                    arrays[i].copy(),
+                    NDArrayShape(1, arrays[i].shape[0]),
+                )
+            )
+        else:
+            transformed.append(arrays[i].copy())
+
+    return _concatenate_list(transformed, axis=0)

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -138,5 +138,127 @@ def test_broadcast() raises:
     )
 
 
+def test_concatenate() raises:
+    var np = Python.import_module("numpy")
+
+    # 1-D concatenation
+    var a1 = nm.arange[nm.f64](0, 3, 1)
+    var b1 = nm.arange[nm.f64](3, 6, 1)
+    var c1 = nm.concatenate(a1, b1, axis=0)
+    var c1np = np.concatenate(
+        Python.list(a1.to_numpy(), b1.to_numpy()), axis=PythonObject(0)
+    )
+    check_is_close(c1, c1np, "`concatenate` 1-D along axis=0 fails.")
+
+    # 2-D concatenation along axis=0
+    var a2 = nm.reshape(nm.arange[nm.f64](0, 6, 1), Shape(2, 3))
+    var b2 = nm.reshape(nm.arange[nm.f64](6, 12, 1), Shape(2, 3))
+    var c2 = nm.concatenate(a2, b2, axis=0)
+    var c2np = np.concatenate(
+        Python.list(a2.to_numpy(), b2.to_numpy()), axis=PythonObject(0)
+    )
+    check_is_close(c2, c2np, "`concatenate` 2-D along axis=0 fails.")
+
+    # 2-D concatenation along axis=1
+    var c3 = nm.concatenate(a2, b2, axis=1)
+    var c3np = np.concatenate(
+        Python.list(a2.to_numpy(), b2.to_numpy()), axis=PythonObject(1)
+    )
+    check_is_close(c3, c3np, "`concatenate` 2-D along axis=1 fails.")
+
+    # 3-D concatenation
+    var a3 = nm.reshape(nm.arange[nm.f64](0, 24, 1), Shape(2, 3, 4))
+    var b3 = nm.reshape(nm.arange[nm.f64](24, 48, 1), Shape(2, 3, 4))
+    for ax in range(3):
+        var c = nm.concatenate(a3, b3, axis=ax)
+        var cnp = np.concatenate(
+            Python.list(a3.to_numpy(), b3.to_numpy()), axis=PythonObject(ax)
+        )
+        check_is_close(
+            c,
+            cnp,
+            String("`concatenate` 3-D along axis={} fails.").format(ax),
+        )
+
+
+def test_column_stack() raises:
+    var np = Python.import_module("numpy")
+
+    # Two 1-D arrays -> (N, 2)
+    var a = nm.arange[nm.f64](0, 3, 1)
+    var b = nm.arange[nm.f64](3, 6, 1)
+    var c = nm.column_stack(a, b)
+    var cnp = np.column_stack(Python.list(a.to_numpy(), b.to_numpy()))
+    check_is_close(c, cnp, "`column_stack` two 1-D arrays fails.")
+
+    # Three 1-D arrays -> (N, 3)
+    var d = nm.arange[nm.f64](6, 9, 1)
+    var e = nm.column_stack(a, b, d)
+    var enp = np.column_stack(
+        Python.list(a.to_numpy(), b.to_numpy(), d.to_numpy())
+    )
+    check_is_close(e, enp, "`column_stack` three 1-D arrays fails.")
+
+    # Two 2-D arrays (like hstack along axis=1)
+    var a2 = nm.reshape(nm.arange[nm.f64](0, 6, 1), Shape(2, 3))
+    var b2 = nm.reshape(nm.arange[nm.f64](6, 10, 1), Shape(2, 2))
+    var f = nm.column_stack(a2, b2)
+    var fnp = np.column_stack(Python.list(a2.to_numpy(), b2.to_numpy()))
+    check_is_close(f, fnp, "`column_stack` two 2-D arrays fails.")
+
+    # Mix of 1-D and 2-D arrays
+    var g1 = nm.arange[nm.f64](0, 3, 1)  # Shape (3,)
+    var g2 = nm.reshape(nm.arange[nm.f64](3, 9, 1), Shape(3, 2))  # Shape (3,2)
+    var g = nm.column_stack(g1, g2)
+    var gnp = np.column_stack(Python.list(g1.to_numpy(), g2.to_numpy()))
+    check_is_close(g, gnp, "`column_stack` mix of 1-D and 2-D fails.")
+
+
+def test_hstack() raises:
+    var np = Python.import_module("numpy")
+
+    # 1-D arrays
+    var a = nm.arange[nm.f64](0, 3, 1)
+    var b = nm.arange[nm.f64](3, 6, 1)
+    var c = nm.hstack(a, b)
+    var cnp = np.hstack(Python.list(a.to_numpy(), b.to_numpy()))
+    check_is_close(c, cnp, "`hstack` 1-D arrays fails.")
+
+    # 2-D arrays
+    var a2 = nm.reshape(nm.arange[nm.f64](0, 6, 1), Shape(2, 3))
+    var b2 = nm.reshape(nm.arange[nm.f64](6, 10, 1), Shape(2, 2))
+    var d = nm.hstack(a2, b2)
+    var dnp = np.hstack(Python.list(a2.to_numpy(), b2.to_numpy()))
+    check_is_close(d, dnp, "`hstack` 2-D arrays fails.")
+
+
+def test_vstack() raises:
+    var np = Python.import_module("numpy")
+
+    # 1-D arrays -> (2, N)
+    var a = nm.arange[nm.f64](0, 3, 1)
+    var b = nm.arange[nm.f64](3, 6, 1)
+    var c = nm.vstack(a, b)
+    var cnp = np.vstack(Python.list(a.to_numpy(), b.to_numpy()))
+    check_is_close(c, cnp, "`vstack` 1-D arrays fails.")
+
+    # 2-D arrays
+    var a2 = nm.reshape(nm.arange[nm.f64](0, 6, 1), Shape(2, 3))
+    var b2 = nm.reshape(nm.arange[nm.f64](6, 12, 1), Shape(2, 3))
+    var d = nm.vstack(a2, b2)
+    var dnp = np.vstack(Python.list(a2.to_numpy(), b2.to_numpy()))
+    check_is_close(d, dnp, "`vstack` 2-D arrays fails.")
+
+
+def test_row_stack() raises:
+    var np = Python.import_module("numpy")
+
+    var a = nm.arange[nm.f64](0, 3, 1)
+    var b = nm.arange[nm.f64](3, 6, 1)
+    var c = nm.row_stack(a, b)
+    var cnp = np.row_stack(Python.list(a.to_numpy(), b.to_numpy()))
+    check_is_close(c, cnp, "`row_stack` 1-D arrays fails.")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Implement numpy-compatible array joining routines in numojo/routines/manipulation.mojo:

- concatenate(): Join arrays along an existing axis
- column_stack(): Stack 1-D arrays as columns into 2-D, or hstack 2-D+ arrays
- row_stack(): Stack arrays vertically (1-D reshaped to (1, N))
- hstack(): Horizontal stacking (axis=0 for 1-D, axis=1 for 2-D+)
- vstack(): Vertical stacking (alias for row_stack)

Tests validate against numpy equivalents for 1-D, 2-D, 3-D, and mixed-dimension inputs.