### PR TITLE
[fix] NDArray.__rmul__ should accept immutable params

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3325,7 +3325,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return math.mul[Self.dtype](self, other)
 
-    def __rmul__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rmul__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar * array`.
         """

--- a/tests/core/test_operations.mojo
+++ b/tests/core/test_operations.mojo
@@ -1,0 +1,16 @@
+import numojo as nm
+from numojo.prelude import *
+from std.testing.testing import assert_true
+from std.testing import TestSuite
+
+
+def test_ndarray_multiplication_commutes() raises:
+    var A = nm.ones[nm.f64](nm.Shape(2, 2))
+    var B = nm.ones[nm.f64](nm.Shape(2, 2))
+    var L = 2.0 * (A @ B)
+    var R = (A @ B) * 2.0
+    assert_true((L == R).all())
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Without this fix, the added test will fail to compile as the result of `(A @ B)` is immutable. This fixes the following error:
```shell
✨ Pixi task (package): pixi run mojo package numojo && cp numojo.mojopkg tests/
NuMojo/tests/core/test_operations.mojo:12:17: error: no matching method in call to '__mul__'
    var L = 2.0 * (A @ B)
            ~~~~^~~~~~~~~
NuMojo/tests/core/test_operations.mojo:1:1: note: candidate not viable: value passed to 'rhs' cannot be converted from 'NDArray' to 'FloatLiteral[rhs.value]', it depends on an unresolved parameter 'rhs.value'
import numojo as nm
^
NuMojo/tests/core/test_operations.mojo:1:1: note: candidate not viable: value passed to 'rhs' cannot be converted from 'NDArray' to 'Float64'
import numojo as nm
```