### PR TITLE
[Mojo] fix mojo version for pixi-backend

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -210,18 +210,18 @@ backend = {name = "pixi-build-mojo", version = "0.*"}
 name = "your_package_name"
 
 [package.host-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 
 [package.build-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [package.run-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [dependencies]
-modular = ">=25.7.0,<26"
+modular = "26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 ```
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,13 +34,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [package.build-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [package.run-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [tasks]
 # compile the package and copy it to the tests folder


### PR DESCRIPTION
There were typos in the installation section of README and in pixi.toml. These have been fixed. 