### PR TITLE
[Mojo ] Update NuMojo to be compatible with mojo v1.0.0b1

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -13,8 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ["ubuntu-22.04", "macos-14"]
-        os: ["ubuntu-22.04"]
+        os: ["macos-14"]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -22,9 +21,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      DEBIAN_FRONTEND: noninteractive
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/README.MD
+++ b/README.MD
@@ -210,18 +210,18 @@ backend = {name = "pixi-build-mojo", version = "0.*"}
 name = "your_package_name"
 
 [package.host-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 
 [package.build-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [package.run-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [dependencies]
-modular = ">=25.7.0,<26"
+modular = "26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 ```
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -7,8 +7,7 @@
 # ===----------------------------------------------------------------------=== #
 """
 NuMojo Top-Level Package (`numojo`)
------------------------------------
-
+===================================
 Central public surface for NuMojo that exposes the primary containers, dtype helpers, common errors,
 and a curated set of NumPy-inspired routines.
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------=== #
 """
 NuMojo Top-Level Package (`numojo`)
-==================================
+-----------------------------------
 
 Central public surface for NuMojo that exposes the primary containers, dtype helpers, common errors,
 and a curated set of NumPy-inspired routines.
@@ -46,7 +46,7 @@ FORMAT FOR DOCSTRING (See "Mojo docstring style guide" for more information)
 7. Notes
 9. References
 10. Examples *
-(Items marked with * are defined by the Mojo docstring style guide.)
+(Items marked with * are defined by the Mojo docstring style guide).
 """
 
 comptime __version__: String = "V0.9.0"
@@ -125,9 +125,9 @@ from numojo.core.type_aliases import (
 # Objects
 from numojo.routines.constants import Constants
 
-comptime pi = numojo.routines.constants.Constants.pi
-comptime e = numojo.routines.constants.Constants.e
-comptime c = numojo.routines.constants.Constants.c
+comptime pi = Constants.pi
+comptime e = Constants.e
+comptime c = Constants.c
 
 # Functions
 # TODO Make explicit imports of each individual function in future
@@ -224,7 +224,7 @@ from numojo.routines.statistics import (
     mode,
     median,
     variance,
-    std,
+    stddev,
 )
 
 from numojo.routines import bitwise

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Core (numojo.core)
-
+---------------------
 This sub module provides the core types and utilities for NuMojo, including fundamental data structures
 like `NDArray` and `Matrix`, dtype aliases, memory layout definitions, error handling utilities, and complex number support.
 It serves as the foundational layer upon which higher-level routines and algorithms are built.

--- a/numojo/core/accelerator/__init__.mojo
+++ b/numojo/core/accelerator/__init__.mojo
@@ -5,11 +5,8 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""
-=====================================
-Accelerator (numojo.core.accelerator)
-=====================================
-
+"""Accelerator (numojo.core.accelerator)
+----------------------------------------
 Accelerator (GPU) support namespace for NuMojo.
 """
 

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Device (numojo.core.accelerator.device)
-
+---------------------------------------
 This module defines the `Device` struct, which represents an execution device for array and matrix operations.
 It supports CPU and GPU devices, with GPU backends for NVIDIA CUDA, AMD ROCm, and Apple Metal.
 """

--- a/numojo/core/complex/__init__.mojo
+++ b/numojo/core/complex/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Complex (numojo.core.complex)
-
+-----------------------------
 Complex number support (SIMD complex types and complex NDArray).
 """
 

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -456,15 +456,6 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         _ = self._re^
         _ = self._im^
 
-    def deep_copy(self) raises -> Self:
-        """
-        Create a deep copy of this ComplexNDArray.
-        """
-        return Self(
-            re=self._re.deep_copy(),
-            im=self._im.deep_copy(),
-        )
-
     def view(mut self) raises -> Self:
         """
         Create a non-owning view of the current ComplexNDArray.

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -82,6 +82,7 @@ import numojo.routines.math.trig as trig
 import numojo.routines.math.exponents as exponents
 import numojo.routines.math.misc as misc
 import numojo.routines.searching as searching
+from numojo.routines.manipulation import reshape
 
 
 # ===----------------------------------------------------------------------=== #
@@ -3294,8 +3295,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             Array of the same data with a new shape.
         """
         var result: Self = ComplexNDArray[Self.cdtype](
-            re=numojo.reshape(self._re, shape=shape, order=order),
-            im=numojo.reshape(self._im, shape=shape, order=order),
+            re=reshape(self._re, shape=shape, order=order),
+            im=reshape(self._im, shape=shape, order=order),
         )
         result._re.flags = self._re.flags
         result._im.flags = self._im.flags

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -424,7 +424,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     #     )
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Copy copy into self.
         """
@@ -438,7 +438,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.print_options = copy.print_options
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """
         Move other into self.
         """
@@ -645,7 +645,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         Examples:
             ```mojo
             import numojo as nm
-            var A = nm.ones[nm.cf32](numojo.Shape(2,3,4))
+
+            var A = nm.ones[nm.cf32](nm.Shape(2,3,4))
             print(A._getitem([1,2,3]))
             ```
 
@@ -876,7 +877,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         Examples:
             ```mojo
             import numojo as nm
-            var a = numojo.arange(10).reshape(nm.Shape(2, 5))
+
+            var a = nm.arange(10).reshape(nm.Shape(2, 5))
             var b = a[:, 2:4]
             print(b) # Output: 2x2 sliced array corresponding to columns 2 and 3 of each row.
             ```

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """"ComplexNDArray (numojo.core.complex.complex_ndarray)
-
+----------------------------------------------------
 Complex NDArray support for NuMojo.
 
 This module provides the `ComplexNDArray` type, which represents N-dimensional arrays
@@ -883,7 +883,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             print(b) # Output: 2x2 sliced array corresponding to columns 2 and 3 of each row.
             ```
         """
-        var n_slices: Int = slices.__len__()
+        var n_slices: Int = len(slices)
         if n_slices > self.ndim:
             raise Error(
                 NumojoError(
@@ -2064,7 +2064,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """
         Get items by a series of either slices or integers.
         """
-        var n_slices: Int = slices.__len__()
+        var n_slices: Int = len(slices)
         if n_slices > self.ndim:
             raise Error(
                 NumojoError(
@@ -3158,7 +3158,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 out += padding + "]"
 
             # Greedy line wrapping
-            if len(out) > options.line_width:
+            if out.byte_length() > options.line_width:
                 var wrapped: String = String("")
                 var line_len: Int = 0
                 for c in out.codepoint_slices():

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -964,7 +964,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     def __invert__(
         self,
     ) -> Self where (
-        Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
+        Self.dtype == DType.bool or Self.dtype.is_integral()
     ):
         """
         Element-wise logical NOT operation on this ComplexSIMD instance.
@@ -978,7 +978,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     def __and__(
         self, other: Self
     ) -> Self where (
-        Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
+        Self.dtype == DType.bool or Self.dtype.is_integral()
     ):
         """
         Element-wise logical AND operation between two ComplexSIMD instances.
@@ -994,7 +994,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     def __or__(
         self, other: Self
     ) -> Self where (
-        Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
+        Self.dtype == DType.bool or Self.dtype.is_integral()
     ):
         """
         Element-wise logical OR operation between two ComplexSIMD instances.
@@ -1010,7 +1010,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     def __xor__(
         self, other: Self
     ) -> Self where (
-        Self.cdtype == ComplexDType.bool or Self.cdtype.is_integral()
+        Self.dtype == DType.bool or Self.dtype.is_integral()
     ):
         """
         Element-wise logical XOR operation between two ComplexSIMD instances.

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """ComplexSIMD (numojo.core.complex.complex_simd)
-
+----------------------------------------------
 Implement the ComplexSIMD type and its operations.
 
 This module provides a ComplexSIMD type that represents complex numbers using SIMD

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -963,9 +963,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
 
     def __invert__(
         self,
-    ) -> Self where (
-        Self.dtype == DType.bool or Self.dtype.is_integral()
-    ):
+    ) -> Self where Self.dtype == DType.bool or Self.dtype.is_integral():
         """
         Element-wise logical NOT operation on this ComplexSIMD instance.
 
@@ -977,9 +975,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
     # --- Comparison operators ---
     def __and__(
         self, other: Self
-    ) -> Self where (
-        Self.dtype == DType.bool or Self.dtype.is_integral()
-    ):
+    ) -> Self where Self.dtype == DType.bool or Self.dtype.is_integral():
         """
         Element-wise logical AND operation between two ComplexSIMD instances.
 
@@ -993,9 +989,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
 
     def __or__(
         self, other: Self
-    ) -> Self where (
-        Self.dtype == DType.bool or Self.dtype.is_integral()
-    ):
+    ) -> Self where Self.dtype == DType.bool or Self.dtype.is_integral():
         """
         Element-wise logical OR operation between two ComplexSIMD instances.
 
@@ -1009,9 +1003,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
 
     def __xor__(
         self, other: Self
-    ) -> Self where (
-        Self.dtype == DType.bool or Self.dtype.is_integral()
-    ):
+    ) -> Self where Self.dtype == DType.bool or Self.dtype.is_integral():
         """
         Element-wise logical XOR operation between two ComplexSIMD instances.
 

--- a/numojo/core/dtype/__init__.mojo
+++ b/numojo/core/dtype/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Dtype (numojo.core.dtype)
-
+-------------------------
 Dtype aliases and dtype-related utilities used across NuMojo.
 """
 

--- a/numojo/core/dtype/complex_dtype.mojo
+++ b/numojo/core/dtype/complex_dtype.mojo
@@ -9,7 +9,7 @@
 # Original source: https://github.com/modularml/mojo
 # ===----------------------------------------------------------------------=== #
 """ComplexDType (numojo.core.dtype.complex_dtype)
-
+----------------------------------------------
 ComplexDType and related utilities for working with complex data types in NuMojo.
 """
 

--- a/numojo/core/dtype/default_dtype.mojo
+++ b/numojo/core/dtype/default_dtype.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Default datatype (numojo.core.dtype.default_dtype)
+"""Default datatype (numojo.core.dtype.default_dtype).
 
 Datatypes Module - Implements rust like aliases for datatypes
 """

--- a/numojo/core/dtype/utility.mojo
+++ b/numojo/core/dtype/utility.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Data type utility functions (numojo.core.dtype.utility)
-
+-------------------------------------------------------
 This module provides utility functions for checking properties of data types (DType) at both compile time and run time.
 """
 

--- a/numojo/core/indexing/__init__.mojo
+++ b/numojo/core/indexing/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Indexing (numojo.core.indexing)
-
+-------------------------------
 Indexing-related helpers and types used by NuMojo core containers.
 """
 

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -201,7 +201,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type](values[i])
             )
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Copy-initialize an IndexBuffer from ancopy IndexBuffer.
 

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -61,7 +61,9 @@ struct IndexBuffer(
 
         self.ndim = size
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.element_type]](size)
             memset_zero(self.ptr, size)
@@ -86,7 +88,9 @@ struct IndexBuffer(
         Initialize an empty IndexBuffer.
         """
         self.ndim = 0
-        self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+        self.ptr = UnsafePointer[
+            Scalar[Self.element_type], Self._origin
+        ].unsafe_dangling()
 
     def __init__(out self, *values: Int):
         """
@@ -97,7 +101,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -115,7 +121,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -130,7 +138,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -145,7 +155,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -162,7 +174,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -177,7 +191,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -194,7 +210,9 @@ struct IndexBuffer(
         """
         self.ndim = copy.ndim
         if copy.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
         memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
@@ -203,7 +221,7 @@ struct IndexBuffer(
         """
         Deinitialize the IndexBuffer and free resources.
         """
-        if self.ndim > 0 and self.ptr:
+        if self.ndim > 0:
             self.ptr.free()
 
     # ===----------------------------------------------------------------------=== #

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """IndexBuffer (numojo.core.indexing.index_buffer)
-
+-----------------------------------------------
 Shared integer buffer backend for shape/strides/item.
 
 This type owns a contiguous heap buffer of Ints and provides

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Item (numojo.core.indexing.item)
-
+-----------------------------------
 Implements Item type.
 
 `Item` is a series of `Int` on the heap used to index into N-dimensional arrays.
@@ -161,7 +161,7 @@ struct Item(
         memset_zero(self._buf.ptr, ndim)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy construct the Item.
 
         Args:

--- a/numojo/core/indexing/offset.mojo
+++ b/numojo/core/indexing/offset.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Offset computation (numojo.core.indexing.offset)
-
+------------------------------------------------
 Indexing offset calculation functions. These functions compute the flat index (offset)
 in memory for a given set of multi-dimensional indices and strides.
 They are used to translate multi-dimensional indexing into flat memory access,

--- a/numojo/core/indexing/slicing.mojo
+++ b/numojo/core/indexing/slicing.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Slicing (numojo.core.indexing.slicing)
-
+--------------------------------------
 This module defines internal data structures and utilities for handling slicing operations in NuMojo.
 """
 

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Traversal (numojo.core.indexing.traversal)
-
+------------------------------------------
 Functions to traverse a multi-dimensional array.
 This module provides both recursive and iterative traversal methods,
 which can be used for various indexing and slicing operations in NuMojo.

--- a/numojo/core/indexing/utility.mojo
+++ b/numojo/core/indexing/utility.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Utility functions (numojo.core.indexing.utility)
+"""Utility functions (numojo.core.indexing.utility).
 
 Implements N-DIMENSIONAL ARRAY UTILITY FUNCTIONS
 

--- a/numojo/core/indexing/validation.mojo
+++ b/numojo/core/indexing/validation.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Validation (numojo.core.indexing.validation)
-
+--------------------------------------------
 Contains utilities for validating indices, shapes, and axes for various indexing and reduction operations.
 """
 

--- a/numojo/core/layout/__init__.mojo
+++ b/numojo/core/layout/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Layout (numojo.core.layout)
-
+---------------------------
 Layout metadata types used by NuMojo arrays and matrices (shape, strides, and flags).
 """
 

--- a/numojo/core/layout/array_methods.mojo
+++ b/numojo/core/layout/array_methods.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Array methods (numojo.core.layout.array_methods)
-
+------------------------------------------------
 This module defines the `NewAxis` struct, which is used to represent the insertion of new axes into array shapes,
 similar to the concept of `None` or `np.newaxis` in NumPy. The `NewAxis` struct can be used to indicate where
 a new singleton dimension should be added to an array, enabling advanced indexing and broadcasting operations.

--- a/numojo/core/layout/flags.mojo
+++ b/numojo/core/layout/flags.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Flags (numojo.core.layout.flags)
-
+-----------------------------------
 Implements Flags type to represent the memory layout information of NuMojo arrays.
 """
 
@@ -154,7 +154,7 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
         self.WRITEABLE = writeable and owndata
         self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Initializes the Flags object by copying the information from
         ancopy Flags object.

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """NDArrayShape (numojo.core.layout.ndshape)
-
+--------------------------------------------
 Implements NDArrayShape type representing the shape of an NDArray.
 The shape is stored as a contiguous buffer of integers, with the number of dimensions (ndim) tracked separately.
 The NDArrayShape provides methods for element access, shape transformations (e.g., permute, reverse),
@@ -263,7 +263,7 @@ struct NDArrayShape(
                     self._buf.init_value(i, 1)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Initializes the NDArrayShape from ancopy NDArrayShape.
         A deep copy of the data buffer is conducted.

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """NDArrayStrides (numojo.core.layout.ndstrides)
-
+------------------------------------------------
 Implements NDArrayStrides type. NDArrayStrides represents the strides of an NDArray,
 which is used to calculate the memory offset for each dimension when indexing into the array.
 """
@@ -322,7 +322,7 @@ struct NDArrayStrides(
                     self._buf.init_value(i, 0)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Initializes the NDArrayStrides from ancopy strides.
         A deep-copy of the elements is conducted.

--- a/numojo/core/matrix/__init__.mojo
+++ b/numojo/core/matrix/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Matrix (numojo.core.matrix)
-
+---------------------------
 2D matrix types and APIs.
 """
 

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -2883,7 +2883,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 < simd2
+            return simd1.lt(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2948,7 +2948,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 <= simd2
+            return simd1.le(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -3013,7 +3013,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 > simd2
+            return simd1.gt(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -3078,7 +3078,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 >= simd2
+            return simd1.ge(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -3146,7 +3146,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 == simd2
+            return simd1.eq(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -3211,7 +3211,7 @@ struct Matrix[
         ](
             simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[DType.bool, simd_width]:
-            return simd1 != simd2
+            return simd1.ne(simd2)
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -2008,6 +2008,7 @@ struct Matrix[
             print(A - B)
             ```
         """
+
         def sub_kernel[
             type: DType, simd_width: Int
         ](
@@ -2091,6 +2092,7 @@ struct Matrix[
             print(A * B)
             ```
         """
+
         def mul_kernel[
             type: DType, simd_width: Int
         ](
@@ -2176,6 +2178,7 @@ struct Matrix[
             print(A / B)
             ```
         """
+
         def truediv_kernel[
             type: DType, simd_width: Int
         ](
@@ -2585,6 +2588,7 @@ struct Matrix[
             print(A // B)  # Element-wise floor division
             ```
         """
+
         def floordiv_kernel[
             type: DType, simd_width: Int
         ](
@@ -2730,6 +2734,7 @@ struct Matrix[
             print(A % B)  # Element-wise modulo
             ```
         """
+
         def mod_kernel[
             type: DType, simd_width: Int
         ](
@@ -2872,6 +2877,7 @@ struct Matrix[
             print(A < B)
             ```
         """
+
         def lt_kernel[
             type: DType, simd_width: Int
         ](
@@ -2883,8 +2889,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, lt_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
@@ -2936,6 +2942,7 @@ struct Matrix[
             print(A <= B)
             ```
         """
+
         def le_kernel[
             type: DType, simd_width: Int
         ](
@@ -2947,8 +2954,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, le_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
@@ -3000,6 +3007,7 @@ struct Matrix[
             print(A > B)
             ```
         """
+
         def gt_kernel[
             type: DType, simd_width: Int
         ](
@@ -3011,8 +3019,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, gt_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
@@ -3064,6 +3072,7 @@ struct Matrix[
             print(A >= B)
             ```
         """
+
         def ge_kernel[
             type: DType, simd_width: Int
         ](
@@ -3075,8 +3084,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, ge_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
@@ -3131,6 +3140,7 @@ struct Matrix[
             print(A == B)
             ```
         """
+
         def eq_kernel[
             type: DType, simd_width: Int
         ](
@@ -3142,8 +3152,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, eq_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
@@ -3195,6 +3205,7 @@ struct Matrix[
             print(A != B)
             ```
         """
+
         def ne_kernel[
             type: DType, simd_width: Int
         ](
@@ -3206,8 +3217,8 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _logic_func_matrix_matrix_to_matrix[Self.dtype, ne_kernel](
-                    self, other
-                )
+                self, other
+            )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -1928,9 +1928,9 @@ struct Matrix[
         def add_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 + scalar2
+            return simd1 + simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2011,9 +2011,9 @@ struct Matrix[
         def sub_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 - scalar2
+            return simd1 - simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2094,9 +2094,9 @@ struct Matrix[
         def mul_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 * scalar2
+            return simd1 * simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2179,9 +2179,9 @@ struct Matrix[
         def truediv_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 / scalar2
+            return simd1 / simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2247,8 +2247,7 @@ struct Matrix[
         )
         comptime width = simd_width_of[Self.dtype]()
 
-        @parameter
-        def vec_pow[w: Int](i: Int):
+        def vec_pow[w: Int](i: Int) {mut result, self, rhs}:
             var vec = self._buf.ptr.load[width=w](i)
             result._buf.ptr.store(i, vec.__pow__(rhs))
 
@@ -2294,8 +2293,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_add[w: Int](i: Int):
+            def vec_add[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a + b)
@@ -2323,8 +2321,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_add_scalar[w: Int](i: Int):
+            def vec_add_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a + other)
 
@@ -2373,8 +2370,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_sub[w: Int](i: Int):
+            def vec_sub[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a - b)
@@ -2402,8 +2398,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_sub_scalar[w: Int](i: Int):
+            def vec_sub_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a - other)
 
@@ -2452,8 +2447,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mul[w: Int](i: Int):
+            def vec_mul[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a * b)
@@ -2481,8 +2475,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mul_scalar[w: Int](i: Int):
+            def vec_mul_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a * other)
 
@@ -2531,8 +2524,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_div[w: Int](i: Int):
+            def vec_div[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a / b)
@@ -2560,8 +2552,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_div_scalar[w: Int](i: Int):
+            def vec_div_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a / other)
 
@@ -2597,9 +2588,9 @@ struct Matrix[
         def floordiv_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 // scalar2
+            return simd1 // simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2680,8 +2671,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_floordiv[w: Int](i: Int):
+            def vec_floordiv[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a // b)
@@ -2709,8 +2699,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_floordiv_scalar[w: Int](i: Int):
+            def vec_floordiv_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a // other)
 
@@ -2744,9 +2733,9 @@ struct Matrix[
         def mod_kernel[
             type: DType, simd_width: Int
         ](
-            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
         ) capturing -> SIMD[type, simd_width]:
-            return scalar1 % scalar2
+            return simd1 % simd2
 
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
@@ -2824,8 +2813,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mod[w: Int](i: Int):
+            def vec_mod[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a % b)
@@ -2853,8 +2841,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mod_scalar[w: Int](i: Int):
+            def vec_mod_scalar[w: Int](i: Int) {mut self, other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a % other)
 
@@ -2885,20 +2872,27 @@ struct Matrix[
             print(A < B)
             ```
         """
+        def lt_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 < simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, lt_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, lt_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, lt_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -2942,20 +2936,27 @@ struct Matrix[
             print(A <= B)
             ```
         """
+        def le_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 <= simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, le_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, le_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, le_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -2999,20 +3000,27 @@ struct Matrix[
             print(A > B)
             ```
         """
+        def gt_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 > simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, gt_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, gt_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, gt_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3056,20 +3064,27 @@ struct Matrix[
             print(A >= B)
             ```
         """
+        def ge_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 >= simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ge_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ge_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ge_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3116,20 +3131,27 @@ struct Matrix[
             print(A == B)
             ```
         """
+        def eq_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 == simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, eq_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, eq_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, eq_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3173,20 +3195,27 @@ struct Matrix[
             print(A != B)
             ```
         """
+        def ne_kernel[
+            type: DType, simd_width: Int
+        ](
+            simd1: SIMD[type, simd_width], simd2: SIMD[type, simd_width]
+        ) capturing -> SIMD[DType.bool, simd_width]:
+            return simd1 != simd2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
-                self, other
-            )
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ne_kernel](
+                    self, other
+                )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ne_kernel](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, ne_kernel](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3997,7 +4026,7 @@ struct Matrix[
             print(A.std())
             ```
         """
-        return stat.std[returned_dtype](self, ddof=ddof)
+        return stat.stddev[returned_dtype](self, ddof=ddof)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -4020,7 +4049,7 @@ struct Matrix[
             print(A.std(axis=1))
             ```
         """
-        return stat.std[returned_dtype](self, axis=axis, ddof=ddof)
+        return stat.stddev[returned_dtype](self, axis=axis, ddof=ddof)
 
     def sum(self) -> Scalar[Self.dtype]:
         """
@@ -4326,8 +4355,7 @@ struct Matrix[
         var matrix = Matrix[datatype](shape, order)
         comptime width = simd_width_of[datatype]()
 
-        @parameter
-        def vec_fill[w: Int](i: Int) {mut matrix, read fill_value}:
+        def vec_fill[w: Int](i: Int) {mut matrix, fill_value}:
             matrix._buf.ptr.store(i, SIMD[datatype, w](fill_value))
 
         vectorize[width](matrix.size, vec_fill)
@@ -4432,7 +4460,6 @@ struct Matrix[
         var result = Matrix[datatype](shape, order)
         comptime width = simd_width_of[datatype]()
 
-        @parameter
         def vec_rand[w: Int](i: Int) {mut result}:
             var rand_vec = SIMD[datatype, w]()
             for j in range(w):

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -34,6 +34,13 @@ from numojo.core.traits.buffered import Buffered
 from numojo.routines.manipulation import broadcast_to, reorder_layout
 from numojo.routines.linalg.misc import issymmetric
 import numojo.routines.statistics as stat
+import numojo.routines.linalg as linalg
+import numojo.routines.logic as logic
+import numojo.routines.math as math_routines
+import numojo.routines.math.extrema as extrema
+import numojo.routines.math.rounding as rounding
+import numojo.routines.searching as searching
+import numojo.routines.sorting as sorting
 
 
 # TODO: Currently the copyinit creates a ref counted view instead of a deep copy.
@@ -3225,7 +3232,7 @@ struct Matrix[
             print(A @ B)
             ```
         """
-        return numojo.linalg.matmul(self, other)
+        return linalg.matmul(self, other)
 
     # # ===-------------------------------------------------------------------===#
     # # Core methods
@@ -3248,7 +3255,7 @@ struct Matrix[
             print(B.all())  # Outputs: False
             ```
         """
-        return numojo.logic.all(self)
+        return logic.all(self)
 
     def all(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3270,7 +3277,7 @@ struct Matrix[
             print(A.all(axis=1))  # Outputs: [[1], [0]]
             ```
         """
-        return numojo.logic.all[Self.dtype](self, axis=axis)
+        return logic.all[Self.dtype](self, axis=axis)
 
     def any(self) -> Scalar[Self.dtype]:
         """
@@ -3288,7 +3295,7 @@ struct Matrix[
             print(B.any())  # Outputs: True
             ```
         """
-        return numojo.logic.any(self)
+        return logic.any(self)
 
     def any(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3300,7 +3307,7 @@ struct Matrix[
         Returns:
             Matrix[dtype]: Matrix of boolean values for each slice along the axis.
         """
-        return numojo.logic.any(self, axis=axis)
+        return logic.any(self, axis=axis)
 
     def argmax(self) raises -> Scalar[DType.int]:
         """
@@ -3316,7 +3323,7 @@ struct Matrix[
             print(A.argmax())  # Outputs: 3
             ```
         """
-        return numojo.math.argmax(self)
+        return searching.argmax(self)
 
     def argmax(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3336,7 +3343,7 @@ struct Matrix[
             print(A.argmax(axis=1))  # Outputs: [[1], [2]]
             ```
         """
-        return numojo.math.argmax(self, axis=axis)
+        return searching.argmax(self, axis=axis)
 
     def argmin(self) raises -> Scalar[DType.int]:
         """
@@ -3352,7 +3359,7 @@ struct Matrix[
             print(A.argmin())  # Outputs: 1
             ```
         """
-        return numojo.math.argmin(self)
+        return searching.argmin(self)
 
     def argmin(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3372,7 +3379,7 @@ struct Matrix[
             print(A.argmin(axis=1))  # Outputs: [[1], [2]]
             ```
         """
-        return numojo.math.argmin(self, axis=axis)
+        return searching.argmin(self, axis=axis)
 
     def argsort(self) raises -> Matrix[DType.int]:
         """
@@ -3388,7 +3395,7 @@ struct Matrix[
             print(A.argsort())  # Outputs: [[1, 3, 0, 2]]
             ```
         """
-        return numojo.math.argsort(self)
+        return sorting.argsort(self)
 
     def argsort(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3408,7 +3415,7 @@ struct Matrix[
             print(A.argsort(axis=1))  # Outputs: [[1, 3, 0], [2, 0, 1]]
             ```
         """
-        return numojo.math.argsort(self, axis=axis)
+        return sorting.argsort(self, axis=axis)
 
     def astype[asdtype: DType](self) -> Matrix[asdtype]:
         """
@@ -3450,7 +3457,7 @@ struct Matrix[
             print(A.cumprod())
             ```
         """
-        return numojo.math.cumprod(self)
+        return math_routines.cumprod(self)
 
     def cumprod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3470,7 +3477,7 @@ struct Matrix[
             print(A.cumprod(axis=1))
             ```
         """
-        return numojo.math.cumprod(self, axis=axis)
+        return math_routines.cumprod(self, axis=axis)
 
     def cumsum(self) raises -> Matrix[Self.dtype]:
         """
@@ -3486,7 +3493,7 @@ struct Matrix[
             print(A.cumsum())
             ```
         """
-        return numojo.math.cumsum(self)
+        return math_routines.cumsum(self)
 
     def cumsum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3506,7 +3513,7 @@ struct Matrix[
             print(A.cumsum(axis=1))
             ```
         """
-        return numojo.math.cumsum(self, axis=axis)
+        return math_routines.cumsum(self, axis=axis)
 
     def fill(self, fill_value: Scalar[Self.dtype]):
         """
@@ -3570,7 +3577,7 @@ struct Matrix[
             print(A.inv())
             ```
         """
-        return numojo.linalg.inv(self)
+        return linalg.inv(self)
 
     def order(self) -> String:
         """
@@ -3684,7 +3691,7 @@ struct Matrix[
             print(A.max())
             ```
         """
-        return numojo.math.extrema.max(self)
+        return extrema.max(self)
 
     def max(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3704,7 +3711,7 @@ struct Matrix[
             print(A.max(axis=1))  # Max of each row
             ```
         """
-        return numojo.math.extrema.max(self, axis=axis)
+        return extrema.max(self, axis=axis)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -3762,7 +3769,7 @@ struct Matrix[
             print(A.min())
             ```
         """
-        return numojo.math.extrema.min(self)
+        return extrema.min(self)
 
     def min(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3782,7 +3789,7 @@ struct Matrix[
             print(A.min(axis=1))  # Min of each row
             ```
         """
-        return numojo.math.extrema.min(self, axis=axis)
+        return extrema.min(self, axis=axis)
 
     def prod(self) -> Scalar[Self.dtype]:
         """
@@ -3798,7 +3805,7 @@ struct Matrix[
             print(A.prod())
             ```
         """
-        return numojo.math.prod(self)
+        return math_routines.prod(self)
 
     def prod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3818,7 +3825,7 @@ struct Matrix[
             print(A.prod(axis=1))
             ```
         """
-        return numojo.math.prod(self, axis=axis)
+        return math_routines.prod(self, axis=axis)
 
     def reshape(
         self, shape: Tuple[Int, Int], order: String = "C"
@@ -3969,7 +3976,7 @@ struct Matrix[
             print(B)  # Outputs a Matrix[Float64] with values [[1.12], [2.68], [3.14]]
             ```
         """
-        return numojo.math.rounding.round(self, decimals=decimals)
+        return rounding.round(self, decimals=decimals)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -4029,7 +4036,7 @@ struct Matrix[
             print(A.sum())
             ```
         """
-        return numojo.math.sum(self)
+        return math_routines.sum(self)
 
     def sum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -4049,7 +4056,7 @@ struct Matrix[
             print(A.sum(axis=1))
             ```
         """
-        return numojo.math.sum(self, axis=axis)
+        return math_routines.sum(self, axis=axis)
 
     def trace(self) raises -> Scalar[Self.dtype]:
         """
@@ -4067,7 +4074,7 @@ struct Matrix[
             print(A.trace())  # Outputs: 15.0
             ```
         """
-        return numojo.linalg.trace(self)
+        return linalg.trace(self)
 
     def issymmetric(self) -> Bool:
         """

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Matrix (numojo.core.matrix)
-
+------------------------------
 This file implements the core 2D matrix type for the NuMojo numerical computing library. It provides efficient, flexible, and memory-safe matrix operations for scientific and engineering applications.
 
 Features:
@@ -33,6 +33,7 @@ from numojo.core.memory.data_container import DataContainer
 from numojo.core.traits.buffered import Buffered
 from numojo.routines.manipulation import broadcast_to, reorder_layout
 from numojo.routines.linalg.misc import issymmetric
+import numojo.routines.statistics as stat
 
 
 # TODO: Currently the copyinit creates a ref counted view instead of a deep copy.
@@ -352,7 +353,6 @@ struct Matrix[
         self.offset = offset
 
     # TODO: prevent copying from views to views or views to owning matrices right now.`where` clause isn't working here either for now, So we use constrained. Move to 'where` clause when it's stable.
-    # TODO: Current copyinit creates an instance with same origin. This should be external origin. fix this so that we can use default `.copy()` method and remove `create_copy()` method.
     @always_inline("nodebug")
     def __copyinit__(out self, copy: Self):
         """
@@ -377,34 +377,6 @@ struct Matrix[
         self.offset = copy.offset
         self.flags = Flags(
             copy.shape, copy.strides, owndata=True, writeable=True
-        )
-
-    # NOTE: perhaps remove this?
-    def deep_copy(self) -> Self:
-        """
-        Returns a deep copy of the matrix.
-
-        The new matrix has its own independent data buffer, shape, and strides.
-
-        Returns:
-            Matrix: A deep copy of the current matrix.
-
-        Example:
-            ```mojo
-            import numojo as nm
-            var mat1 = nm.Matrix[nm.f32](shape=(2, 3))
-            var mat2 = mat1.deep_copy()
-            ```
-        """
-        # This is corect only for owned matrices.
-        # For views, we gotta create copy by iterating over all elements.
-        var new_buf = self._buf.deep_copy()
-        return Self(
-            data=new_buf^,
-            is_view=False,
-            shape=self.shape,
-            strides=self.strides,
-            offset=self.offset,
         )
 
     def view(mut self) raises -> Self:
@@ -1945,21 +1917,29 @@ struct Matrix[
             print(A + B)
             ```
         """
+
+        def add_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 + scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, add_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, add_kernel
             ](broadcast_to[Self.dtype](self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, add_kernel
             ](self, broadcast_to[Self.dtype](other, self.shape, self.order()))
 
     def __add__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2021,21 +2001,28 @@ struct Matrix[
             print(A - B)
             ```
         """
+        def sub_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 - scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, sub_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, sub_kernel
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, sub_kernel
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __sub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2097,21 +2084,28 @@ struct Matrix[
             print(A * B)
             ```
         """
+        def mul_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 * scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, mul_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, mul_kernel
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, mul_kernel
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __mul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2175,21 +2169,28 @@ struct Matrix[
             print(A / B)
             ```
         """
+        def truediv_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 / scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, truediv_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, truediv_kernel
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, truediv_kernel
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __truediv__(
@@ -2240,7 +2241,7 @@ struct Matrix[
         comptime width = simd_width_of[Self.dtype]()
 
         @parameter
-        def vec_pow[w: Int](i: Int) unified {mut result, read self, read rhs}:
+        def vec_pow[w: Int](i: Int):
             var vec = self._buf.ptr.load[width=w](i)
             result._buf.ptr.store(i, vec.__pow__(rhs))
 
@@ -2287,7 +2288,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_add[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a + b)
@@ -2316,7 +2317,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_add_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a + other)
 
@@ -2366,7 +2367,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_sub[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a - b)
@@ -2395,7 +2396,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_sub_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a - other)
 
@@ -2445,7 +2446,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_mul[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a * b)
@@ -2474,7 +2475,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_mul_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a * other)
 
@@ -2524,7 +2525,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_div[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a / b)
@@ -2553,7 +2554,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_div_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a / other)
 
@@ -2586,21 +2587,28 @@ struct Matrix[
             print(A // B)  # Element-wise floor division
             ```
         """
+        def floordiv_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 // scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, floordiv_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, floordiv_kernel
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, floordiv_kernel
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __floordiv__(
@@ -2666,7 +2674,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_floordiv[w: Int](i: Int) unified {mut self, read other}:
+            def vec_floordiv[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a // b)
@@ -2695,9 +2703,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_floordiv_scalar[
-                w: Int
-            ](i: Int) unified {mut self, read other}:
+            def vec_floordiv_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a // other)
 
@@ -2728,21 +2734,28 @@ struct Matrix[
             print(A % B)  # Element-wise modulo
             ```
         """
+        def mod_kernel[
+            type: DType, simd_width: Int
+        ](
+            scalar1: SIMD[type, simd_width], scalar2: SIMD[type, simd_width]
+        ) capturing -> SIMD[type, simd_width]:
+            return scalar1 % scalar2
+
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, mod_kernel
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, mod_kernel
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, mod_kernel
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __mod__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2805,7 +2818,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_mod[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a % b)
@@ -2834,7 +2847,7 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             @parameter
-            def vec_mod_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod_scalar[w: Int](i: Int):
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a % other)
 
@@ -3709,7 +3722,7 @@ struct Matrix[
             print(A.mean())
             ```
         """
-        return numojo.statistics.mean[returned_dtype](self)
+        return stat.mean[returned_dtype](self)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -3731,7 +3744,7 @@ struct Matrix[
             print(A.mean(axis=1))
             ```
         """
-        return numojo.statistics.mean[returned_dtype](self, axis=axis)
+        return stat.mean[returned_dtype](self, axis=axis)
 
     def min(self) raises -> Scalar[Self.dtype]:
         """
@@ -3977,7 +3990,7 @@ struct Matrix[
             print(A.std())
             ```
         """
-        return numojo.statistics.std[returned_dtype](self, ddof=ddof)
+        return stat.std[returned_dtype](self, ddof=ddof)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -4000,7 +4013,7 @@ struct Matrix[
             print(A.std(axis=1))
             ```
         """
-        return numojo.statistics.std[returned_dtype](self, axis=axis, ddof=ddof)
+        return stat.std[returned_dtype](self, axis=axis, ddof=ddof)
 
     def sum(self) -> Scalar[Self.dtype]:
         """
@@ -4146,7 +4159,7 @@ struct Matrix[
             print(A.variance())
             ```
         """
-        return numojo.statistics.variance[returned_dtype](self, ddof=ddof)
+        return stat.variance[returned_dtype](self, ddof=ddof)
 
     def variance[
         returned_dtype: DType = DType.float64
@@ -4169,9 +4182,7 @@ struct Matrix[
             print(A.variance(axis=1))
             ```
         """
-        return numojo.statistics.variance[returned_dtype](
-            self, axis=axis, ddof=ddof
-        )
+        return stat.variance[returned_dtype](self, axis=axis, ddof=ddof)
 
     # # ===-------------------------------------------------------------------===#
     # # To other data types
@@ -4309,7 +4320,7 @@ struct Matrix[
         comptime width = simd_width_of[datatype]()
 
         @parameter
-        def vec_fill[w: Int](i: Int) unified {mut matrix, read fill_value}:
+        def vec_fill[w: Int](i: Int) {mut matrix, read fill_value}:
             matrix._buf.ptr.store(i, SIMD[datatype, w](fill_value))
 
         vectorize[width](matrix.size, vec_fill)
@@ -4415,7 +4426,7 @@ struct Matrix[
         comptime width = simd_width_of[datatype]()
 
         @parameter
-        def vec_rand[w: Int](i: Int) unified {mut result}:
+        def vec_rand[w: Int](i: Int) {mut result}:
             var rand_vec = SIMD[datatype, w]()
             for j in range(w):
                 rand_vec[j] = random_float64(0, 1).cast[datatype]()
@@ -4969,9 +4980,9 @@ struct _MatrixIter[
 # TODO: we can move the checks in these functions to the caller functions to avoid redundant checks.
 def _arithmetic_func_matrix_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](
+    simd_func: def[type: DType, simd_width: Int](
         SIMD[type, simd_width], SIMD[type, simd_width]
-    ) -> SIMD[type, simd_width],
+    ) capturing -> SIMD[type, simd_width],
 ](A: Matrix[dtype], B: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Perform element-wise arithmetic operation between two matrices using a SIMD function.
@@ -5022,8 +5033,7 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
-    @parameter
-    def vec_func[simd_width: Int](i: Int) unified {mut res, read A, read B}:
+    def vec_func[simd_width: Int](i: Int) {mut res, read A, read B}:
         res._buf.ptr.store(
             i,
             simd_func(
@@ -5038,9 +5048,9 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
 def _arithmetic_func_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](SIMD[type, simd_width]) -> SIMD[
-        type, simd_width
-    ],
+    simd_func: def[type: DType, simd_width: Int](
+        SIMD[type, simd_width]
+    ) capturing -> SIMD[type, simd_width],
 ](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply a unary SIMD function element-wise to a matrix.
@@ -5062,8 +5072,7 @@ def _arithmetic_func_matrix_to_matrix[
 
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
-    @parameter
-    def vec_func[simd_width: Int](i: Int) unified {mut C, read A}:
+    def vec_func[simd_width: Int](i: Int) {mut C, read A}:
         C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
@@ -5073,9 +5082,9 @@ def _arithmetic_func_matrix_to_matrix[
 
 def _logic_func_matrix_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](
+    simd_func: def[type: DType, simd_width: Int](
         SIMD[type, simd_width], SIMD[type, simd_width]
-    ) -> SIMD[DType.bool, simd_width],
+    ) capturing -> SIMD[DType.bool, simd_width],
 ](A: Matrix[dtype], B: Matrix[dtype]) raises -> Matrix[DType.bool]:
     """
     Perform element-wise logical comparison between two matrices using a SIMD function.
@@ -5130,8 +5139,7 @@ def _logic_func_matrix_matrix_to_matrix[
 
     # Use vectorized comparison for better performance
     # Process elements using input dtype width, then store results as bool
-    @parameter
-    def vec_compare[w: Int](i: Int) unified {mut C, read A, read B}:
+    def vec_compare[w: Int](i: Int) {mut C, read A, read B}:
         var a_vec = A._buf.ptr.load[width=w](i)
         var b_vec = B._buf.ptr.load[width=w](i)
         var result = simd_func[dtype, w](a_vec, b_vec)

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -361,7 +361,7 @@ struct Matrix[
 
     # TODO: prevent copying from views to views or views to owning matrices right now.`where` clause isn't working here either for now, So we use constrained. Move to 'where` clause when it's stable.
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Initialize a new matrix by copying data from ancopy matrix.
 
@@ -411,7 +411,7 @@ struct Matrix[
         )
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """
         Transfer ownership of resources from `other` to `self`.
 

--- a/numojo/core/memory/__init__.mojo
+++ b/numojo/core/memory/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Memory (numojo.core.memory)
-
+---------------------------
 Low-level memory/storage utilities used by NuMojo core containers.
 """
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -208,7 +208,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
         Deep copy constructor. Allocates new storage and copies all data.
 
@@ -228,7 +228,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """
         Move constructor.
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -6,14 +6,13 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """DataContainer (numojo.core.memory.data_container)
-
+-----------------------------------
 A reference-counted container for contiguous data buffers, used for NDArray and Matrix.
-
 DataContainer manages memory ownership and reference counting for shared or external data.
 """
 
 from std.memory import UnsafePointer, memcpy
-from std.os.atomic import Atomic, Consistency, fence
+from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 
 from numojo.core.error import NumojoError
@@ -221,7 +220,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = copy.ownership
 
         if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
     def deep_copy(self) -> Self:
         """
@@ -265,10 +264,10 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Consistency.RELEASE](1) != 1:
+        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
             return
 
-        fence[ordering=Consistency.ACQUIRE]()
+        fence[ordering=Ordering.ACQUIRE]()
         if self.ptr and self.size > 0:
             self.ptr.free()
         self._refcount.free()
@@ -434,7 +433,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Consistency.MONOTONIC]()
+        return self._refcount[].load[ordering=Ordering.RELAXED]()
 
     def share(mut self) raises -> DataContainer[Self.dtype]:
         """
@@ -456,7 +455,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = DataContainer[Self.dtype](
             ptr=self.ptr,

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -82,9 +82,8 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     DataContainer can either own its memory (managed) or provide a view into external data (external).
     Managed containers use reference counting for shared ownership. External containers do not manage or free memory.
 
-    Copying a managed DataContainer with `.copy()` increments the reference count that still points to the same data.
-    Copying an external container creates another non-owning view.
-    Use `deep_copy()` to create an owned instance.
+    Copying a DataContainer with `.copy()` creates an independent owned copy with its own allocation.
+    Use `.share()` to create a shared view that increments the reference count.
 
     Fields:
         ptr: Pointer to the data array.
@@ -116,7 +115,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         Create an empty, managed DataContainer.
         """
-        self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+        self.ptr = UnsafePointer[
+            Scalar[Self.dtype], Self.origin
+        ].unsafe_dangling()
         self._refcount = alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
@@ -139,7 +140,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
@@ -164,8 +167,6 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if size < 0:
             abort("DataContainer: __init__() size must be non-negative")
-        if not ptr:
-            abort("DataContainer: __init__() ptr must be non-null")
         self.size = size
         if copy:
             self._refcount = alloc[Atomic[DType.uint64]](1)
@@ -174,7 +175,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[Atomic[DType.uint64], Self.origin]()
+            self._refcount = UnsafePointer[
+                Atomic[DType.uint64], Self.origin
+            ].unsafe_dangling()
             self.ptr = ptr
             self.ownership = Ownership.External
 
@@ -207,34 +210,22 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __copyinit__(out self, copy: Self):
         """
-        Copy constructor.
-
-        Increments the reference count for managed containers.
+        Deep copy constructor. Allocates new storage and copies all data.
 
         Args:
             copy: DataContainer to copy from.
         """
         self.size = copy.size
-        self.ptr = copy.ptr
-        self._refcount = copy._refcount
-        self.ownership = copy.ownership
-
-        if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
-
-    def deep_copy(self) -> Self:
-        """
-        Create a deep copy of the DataContainer.
-
-        Returns:
-            A new DataContainer with its own copy of the data.
-        """
-        if self.size == 0:
-            return DataContainer[Self.dtype]()
-
-        var result = DataContainer[Self.dtype](self.size)
-        memcpy(dest=result.ptr, src=self.ptr, count=self.size)
-        return result^
+        self.ownership = Ownership.Managed
+        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount[] = Atomic[DType.uint64](1)
+        if copy.size == 0:
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
+        else:
+            self.ptr = alloc[Scalar[Self.dtype]](copy.size)
+            memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
     def __moveinit__(out self, deinit take: Self):
@@ -268,7 +259,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             return
 
         fence[ordering=Ordering.ACQUIRE]()
-        if self.ptr and self.size > 0:
+        if self.size > 0:
             self.ptr.free()
         self._refcount.free()
 
@@ -419,9 +410,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Returns:
             True if refcounting is enabled, False otherwise.
         """
-        return (
-            self._refcount != UnsafePointer[Atomic[DType.uint64], Self.origin]()
-        )
+        return self.ownership == Ownership.Managed
 
     @always_inline
     def ref_count(ref self) -> UInt64:

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -418,7 +418,9 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 
 def _dlpack_deleter_impl[
     dtype: DType
-](managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]) capturing -> None:
+](
+    managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]
+) capturing -> None:
     """Type-specific deleter callback for DLManagedTensor."""
     if not managed_tensor_ptr:
         return

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """DLPack (numojo.core.memory.dlpack)
-
+----------------------------------
 This module implements the DLPack protocol for zero-copy tensor exchange
 between NuMojo and other array libraries (NumPy, PyTorch, JAX, etc.).
 
@@ -403,9 +403,9 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         self.data_container = copy.data_container.copy()
 
     def __del__(deinit self):
-        if self.shape:
+        if Int(self.shape) != 0:
             self.shape.free()
-        if self.strides:
+        if Int(self.strides) != 0:
             self.strides.free()
         # TODO: note sure if we should free it explicitly, gotta check this with tests.
         _ = self.data_container^
@@ -422,11 +422,11 @@ def _dlpack_deleter_impl[
     managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]
 ) capturing -> None:
     """Type-specific deleter callback for DLManagedTensor."""
-    if not managed_tensor_ptr:
+    if Int(managed_tensor_ptr) == 0:
         return
 
     var ctx = managed_tensor_ptr[].manager_ctx
-    if ctx:
+    if Int(ctx) != 0:
         var metadata_ptr = ctx.bitcast[DLPackMetadata[dtype]]()
         metadata_ptr.destroy_pointee()
         metadata_ptr.free()
@@ -547,7 +547,7 @@ def _extract_dlpack_pointer(
 
     var p = result_obj.unsafe_get_as_pointer[DType.uint8]()
 
-    if not p:
+    if Int(p) == 0:
         raise Error(
             "_extract_dlpack_pointer: PyCapsule_GetPointer returned NULL"
             " - capsule may be invalid or already consumed"
@@ -609,7 +609,7 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
     var actual_capsule: PythonObject = capsule.__dlpack__()
     var managed_tensor_ptr = _extract_dlpack_pointer(actual_capsule)
 
-    if not managed_tensor_ptr:
+    if Int(managed_tensor_ptr) == 0:
         raise Error("from_dlpack: received null DLManagedTensor pointer")
 
     var dl_tensor = managed_tensor_ptr[].dl_tensor
@@ -636,7 +636,7 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
         shape[i] = Int(dl_tensor.shape[i])
 
     var strides: NDArrayStrides
-    if dl_tensor.strides:
+    if Int(dl_tensor.strides) != 0:
         strides = NDArrayStrides(ndim=ndim, initialized=True)
         for i in range(ndim):
             strides[i] = Int(dl_tensor.strides[i])

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -396,7 +396,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         self.ndim = ndim
         self.data_container = data_container^
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         self.shape = copy.shape
         self.strides = copy.strides
         self.ndim = copy.ndim
@@ -407,7 +407,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
             self.shape.free()
         if self.strides:
             self.strides.free()
-        # TODO: note sure if we should free it explicitly, gotta check this.
+        # TODO: note sure if we should free it explicitly, gotta check this with tests.
         _ = self.data_container^
 
 

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -311,9 +311,9 @@ struct DLTensor(ImplicitlyCopyable, Movable):
         self.byte_offset = byte_offset
 
 
-comptime DLManagedTensorDeleter = fn(
+comptime DLManagedTensorDeleter = def(
     UnsafePointer[DLManagedTensor, MutAnyOrigin]
-) -> None
+) capturing -> None
 
 
 # TODO: This is the old API, current API requires using DLManagedTensorVersioned which has a version field for future compatibility.
@@ -418,7 +418,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 
 def _dlpack_deleter_impl[
     dtype: DType
-](managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]) -> None:
+](managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]) capturing -> None:
     """Type-specific deleter callback for DLManagedTensor."""
     if not managed_tensor_ptr:
         return

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -17,7 +17,7 @@ This module provides three storage structs:
   `HostStorage` and `DeviceStorage` at compile time based on a `Device` parameter.
 """
 from std.memory import UnsafePointer
-from std.atomic import Atomic, Consistency, fence
+from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
@@ -184,7 +184,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = copy.ownership
 
         if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
     @always_inline
     def __moveinit__(out self, deinit take: Self):
@@ -215,10 +215,10 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Consistency.RELEASE](1) != 1:
+        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
             return
 
-        fence[ordering=Consistency.ACQUIRE]()
+        fence[ordering=Ordering.ACQUIRE]()
         if self.size > 0:
             self.ptr.free()
         self._refcount.free()
@@ -390,7 +390,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Consistency.MONOTONIC]()
+        return self._refcount[].load[ordering=Ordering.RELAXED]()
 
     def share(mut self) raises -> HostStorage[Self.dtype]:
         """Create a new handle that shares this container's data and refcount.
@@ -413,7 +413,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = HostStorage[Self.dtype](
             ptr=self.ptr,

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Storage (numojo.core.memory.storage)
-
+---------------------------------------
 Backend storage containers for accelerator-aware data management.
 
 This module provides three storage structs:
@@ -17,7 +17,7 @@ This module provides three storage structs:
   `HostStorage` and `DeviceStorage` at compile time based on a `Device` parameter.
 """
 from std.memory import UnsafePointer
-from std.os.atomic import Atomic, Consistency, fence
+from std.atomic import Atomic, Consistency, fence
 from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
@@ -73,7 +73,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
-        self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+        self.ptr = UnsafePointer[
+            Scalar[Self.dtype], Self.origin
+        ].unsafe_dangling()
         self._refcount = alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
@@ -98,7 +100,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
@@ -123,8 +127,6 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if size < 0:
             abort("HostStorage: __init__() size must be non-negative")
-        if not ptr:
-            abort("HostStorage: __init__() ptr must be non-null")
 
         self.size = size
         if copy:
@@ -134,7 +136,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[Atomic[DType.uint64], Self.origin]()
+            self._refcount = UnsafePointer[
+                Atomic[DType.uint64], Self.origin
+            ].unsafe_dangling()
             self.ptr = ptr
             self.ownership = Ownership.External
 
@@ -215,7 +219,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             return
 
         fence[ordering=Consistency.ACQUIRE]()
-        if self.ptr and self.size > 0:
+        if self.size > 0:
             self.ptr.free()
         self._refcount.free()
 
@@ -375,9 +379,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         Returns:
             Whether reference counting is active.
         """
-        return (
-            self._refcount != UnsafePointer[Atomic[DType.uint64], Self.origin]()
-        )
+        return self.ownership == Ownership.Managed
 
     @always_inline
     def ref_count(ref self) -> UInt64:
@@ -389,22 +391,6 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return 0
         return self._refcount[].load[ordering=Consistency.MONOTONIC]()
-
-    def deep_copy(self) -> Self:
-        """Create an independent managed copy of this container.
-
-        The returned container has its own allocation and a refcount of 1,
-        regardless of the source ownership mode.
-
-        Returns:
-            A new `HostStorage` that owns a copy of the data.
-        """
-        if self.size == 0:
-            return HostStorage[Self.dtype]()
-
-        var result = HostStorage[Self.dtype](self.size)
-        memcpy(dest=result.ptr, src=self.ptr, count=self.size)
-        return result^
 
     def share(mut self) raises -> HostStorage[Self.dtype]:
         """Create a new handle that shares this container's data and refcount.
@@ -602,8 +588,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     the other remains `None`.
 
     Shallow copies (via `__copyinit__`) share the underlying allocation
-    and increment the reference count.  Use `deep_copy()` for an
-    independent owned copy.
+    and increment the reference count.  Use `.share()` for an explicit shared handle.
 
     Parameters:
         dtype: The element type stored in the container.
@@ -695,8 +680,6 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
             abort(
                 "AcceleratorDataContainer: __init__() size must be non-negative"
             )
-        if not ptr:
-            abort("AcceleratorDataContainer: __init__() ptr must be non-null")
 
         self.size = size
         self.host_storage = HostStorage[Self.dtype](
@@ -889,39 +872,6 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # ===----------------------------------------------------------------------===#
     # Reference Counting and Sharing
     # ===----------------------------------------------------------------------===#
-
-    def deep_copy(self) raises -> Self:
-        """Create an independent managed copy of this container.
-
-        For CPU containers the data is copied via `memcpy`.  For GPU
-        containers the copy is enqueued on the device context.
-
-        Returns:
-            A new `AcceleratorDataContainer` that owns its own data.
-        """
-        if self.size == 0:
-            return AcceleratorDataContainer[Self.dtype, Self.device]()
-
-        comptime if Self.device.type == "cpu":
-            var result = AcceleratorDataContainer[Self.dtype, Self.device](
-                self.size
-            )
-            memcpy(
-                dest=result.host_storage.unsafe_value().ptr,
-                src=self.host_storage.unsafe_value().ptr,
-                count=self.size,
-            )
-            return result^
-        else:
-            var result = AcceleratorDataContainer[Self.dtype, Self.device](
-                self.size
-            )
-            var ctx = self.device_storage.unsafe_value().buffer.context()
-            ctx.enqueue_copy(
-                result.device_storage.unsafe_value().buffer,
-                self.device_storage.unsafe_value().buffer,
-            )
-            return result^
 
     def share(
         mut self,

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -169,7 +169,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Shallow-copy constructor.
 
         Copies the pointer and refcount, then atomically increments the
@@ -187,7 +187,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor.
 
         Transfers all fields without touching the reference count.
@@ -484,7 +484,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = buffer
         self.size = size
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Shallow-copy constructor.
 
         Copies the `DeviceBuffer` handle.  The GPU runtime determines
@@ -496,7 +496,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = copy.buffer
         self.size = copy.size
 
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor.
 
         Transfers the buffer handle without copying.
@@ -690,7 +690,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.device_storage = None
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Shallow-copy constructor.
 
         Shares the underlying storage.  For CPU containers this increments
@@ -705,7 +705,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.size = copy.size
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move constructor.
 
         Transfers all fields without touching reference counts.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -80,6 +80,13 @@ import numojo.routines.bitwise as bitwise
 import numojo.routines.math.arithmetic as arithmetic
 import numojo.routines.math.rounding as rounding
 import numojo.routines.searching as searching
+import numojo.routines.linalg as linalg
+import numojo.routines.sorting as sorting
+import numojo.routines.manipulation as manipulation
+import numojo.routines.statistics as statistics
+from numojo.routines.indexing import clip, compress
+from numojo.routines.manipulation import reshape
+import numojo.routines.math as numojo_math
 
 comptime IndexTypes = Variant[Int, NewAxis, EllipsisType, Slice]
 """IndexTypes is used to represent the different kinds of indices that can be used for indexing and slicing operations on the NDArray.
@@ -2148,7 +2155,7 @@ struct NDArray[dtype: DType = DType.float64](
             ```mojo
             import numojo as nm
             from numojo.prelude import *
-            var A = numojo.random.rand[numojo.i16](2, 2, 2)
+            var A = nm.random.rand[numojo.i16](2, 2, 2)
             A[Item(0, 1, 1)] = 10
             ```
         """
@@ -2580,6 +2587,8 @@ struct NDArray[dtype: DType = DType.float64](
 
         Examples:
             ```mojo
+            import numojo as nm
+
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
             a.__setitem__(1, 2, scalar=99)           # single element
             a.__setitem__(1, Slice(2,4), scalar=0)   # one row, partial column
@@ -3474,9 +3483,9 @@ struct NDArray[dtype: DType = DType.float64](
     # ===--- In-place helper methods (view-safe) ---===#
 
     def _inplace_scalar_op[
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](mut self, other: SIMD[Self.dtype, 1]):
         """Apply a binary SIMD operation in-place: self[i] = func(self[i], s).
 
@@ -3493,7 +3502,6 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            @parameter
             def vec_op[w: Int](i: Int) {mut self, read other}:
                 self._buf.ptr.store(
                     self.offset + i,
@@ -3518,9 +3526,9 @@ struct NDArray[dtype: DType = DType.float64](
                 )
 
     def _inplace_array_op[
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](mut self, other: Self) raises:
         """Apply a binary SIMD operation in-place: self[i] = func(self[i], o[i]).
 
@@ -3549,8 +3557,6 @@ struct NDArray[dtype: DType = DType.float64](
         var other_c = other.contiguous()
 
         if self.is_c_contiguous():
-
-            @parameter
             def vec_op[w: Int](i: Int) {mut self, read other_c}:
                 self._buf.ptr.store(
                     self.offset + i,
@@ -3578,11 +3584,19 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __iadd__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array += scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__add__](other)
+        def add_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a + b
+        self._inplace_scalar_op[add_kernel](other)
 
     def __iadd__(mut self, other: Self) raises:
         """Enables `array += array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__add__](other)
+        def add_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a + b
+        self._inplace_array_op[add_kernel](other)
 
     def __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
@@ -3604,14 +3618,22 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array -= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__sub__](other)
+        def sub_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a - b
+        self._inplace_scalar_op[sub_kernel](other)
 
     def __isub__(mut self, other: Self) raises:
         """Enables `array -= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__sub__](other)
+        def sub_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a - b
+        self._inplace_array_op[sub_kernel](other)
 
     def __matmul__(self, other: Self) raises -> Self:
-        return numojo.linalg.matmul(self, other)
+        return linalg.matmul(self, other)
 
     def __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
@@ -3633,11 +3655,19 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array *= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__mul__](other)
+        def mul_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a * b
+        self._inplace_scalar_op[mul_kernel](other)
 
     def __imul__(mut self, other: Self) raises:
         """Enables `array *= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__mul__](other)
+        def mul_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a * b
+        self._inplace_array_op[mul_kernel](other)
 
     def __abs__(self) -> Self:
         return abs(self)
@@ -3678,7 +3708,6 @@ struct NDArray[dtype: DType = DType.float64](
         var p_c = p.contiguous()
         var result = NDArray[Self.dtype](self.shape)
 
-        @parameter
         def vectorized_pow[
             simd_width: Int
         ](index: Int) {mut result, read src, read p_c}:
@@ -3695,7 +3724,6 @@ struct NDArray[dtype: DType = DType.float64](
         """Enables `array **= int`. View-safe: modifies buffer in-place."""
         if self.is_c_contiguous():
 
-            @parameter
             def vec_pow[w: Int](i: Int) {mut self, read p}:
                 self._buf.ptr.store(
                     self.offset + i,
@@ -3719,7 +3747,6 @@ struct NDArray[dtype: DType = DType.float64](
     def _elementwise_pow(self, p: Int) raises -> Self:
         var src = self.contiguous()
 
-        @parameter
         def array_scalar_vectorize[
             simd_width: Int
         ](index: Int) {mut src, read p} -> None:
@@ -3745,11 +3772,19 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __itruediv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array /= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__truediv__](s)
+        def div_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a / b
+        self._inplace_scalar_op[div_kernel](s)
 
     def __itruediv__(mut self, other: Self) raises:
         """Enables `array /= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__truediv__](other)
+        def div_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a / b
+        self._inplace_array_op[div_kernel](other)
 
     def __rtruediv__(self, s: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -3771,11 +3806,19 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __ifloordiv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array //= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__floordiv__](s)
+        def floor_div_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a.__floordiv__(b)
+        self._inplace_scalar_op[floor_div_kernel](s)
 
     def __ifloordiv__(mut self, other: Self) raises:
         """Enables `array //= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__floordiv__](other)
+        def floor_div_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a.__floordiv__(b)
+        self._inplace_array_op[floor_div_kernel](other)
 
     def __rfloordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -3797,11 +3840,19 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imod__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array %= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__mod__](other)
+        def mod_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a % b
+        self._inplace_scalar_op[mod_kernel](other)
 
     def __imod__(mut self, other: NDArray[Self.dtype]) raises:
         """Enables `array %= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__mod__](other)
+        def mod_kernel[type: DType, simd_w: Int](
+            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w]:
+            return a % b
+        self._inplace_array_op[mod_kernel](other)
 
     def __rmod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -4240,7 +4291,6 @@ struct NDArray[dtype: DType = DType.float64](
         var a = self.contiguous()
         var result: Bool = True
 
-        @parameter
         def vectorized_all[
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
@@ -4267,7 +4317,6 @@ struct NDArray[dtype: DType = DType.float64](
         var a = self.contiguous()
         var result: Bool = False
 
-        @parameter
         def vectorized_any[
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
@@ -4312,7 +4361,7 @@ struct NDArray[dtype: DType = DType.float64](
             The indices of the sorted NDArray.
         """
 
-        return numojo.sorting.argsort(self)
+        return sorting.argsort(self)
 
     def argsort(mut self, axis: Int) raises -> NDArray[DType.int]:
         """Sorts the NDArray and returns the sorted indices. See
@@ -4322,7 +4371,7 @@ struct NDArray[dtype: DType = DType.float64](
             The indices of the sorted NDArray.
         """
 
-        return numojo.sorting.argsort(self, axis=axis)
+        return sorting.argsort(self, axis=axis)
 
     def astype[target: DType](self) raises -> NDArray[target]:
         """Converts the type of the array.
@@ -4341,7 +4390,7 @@ struct NDArray[dtype: DType = DType.float64](
         """Limits the values in an array between `[a_min, a_max]`.
 
         If `a_min` is greater than `a_max`, the value is equal to `a_max`. See
-        `numojo.clip()` for more details.
+        `clip()` for more details.
 
         Args:
             a_min: The minimum value.
@@ -4351,7 +4400,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with the clipped values.
         """
 
-        return numojo.clip(self, a_min, a_max)
+        return clip(self, a_min, a_max)
 
     def compress(
         self, condition: NDArray[DType.bool], axis: Int
@@ -4378,7 +4427,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the condition contains no `True` values.
         """
 
-        return numojo.compress(condition=condition, a=self, axis=axis)
+        return compress(condition=condition, a=self, axis=axis)
 
     def compress(self, condition: NDArray[DType.bool]) raises -> Self:
         """Returns selected slices of an array along a given axis.
@@ -4401,7 +4450,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the condition contains no `True` values.
         """
 
-        return numojo.compress(condition=condition, a=self)
+        return compress(condition=condition, a=self)
 
     def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.
@@ -4489,7 +4538,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative product of all items.
         """
-        return numojo.math.cumprod[Self.dtype](self)
+        return numojo_math.cumprod[Self.dtype](self)
 
     def cumprod(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative product of the array along the given axis.
@@ -4500,7 +4549,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative product along the axis.
         """
-        return numojo.math.cumprod[Self.dtype](self.copy(), axis=axis)
+        return numojo_math.cumprod[Self.dtype](self.copy(), axis=axis)
 
     def cumsum(self) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of all items of an array. The array is
@@ -4509,7 +4558,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative sum of all items.
         """
-        return numojo.math.cumsum[Self.dtype](self)
+        return numojo_math.cumsum[Self.dtype](self)
 
     def cumsum(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of the array along the given axis.
@@ -4520,7 +4569,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative sum along the axis.
         """
-        return numojo.math.cumsum[Self.dtype](self.copy(), axis=axis)
+        return numojo_math.cumsum[Self.dtype](self.copy(), axis=axis)
 
     def diagonal(self, offset: Int = 0) raises -> Self:
         """Returns specific diagonals.
@@ -4537,7 +4586,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the array is not 2D.
             Error: If the offset is beyond the shape of the array.
         """
-        return numojo.linalg.diagonal(self, offset=offset)
+        return linalg.diagonal(self, offset=offset)
 
     def fill(mut self, val: Scalar[Self.dtype]):
         """Fills all items of the array with the given value.
@@ -4854,7 +4903,7 @@ struct NDArray[dtype: DType = DType.float64](
             The max value.
         """
 
-        return numojo.math.max(self)
+        return numojo_math.max(self)
 
     def max(self, axis: Int) raises -> Self:
         """Finds the max value of an array along the axis. The number of
@@ -4869,7 +4918,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with reduced number of dimensions.
         """
 
-        return numojo.math.max(self, axis=axis)
+        return numojo_math.max(self, axis=axis)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -4879,7 +4928,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The mean of the array.
         """
-        return numojo.statistics.mean[returned_dtype](self)
+        return statistics.mean[returned_dtype](self)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -4892,7 +4941,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An NDArray.
         """
-        return numojo.statistics.mean[returned_dtype](self, axis)
+        return statistics.mean[returned_dtype](self, axis)
 
     def median[
         returned_dtype: DType = DType.float64
@@ -4926,7 +4975,7 @@ struct NDArray[dtype: DType = DType.float64](
             The min value.
         """
 
-        return numojo.math.min(self)
+        return numojo_math.min(self)
 
     def min(self, axis: Int) raises -> Self:
         """Finds the min value of an array along the axis. The number of
@@ -4941,7 +4990,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with reduced number of dimensions.
         """
 
-        return numojo.math.min(self, axis=axis)
+        return numojo_math.min(self, axis=axis)
 
     def nditer(self) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
         """Returns an iterator yielding the array elements according to the
@@ -5026,7 +5075,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             A scalar.
         """
-        return numojo.math.prod(self)
+        return numojo_math.prod(self)
 
     def prod(self, axis: Int) raises -> Self:
         """Computes the product of array elements over a given axis.
@@ -5038,7 +5087,7 @@ struct NDArray[dtype: DType = DType.float64](
             An NDArray.
         """
 
-        return numojo.math.prod(self, axis=axis)
+        return numojo_math.prod(self, axis=axis)
 
     # TODO: make it inplace?
     def reshape(
@@ -5053,7 +5102,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of the same data with a new shape.
         """
-        var result = numojo.reshape(self, shape=shape, order=order)
+        var result = reshape(self, shape=shape, order=order)
         return result^
 
     def resize(mut self, shape: NDArrayShape) raises:
@@ -5132,7 +5181,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     def sort(mut self, axis: Int = -1, stable: Bool = False) raises:
         """Sorts the array in-place along the given axis using quick sort. The
-        default axis is -1. See `numojo.sorting.sort` for more information.
+        default axis is -1. See `sorting.sort` for more information.
 
         Args:
             axis: The axis along which the array is sorted. Defaults to -1.
@@ -5156,7 +5205,7 @@ struct NDArray[dtype: DType = DType.float64](
                     location="NDArray.sort(axis: Int)",
                 )
             )
-        numojo.sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
+        sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -5170,7 +5219,7 @@ struct NDArray[dtype: DType = DType.float64](
             ddof: The delta degree of freedom.
         """
 
-        return std[returned_dtype](self, ddof=ddof)
+        return stddev[returned_dtype](self, ddof=ddof)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -5185,7 +5234,7 @@ struct NDArray[dtype: DType = DType.float64](
             ddof: The delta degree of freedom.
         """
 
-        return std[returned_dtype](self, axis=axis, ddof=ddof)
+        return stddev[returned_dtype](self, axis=axis, ddof=ddof)
 
     def sum(self) raises -> Scalar[Self.dtype]:
         """Returns the sum of all array elements.
@@ -5218,9 +5267,9 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The transposed array.
 
-        Defined in `numojo.routines.manipulation.transpose`.
+        Defined in `manipulation.transpose`.
         """
-        return numojo.routines.manipulation.transpose(self, axes)
+        return manipulation.transpose(self, axes)
 
     def T(self) raises -> Self:
         """Transposes the array when `axes` is not given.
@@ -5231,9 +5280,9 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The transposed array.
 
-        Defined in `numojo.routines.manipulation.transpose`.
+        Defined in `manipulation.transpose`.
         """
-        return numojo.routines.manipulation.transpose(self.copy())
+        return manipulation.transpose(self.copy())
 
     def tolist(self) -> List[Scalar[Self.dtype]]:
         """Converts the NDArray to a 1-D list in row-major (C) order.
@@ -5315,7 +5364,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The trace of the ndarray.
         """
-        return numojo.linalg.trace[Self.dtype](self, offset, axis1, axis2)
+        return linalg.trace[Self.dtype](self, offset, axis1, axis2)
 
     # TODO: Remove the underscore in the method name when view is supported.
     # def _transpose(self) raises -> Self:
@@ -5599,7 +5648,7 @@ struct _NDArrayIter[
             return result^
 
         else:  # 0-D array
-            var result: NDArray[Self.dtype] = numojo.creation._0darray[
+            var result: NDArray[Self.dtype] = creation._0darray[
                 Self.dtype
             ](self._buf.ptr[self.offset + index])
             return result^

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3649,7 +3649,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return math.mul[Self.dtype](self, other)
 
-    def __rmul__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rmul__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar * array`.
         """

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4210,7 +4210,7 @@ struct NDArray[dtype: DType = DType.float64](
                         out += separator
                 out += padding + "]"
 
-            if len(out) > options.line_width:
+            if out.byte_length() > options.line_width:
                 var wrapped: String = String("")
                 var line_len: Int = 0
                 for c in out.codepoint_slices():

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -84,7 +84,8 @@ import numojo.routines.linalg as linalg
 import numojo.routines.sorting as sorting
 import numojo.routines.manipulation as manipulation
 import numojo.routines.statistics as statistics
-from numojo.routines.indexing import clip, compress
+from numojo.routines.indexing import compress
+from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
 import numojo.routines.math as numojo_math
 
@@ -325,7 +326,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = PrintOptions()
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copies `copy` into `self`.
 
         Performs a deep copy. The new array owns its data.
@@ -370,7 +371,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Moves `take` into `self`.
 
         Args:
@@ -2155,7 +2156,7 @@ struct NDArray[dtype: DType = DType.float64](
             ```mojo
             import numojo as nm
             from numojo.prelude import *
-            var A = nm.random.rand[numojo.i16](2, 2, 2)
+            var A = nm.random.rand[nm.i16](2, 2, 2)
             A[Item(0, 1, 1)] = 10
             ```
         """
@@ -2557,6 +2558,8 @@ struct NDArray[dtype: DType = DType.float64](
 
         Examples:
             ```mojo
+            import numojo as nm
+            
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
             a.__setitem__(Slice(1,3), Slice(1,3), scalar=99)
             ```

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """NDArray (numojo.core.ndarray)
-
+--------------------------------
 This module implements the core `NDArray` type, which is the fundamental data structure for multi-dimensional arrays in NuMojo.
 It provides efficient storage, indexing, slicing, and basic operations on N-dimensional arrays. The `NDArray` is designed to be flexible and performant, supporting various memory layouts and data types.
 
@@ -339,30 +339,6 @@ struct NDArray[dtype: DType = DType.float64](
             writeable=True,
         )
         self.print_options = copy.print_options
-
-    def deep_copy(self) raises -> Self:
-        """
-        Create a deep copy of the NDArray.
-
-        Returns:
-            A new NDArray instance with its own data buffer, identical to `self`.
-            Changes to the copy do not affect the original array.
-
-        Example:
-            ```mojo
-            import numojo as nm
-            var arr = nm.ones[nm.f32](nm.Shape(2, 3))
-            var arr_copy = arr.deep_copy()
-            ```
-        """
-        var new_buf = self._buf.deep_copy()
-        return Self(
-            data=new_buf^,
-            is_view=False,
-            shape=self.shape,
-            strides=self.strides,
-            offset=self.offset,
-        )
 
     def view(mut self) raises -> Self:
         """
@@ -3518,7 +3494,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             @parameter
-            def vec_op[w: Int](i: Int) unified {mut self, read other}:
+            def vec_op[w: Int](i: Int) {mut self, read other}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3575,7 +3551,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             @parameter
-            def vec_op[w: Int](i: Int) unified {mut self, read other_c}:
+            def vec_op[w: Int](i: Int) {mut self, read other_c}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3705,7 +3681,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         def vectorized_pow[
             simd_width: Int
-        ](index: Int) unified {mut result, read src, read p_c}:
+        ](index: Int) {mut result, read src, read p_c}:
             result._buf.ptr.store(
                 index,
                 src._buf.ptr.load[width=simd_width](index)
@@ -3720,7 +3696,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             @parameter
-            def vec_pow[w: Int](i: Int) unified {mut self, read p}:
+            def vec_pow[w: Int](i: Int) {mut self, read p}:
                 self._buf.ptr.store(
                     self.offset + i,
                     builtin_math.pow(
@@ -3746,7 +3722,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         def array_scalar_vectorize[
             simd_width: Int
-        ](index: Int) unified {mut src, read p} -> None:
+        ](index: Int) {mut src, read p} -> None:
             src._buf.ptr.store(
                 index,
                 builtin_math.pow(src._buf.ptr.load[width=simd_width](index), p),
@@ -4267,7 +4243,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         def vectorized_all[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             result = result and builtin_bool.all(
                 (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
             )
@@ -4294,7 +4270,7 @@ struct NDArray[dtype: DType = DType.float64](
         @parameter
         def vectorized_any[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             result = result or builtin_bool.any(
                 (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
             )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -2559,7 +2559,7 @@ struct NDArray[dtype: DType = DType.float64](
         Examples:
             ```mojo
             import numojo as nm
-            
+
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
             a.__setitem__(Slice(1,3), Slice(1,3), scalar=99)
             ```
@@ -3560,6 +3560,7 @@ struct NDArray[dtype: DType = DType.float64](
         var other_c = other.contiguous()
 
         if self.is_c_contiguous():
+
             def vec_op[w: Int](i: Int) {mut self, read other_c}:
                 self._buf.ptr.store(
                     self.offset + i,
@@ -3587,18 +3588,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __iadd__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array += scalar`. View-safe: modifies buffer in-place."""
-        def add_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def add_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a + b
+
         self._inplace_scalar_op[add_kernel](other)
 
     def __iadd__(mut self, other: Self) raises:
         """Enables `array += array`. View-safe: modifies buffer in-place."""
-        def add_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def add_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a + b
+
         self._inplace_array_op[add_kernel](other)
 
     def __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
@@ -3621,18 +3630,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array -= scalar`. View-safe: modifies buffer in-place."""
-        def sub_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def sub_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a - b
+
         self._inplace_scalar_op[sub_kernel](other)
 
     def __isub__(mut self, other: Self) raises:
         """Enables `array -= array`. View-safe: modifies buffer in-place."""
-        def sub_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def sub_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a - b
+
         self._inplace_array_op[sub_kernel](other)
 
     def __matmul__(self, other: Self) raises -> Self:
@@ -3658,18 +3675,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array *= scalar`. View-safe: modifies buffer in-place."""
-        def mul_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def mul_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a * b
+
         self._inplace_scalar_op[mul_kernel](other)
 
     def __imul__(mut self, other: Self) raises:
         """Enables `array *= array`. View-safe: modifies buffer in-place."""
-        def mul_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def mul_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a * b
+
         self._inplace_array_op[mul_kernel](other)
 
     def __abs__(self) -> Self:
@@ -3775,18 +3800,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __itruediv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array /= scalar`. View-safe: modifies buffer in-place."""
-        def div_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def div_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a / b
+
         self._inplace_scalar_op[div_kernel](s)
 
     def __itruediv__(mut self, other: Self) raises:
         """Enables `array /= array`. View-safe: modifies buffer in-place."""
-        def div_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def div_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a / b
+
         self._inplace_array_op[div_kernel](other)
 
     def __rtruediv__(self, s: SIMD[Self.dtype, 1]) raises -> Self:
@@ -3809,18 +3842,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __ifloordiv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array //= scalar`. View-safe: modifies buffer in-place."""
-        def floor_div_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def floor_div_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a.__floordiv__(b)
+
         self._inplace_scalar_op[floor_div_kernel](s)
 
     def __ifloordiv__(mut self, other: Self) raises:
         """Enables `array //= array`. View-safe: modifies buffer in-place."""
-        def floor_div_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def floor_div_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a.__floordiv__(b)
+
         self._inplace_array_op[floor_div_kernel](other)
 
     def __rfloordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
@@ -3843,18 +3884,26 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imod__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array %= scalar`. View-safe: modifies buffer in-place."""
-        def mod_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def mod_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a % b
+
         self._inplace_scalar_op[mod_kernel](other)
 
     def __imod__(mut self, other: NDArray[Self.dtype]) raises:
         """Enables `array %= array`. View-safe: modifies buffer in-place."""
-        def mod_kernel[type: DType, simd_w: Int](
-            a: SIMD[type, simd_w], b: SIMD[type, simd_w]
-        ) capturing -> SIMD[type, simd_w]:
+
+        def mod_kernel[
+            type: DType, simd_w: Int
+        ](a: SIMD[type, simd_w], b: SIMD[type, simd_w]) capturing -> SIMD[
+            type, simd_w
+        ]:
             return a % b
+
         self._inplace_array_op[mod_kernel](other)
 
     def __rmod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
@@ -5651,9 +5700,9 @@ struct _NDArrayIter[
             return result^
 
         else:  # 0-D array
-            var result: NDArray[Self.dtype] = creation._0darray[
-                Self.dtype
-            ](self._buf.ptr[self.offset + index])
+            var result: NDArray[Self.dtype] = creation._0darray[Self.dtype](
+                self._buf.ptr[self.offset + index]
+            )
             return result^
 
 

--- a/numojo/core/traits/__init__.mojo
+++ b/numojo/core/traits/__init__.mojo
@@ -1,8 +1,5 @@
-"""
-=====================================
-Traits (numojo.core.traits)
-=====================================
-
+"""Traits (numojo.core.traits)
+------------------------------
 Trait/protocol abstractions used across NuMojo core containers and internals.
 """
 

--- a/numojo/core/traits/backend.mojo
+++ b/numojo/core/traits/backend.mojo
@@ -76,7 +76,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        func: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self, array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -97,7 +97,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_2_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
@@ -129,7 +129,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_array_1_scalar_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
@@ -161,7 +161,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_scalar_1_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](self, scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[
@@ -189,7 +189,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_compare_2_arrays[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](
@@ -220,7 +220,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_compare_array_and_scalar[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](
@@ -251,7 +251,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_is[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        func: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
         ],
     ](self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -259,7 +259,7 @@ trait Backend(ImplicitlyDestructible):
 
     # def math_func_simd_int[
     #     dtype: DType,
-    #     func: fn[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
+    #     func: def[type: DType, simd_w: Int] (SIMD[type, simd_w], Int) -> SIMD[
     #         type, simd_w
     #     ],
     # ](self, array1: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -7,8 +7,7 @@
 # ===----------------------------------------------------------------------=== #
 """
 NuMojo Prelude (`numojo.prelude`)
-================================
-
+=================================
 The prelude is the recommended “batteries-included” import for day-to-day use.
 
 Why it exists:

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Routines module (numojo.routines)
-
+---------------------------------
 This modules groups NumPy-like functionality by topic (math, linalg, statistics,
 creation, manipulation, etc.).
 

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -122,7 +122,7 @@ from .math import (
     hypot_fma,
 )
 
-from .statistics import mean, mode, median, variance, std
+from .statistics import mean, mode, median, variance, stddev
 
 from .bitwise import invert
 

--- a/numojo/routines/bitwise.mojo
+++ b/numojo/routines/bitwise.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Bit-wise operations module (`numojo.routines.bitwise`)
-
+---------------------------------------------------------
 This module implements bit-wise operations on NDArrays, such as bitwise AND, OR, XOR, and NOT (invert).
 """
 
@@ -51,8 +51,10 @@ def invert[
         var result2 = invert(arr2) # result2 is [false, true, false
         ```
     """
-    def kernel[type: DType, simd_w: Int](scalar: SIMD[type, simd_w]) -> SIMD[
-        DType.bool, simd_w
-    ]
+
+    def kernel[
+        type: DType, simd_w: Int
+    ](scalar: SIMD[type, simd_w]) capturing -> SIMD[type, simd_w]:
         return ~scalar
+
     return HostExecutor.apply_unary[dtype, kernel](array)

--- a/numojo/routines/bitwise.mojo
+++ b/numojo/routines/bitwise.mojo
@@ -51,4 +51,8 @@ def invert[
         var result2 = invert(arr2) # result2 is [false, true, false
         ```
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__invert__](array)
+    def kernel[type: DType, simd_w: Int](scalar: SIMD[type, simd_w]) -> SIMD[
+        DType.bool, simd_w
+    ]
+        return ~scalar
+    return HostExecutor.apply_unary[dtype, kernel](array)

--- a/numojo/routines/constants.mojo
+++ b/numojo/routines/constants.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Constants (numojo.routines.constants)
-
+-------------------------------------
 This module defines physical and mathematical constants for use in numerical computations.
 The constants are defined as class attributes of the `Constants` class, which is designed to be immutable and efficient for compile-time evaluation.
 """

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Creation routines (numojo.routines.creation)
-
+-----------------------------------------------
 # TODO (In order of priority)
 1) Implement axis argument for the NDArray creation functions
 2) Separate `array(object)` and `NDArray.__init__(shape)`.
@@ -1996,7 +1996,7 @@ def tril[
     var final_offset: Int = 1
     var result: NDArray[
         dtype
-    ] = m.deep_copy()  # * We should move this to be inplace operation perhaps.
+    ] = m.copy()  # * We should move this to be inplace operation perhaps.
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(i + 1 + k, m.shape[1]):
@@ -2059,7 +2059,7 @@ def triu[
     """
     var initial_offset: Int = 1
     var final_offset: Int = 1
-    var result: NDArray[dtype] = m.deep_copy()
+    var result: NDArray[dtype] = m.copy()
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(0, i + k):
@@ -2195,7 +2195,6 @@ def astype[
 
     comptime if target == DType.bool:
 
-        @parameter
         def vectorized_astype[
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
@@ -2208,10 +2207,9 @@ def astype[
     else:
         comptime if target == DType.bool:
 
-            @parameter
             def vectorized_astypenb_from_b[
                 simd_width: Int
-            ](idx: Int) unified {mut result, read a} -> None:
+            ](idx: Int) {mut result, read a} -> None:
                 result._buf.ptr.store(
                     idx,
                     (a._buf.ptr + idx)
@@ -2223,10 +2221,9 @@ def astype[
 
         else:
 
-            @parameter
             def vectorized_astypenb[
                 simd_width: Int
-            ](idx: Int) unified {mut result, read a} -> None:
+            ](idx: Int) {mut result, read a} -> None:
                 result._buf.ptr.store(
                     idx, a._buf.ptr.load[width=simd_width](idx).cast[target]()
                 )

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2345,7 +2345,7 @@ def fromstring[
                 var number = atof(number_as_str).cast[dtype]()
                 data.append(number)  # Add the number to the data buffer
                 number_as_str = ""  # Clean the number cache
-                shape[-1] = shape[-1] + 1
+                shape[len(shape) - 1] = shape[len(shape) - 1] + 1
         if chr(Int(b)) == "]":
             level = level - 1
             if level < 0:

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2198,7 +2198,7 @@ def astype[
         @parameter
         def vectorized_astype[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             (result.unsafe_ptr() + idx).strided_store[width=simd_width](
                 a._buf.ptr.load[width=simd_width](idx).cast[target](), 1
             )

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -17,6 +17,7 @@ from std.sys import simd_width_of
 from numojo.core.layout import Flags, NDArrayShape, NDArrayStrides
 from numojo.routines.creation import arange
 from numojo.core.ndarray import NDArray
+from numojo.routines.creation import _0darray
 
 # ===----------------------------------------------------------------------=== #
 # `apply_along_axis`
@@ -34,7 +35,7 @@ from numojo.core.ndarray import NDArray
 
 # def apply_along_axis[
 #     dtype: DType,
-#     func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
+#     func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
 #         dtype_func
 #     ],
 # ](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
@@ -60,7 +61,7 @@ from numojo.core.ndarray import NDArray
 #     var res: NDArray[dtype]
 
 #     if a.ndim == 1:
-#         res = numojo.creation._0darray[dtype](0)
+#         res = _0darray[dtype](0)
 #         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
 #     else:
@@ -82,9 +83,9 @@ from numojo.core.ndarray import NDArray
 
 def apply_along_axis_reduce_to_int[
     dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
-        DType.int
-    ],
+    func1d: def[dtype_func: DType](
+        NDArray[dtype_func]
+    ) capturing raises -> Scalar[DType.int],
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
@@ -109,7 +110,7 @@ def apply_along_axis_reduce_to_int[
     var res: NDArray[DType.int]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[DType.int](0)
+        res = _0darray[DType.int](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
     else:
@@ -131,9 +132,9 @@ def apply_along_axis_reduce_to_int[
 
 def apply_along_axis_reduce[
     dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
-        dtype_func
-    ],
+    func1d: def[dtype_func: DType](
+        NDArray[dtype_func]
+    ) capturing raises -> Scalar[dtype_func],
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
@@ -160,7 +161,7 @@ def apply_along_axis_reduce[
     var res: NDArray[dtype]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[dtype](0)
+        res = _0darray[dtype](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
     else:
@@ -194,9 +195,9 @@ def apply_along_axis_reduce[
 def apply_along_axis_reduce_with_dtype[
     dtype: DType,
     returned_dtype: DType,
-    func1d: fn[dtype_func: DType, returned_dtype_func: DType](
+    func1d: def[dtype_func: DType, returned_dtype_func: DType](
         NDArray[dtype_func]
-    ) raises -> Scalar[returned_dtype_func],
+    ) capturing raises -> Scalar[returned_dtype_func],
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[returned_dtype]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
@@ -222,7 +223,7 @@ def apply_along_axis_reduce_with_dtype[
     var res: NDArray[returned_dtype]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[returned_dtype](0)
+        res = _0darray[returned_dtype](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype, returned_dtype](a))
 
     else:
@@ -248,9 +249,9 @@ def apply_along_axis_reduce_with_dtype[
 
 def apply_along_axis_preserve[
     dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
-        dtype_func
-    ],
+    func1d: def[dtype_func: DType](
+        NDArray[dtype_func]
+    ) capturing raises -> NDArray[dtype_func],
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Applies a function to a NDArray by axis without reducing that dimension.
@@ -326,7 +327,9 @@ def apply_along_axis_preserve[
 
 def apply_along_axis_inplace[
     dtype: DType,
-    func1d: fn[dtype_func: DType](mut NDArray[dtype_func]) raises -> None,
+    func1d: def[dtype_func: DType](
+        mut NDArray[dtype_func]
+    ) capturing raises -> None,
 ](mut a: NDArray[dtype], axis: Int) raises -> None:
     """
     Applies a function to a NDArray by axis without reducing that dimension.
@@ -391,9 +394,9 @@ def apply_along_axis_inplace[
 
 def apply_along_axis_indices[
     dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
-        DType.int
-    ],
+    func1d: def[dtype_func: DType](
+        NDArray[dtype_func]
+    ) capturing raises -> NDArray[DType.int],
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """
     Applies a function to a NDArray by axis without reducing that dimension.

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Functional programming (numojo.routines.functional)
-
+---------------------------------------------------
 This module implements functional programming utilities for NDArray operations, such as `apply_along_axis`.
 """
 

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -35,7 +35,7 @@ from numojo.routines.creation import _0darray
 
 # def apply_along_axis[
 #     dtype: DType,
-#     func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
+#     func1d: def[dtype_func: DType](NDArray[dtype_func]) raises thin -> Scalar[
 #         dtype_func
 #     ],
 # ](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -6,11 +6,11 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Indexing routines (numojo.routines.indexing)
-
+-----------------------------------------------
 - Generating index arrays
 - Indexing-like operations
 - Inserting data into arrays
-- Iterating over arrays
+- Iterating over arrays.
 """
 
 from std.memory import memcpy

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -17,6 +17,7 @@ from std.memory import memcpy
 from std.sys import simd_width_of
 from std.algorithm import vectorize
 
+from numojo import broadcast_to
 from numojo.core.ndarray import NDArray
 from numojo.core.layout import NDArrayStrides
 from numojo.core.indexing import IndexMethods
@@ -322,7 +323,7 @@ def take_along_axis[
         arr_shape_new[normalized_axis] = indices.shape[normalized_axis]
 
         try:
-            broadcasted_indices = numojo.broadcast_to(indices, arr_shape_new)
+            broadcasted_indices = broadcast_to(indices, arr_shape_new)
         except e:
             raise Error(
                 String(

--- a/numojo/routines/io/__init__.mojo
+++ b/numojo/routines/io/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """I/O routines (numojo.routines.io)
-
+---------------------------------
 This module provides functions for reading and writing arrays to and from files, as well as formatting options for printing arrays.
 """
 from .files import loadtxt, savetxt, load, save

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -6,14 +6,14 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """File I/O (numojo.routines.io.files)
-
+--------------------------------------
 This module provides functions for reading and writing arrays to and from files.
 """
 from std.collections.optional import Optional
 from std.python import Python, PythonObject
 from std.memory import UnsafePointer, Span
 
-from numojo.routines.creation import fromstring
+from numojo.routines.creation import fromstring, array
 
 # We call into the numpy backend for now, this at least let's people go back and forth smoothly.
 # might consider implementing a funciton to write a .numojo file which can be read by both numpy and numojo.
@@ -50,8 +50,8 @@ def load[
         encoding=PythonObject(encoding),
         max_header_size=PythonObject(max_header_size),
     )
-    var array = numojo.array[dtype](data=data)
-    return array^
+    var arr = array[dtype](data=data)
+    return arr^
 
 
 # @parameter
@@ -255,8 +255,8 @@ def loadtxt[
         skiprows=PythonObject(skiprows),
         ndmin=PythonObject(ndmin),
     )
-    var array = numojo.array[dtype](data=data)
-    return array^
+    var arr = array[dtype](data=data)
+    return arr^
 
 
 def savetxt[

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Formatting (numojo.routines.io.formatting)
-
+------------------------------------------
 This module provides functions for formatting arrays and values for printing, including options for precision, scientific notation, and complex number formatting.
 """
 from std.math import pow

--- a/numojo/routines/linalg/__init__.mojo
+++ b/numojo/routines/linalg/__init__.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Linear algebra routines (numojo.routines.linalg)
-
+------------------------------------------------
 This module provides functions for linear algebra operations, including matrix decompositions, norms, products, and solving linear systems etc.
 """
 from .decompositions import lu_decomposition, qr, eig

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Decompositions (numojo.routines.linalg.decompositions)
-
+---------------------------------------------------------
 This module provides functions for matrix decompositions, including LU decomposition, QR decomposition, and eigenvalue decomposition for symmetric matrices.
 """
 from std.sys import simd_width_of

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -28,10 +28,9 @@ def _compute_householder[
     comptime sqrt2: Scalar[dtype] = 1.4142135623730951
     var rRows = R.shape[0]
 
-    @parameter
     def load_store_vec[
         n_elements: Int
-    ](i: Int) unified {mut H, mut R, read work_index}:
+    ](i: Int) {mut H, mut R, read work_index}:
         var r_value = R._load[n_elements](i + work_index, work_index)
         H._store[n_elements](i + work_index, work_index, r_value)
         R._store[n_elements](i + work_index, work_index, 0.0)
@@ -40,10 +39,9 @@ def _compute_householder[
 
     var norm = Scalar[dtype](0)
 
-    @parameter
     def calculate_norm[
         width: Int
-    ](i: Int) unified {mut norm, read H, read work_index}:
+    ](i: Int) {mut norm, read H, read work_index}:
         norm += (H._load[width=width](i, work_index) ** 2).reduce_add()
 
     vectorize[simd_width](rRows, calculate_norm)
@@ -61,10 +59,9 @@ def _compute_householder[
 
     R._store(work_index, work_index, -1 / scaling_factor)
 
-    @parameter
     def scaling_factor_vec[
         simd_width: Int
-    ](i: Int) unified {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
@@ -76,10 +73,9 @@ def _compute_householder[
 
     scaling_factor = builtin_math.sqrt(1.0 / increment)
 
-    @parameter
     def scaling_factor_increment_vec[
         simd_width: Int
-    ](i: Int) unified {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
@@ -103,20 +99,18 @@ def _apply_householder[
     for j in range(column_start, aCols):
         var dot: SIMD[dtype, 1] = 0.0
 
-        @parameter
         def calculate_norm[
             width: Int
-        ](i: Int) unified {mut dot, read H, read A, read work_index, read j}:
+        ](i: Int) {mut dot, read H, read A, read work_index, read j}:
             dot += (
                 H._load[width=width](i, work_index) * A._load[width=width](i, j)
             ).reduce_add()
 
         vectorize[simdwidth](aRows, calculate_norm)
 
-        @parameter
         def closure[
             width: Int
-        ](i: Int) unified {mut A, read H, read work_index, read j, read dot}:
+        ](i: Int) {mut A, read H, read work_index, read j, read dot}:
             val = A._load[width](i, j) - H._load[width](i, work_index) * dot
             A._store(i, j, val)
 
@@ -200,7 +194,6 @@ def lu_decomposition[
     )
 
     # Fill in L and U
-    # @parameter
     # def calculate(i: Int):
     for i in range(0, n):
         for j in range(i, n):

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -28,9 +28,7 @@ def _compute_householder[
     comptime sqrt2: Scalar[dtype] = 1.4142135623730951
     var rRows = R.shape[0]
 
-    def load_store_vec[
-        n_elements: Int
-    ](i: Int) {mut H, mut R, read work_index}:
+    def load_store_vec[n_elements: Int](i: Int) {mut H, mut R, read work_index}:
         var r_value = R._load[n_elements](i + work_index, work_index)
         H._store[n_elements](i + work_index, work_index, r_value)
         R._store[n_elements](i + work_index, work_index, 0.0)
@@ -39,9 +37,7 @@ def _compute_householder[
 
     var norm = Scalar[dtype](0)
 
-    def calculate_norm[
-        width: Int
-    ](i: Int) {mut norm, read H, read work_index}:
+    def calculate_norm[width: Int](i: Int) {mut norm, read H, read work_index}:
         norm += (H._load[width=width](i, work_index) ** 2).reduce_add()
 
     vectorize[simd_width](rRows, calculate_norm)

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Miscellaneous Linear Algebra Routines (numojo.routines.linalg.misc)
-
+-------------------------------------------------------------------
 This module provides miscellaneous linear algebra routines, such as extracting diagonals and checking for symmetry.
 """
 

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Norms and other numbers (numojo.routines.linalg.norms)
-
+------------------------------------------------------
 This module provides functions for computing quantities related to linear algebra, such as determinants and traces.
 """
 

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -97,6 +97,7 @@ def dot[
     comptime width = simd_width_of[dtype]()
     if array1.ndim == array2.ndim == 1:
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(array1.size))
+
         def vectorized_dot[
             simd_width: Int
         ](idx: Int) {mut result, read array1, read array2} -> None:
@@ -280,6 +281,7 @@ def matmul_2darray[
     @parameter
     def calculate_A_rows(m: Int):
         for k in range(t1):
+
             def dot[
                 simd_width: Int
             ](n: Int) {
@@ -428,11 +430,10 @@ def matmul[
         @parameter
         def calculate_resultresult(m: Int):
             for k in range(A.shape[1]):
+
                 def dot[
                     simd_width: Int
-                ](n: Int) {
-                    mut result, read A, read B, read m, read k
-                } -> None:
+                ](n: Int) {mut result, read A, read B, read m, read k} -> None:
                     result._store[simd_width](
                         m,
                         n,
@@ -451,11 +452,10 @@ def matmul[
         @parameter
         def calculate_FF(n: Int):
             for k in range(A.shape[1]):
+
                 def dot_F[
                     simd_width: Int
-                ](m: Int) {
-                    mut result, read A, read B, read n, read k
-                } -> None:
+                ](m: Int) {mut result, read A, read B, read n, read k} -> None:
                     result._store[simd_width](
                         m,
                         n,
@@ -475,11 +475,10 @@ def matmul[
         def calculate_resultF(m: Int):
             for n in range(B.shape[1]):
                 var sum: Scalar[dtype] = 0.0
+
                 def dot_product[
                     simd_width: Int
-                ](k: Int) {
-                    mut sum, read A, read B, read m, read n
-                } -> None:
+                ](k: Int) {mut sum, read A, read B, read m, read n} -> None:
                     sum += (
                         A._load[simd_width](m, k) * B._load[simd_width](k, n)
                     ).reduce_add()

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Matrix and vector products (numojo.routines.linalg.products)
-
+---------------------------------------------------------------
 This module provides functions for computing products of vectors and matrices, such as cross product, dot product, and matrix multiplication.
 """
 
@@ -97,11 +97,9 @@ def dot[
     comptime width = simd_width_of[dtype]()
     if array1.ndim == array2.ndim == 1:
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(array1.size))
-
-        @parameter
         def vectorized_dot[
             simd_width: Int
-        ](idx: Int) unified {mut result, read array1, read array2} -> None:
+        ](idx: Int) {mut result, read array1, read array2} -> None:
             result._buf.ptr.store(
                 idx,
                 array1._buf.ptr.load[width=simd_width](idx)
@@ -153,10 +151,9 @@ def matmul_tiled_unrolled_parallelized[
         def calc_tile[tile_x: Int, tile_y: Int](x: Int, y: Int):
             for k in range(y, y + tile_y):
 
-                @parameter
                 def dot[
                     simd_width: Int
-                ](n: Int) unified {
+                ](n: Int) {
                     mut result,
                     read A,
                     read B,
@@ -283,11 +280,9 @@ def matmul_2darray[
     @parameter
     def calculate_A_rows(m: Int):
         for k in range(t1):
-
-            @parameter
             def dot[
                 simd_width: Int
-            ](n: Int) unified {
+            ](n: Int) {
                 mut result, read A, read B, read t2, read t1, read k, read m
             } -> None:
                 result._buf.ptr.store(
@@ -433,11 +428,9 @@ def matmul[
         @parameter
         def calculate_resultresult(m: Int):
             for k in range(A.shape[1]):
-
-                @parameter
                 def dot[
                     simd_width: Int
-                ](n: Int) unified {
+                ](n: Int) {
                     mut result, read A, read B, read m, read k
                 } -> None:
                     result._store[simd_width](
@@ -458,11 +451,9 @@ def matmul[
         @parameter
         def calculate_FF(n: Int):
             for k in range(A.shape[1]):
-
-                @parameter
                 def dot_F[
                     simd_width: Int
-                ](m: Int) unified {
+                ](m: Int) {
                     mut result, read A, read B, read n, read k
                 } -> None:
                     result._store[simd_width](
@@ -484,11 +475,9 @@ def matmul[
         def calculate_resultF(m: Int):
             for n in range(B.shape[1]):
                 var sum: Scalar[dtype] = 0.0
-
-                @parameter
                 def dot_product[
                     simd_width: Int
-                ](k: Int) unified {
+                ](k: Int) {
                     mut sum, read A, read B, read m, read n
                 } -> None:
                     sum += (

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Linear Algebra Solver (numojo.routines.linalg.solving)
-
+------------------------------------------------------
 Provides:
     - Solver of `Ax = y` using LU decomposition algorithm.
     - Inverse of an invertible matrix.

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -396,16 +396,16 @@ def solve[
 
     var A_pivoted_Pair: Tuple[
         Matrix[dtype], Matrix[dtype], Int
-    ] = partial_pivoting(A.deep_copy())
+    ] = partial_pivoting(A.copy())
 
-    var pivoted_A = A_pivoted_Pair[0].deep_copy()
-    var P = A_pivoted_Pair[1].deep_copy()
+    var pivoted_A = A_pivoted_Pair[0].copy()
+    var P = A_pivoted_Pair[1].copy()
 
     var L_U: Tuple[Matrix[dtype], Matrix[dtype]] = lu_decomposition[dtype](
         pivoted_A
     )
-    L = L_U[0].deep_copy()
-    U = L_U[1].deep_copy()
+    L = L_U[0].copy()
+    U = L_U[1].copy()
 
     var m: Int = A.shape[0]
     var n: Int = Y.shape[1]

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -62,7 +62,7 @@ def greater[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a > b
+        return a.gt(b)
 
     return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, array2)
 
@@ -103,7 +103,7 @@ def greater[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a > b
+        return a.gt(b)
 
     return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, scalar)
 
@@ -145,7 +145,7 @@ def greater_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a >= b
+        return a.ge(b)
 
     return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, array2)
 
@@ -186,7 +186,7 @@ def greater_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a >= b
+        return a.ge(b)
 
     return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, scalar)
 
@@ -228,7 +228,7 @@ def less[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a < b
+        return a.lt(b)
 
     return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, array2)
 
@@ -269,7 +269,7 @@ def less[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a < b
+        return a.lt(b)
 
     return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, scalar)
 
@@ -311,7 +311,7 @@ def less_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a <= b
+        return a.le(b)
 
     return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, array2)
 
@@ -352,7 +352,7 @@ def less_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a <= b
+        return a.le(b)
 
     return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, scalar)
 
@@ -394,7 +394,7 @@ def equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a == b
+        return a.eq(b)
 
     return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, array2)
 
@@ -435,7 +435,7 @@ def equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a == b
+        return a.eq(b)
 
     return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, scalar)
 
@@ -477,7 +477,7 @@ def not_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a != b
+        return a.ne(b)
 
     return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, array2)
 
@@ -518,7 +518,7 @@ def not_equal[
     ) -> SIMD[
         DType.bool, simd_w
     ]:
-        return a != b
+        return a.ne(b)
 
     return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, scalar)
 

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -52,12 +52,18 @@ def greater[
         print(greater[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
+
     @parameter
-    def gt_kernel[type: DType, simd_w: Int](
+    def gt_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a > b
+
     return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, array2)
 
 
@@ -87,12 +93,18 @@ def greater[
         print(greater[nm.f64](arr, 2.0))  # Output: [False, False, True]
         ```
     """
+
     @parameter
-    def gt_kernel[type: DType, simd_w: Int](
+    def gt_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a > b
+
     return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, scalar)
 
 
@@ -123,12 +135,18 @@ def greater_equal[
         print(greater_equal[nm.f64](arr1, arr2))  # Output: [True, True, False]
         ```
     """
+
     @parameter
-    def ge_kernel[type: DType, simd_w: Int](
+    def ge_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a >= b
+
     return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, array2)
 
 
@@ -158,12 +176,18 @@ def greater_equal[
         print(greater_equal[nm.f64](arr, 2.0))  # Output: [False, True, True]
         ```
     """
+
     @parameter
-    def ge_kernel[type: DType, simd_w: Int](
+    def ge_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a >= b
+
     return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, scalar)
 
 
@@ -194,12 +218,18 @@ def less[
         print(less[nm.f64](arr1, arr2))  # Output: [False, True, False]
         ```
     """
+
     @parameter
-    def lt_kernel[type: DType, simd_w: Int](
+    def lt_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a < b
+
     return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, array2)
 
 
@@ -229,12 +259,18 @@ def less[
         print(less[nm.f64](arr, 2.0))  # Output: [True, False, False]
         ```
     """
+
     @parameter
-    def lt_kernel[type: DType, simd_w: Int](
+    def lt_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a < b
+
     return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, scalar)
 
 
@@ -265,12 +301,18 @@ def less_equal[
         print(less_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
+
     @parameter
-    def le_kernel[type: DType, simd_w: Int](
+    def le_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a <= b
+
     return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, array2)
 
 
@@ -300,12 +342,18 @@ def less_equal[
         print(less_equal[nm.f64](arr, 2.0))  # Output: [True, True, False]
         ```
     """
+
     @parameter
-    def le_kernel[type: DType, simd_w: Int](
+    def le_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a <= b
+
     return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, scalar)
 
 
@@ -336,12 +384,18 @@ def equal[
         print(equal[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
+
     @parameter
-    def eq_kernel[type: DType, simd_w: Int](
+    def eq_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a == b
+
     return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, array2)
 
 
@@ -371,12 +425,18 @@ def equal[
         print(equal[nm.f64](arr, 2.0))  # Output: [False, True, False]
         ```
     """
+
     @parameter
-    def eq_kernel[type: DType, simd_w: Int](
+    def eq_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a == b
+
     return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, scalar)
 
 
@@ -407,12 +467,18 @@ def not_equal[
         print(not_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
+
     @parameter
-    def ne_kernel[type: DType, simd_w: Int](
+    def ne_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a != b
+
     return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, array2)
 
 
@@ -442,12 +508,18 @@ def not_equal[
         print(not_equal[nm.f64](arr, 2.0))  # Output: [True, False, True]
         ```
     """
+
     @parameter
-    def ne_kernel[type: DType, simd_w: Int](
+    def ne_kernel[
+        type: DType, simd_w: Int
+    ](
         a: SIMD[type, simd_w],
         b: SIMD[type, simd_w],
-    ) -> SIMD[DType.bool, simd_w]:
+    ) -> SIMD[
+        DType.bool, simd_w
+    ]:
         return a != b
+
     return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, scalar)
 
 

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Comparison routines (numojo.routines.logic.comparison)
-
+---------------------------------------------------------
 Implements comparison math routines for NDArrays and Matrices.
 """
 
@@ -52,7 +52,13 @@ def greater[
         print(greater[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, array2)
+    @parameter
+    def gt_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a > b
+    return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, array2)
 
 
 def greater[
@@ -81,7 +87,13 @@ def greater[
         print(greater[nm.f64](arr, 2.0))  # Output: [False, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, scalar)
+    @parameter
+    def gt_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a > b
+    return HostExecutor.apply_binary_predicate[dtype, gt_kernel](array1, scalar)
 
 
 def greater_equal[
@@ -111,7 +123,13 @@ def greater_equal[
         print(greater_equal[nm.f64](arr1, arr2))  # Output: [True, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, array2)
+    @parameter
+    def ge_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a >= b
+    return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, array2)
 
 
 def greater_equal[
@@ -140,7 +158,13 @@ def greater_equal[
         print(greater_equal[nm.f64](arr, 2.0))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, scalar)
+    @parameter
+    def ge_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a >= b
+    return HostExecutor.apply_binary_predicate[dtype, ge_kernel](array1, scalar)
 
 
 def less[
@@ -170,7 +194,13 @@ def less[
         print(less[nm.f64](arr1, arr2))  # Output: [False, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, array2)
+    @parameter
+    def lt_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a < b
+    return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, array2)
 
 
 def less[
@@ -199,7 +229,13 @@ def less[
         print(less[nm.f64](arr, 2.0))  # Output: [True, False, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, scalar)
+    @parameter
+    def lt_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a < b
+    return HostExecutor.apply_binary_predicate[dtype, lt_kernel](array1, scalar)
 
 
 def less_equal[
@@ -229,7 +265,13 @@ def less_equal[
         print(less_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, array2)
+    @parameter
+    def le_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a <= b
+    return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, array2)
 
 
 def less_equal[
@@ -258,7 +300,13 @@ def less_equal[
         print(less_equal[nm.f64](arr, 2.0))  # Output: [True, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, scalar)
+    @parameter
+    def le_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a <= b
+    return HostExecutor.apply_binary_predicate[dtype, le_kernel](array1, scalar)
 
 
 def equal[
@@ -288,7 +336,13 @@ def equal[
         print(equal[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, array2)
+    @parameter
+    def eq_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a == b
+    return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, array2)
 
 
 def equal[
@@ -317,7 +371,13 @@ def equal[
         print(equal[nm.f64](arr, 2.0))  # Output: [False, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, scalar)
+    @parameter
+    def eq_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a == b
+    return HostExecutor.apply_binary_predicate[dtype, eq_kernel](array1, scalar)
 
 
 def not_equal[
@@ -347,7 +407,13 @@ def not_equal[
         print(not_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ne](array1, array2)
+    @parameter
+    def ne_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a != b
+    return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, array2)
 
 
 def not_equal[
@@ -376,7 +442,13 @@ def not_equal[
         print(not_equal[nm.f64](arr, 2.0))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ne](array1, scalar)
+    @parameter
+    def ne_kernel[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w],
+        b: SIMD[type, simd_w],
+    ) -> SIMD[DType.bool, simd_w]:
+        return a != b
+    return HostExecutor.apply_binary_predicate[dtype, ne_kernel](array1, scalar)
 
 
 # ===------------------------------------------------------------------------===#

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -68,11 +68,13 @@ def isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isinf(arr))  # Output: [False, False, False, False, False]
         ```
     """
+
     @parameter
     def is_inf_kernel[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return math.isinf(x)
+
     return HostExecutor.apply_unary_predicate[dtype, is_inf_kernel](array)
 
 
@@ -99,11 +101,13 @@ def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isfinite(arr))  # Output: [True, True, True]
         ```
     """
+
     @parameter
     def is_finite_kernel[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return math.isfinite(x)
+
     return HostExecutor.apply_unary_predicate[dtype, is_finite_kernel](array)
 
 
@@ -130,11 +134,13 @@ def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isnan(arr))  # Output: [False, False, False]
         ```
     """
+
     @parameter
     def is_nan_kernel[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return math.isnan(x)
+
     return HostExecutor.apply_unary_predicate[dtype, is_nan_kernel](array)
 
 
@@ -161,11 +167,13 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isneginf(arr))  # Output: [False, False, False]
         ```
     """
+
     @parameter
     def is_neginf[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
+
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 
@@ -192,6 +200,7 @@ def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isposinf(arr))  # Output: [False, False, False]
         ```
     """
+
     @parameter
     def is_posinf[
         dtype: DType, simd_width: Int

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -6,8 +6,8 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Contents routines (numojo.routines.logic.contents)
-
-Implements Checking routines: currently not SIMD due to bool bit packing issue
+-----------------------------------------------------
+Implements Checking routines: currently not SIMD due to bool bit packing issue.
 """
 
 import std.math as math
@@ -68,7 +68,12 @@ def isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isinf(arr))  # Output: [False, False, False, False, False]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isinf](array)
+    @parameter
+    def is_inf_kernel[
+        dtype: DType, simd_width: Int
+    ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
+        return math.isinf(x)
+    return HostExecutor.apply_unary_predicate[dtype, is_inf_kernel](array)
 
 
 def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -94,7 +99,12 @@ def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isfinite(arr))  # Output: [True, True, True]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isfinite](array)
+    @parameter
+    def is_finite_kernel[
+        dtype: DType, simd_width: Int
+    ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
+        return math.isfinite(x)
+    return HostExecutor.apply_unary_predicate[dtype, is_finite_kernel](array)
 
 
 def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -120,7 +130,12 @@ def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isnan(arr))  # Output: [False, False, False]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isnan](array)
+    @parameter
+    def is_nan_kernel[
+        dtype: DType, simd_width: Int
+    ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
+        return math.isnan(x)
+    return HostExecutor.apply_unary_predicate[dtype, is_nan_kernel](array)
 
 
 def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -146,12 +161,11 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isneginf(arr))  # Output: [False, False, False]
         ```
     """
-
+    @parameter
     def is_neginf[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
-
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 
@@ -178,7 +192,7 @@ def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isposinf(arr))  # Output: [False, False, False]
         ```
     """
-
+    @parameter
     def is_posinf[
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Logical Operations Module (numojo.routines.logic.logical_ops)
-
+----------------------------------------------------------------
 This module implements element-wise logical operations for NDArray, ComplexNDArray, and Matrix types in the NuMojo library.
 """
 
@@ -64,6 +64,7 @@ def logical_and[
             )
         )
 
+    @parameter
     def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
@@ -115,6 +116,7 @@ def logical_or[
             )
         )
 
+    @parameter
     def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
@@ -153,6 +155,7 @@ def logical_not[
         ```
     """
 
+    @parameter
     def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
@@ -204,6 +207,7 @@ def logical_xor[
             )
         )
 
+    @parameter
     def kernel[
         dtype: DType, width: Int
     ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
@@ -247,7 +251,7 @@ def logical_and[
 
         var a = nm.arange[ci32](CScalar[ci32](0), CScalar[ci32](10))
         var b = nm.arange[ci32](CScalar[ci32](5), CScalar[ci32](15))
-        var result = logical_and(a, b)
+        var result = logical_and[ci32](a, b)
         ```
     """
     if a.shape != b.shape:
@@ -297,7 +301,7 @@ def logical_or[
 
         var a = nm.arange[ci32](CScalar[ci32](0), CScalar[ci32](10))
         var b = nm.arange[ci32](CScalar[ci32](5), CScalar[ci32](15))
-        var result = logical_or(a, b)
+        var result = logical_or[ci32](a, b)
         ```
     """
     if a.shape != b.shape:
@@ -320,7 +324,7 @@ def logical_or[
 def logical_not[
     cdtype: ComplexDType
 ](a: ComplexNDArray[cdtype]) raises -> ComplexNDArray[cdtype] where (
-    cdtype == ComplexDType.bool or cdtype.is_integral()
+    cdtype.dtype == DType.bool or cdtype.dtype.is_integral()
 ):
     """
     Element-wise logical NOT operation on a complex array.
@@ -343,7 +347,7 @@ def logical_not[
         from numojo.routines.logic.logical_ops import logical_not
 
         var a = nm.arange[ci32](CScalar[ci32](0), CScalar[ci32](10))
-        var result = logical_not(a)
+        var result = logical_not[ci32](a)
         ```
     """
     var res: ComplexNDArray[cdtype] = ComplexNDArray[cdtype](a.shape)
@@ -382,7 +386,7 @@ def logical_xor[
 
         var a = nm.arange[ci32](CScalar[ci32](0), CScalar[ci32](10))
         var b = nm.arange[ci32](CScalar[ci32](5), CScalar[ci32](15))
-        var result = logical_xor(a, b)
+        var result = logical_xor[ci32](a, b)
         ```
     """
     if a.shape != b.shape:

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -352,7 +352,7 @@ def logical_not[
     """
     var res: ComplexNDArray[cdtype] = ComplexNDArray[cdtype](a.shape)
     for i in range(res.size):
-        res.store(i, ~a.load(i))
+        res.store(i, a.load(i).__invert__())
     return res^
 
 

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -226,7 +226,7 @@ def logical_and[
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
 ) raises -> ComplexNDArray[cdtype] where (
-    cdtype == ComplexDType.bool or cdtype.is_integral()
+    cdtype.dtype == DType.bool or cdtype.dtype.is_integral()
 ):
     """
     Element-wise logical AND operation between two complex arrays.
@@ -276,7 +276,7 @@ def logical_or[
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
 ) raises -> ComplexNDArray[cdtype] where (
-    cdtype == ComplexDType.bool or cdtype.is_integral()
+    cdtype.dtype == DType.bool or cdtype.dtype.is_integral()
 ):
     """
     Element-wise logical OR operation between two complex arrays.
@@ -361,7 +361,7 @@ def logical_xor[
 ](
     a: ComplexNDArray[cdtype], b: ComplexNDArray[cdtype]
 ) raises -> ComplexNDArray[cdtype] where (
-    cdtype == ComplexDType.bool or cdtype.is_integral()
+    cdtype.dtype == DType.bool or cdtype.dtype.is_integral()
 ):
     """
     Element-wise logical XOR operation between two complex arrays.

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Truth value testing (numojo.routines.logic.truth)
-
+----------------------------------------------------
 This module implements the truth value testing functions, such as `all` and `any`, for both `NDArray` and `Matrix`.
 """
 
@@ -45,10 +45,9 @@ def all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](True)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    @parameter
     def closure[
         simd_width: Int
-    ](idx: Int) unified {mut result, read array} -> None:
+    ](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result & simd_data).reduce_and()
 
@@ -78,10 +77,9 @@ def any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](False)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    @parameter
     def closure[
         simd_width: Int
-    ](idx: Int) unified {mut result, read array} -> None:
+    ](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result | simd_data).reduce_or()
 
@@ -107,8 +105,7 @@ def all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](1)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def closure[width: Int](i: Int) unified {mut res, read A}:
+    def closure[width: Int](i: Int) {mut res, read A}:
         res = (res & A._buf.ptr.load[width=width](i)).reduce_and()
 
     vectorize[width](A.size, closure)
@@ -126,9 +123,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.ones[dtype](shape=(1, A.shape[1]))
 
         for i in range(A.shape[0]):
-
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) & A._load[width](i, j)
                 )
@@ -142,8 +137,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -171,8 +165,7 @@ def any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](0)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_and[width: Int](i: Int) unified {mut res, read A}:
+    def cal_and[width: Int](i: Int) {mut res, read A}:
         res = res | A._buf.ptr.load[width=width](i).reduce_or()
 
     vectorize[width](A.size, cal_and)
@@ -190,9 +183,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.zeros[dtype](shape=(1, A.shape[1]))
 
         for i in range(A.shape[0]):
-
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) | A._load[width](i, j)
                 )
@@ -206,8 +197,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -45,9 +45,7 @@ def all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](True)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    def closure[
-        simd_width: Int
-    ](idx: Int) {mut result, read array} -> None:
+    def closure[simd_width: Int](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result & simd_data).reduce_and()
 
@@ -77,9 +75,7 @@ def any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](False)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    def closure[
-        simd_width: Int
-    ](idx: Int) {mut result, read array} -> None:
+    def closure[simd_width: Int](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result | simd_data).reduce_or()
 
@@ -123,6 +119,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.ones[dtype](shape=(1, A.shape[1]))
 
         for i in range(A.shape[0]):
+
             def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) & A._load[width](i, j)
@@ -183,6 +180,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         var B = Matrix.zeros[dtype](shape=(1, A.shape[1]))
 
         for i in range(A.shape[0]):
+
             def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) | A._load[width](i, j)

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Manipulation routines (numojo.routines.manipulation)
-
+----------------------------------------------------
 This module implements routines that manipulate the shape and layout of arrays, such as reshaping, transposing, broadcasting, and flipping.
 """
 

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -40,11 +40,15 @@ def add[
     Returns:
         The element-wise sum of `array1` and`array2`.
     """
+
     @parameter
     def add_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 + simd2
+
     return HostExecutor.apply_binary[dtype, add_kernel](array1, array2)
 
 
@@ -64,11 +68,15 @@ def add[
     Returns:
         The element-wise sum of array and scalar.
     """
+
     @parameter
     def add_kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w], scalar_simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w], scalar_simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd + scalar_simd
+
     return HostExecutor.apply_binary[dtype, add_kernel](array, scalar)
 
 
@@ -88,11 +96,15 @@ def add[
     Returns:
         The element-wise sum of scalar and array.
     """
+
     @parameter
     def add_kernel[
         dtype: DType, simd_w: Int
-    ](scalar_simd: SIMD[dtype, simd_w], simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](scalar_simd: SIMD[dtype, simd_w], simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return scalar_simd + simd
+
     return HostExecutor.apply_binary[dtype, add_kernel](scalar, array)
 
 
@@ -160,8 +172,11 @@ def sub[
     @parameter
     def sub_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 - simd2
+
     return HostExecutor.apply_binary[dtype, sub_kernel](array1, array2)
 
 
@@ -185,8 +200,11 @@ def sub[
     @parameter
     def sub_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 - simd2
+
     return HostExecutor.apply_binary[dtype, sub_kernel](array, scalar)
 
 
@@ -210,8 +228,11 @@ def sub[
     @parameter
     def sub_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 - simd2
+
     return HostExecutor.apply_binary[dtype, sub_kernel](scalar, array)
 
 
@@ -240,8 +261,11 @@ def mod[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](array1, array2)
 
 
@@ -265,8 +289,11 @@ def mod[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](array, scalar)
 
 
@@ -290,8 +317,11 @@ def mod[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](scalar, array)
 
 
@@ -323,8 +353,11 @@ def mul[
     @parameter
     def mul_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 * simd2
+
     return HostExecutor.apply_binary[dtype, mul_kernel](array1, array2)
 
 
@@ -348,8 +381,11 @@ def mul[
     @parameter
     def mul_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 * simd2
+
     return HostExecutor.apply_binary[dtype, mul_kernel](array, scalar)
 
 
@@ -373,8 +409,11 @@ def mul[
     @parameter
     def mul_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 * simd2
+
     return HostExecutor.apply_binary[dtype, mul_kernel](scalar, array)
 
 
@@ -444,8 +483,11 @@ def div[
     @parameter
     def truediv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 / simd2
+
     return HostExecutor.apply_binary[dtype, truediv_kernel](array1, array2)
 
 
@@ -469,8 +511,11 @@ def div[
     @parameter
     def truediv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 / simd2
+
     return HostExecutor.apply_binary[dtype, truediv_kernel](array, scalar)
 
 
@@ -494,8 +539,11 @@ def div[
     @parameter
     def truediv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 / simd2
+
     return HostExecutor.apply_binary[dtype, truediv_kernel](scalar, array)
 
 
@@ -527,8 +575,11 @@ def floor_div[
     @parameter
     def floordiv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 // simd2
+
     return HostExecutor.apply_binary[dtype, floordiv_kernel](array1, array2)
 
 
@@ -552,8 +603,11 @@ def floor_div[
     @parameter
     def floordiv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 // simd2
+
     return HostExecutor.apply_binary[dtype, floordiv_kernel](array, scalar)
 
 
@@ -577,8 +631,11 @@ def floor_div[
     @parameter
     def floordiv_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 // simd2
+
     return HostExecutor.apply_binary[dtype, floordiv_kernel](scalar, array)
 
 
@@ -616,11 +673,14 @@ def fma[
     @parameter
     def fma_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w], simd3: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](
+        simd1: SIMD[dtype, simd_w],
+        simd2: SIMD[dtype, simd_w],
+        simd3: SIMD[dtype, simd_w],
+    ) -> SIMD[dtype, simd_w]:
         return simd1.fma(simd2, simd3)
-    return HostExecutor.apply_ternary[dtype, fma_kernel](
-        array1, array2, array3
-    )
+
+    return HostExecutor.apply_ternary[dtype, fma_kernel](array1, array2, array3)
 
 
 def fma[
@@ -649,11 +709,14 @@ def fma[
     @parameter
     def fma_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w], simd3: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](
+        simd1: SIMD[dtype, simd_w],
+        simd2: SIMD[dtype, simd_w],
+        simd3: SIMD[dtype, simd_w],
+    ) -> SIMD[dtype, simd_w]:
         return simd1.fma(simd2, simd3)
-    return HostExecutor.apply_ternary[dtype, fma_kernel](
-        array1, array2, simd
-    )
+
+    return HostExecutor.apply_ternary[dtype, fma_kernel](array1, array2, simd)
 
 
 # ===------------------------------------------------------------------------===#
@@ -684,8 +747,11 @@ def remainder[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](array1, array2)
 
 
@@ -709,8 +775,11 @@ def remainder[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](array, scalar)
 
 
@@ -734,6 +803,9 @@ def remainder[
     @parameter
     def mod_kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return simd1 % simd2
+
     return HostExecutor.apply_binary[dtype, mod_kernel](scalar, array)

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -338,7 +338,7 @@ def mul[
             "math:arithmetic:mul(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
             " No arrays in arguments"
         )
-    var result_array: NDArray[dtype] = array_list[0].deep_copy()
+    var result_array: NDArray[dtype] = array_list[0].copy()
     for i in range(1, len(array_list)):
         result_array = mul[dtype](result_array, array_list[i])
     result_array = mul[dtype](result_array, scalar_part)

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -118,9 +118,10 @@ def add[
     var scalar_part: Scalar[dtype] = 0
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            # TODO: Figure out how to remove this unnecessary copy here (even though we take values as owned.            array_list.append(values[i].copy().take[NDArray[dtype]]())
+            # TODO: Figure out how to remove this unnecessary copy here (even though we take values as owned.
+            array_list.append(values[i].copy().unsafe_take[NDArray[dtype]]())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part += values[i].copy().take[Scalar[dtype]]()
+            scalar_part += values[i].copy().unsafe_take[Scalar[dtype]]()
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:add(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
@@ -155,7 +156,13 @@ def sub[
     Returns:
         The element-wise difference of `array1` and`array2`.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](array1, array2)
+
+    @parameter
+    def sub_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 - simd2
+    return HostExecutor.apply_binary[dtype, sub_kernel](array1, array2)
 
 
 def sub[
@@ -174,7 +181,13 @@ def sub[
     Returns:
         The element-wise difference of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](array, scalar)
+
+    @parameter
+    def sub_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 - simd2
+    return HostExecutor.apply_binary[dtype, sub_kernel](array, scalar)
 
 
 def sub[
@@ -193,7 +206,13 @@ def sub[
     Returns:
         The element-wise difference of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](scalar, array)
+
+    @parameter
+    def sub_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 - simd2
+    return HostExecutor.apply_binary[dtype, sub_kernel](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -217,7 +236,13 @@ def mod[
     Returns:
         A NDArray equal to array1 % array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](array1, array2)
 
 
 def mod[
@@ -236,7 +261,13 @@ def mod[
     Returns:
         A NDArray equal to array % scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](array, scalar)
 
 
 def mod[
@@ -255,7 +286,13 @@ def mod[
     Returns:
         A NDArray equal to scalar % array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](scalar, array)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -282,7 +319,13 @@ def mul[
     Returns:
         A NDArray equal to array1*array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](array1, array2)
+
+    @parameter
+    def mul_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 * simd2
+    return HostExecutor.apply_binary[dtype, mul_kernel](array1, array2)
 
 
 def mul[
@@ -301,7 +344,13 @@ def mul[
     Returns:
         The element-wise product of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](array, scalar)
+
+    @parameter
+    def mul_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 * simd2
+    return HostExecutor.apply_binary[dtype, mul_kernel](array, scalar)
 
 
 def mul[
@@ -320,7 +369,13 @@ def mul[
     Returns:
         The element-wise product of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](scalar, array)
+
+    @parameter
+    def mul_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 * simd2
+    return HostExecutor.apply_binary[dtype, mul_kernel](scalar, array)
 
 
 def mul[
@@ -345,9 +400,9 @@ def mul[
     var scalar_part: Scalar[dtype] = 1
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            array_list.append(values[i].take[NDArray[dtype]]())
+            array_list.append(values[i].copy().unsafe_take[NDArray[dtype]]())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part *= values[i].take[Scalar[dtype]]()
+            scalar_part *= values[i].copy().unsafe_take[Scalar[dtype]]()
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:mul(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
@@ -385,7 +440,13 @@ def div[
     Returns:
         A NDArray equal to array1/array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array1, array2)
+
+    @parameter
+    def truediv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 / simd2
+    return HostExecutor.apply_binary[dtype, truediv_kernel](array1, array2)
 
 
 def div[
@@ -404,7 +465,13 @@ def div[
     Returns:
         The element-wise quotient of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array, scalar)
+
+    @parameter
+    def truediv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 / simd2
+    return HostExecutor.apply_binary[dtype, truediv_kernel](array, scalar)
 
 
 def div[
@@ -423,7 +490,13 @@ def div[
     Returns:
         The element-wise quotient of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](scalar, array)
+
+    @parameter
+    def truediv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 / simd2
+    return HostExecutor.apply_binary[dtype, truediv_kernel](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -450,7 +523,13 @@ def floor_div[
     Returns:
         A NDArray equal to array1/array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array1, array2)
+
+    @parameter
+    def floordiv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 // simd2
+    return HostExecutor.apply_binary[dtype, floordiv_kernel](array1, array2)
 
 
 def floor_div[
@@ -469,7 +548,13 @@ def floor_div[
     Returns:
         The element-wise quotient of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array, scalar)
+
+    @parameter
+    def floordiv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 // simd2
+    return HostExecutor.apply_binary[dtype, floordiv_kernel](array, scalar)
 
 
 def floor_div[
@@ -488,7 +573,13 @@ def floor_div[
     Returns:
         The element-wise quotient of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](scalar, array)
+
+    @parameter
+    def floordiv_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 // simd2
+    return HostExecutor.apply_binary[dtype, floordiv_kernel](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -521,7 +612,13 @@ def fma[
     """
     # TODO: Support passing through the FastMathFlag parameter
     # For now, FastMathFlag.CONTRACT is was default prior to this error.
-    return HostExecutor.apply_ternary[dtype, SIMD.fma[FastMathFlag.CONTRACT]](
+
+    @parameter
+    def fma_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w], simd3: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1.fma(simd2, simd3)
+    return HostExecutor.apply_ternary[dtype, fma_kernel](
         array1, array2, array3
     )
 
@@ -548,7 +645,13 @@ def fma[
     Returns:
         A a new NDArray that is NDArray with the function func applied.
     """
-    return HostExecutor.apply_ternary[dtype, SIMD.fma[FastMathFlag.CONTRACT]](
+
+    @parameter
+    def fma_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w], simd3: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1.fma(simd2, simd3)
+    return HostExecutor.apply_ternary[dtype, fma_kernel](
         array1, array2, simd
     )
 
@@ -577,7 +680,13 @@ def remainder[
     Returns:
         A NDArray equal to array1//array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](array1, array2)
 
 
 def remainder[
@@ -596,7 +705,13 @@ def remainder[
     Returns:
         A NDArray equal to array//scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](array, scalar)
 
 
 def remainder[
@@ -615,4 +730,10 @@ def remainder[
     Returns:
         A NDArray equal to scalar//array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](scalar, array)
+
+    @parameter
+    def mod_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 % simd2
+    return HostExecutor.apply_binary[dtype, mod_kernel](scalar, array)

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -5,8 +5,8 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Arithmetic routines for NuMojo (numojo.routines.math.arithmetic).
-
+"""Arithmetic routines for NuMojo (numojo.routines.math.arithmetic)
+-------------------------------------------------------------------
 Implements addition, subtraction, multiplication, division, floor division, fused multiply-add, and remainder helpers for NDArrays.
 """
 
@@ -40,7 +40,12 @@ def add[
     Returns:
         The element-wise sum of `array1` and`array2`.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](array1, array2)
+    @parameter
+    def add_kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd1 + simd2
+    return HostExecutor.apply_binary[dtype, add_kernel](array1, array2)
 
 
 def add[
@@ -59,7 +64,12 @@ def add[
     Returns:
         The element-wise sum of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](array, scalar)
+    @parameter
+    def add_kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w], scalar_simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd + scalar_simd
+    return HostExecutor.apply_binary[dtype, add_kernel](array, scalar)
 
 
 def add[
@@ -78,7 +88,12 @@ def add[
     Returns:
         The element-wise sum of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](scalar, array)
+    @parameter
+    def add_kernel[
+        dtype: DType, simd_w: Int
+    ](scalar_simd: SIMD[dtype, simd_w], simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return scalar_simd + simd
+    return HostExecutor.apply_binary[dtype, add_kernel](scalar, array)
 
 
 def add[
@@ -103,9 +118,9 @@ def add[
     var scalar_part: Scalar[dtype] = 0
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            array_list.append(values[i].take[NDArray[dtype]]())
+            # TODO: Figure out how to remove this unnecessary copy here (even though we take values as owned.            array_list.append(values[i].copy().take[NDArray[dtype]]())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part += values[i].take[Scalar[dtype]]()
+            scalar_part += values[i].copy().take[Scalar[dtype]]()
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:add(*values:Variant[NDArray[dtype],Scalar[dtype]]):"

--- a/numojo/routines/math/differences.mojo
+++ b/numojo/routines/math/differences.mojo
@@ -104,7 +104,7 @@ def diff[
         The n-th order difference of the input array.
     """
 
-    var current: NDArray[dtype] = array.deep_copy()
+    var current: NDArray[dtype] = array.copy()
 
     for _ in range(n):
         var result: NDArray[dtype] = NDArray[dtype](

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -49,7 +49,13 @@ def exp[
         var result = nm.exp(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.exp](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.exp(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def exp[
@@ -105,7 +111,13 @@ def exp2[
         var result = nm.exp2(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.exp2](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.exp2(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def exp2[
@@ -160,7 +172,13 @@ def expm1[
         var result = nm.expm1(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.expm1](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.expm1(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def expm1[
@@ -219,7 +237,13 @@ def log[
         var result = nm.log(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.log(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def log[
@@ -274,7 +298,13 @@ def log2[
         var result = nm.log2(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log2](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.log2(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def log2[
@@ -327,7 +357,13 @@ def log10[
         var result = nm.log10(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log10](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.log10(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def log10[
@@ -382,7 +418,13 @@ def log1p[
         var result = nm.log1p(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log1p](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.log1p(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def log1p[

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -49,11 +49,15 @@ def exp[
         var result = nm.exp(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.exp(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -110,11 +114,15 @@ def exp2[
         var result = nm.exp2(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.exp2(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -170,11 +178,15 @@ def expm1[
         var result = nm.expm1(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.expm1(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -234,11 +246,15 @@ def log[
         var result = nm.log(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.log(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -294,11 +310,15 @@ def log2[
         var result = nm.log2(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.log2(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -352,11 +372,15 @@ def log10[
         var result = nm.log10(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.log10(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -412,11 +436,15 @@ def log1p[
         var result = nm.log1p(arr)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.log1p(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -49,11 +49,10 @@ def exp[
         var result = nm.exp(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.exp(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -111,11 +110,10 @@ def exp2[
         var result = nm.exp2(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.exp2(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -172,11 +170,10 @@ def expm1[
         var result = nm.expm1(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.expm1(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -237,11 +234,10 @@ def log[
         var result = nm.log(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.log(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -298,11 +294,10 @@ def log2[
         var result = nm.log2(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.log2(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -357,11 +352,10 @@ def log10[
         var result = nm.log10(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.log10(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -418,11 +412,10 @@ def log1p[
         var result = nm.log1p(arr)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.log1p(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -63,7 +63,7 @@ def extrema_1d[
         @parameter
         def vectorize_max[
             simd_width: Int
-        ](offset: Int) unified {mut value, read a}:
+        ](offset: Int) {mut value, read a}:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
             if temp >= value:
                 value = temp
@@ -77,7 +77,7 @@ def extrema_1d[
         @parameter
         def vectorize_min[
             simd_width: Int
-        ](offset: Int) unified {mut value, read a} -> None:
+        ](offset: Int) {mut value, read a} -> None:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
             if temp < value:
                 value = temp
@@ -576,7 +576,13 @@ def minimum[
         var m = nm.minimum(a, b)
         ```
     """
-    return HostExecutor.apply_binary[dtype, builtin_min](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return builtin_min(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 
 def maximum[
@@ -605,4 +611,10 @@ def maximum[
         var m = nm.maximum(a, b)
         ```
     """
-    return HostExecutor.apply_binary[dtype, builtin_max](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return builtin_max(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -60,9 +60,7 @@ def extrema_1d[
 
     comptime if is_max:
 
-        def vectorize_max[
-            simd_width: Int
-        ](offset: Int) {mut value, a}:
+        def vectorize_max[simd_width: Int](offset: Int) {mut value, a}:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
             if temp >= value:
                 value = temp
@@ -73,9 +71,7 @@ def extrema_1d[
 
     else:
 
-        def vectorize_min[
-            simd_width: Int
-        ](offset: Int) {mut value, a} -> None:
+        def vectorize_min[simd_width: Int](offset: Int) {mut value, a} -> None:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
             if temp < value:
                 value = temp
@@ -114,7 +110,9 @@ def max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
         return extrema_1d[is_max=True](ravel(a))
 
 
-def extrema_1d_max[dtype: DType](a: NDArray[dtype]) capturing raises -> Scalar[dtype]:
+def extrema_1d_max[
+    dtype: DType
+](a: NDArray[dtype]) capturing raises -> Scalar[dtype]:
     """
     Find the max value in a 1-D array.
     """
@@ -574,11 +572,15 @@ def minimum[
         var m = nm.minimum(a, b)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return builtin_min(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 
@@ -608,9 +610,13 @@ def maximum[
         var m = nm.maximum(a, b)
         ```
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return builtin_max(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -34,7 +34,7 @@ from numojo.routines.manipulation import ravel
 
 def extrema_1d[
     dtype: DType, //, is_max: Bool
-](a: NDArray[dtype]) raises -> Scalar[dtype]:
+](a: NDArray[dtype]) capturing raises -> Scalar[dtype]:
     """
     Find the max or min value in the buffer.
 
@@ -60,10 +60,9 @@ def extrema_1d[
 
     comptime if is_max:
 
-        @parameter
         def vectorize_max[
             simd_width: Int
-        ](offset: Int) {mut value, read a}:
+        ](offset: Int) {mut value, a}:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
             if temp >= value:
                 value = temp
@@ -74,10 +73,9 @@ def extrema_1d[
 
     else:
 
-        @parameter
         def vectorize_min[
             simd_width: Int
-        ](offset: Int) {mut value, read a} -> None:
+        ](offset: Int) {mut value, a} -> None:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
             if temp < value:
                 value = temp
@@ -116,7 +114,7 @@ def max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
         return extrema_1d[is_max=True](ravel(a))
 
 
-def extrema_1d_max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def extrema_1d_max[dtype: DType](a: NDArray[dtype]) capturing raises -> Scalar[dtype]:
     """
     Find the max value in a 1-D array.
     """
@@ -576,7 +574,6 @@ def minimum[
         var m = nm.minimum(a, b)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -611,7 +608,6 @@ def maximum[
         var m = nm.maximum(a, b)
         ```
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int

--- a/numojo/routines/math/floating.mojo
+++ b/numojo/routines/math/floating.mojo
@@ -39,4 +39,10 @@ def copysign[
     Returns:
         A NDArray with the magnitude of `array2` and the sign of `array1`.
     """
-    return HostExecutor.apply_binary[dtype, math.copysign](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.copysign(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/floating.mojo
+++ b/numojo/routines/math/floating.mojo
@@ -5,8 +5,8 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Floating-point routines for NuMojo (numojo.routines.math.floating).
-
+"""Floating-point routines for NuMojo (numojo.routines.math.floating)
+---------------------------------------------------------------------
 Implements floating-point specific helpers on NDArrays, such as `copysign`.
 """
 
@@ -39,7 +39,6 @@ def copysign[
     Returns:
         A NDArray with the magnitude of `array2` and the sign of `array1`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int

--- a/numojo/routines/math/floating.mojo
+++ b/numojo/routines/math/floating.mojo
@@ -39,9 +39,13 @@ def copysign[
     Returns:
         A NDArray with the magnitude of `array2` and the sign of `array1`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return math.copysign(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/hyper.mojo
+++ b/numojo/routines/math/hyper.mojo
@@ -5,8 +5,8 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Hyperbolic routines for NuMojo (numojo.routines.math.hyper).
-
+"""Hyperbolic routines for NuMojo (numojo.routines.math.hyper)
+--------------------------------------------------------------
 Implements hyperbolic and inverse hyperbolic functions for NDArrays and Matrices.
 """
 
@@ -37,11 +37,10 @@ def acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acosh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.acosh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -59,11 +58,10 @@ def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asinh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.asinh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -81,11 +79,10 @@ def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atanh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.atanh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -108,7 +105,12 @@ def arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (arccosh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.acosh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -124,7 +126,12 @@ def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (acosh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.acosh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -140,7 +147,12 @@ def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (arcsinh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.asinh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -156,7 +168,12 @@ def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (asinh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.asinh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -172,7 +189,12 @@ def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (arctanh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atanh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.atanh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -188,7 +210,12 @@ def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (atanh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atanh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.atanh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -209,11 +236,10 @@ def cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cosh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.cosh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -231,11 +257,10 @@ def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sinh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.sinh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -253,11 +278,10 @@ def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tanh of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.tanh(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -279,7 +303,12 @@ def cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cosh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.cosh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.cosh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -294,7 +323,12 @@ def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sinh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.sinh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.sinh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -309,4 +343,9 @@ def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tanh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.tanh](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.tanh(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)

--- a/numojo/routines/math/hyper.mojo
+++ b/numojo/routines/math/hyper.mojo
@@ -37,7 +37,13 @@ def acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acosh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.acosh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.acosh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -53,7 +59,13 @@ def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asinh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.asinh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.asinh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -69,7 +81,13 @@ def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atanh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.atanh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.atanh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -191,7 +209,13 @@ def cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cosh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.cosh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.cosh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -207,7 +231,13 @@ def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sinh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.sinh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.sinh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -223,7 +253,13 @@ def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tanh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.tanh](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.tanh(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#

--- a/numojo/routines/math/hyper.mojo
+++ b/numojo/routines/math/hyper.mojo
@@ -37,11 +37,15 @@ def acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acosh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acosh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -58,11 +62,15 @@ def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asinh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asinh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -79,11 +87,15 @@ def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atanh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atanh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -105,11 +117,15 @@ def arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (arccosh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acosh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -126,11 +142,15 @@ def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (acosh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acosh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -147,11 +167,15 @@ def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (arcsinh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asinh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -168,11 +192,15 @@ def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (asinh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asinh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -189,11 +217,15 @@ def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (arctanh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atanh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -210,11 +242,15 @@ def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (atanh) of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atanh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -236,11 +272,15 @@ def cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cosh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.cosh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -257,11 +297,15 @@ def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sinh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.sinh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -278,11 +322,15 @@ def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tanh of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.tanh(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -303,11 +351,15 @@ def cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cosh of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.cosh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -323,11 +375,15 @@ def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sinh of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.sinh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -343,9 +399,13 @@ def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tanh of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.tanh(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)

--- a/numojo/routines/math/misc.mojo
+++ b/numojo/routines/math/misc.mojo
@@ -33,11 +33,15 @@ def cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to array**(1/3).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return stdlib_math.cbrt(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -115,11 +119,13 @@ def rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to 1/NDArray**(1/2).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return _mt_rsqrt(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -136,11 +142,13 @@ def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to NDArray**(1/2).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return stdlib_math.sqrt(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -168,9 +176,13 @@ def scalb[
     Returns:
         A NDArray with values equal to scalb(array1, array2).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return stdlib_math.scalb(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/misc.mojo
+++ b/numojo/routines/math/misc.mojo
@@ -5,8 +5,8 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Miscellaneous math routines for NuMojo (numojo.routines.math.misc).
-
+"""Miscellaneous math routines for NuMojo (numojo.routines.math.misc)
+---------------------------------------------------------------------
 Implements miscellaneous math helpers on NDArrays, including cube root, clipping, reciprocal square root, square root, and scalb.
 """
 
@@ -33,7 +33,12 @@ def cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to array**(1/3).
     """
-    return HostExecutor.apply_unary[dtype, stdlib_math.cbrt](array)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return stdlib_math.cbrt(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -110,7 +115,12 @@ def rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to 1/NDArray**(1/2).
     """
-    return HostExecutor.apply_unary[dtype, _mt_rsqrt](array)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return _mt_rsqrt(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -126,7 +136,12 @@ def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to NDArray**(1/2).
     """
-    return HostExecutor.apply_unary[dtype, stdlib_math.sqrt](array)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return stdlib_math.sqrt(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -153,4 +168,9 @@ def scalb[
     Returns:
         A NDArray with values equal to scalb(array1, array2).
     """
-    return HostExecutor.apply_binary[dtype, stdlib_math.scalb](array1, array2)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return stdlib_math.scalb(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -49,8 +49,7 @@ def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
     var res = Scalar[dtype](1)
 
-    @parameter
-    def cal_vec[width: Int](i: Int) {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, A}:
         res *= A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -109,8 +108,7 @@ def prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](1)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_vec[width: Int](i: Int) {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, A}:
         res = res * A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -128,6 +126,8 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     Example:
     ```mojo
     from numojo import Matrix
+    import numojo.routines.math as mat
+
     var A = Matrix.rand(shape=(100, 100))
     print(mat.prod(A, axis=0))
     print(mat.prod(A, axis=1))
@@ -141,8 +141,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, A, i}:
                 B._store[width](
                     0, j, B._load[width](0, j) * A._load[width](i, j)
                 )
@@ -156,8 +155,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_vec[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_vec[width: Int](j: Int) {mut B, A, i}:
                 B._store(
                     i,
                     0,
@@ -250,6 +248,8 @@ def cumprod[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     Example:
     ```mojo
     from numojo import Matrix
+    import numojo.routines.math as mat
+
     var A = Matrix.rand(shape=(100, 100))
     print(mat.cumprod(A))
     ```
@@ -282,6 +282,8 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     Example:
     ```mojo
     from numojo import Matrix
+    import numojo.routines.math as mat
+
     var A = Matrix.rand(shape=(100, 100))
     print(mat.cumprod(A, axis=0))
     print(mat.cumprod(A, axis=1))
@@ -296,10 +298,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     else:
         for j in range(result.shape[1]):
 
-            @parameter
             def copy_col[
                 width: Int
-            ](i: Int) {mut result, read A, read j}:
+            ](i: Int) {mut result, A, j}:
                 result._store[width](i, j, A._load[width](i, j))
 
             vectorize[width](A.shape[0], copy_col)
@@ -308,10 +309,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if A.is_c_contiguous():
             for i in range(1, A.shape[0]):
 
-                @parameter
                 def cal_vec_row[
                     width: Int
-                ](j: Int) {mut result, read i}:
+                ](j: Int) {mut result, i}:
                     result._store[width](
                         i,
                         j,
@@ -336,10 +336,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         else:
             for j in range(1, A.shape[1]):
 
-                @parameter
                 def cal_vec_column[
                     width: Int
-                ](i: Int) {mut result, read j}:
+                ](i: Int) {mut result, j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -298,9 +298,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     else:
         for j in range(result.shape[1]):
 
-            def copy_col[
-                width: Int
-            ](i: Int) {mut result, A, j}:
+            def copy_col[width: Int](i: Int) {mut result, A, j}:
                 result._store[width](i, j, A._load[width](i, j))
 
             vectorize[width](A.shape[0], copy_col)
@@ -309,9 +307,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if A.is_c_contiguous():
             for i in range(1, A.shape[0]):
 
-                def cal_vec_row[
-                    width: Int
-                ](j: Int) {mut result, i}:
+                def cal_vec_row[width: Int](j: Int) {mut result, i}:
                     result._store[width](
                         i,
                         j,
@@ -336,9 +332,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         else:
             for j in range(1, A.shape[1]):
 
-                def cal_vec_column[
-                    width: Int
-                ](i: Int) {mut result, j}:
+                def cal_vec_column[width: Int](i: Int) {mut result, j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -50,7 +50,7 @@ def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var res = Scalar[dtype](1)
 
     @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res *= A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -110,7 +110,7 @@ def prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res = res * A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -142,7 +142,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         for i in range(A.shape[0]):
 
             @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) * A._load[width](i, j)
                 )
@@ -157,7 +157,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         @parameter
         def cal_rows(i: Int):
             @parameter
-            def cal_vec[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -299,7 +299,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             @parameter
             def copy_col[
                 width: Int
-            ](i: Int) unified {mut result, read A, read j}:
+            ](i: Int) {mut result, read A, read j}:
                 result._store[width](i, j, A._load[width](i, j))
 
             vectorize[width](A.shape[0], copy_col)
@@ -311,7 +311,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
                 @parameter
                 def cal_vec_row[
                     width: Int
-                ](j: Int) unified {mut result, read i}:
+                ](j: Int) {mut result, read i}:
                     result._store[width](
                         i,
                         j,
@@ -339,7 +339,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
                 @parameter
                 def cal_vec_column[
                     width: Int
-                ](i: Int) unified {mut result, read j}:
+                ](i: Int) {mut result, read j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -53,7 +53,13 @@ def tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to abs(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__abs__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__abs__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -74,7 +80,13 @@ def tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to floor(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__floor__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__floor__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -90,7 +102,13 @@ def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to ceil(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__ceil__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__ceil__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -106,7 +124,13 @@ def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to trunc(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__trunc__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__trunc__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -122,7 +146,13 @@ def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to round(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__round__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -138,7 +168,13 @@ def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise rounding of `array` to the nearest integer with ties to even.
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return simd.__round__()
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # def round_half_down[
@@ -208,4 +244,10 @@ def nextafter[
     Returns:
         The element-wise nextafter of `array1` toward `array2`.
     """
-    return HostExecutor.apply_binary[dtype, builtin_nextafter](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return builtin_nextafter(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -53,7 +53,6 @@ def tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to abs(array).
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -80,7 +79,6 @@ def tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to floor(array).
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -102,7 +100,6 @@ def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to ceil(array).
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -124,7 +121,6 @@ def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to trunc(array).
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -146,7 +142,6 @@ def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to round(array).
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -168,7 +163,6 @@ def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise rounding of `array` to the nearest integer with ties to even.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
@@ -244,7 +238,6 @@ def nextafter[
     Returns:
         The element-wise nextafter of `array1` toward `array2`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -53,11 +53,13 @@ def tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to abs(array).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__abs__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -79,11 +81,13 @@ def tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to floor(array).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__floor__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -100,11 +104,13 @@ def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to ceil(array).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__ceil__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -121,11 +127,13 @@ def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to trunc(array).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__trunc__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -142,11 +150,13 @@ def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to round(array).
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__round__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -163,11 +173,13 @@ def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise rounding of `array` to the nearest integer with ties to even.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
     ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
         return simd.__round__()
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -238,9 +250,13 @@ def nextafter[
     Returns:
         The element-wise nextafter of `array1` toward `array2`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ]:
         return builtin_nextafter(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -48,7 +48,7 @@ def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var result: Scalar[dtype] = Scalar[dtype](0)
 
     @parameter
-    def cal_vec[width: Int](i: Int) unified {mut result, read A}:
+    def cal_vec[width: Int](i: Int) {mut result, read A}:
         result += A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -145,7 +145,7 @@ def sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res = res + A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -181,7 +181,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             @parameter
             def calc_columns(j: Int):
                 @parameter
-                def col_sum[width: Int](i: Int) unified {mut B, read j, read A}:
+                def col_sum[width: Int](i: Int) {mut B, read j, read A}:
                     B._store(
                         0,
                         j,
@@ -197,7 +197,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
                 @parameter
                 def cal_vec_sum[
                     width: Int
-                ](j: Int) unified {mut B, read i, read A}:
+                ](j: Int) {mut B, read i, read A}:
                     B._store[width](
                         0, j, B._load[width](0, j) + A._load[width](i, j)
                     )
@@ -214,7 +214,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             @parameter
             def cal_rows(i: Int):
                 @parameter
-                def cal_vec[width: Int](j: Int) unified {mut B, read i, read A}:
+                def cal_vec[width: Int](j: Int) {mut B, read i, read A}:
                     B._store(
                         i,
                         0,
@@ -374,7 +374,7 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
                 @parameter
                 def cal_vec_sum_column[
                     width: Int
-                ](j: Int) unified {mut result, read i}:
+                ](j: Int) {mut result, read i}:
                     result._store[width](
                         i,
                         j,
@@ -402,7 +402,7 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
                 @parameter
                 def cal_vec_sum_row[
                     width: Int
-                ](i: Int) unified {mut result, read j}:
+                ](i: Int) {mut result, read j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -190,9 +190,8 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             parallelize[calc_columns](A.shape[1], A.shape[1])
         else:
             for i in range(A.shape[0]):
-                def cal_vec_sum[
-                    width: Int
-                ](j: Int) {mut B, i, A}:
+
+                def cal_vec_sum[width: Int](j: Int) {mut B, i, A}:
                     B._store[width](
                         0, j, B._load[width](0, j) + A._load[width](i, j)
                     )
@@ -364,9 +363,8 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     if axis == 0:
         if result.is_c_contiguous():
             for i in range(1, A.shape[0]):
-                def cal_vec_sum_column[
-                    width: Int
-                ](j: Int) {mut result, i}:
+
+                def cal_vec_sum_column[width: Int](j: Int) {mut result, i}:
                     result._store[width](
                         i,
                         j,
@@ -390,9 +388,8 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             return result^
         else:
             for j in range(1, A.shape[1]):
-                def cal_vec_sum_row[
-                    width: Int
-                ](i: Int) {mut result, j}:
+
+                def cal_vec_sum_row[width: Int](i: Int) {mut result, j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -47,8 +47,7 @@ def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
     var result: Scalar[dtype] = Scalar[dtype](0)
 
-    @parameter
-    def cal_vec[width: Int](i: Int) {mut result, read A}:
+    def cal_vec[width: Int](i: Int) {mut result, A}:
         result += A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -144,8 +143,7 @@ def sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](0)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_vec[width: Int](i: Int) {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, A}:
         res = res + A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -165,7 +163,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     from numojo import Matrix
     import numojo.routines.math as mat
 
-    var mat = Matrix.rand(shape=(100, 100))
+    var A = Matrix.rand(shape=(100, 100))
     print(mat.sum(A, axis=0))
     print(mat.sum(A, axis=1))
     ```
@@ -180,8 +178,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
             @parameter
             def calc_columns(j: Int):
-                @parameter
-                def col_sum[width: Int](i: Int) {mut B, read j, read A}:
+                def col_sum[width: Int](i: Int) {mut B, j, A}:
                     B._store(
                         0,
                         j,
@@ -193,11 +190,9 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             parallelize[calc_columns](A.shape[1], A.shape[1])
         else:
             for i in range(A.shape[0]):
-
-                @parameter
                 def cal_vec_sum[
                     width: Int
-                ](j: Int) {mut B, read i, read A}:
+                ](j: Int) {mut B, i, A}:
                     B._store[width](
                         0, j, B._load[width](0, j) + A._load[width](i, j)
                     )
@@ -213,8 +208,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
             @parameter
             def cal_rows(i: Int):
-                @parameter
-                def cal_vec[width: Int](j: Int) {mut B, read i, read A}:
+                def cal_vec[width: Int](j: Int) {mut B, i, A}:
                     B._store(
                         i,
                         0,
@@ -370,11 +364,9 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     if axis == 0:
         if result.is_c_contiguous():
             for i in range(1, A.shape[0]):
-
-                @parameter
                 def cal_vec_sum_column[
                     width: Int
-                ](j: Int) {mut result, read i}:
+                ](j: Int) {mut result, i}:
                     result._store[width](
                         i,
                         j,
@@ -398,11 +390,9 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
             return result^
         else:
             for j in range(1, A.shape[1]):
-
-                @parameter
                 def cal_vec_sum_row[
                     width: Int
-                ](i: Int) {mut result, read j}:
+                ](i: Int) {mut result, j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/trig.mojo
+++ b/numojo/routines/math/trig.mojo
@@ -37,11 +37,15 @@ def acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acos of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acos(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -58,11 +62,15 @@ def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asin of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asin(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -79,11 +87,15 @@ def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atan of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atan(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -109,11 +121,15 @@ def atan2[
     References:
         https://en.wikipedia.org/wiki/Atan2.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atan2(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 
@@ -135,11 +151,15 @@ def arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acos(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -156,11 +176,15 @@ def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.acos(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -177,11 +201,15 @@ def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asin(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -198,11 +226,15 @@ def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.asin(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -219,11 +251,15 @@ def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atan(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -240,11 +276,15 @@ def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.atan(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -266,11 +306,15 @@ def cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cos of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.cos(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -287,11 +331,15 @@ def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sin of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.sin(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -308,11 +356,15 @@ def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tan of `array`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.tan(simd)
+
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
@@ -334,11 +386,15 @@ def cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cos of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.cos(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -355,11 +411,15 @@ def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sin of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.sin(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -376,11 +436,15 @@ def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tan of `A`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.tan(simd)
+
     return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
@@ -408,11 +472,15 @@ def hypot[
     Returns:
         The element-wise hypotenuse of `array1` and `array2`.
     """
+
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[
+        dtype, simd_w
+    ] where dtype.is_floating_point():
         return math.hypot(simd1, simd2)
+
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 

--- a/numojo/routines/math/trig.mojo
+++ b/numojo/routines/math/trig.mojo
@@ -37,7 +37,13 @@ def acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acos of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.acos](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.acos(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -53,7 +59,13 @@ def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asin of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.asin](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.asin(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -69,7 +81,13 @@ def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atan of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.atan](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.atan(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def atan2[
@@ -94,7 +112,13 @@ def atan2[
     References:
         https://en.wikipedia.org/wiki/Atan2.
     """
-    return HostExecutor.apply_binary[dtype, math.atan2](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.atan2(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 
 # ===------------------------------------------------------------------------===#
@@ -216,7 +240,13 @@ def cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cos of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.cos](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.cos(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -232,7 +262,13 @@ def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sin of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.sin](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.sin(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -248,7 +284,13 @@ def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tan of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.tan](array)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.tan(simd)
+    return HostExecutor.apply_unary[dtype, _kernel](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -328,7 +370,13 @@ def hypot[
     Returns:
         The element-wise hypotenuse of `array1` and `array2`.
     """
-    return HostExecutor.apply_binary[dtype, math.hypot](array1, array2)
+    return 
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+        return math.hypot(simd1, simd2)
+    return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
 
 def hypot_fma[

--- a/numojo/routines/math/trig.mojo
+++ b/numojo/routines/math/trig.mojo
@@ -37,11 +37,10 @@ def acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acos of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.acos(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -59,11 +58,10 @@ def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asin of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.asin(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -81,11 +79,10 @@ def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atan of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.atan(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -112,11 +109,10 @@ def atan2[
     References:
         https://en.wikipedia.org/wiki/Atan2.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.atan2(simd1, simd2)
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 
@@ -139,7 +135,12 @@ def arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.acos(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -155,7 +156,12 @@ def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.acos(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -171,7 +177,12 @@ def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.asin(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -187,7 +198,12 @@ def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.asin(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -203,7 +219,12 @@ def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atan](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.atan(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -219,7 +240,12 @@ def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atan](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.atan(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -240,11 +266,10 @@ def cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cos of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.cos(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -262,11 +287,10 @@ def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sin of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.sin(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -284,11 +308,10 @@ def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tan of `array`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.tan(simd)
     return HostExecutor.apply_unary[dtype, _kernel](array)
 
@@ -311,7 +334,12 @@ def cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.cos](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.cos(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -327,7 +355,12 @@ def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.sin](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.sin(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -343,7 +376,12 @@ def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.tan](A)
+    @parameter
+    def _kernel[
+        dtype: DType, simd_w: Int
+    ](simd: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
+        return math.tan(simd)
+    return _arithmetic_func_matrix_to_matrix[dtype, _kernel](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -370,11 +408,10 @@ def hypot[
     Returns:
         The element-wise hypotenuse of `array1` and `array2`.
     """
-    return 
     @parameter
     def _kernel[
         dtype: DType, simd_w: Int
-    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w]:
+    ](simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]) -> SIMD[dtype, simd_w] where dtype.is_floating_point():
         return math.hypot(simd1, simd2)
     return HostExecutor.apply_binary[dtype, _kernel](array1, array2)
 

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -38,7 +38,7 @@ struct HostExecutor:
     def apply_unary[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](scalar: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
@@ -62,7 +62,7 @@ struct HostExecutor:
     def apply_binary[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
@@ -89,7 +89,7 @@ struct HostExecutor:
     def apply_unary_predicate[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
         ],
     ](simd: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
@@ -113,7 +113,7 @@ struct HostExecutor:
     def apply_binary_predicate[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
@@ -139,7 +139,7 @@ struct HostExecutor:
     @staticmethod
     def apply_unary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -183,7 +183,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -242,7 +242,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](array: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[dtype]:
@@ -288,7 +288,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](scalar: SIMD[dtype, 1], array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -335,7 +335,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w], Int) -> SIMD[
+        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w], Int) -> SIMD[
             type, simd_w
         ],
     ](array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
@@ -376,7 +376,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[
@@ -445,7 +445,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[
@@ -500,7 +500,7 @@ struct HostExecutor:
     @staticmethod
     def apply_unary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
         ],
     ](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -539,7 +539,7 @@ struct HostExecutor:
     @staticmethod
     def apply_ternary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
@@ -609,7 +609,7 @@ struct HostExecutor:
     @staticmethod
     def apply_ternary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
+        kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
 """Math operations backend (numojo.routines.operations.backend).
-
+----------------------------------------------------------------
 Defines vectorized backend structures and reusable SIMD math primitives consumed by the math submodules.
 """
 
@@ -38,9 +38,9 @@ struct HostExecutor:
     def apply_unary[
         dtype: DType,
         simd_width: Int,
-        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
+        kernel: def[type: DType, simd_w: Int](
+            SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w],
     ](scalar: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
         """
         Applies a SIMD-compatible unary function to a SIMD value.
@@ -64,7 +64,7 @@ struct HostExecutor:
         simd_width: Int,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
         dtype, simd_width
     ]:
@@ -89,9 +89,9 @@ struct HostExecutor:
     def apply_unary_predicate[
         dtype: DType,
         simd_width: Int,
-        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
+        kernel: def[type: DType, simd_w: Int](
+            SIMD[type, simd_w]
+        ) capturing -> SIMD[DType.bool, simd_w],
     ](simd: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         """
         Applies a SIMD-compatible unary predicate to a SIMD value.
@@ -115,7 +115,7 @@ struct HostExecutor:
         simd_width: Int,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        ) capturing -> SIMD[DType.bool, simd_w],
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
         DType.bool, simd_width
     ]:
@@ -139,9 +139,9 @@ struct HostExecutor:
     @staticmethod
     def apply_unary[
         dtype: DType,
-        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
+        kernel: def[type: DType, simd_w: Int](
+            SIMD[type, simd_w]
+        ) capturing -> SIMD[type, simd_w],
     ](array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible unary function to an NDArray.
@@ -171,8 +171,7 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
-        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(i, kernel[dtype, simd_w](simd_data))
 
@@ -185,7 +184,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to two NDArrays.
@@ -226,10 +225,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read array2}:
+        ](i: Int) {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
@@ -244,7 +242,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](array: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to an NDArray and a scalar.
@@ -273,10 +271,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read scalar}:
+        ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
                 i, kernel[dtype, simd_w](simd_data1, scalar)
@@ -290,7 +287,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](scalar: SIMD[dtype, 1], array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to a scalar and an NDArray.
@@ -320,10 +317,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read scalar}:
+        ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
                 i, kernel[dtype, simd_w](scalar, simd_data1)
@@ -335,9 +331,9 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
+        kernel: def[type: DType, simd_w: Int](
+            SIMD[type, simd_w], Int
+        ) capturing -> SIMD[type, simd_w],
     ](array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to an NDArray and an Int scalar.
@@ -360,10 +356,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read intval}:
+        ](i: Int) {mut result_array, read array, read intval}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
 
             result_array._buf.ptr.store(
@@ -378,7 +373,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        ) capturing -> SIMD[DType.bool, simd_w],
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[
         DType.bool
     ]:
@@ -426,10 +421,9 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read array2}:
+        ](i: Int) {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
 
@@ -447,7 +441,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        ) capturing -> SIMD[DType.bool, simd_w],
     ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[
         DType.bool
     ]:
@@ -482,10 +476,9 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read scalar}:
+        ](i: Int) {mut result_array, read array1, read scalar}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = SIMD[dtype, simd_w](scalar)
             bool_simd_store[simd_w](
@@ -500,9 +493,9 @@ struct HostExecutor:
     @staticmethod
     def apply_unary_predicate[
         dtype: DType,
-        kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
+        kernel: def[type: DType, simd_w: Int](
+            SIMD[type, simd_w]
+        ) capturing -> SIMD[DType.bool, simd_w],
     ](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         """
         Applies a SIMD-compatible unary predicate to an NDArray, returning a boolean NDArray.
@@ -524,8 +517,7 @@ struct HostExecutor:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
-        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             bool_simd_store[simd_w](
                 result_array._buf.ptr,
@@ -541,7 +533,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](
         array1: NDArray[dtype], array2: NDArray[dtype], array3: NDArray[dtype]
     ) raises -> NDArray[dtype]:
@@ -590,12 +582,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simdwidth: Int
-        ](i: Int) unified {
-            mut result_array, read array1, read array2, read array3
-        }:
+        ](i: Int) {mut result_array, read array1, read array2, read array3}:
             var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
             var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
             var simd_data3 = array3._buf.ptr.load[width=simdwidth](i)
@@ -611,7 +600,7 @@ struct HostExecutor:
         dtype: DType,
         kernel: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        ) capturing -> SIMD[type, simd_w],
     ](
         array1: NDArray[dtype], array2: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[dtype]:
@@ -652,12 +641,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simdwidth: Int
-        ](i: Int) unified {
-            mut result_array, read array1, read array2, read scalar
-        }:
+        ](i: Int) {mut result_array, read array1, read array2, read scalar}:
             var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
             var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
             result_array._buf.ptr.store(

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -7,7 +7,7 @@
 # ===----------------------------------------------------------------------=== #
 
 """Random (numojo.routines.random)
-
+-------------------------------
 Creates array of the given shape and populate it with random samples from
 a certain distribution.
 

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -25,7 +25,9 @@ from numojo.routines.math.extrema import _max, _min
 from numojo.routines.functional import apply_along_axis_reduce_to_int
 
 
-def argmax_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmax_1d[
+    dtype: DType
+](a: NDArray[dtype]) capturing raises -> Scalar[DType.int]:
     """Returns the index of the maximum value in the buffer.
     Regardless of the shape of input, it is treated as a 1-d array.
 
@@ -55,7 +57,9 @@ def argmax_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
     return Scalar[DType.int](result)
 
 
-def argmin_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[DType.int]:
+def argmin_1d[
+    dtype: DType
+](a: NDArray[dtype]) capturing raises -> Scalar[DType.int]:
     """Returns the index of the minimum value in the buffer.
     Regardless of the shape of input, it is treated as a 1-d array.
 

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """"Searching routines (numojo.routines.searching)
-
+----------------------------------------------
 This module implements searching routines for finding indices of extrema (argmax and argmin) in NDArrays and Matrices.
 """
 

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -453,7 +453,9 @@ def bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 ##############
 
 
-def quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
+def quick_sort_1d[
+    dtype: DType
+](a: NDArray[dtype]) capturing raises -> NDArray[dtype]:
     """
     Sort array using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -479,7 +481,7 @@ def quick_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
 
 def quick_sort_stable_1d[
     dtype: DType
-](a: NDArray[dtype]) raises -> NDArray[dtype]:
+](a: NDArray[dtype]) capturing raises -> NDArray[dtype]:
     """
     Sort array using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -502,7 +504,7 @@ def quick_sort_stable_1d[
     return result^
 
 
-def quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
+def quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) capturing raises:
     """
     Sort array in-place using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -523,7 +525,9 @@ def quick_sort_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
     return
 
 
-def quick_sort_stable_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
+def quick_sort_stable_inplace_1d[
+    dtype: DType
+](mut a: NDArray[dtype]) capturing raises:
     """
     Sort array in-place using quick sort method.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -548,7 +552,7 @@ def quick_sort_stable_inplace_1d[dtype: DType](mut a: NDArray[dtype]) raises:
 
 def argsort_quick_sort_1d[
     dtype: DType
-](a: NDArray[dtype]) raises -> NDArray[DType.int]:
+](a: NDArray[dtype]) capturing raises -> NDArray[DType.int]:
     """
     Returns the indices that would sort the buffer of an array.
     Regardless of the shape of input, it is treated as a 1-d array.

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """Sorting routines (numojo.routines.sorting)
-
+------------------------------------------
 This module implements sorting routines for NDArrays and Matrices, including `sort` and `argsort` functions.
 
 SECTIONS OF THIS FILE:

--- a/numojo/routines/statistics/__init__.mojo
+++ b/numojo/routines/statistics/__init__.mojo
@@ -17,5 +17,5 @@ from .averages import (
     mode,
     median,
     variance,
-    std,
+    stddev,
 )

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -31,7 +31,7 @@ from numojo.routines.functional import (
 # not sure what's the side effect of using a returned dtype and casting to it. There could be some precision loss?
 def mean_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
-](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
+](a: NDArray[dtype]) capturing raises -> Scalar[returned_dtype]:
     """
     Calculate the arithmetic average of all items in an array.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -155,7 +155,7 @@ def mean[
 
 def median_1d[
     dtype: DType, //, returned_dtype: DType = DType.float64
-](a: NDArray[dtype]) raises -> Scalar[returned_dtype]:
+](a: NDArray[dtype]) capturing raises -> Scalar[returned_dtype]:
     """
     Median value of all items an array.
     Regardless of the shape of input, it is treated as a 1-d array.
@@ -232,7 +232,7 @@ def median[
     ](a=a, axis=normalized_axis)
 
 
-def mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+def mode_1d[dtype: DType](a: NDArray[dtype]) capturing raises -> Scalar[dtype]:
     """
     Returns mode of all items of an array.
     Regardless of the shape of input, it is treated as a 1-d array.

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -313,7 +313,7 @@ def mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     )
 
 
-def std[
+def stddev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -338,7 +338,7 @@ def std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-def std[
+def stddev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], axis: Int, ddof: Int = 0) raises -> NDArray[
     returned_dtype
@@ -380,7 +380,7 @@ def std[
     return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** 0.5
 
 
-def std[
+def stddev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -405,7 +405,7 @@ def std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-def std[
+def stddev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
     """

--- a/pixi.lock
+++ b/pixi.lock
@@ -41,10 +41,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py313hf6604e3_0.conda
@@ -96,10 +96,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.0-h1b79a29_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.4-hc7d1edf_0.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b1-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.3-py313he4a34aa_0.conda
@@ -710,10 +710,10 @@ packages:
   license_family: APACHE
   size: 286406
   timestamp: 1776846235007
-- conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
+- conda: https://conda.modular.com/max/noarch/mblack-26.3.0-release.conda
   noarch: python
-  sha256: 3c2fceb89cefca899dcd7c8f26a6202acacb2a073e4cb2ef365514a465d01dcd
-  md5: dd13667299b9b66b8b314dc8d95b54a3
+  sha256: c7c36d5b223862acffaaacdfc6f672ca198a046a66f4a956ca57933123fb93b2
+  md5: 63c657fb1780079c3f6cbb7a758a16d2
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -723,55 +723,55 @@ packages:
   - platformdirs >=2
   - tomli >=1.1.0
   license: LicenseRef-Modular-Proprietary
-  size: 133798
-  timestamp: 1773780198354
-- conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
-  sha256: 4d7047466c13d92b1c8eb19c6d203a8503afbd2b1ad63eb5289a8f4bbf4d2945
-  md5: 61318988733a695066b39704f6e08bd2
+  size: 135000
+  timestamp: 1777574970629
+- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b1-release.conda
+  sha256: a8f36a83ece187307d7d78c152828eac58edb002d515de2bcbe9f5a19388b70c
+  md5: 11bdf0256d179b89dc00ca4150c6963c
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.2.0
-  - mblack ==26.2.0
+  - mojo-compiler ==1.0.0b1
+  - mblack ==26.3.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 89753715
-  timestamp: 1773797215278
-- conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
-  sha256: e35b8d34564b30189c5a985990466b4283f9e1d897baf23fe9ddbcbc9283459c
-  md5: 12e4d8397c451b7c8a55ff5a759ce00b
+  size: 94106548
+  timestamp: 1777595784229
+- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b1-release.conda
+  sha256: 2980b825e3eedb153f68f74edeaae6a7b819912c3eb6e49f1eed7d25f883e050
+  md5: b5f2c6b04a9e2bbe199fef1ea5677014
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.2.0
-  - mblack ==26.2.0
+  - mojo-compiler ==1.0.0b1
+  - mblack ==26.3.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 81534498
-  timestamp: 1773797099755
-- conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
-  sha256: e53f30d72a65e6b0a67745e6988f978d8f6ecc14531420631c9719eb9c7b9c2b
-  md5: e3a673daa0ddf3ca6af297daee4ceab5
+  size: 83375027
+  timestamp: 1777596028766
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b1-release.conda
+  sha256: 706c7f8e2be740dda8039bf96182b578bfbbd9220ca1a7f762e1f82acc4eb784
+  md5: 2fc6038c3837e50bb855bcf7f930c1c9
   depends:
-  - mojo-python ==0.26.2.0
+  - mojo-python ==1.0.0b1
   license: LicenseRef-Modular-Proprietary
-  size: 89091679
-  timestamp: 1773797216619
-- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
-  sha256: e82cb7ce1a756876a233d364d5397adca5ad7e20fff5204c1c7e93aefe4549b5
-  md5: 96e3ec50a2ea4abdb9fc4f3f89dc874b
+  size: 89421276
+  timestamp: 1777595833113
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b1-release.conda
+  sha256: 3e0d6e6e814cb39d14d24234eb8f2ac6524379ea0a9c398a54e77598844e96d6
+  md5: fe08c02512b02563a0b878eeb32a684b
   depends:
-  - mojo-python ==0.26.2.0
+  - mojo-python ==1.0.0b1
   license: LicenseRef-Modular-Proprietary
-  size: 67499721
-  timestamp: 1773797103208
-- conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
+  size: 67503416
+  timestamp: 1777596016502
+- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b1-release.conda
   noarch: python
-  sha256: 2d9e350cfe7a0ae5d96dea13c082b09f21aac8ac4caa3e5def6b075930348fa1
-  md5: 67a4fc0d47e84d3a91c4f12cc912c7ac
+  sha256: b0554c7705685c86e8a8063bcd11ed58897a498c8e1e19ef045f5ebba2c8874f
+  md5: d0ad2f8ba3758f03bfda84d92bb34b67
   depends:
   - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 22936
-  timestamp: 1773780198161
+  size: 23114
+  timestamp: 1777594699418
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,13 +34,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-mojo = "1.0.0b1*"
+mojo = "==1.0.0b1"
 
 [package.build-dependencies]
-mojo = "1.0.0b1*"
+mojo = "==1.0.0b1"
 
 [package.run-dependencies]
-mojo = "1.0.0b1"
+mojo = "==1.0.0b1"
 
 [tasks]
 # compile the package and copy it to the tests folder

--- a/pixi.toml
+++ b/pixi.toml
@@ -6,6 +6,7 @@ authors = [
   "mmenendezg <>",
   "sandstromviktor <>",
   "durnwalder <>",
+  "sauterp <>",
 ]
 channels = [
   "https://conda.modular.com/max",

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,13 +34,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-mojo = "0.26.2.*"
+mojo = "1.0.0b1*"
 
 [package.build-dependencies]
-mojo = "0.26.2.*"
+mojo = "1.0.0b1*"
 
 [package.run-dependencies]
-mojo = "0.26.2.*"
+mojo = "1.0.0b1"
 
 [tasks]
 # compile the package and copy it to the tests folder
@@ -72,4 +72,4 @@ release = "clear && pixi run final && pixi run doc_pages"
 numpy = ">=2.4.2,<3"
 python = ">=3.13,<3.14"
 scipy = ">=1.17.0,<2"
-mojo = ">=0.26.2.0,<0.27"
+mojo = ">=1.0.0b1,<2"

--- a/tests/core/test_complexArray.mojo
+++ b/tests/core/test_complexArray.mojo
@@ -156,7 +156,7 @@ def _make_complex_2x3() raises -> ComplexNDArray[cf32]:
 
 def test_complex_array_deep_copy_independent() raises:
     var c = _make_complex_2x3()
-    var d = c.deep_copy()
+    var d = c.copy()
     d.itemset(0, ComplexSIMD[cf32](99.0, 88.0))
     assert_almost_equal(c.item(0).re, 1.0, "deep_copy modified source")
     assert_almost_equal(c.item(0).im, 0.0, "deep_copy modified source")

--- a/tests/core/test_operations.mojo
+++ b/tests/core/test_operations.mojo
@@ -1,0 +1,16 @@
+import numojo as nm
+from numojo.prelude import *
+from std.testing.testing import assert_true
+from std.testing import TestSuite
+
+
+def test_ndarray_multiplication_commutes() raises:
+    var A = nm.ones[nm.f64](nm.Shape(2, 2))
+    var B = nm.ones[nm.f64](nm.Shape(2, 2))
+    var L = 2.0 * (A @ B)
+    var R = (A @ B) * 2.0
+    assert_true((L == R).all())
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -1052,7 +1052,7 @@ def _make_1d_offset_view(
     """
     var view = parent.view()
     view.offset = offset
-    view.size = size 
+    view.size = size
     view.shape = NDArrayShape(size)
     view.ndim = 1
     view.strides = NDArrayStrides(shape=view.shape)

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -1046,13 +1046,13 @@ def test_ndarray_sliced_view_manipulation() raises:
 
 
 def _make_1d_offset_view(
-    parent: nm.NDArray[nm.f64], offset: Int, size: Int
+    mut parent: nm.NDArray[nm.f64], offset: Int, size: Int
 ) raises -> nm.NDArray[nm.f64]:
     """Create a 1-D view into `parent` starting at `offset` with `size` elems.
     """
-    var view = parent.copy()
+    var view = parent.view()
     view.offset = offset
-    view.size = size
+    view.size = size 
     view.shape = NDArrayShape(size)
     view.ndim = 1
     view.strides = NDArrayStrides(shape=view.shape)
@@ -1060,7 +1060,7 @@ def _make_1d_offset_view(
 
 
 def _make_2d_offset_view(
-    parent: nm.NDArray[nm.f64],
+    mut parent: nm.NDArray[nm.f64],
     offset: Int,
     rows: Int,
     cols: Int,
@@ -1068,7 +1068,7 @@ def _make_2d_offset_view(
     stride1: Int,
 ) raises -> nm.NDArray[nm.f64]:
     """Create a 2-D view into `parent`."""
-    var view = parent.copy()
+    var view = parent.view()
     view.offset = offset
     view.size = rows * cols
     view.shape = NDArrayShape(rows, cols)

--- a/tests/routines/test_indexing.mojo
+++ b/tests/routines/test_indexing.mojo
@@ -29,9 +29,7 @@ def test_compress() raises:
         "`compress` 1-d array is broken",
     )
     check(
-        nm.indexing.compress(
-            nm.array[boolean]("[0,1,1,0,1,0,1,0,1,1,1]"), a
-        ),
+        nm.indexing.compress(nm.array[boolean]("[0,1,1,0,1,0,1,0,1,1,1]"), a),
         np.compress(
             np.array(Python.list(0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1)), anp
         ),

--- a/tests/routines/test_indexing.mojo
+++ b/tests/routines/test_indexing.mojo
@@ -5,7 +5,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """
-Test indexing module `numojo.routines.indexing`.
+Test indexing module `nm.routines.indexing`.
 """
 from std.python import Python
 from std.testing.testing import assert_true, assert_almost_equal, assert_equal
@@ -13,6 +13,7 @@ from utils_for_test import check, check_is_close
 from std.testing import TestSuite
 
 from numojo.prelude import *
+import numojo as nm
 
 
 def test_compress() raises:
@@ -23,12 +24,12 @@ def test_compress() raises:
     var bnp = b.to_numpy()
 
     check(
-        numojo.indexing.compress(nm.array[boolean]("[0, 1, 1, 0]"), b),
+        nm.indexing.compress(nm.array[boolean]("[0, 1, 1, 0]"), b),
         np.compress(np.array(Python.list(0, 1, 1, 0)), bnp),
         "`compress` 1-d array is broken",
     )
     check(
-        numojo.indexing.compress(
+        nm.indexing.compress(
             nm.array[boolean]("[0,1,1,0,1,0,1,0,1,1,1]"), a
         ),
         np.compress(

--- a/tests/routines/test_io.mojo
+++ b/tests/routines/test_io.mojo
@@ -7,6 +7,7 @@ from numojo.prelude import *
 from numojo.routines.io.files import load, save, loadtxt, savetxt
 from numojo import ones, full
 
+
 def test_save_and_load() raises:
     var np = Python.import_module("numpy")
     var arr = ones[nm.f32](nm.Shape(10, 15))

--- a/tests/routines/test_io.mojo
+++ b/tests/routines/test_io.mojo
@@ -1,13 +1,15 @@
-from numojo.routines.io.files import load, save, loadtxt, savetxt
-from numojo import ones, full
 from std.python import Python
 from std import os
 from std.testing import TestSuite
 
+import numojo as nm
+from numojo.prelude import *
+from numojo.routines.io.files import load, save, loadtxt, savetxt
+from numojo import ones, full
 
 def test_save_and_load() raises:
     var np = Python.import_module("numpy")
-    var arr = ones[numojo.f32](numojo.Shape(10, 15))
+    var arr = ones[nm.f32](nm.Shape(10, 15))
     var fname = "test_save_load.npy"
     save(fname=fname, array=arr)
     # Load with numpy for cross-check
@@ -22,7 +24,7 @@ def test_save_and_load() raises:
 
 def test_savetxt_and_loadtxt() raises:
     var np = Python.import_module("numpy")
-    var arr = full[numojo.f32](numojo.Shape(10, 15), fill_value=5.0)
+    var arr = full[nm.f32](nm.Shape(10, 15), fill_value=5.0)
     var fname = "test_savetxt_loadtxt.txt"
     savetxt(fname, arr, fmt="%.2f")
     # Load with numpy for cross-check

--- a/tests/routines/test_linalg.mojo
+++ b/tests/routines/test_linalg.mojo
@@ -1,8 +1,9 @@
-import numojo as nm
-from numojo.prelude import *
 from std.python import Python, PythonObject
 from utils_for_test import check, check_is_close, check_values_close
 from std.testing import TestSuite
+
+import numojo as nm
+from numojo.prelude import *
 
 # ===-----------------------------------------------------------------------===#
 # Matmul

--- a/tests/routines/test_logic.mojo
+++ b/tests/routines/test_logic.mojo
@@ -1,9 +1,10 @@
-import numojo as nm
-from numojo.prelude import *
 from std.python import Python, PythonObject
 from std.testing.testing import assert_raises, assert_true, assert_equal
 from std.testing import TestSuite
 from utils_for_test import check
+
+import numojo as nm
+from numojo.prelude import *
 from numojo.routines.logic.comparison import allclose, isclose, array_equal
 from numojo.routines.logic.contents import isposinf, isneginf
 

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -6,6 +6,7 @@ from std.testing import TestSuite
 import numojo as nm
 from numojo import *
 
+
 def test_arr_manipulation() raises:
     var np = Python.import_module("numpy")
 

--- a/tests/routines/test_manipulation.mojo
+++ b/tests/routines/test_manipulation.mojo
@@ -1,10 +1,10 @@
-import numojo as nm
-from numojo import *
 from std.testing.testing import assert_true, assert_almost_equal, assert_equal
 from utils_for_test import check, check_is_close
 from std.python import Python, PythonObject
 from std.testing import TestSuite
 
+import numojo as nm
+from numojo import *
 
 def test_arr_manipulation() raises:
     var np = Python.import_module("numpy")

--- a/tests/routines/test_math.mojo
+++ b/tests/routines/test_math.mojo
@@ -1,5 +1,3 @@
-import numojo as nm
-from numojo.prelude import *
 from std.python import Python, PythonObject
 from std.testing.testing import assert_raises, assert_true
 from utils_for_test import (
@@ -9,6 +7,9 @@ from utils_for_test import (
     check_with_dtype,
 )
 from std.testing import TestSuite
+
+import numojo as nm
+from numojo.prelude import *
 
 # ===-----------------------------------------------------------------------===#
 # Sums, products, differences

--- a/tests/routines/test_random.mojo
+++ b/tests/routines/test_random.mojo
@@ -1,11 +1,11 @@
 from std.math import sqrt
-import numojo as nm
-from numojo.prelude import *
 from std.python import Python, PythonObject
 from utils_for_test import check, check_is_close
 from std.testing.testing import assert_true, assert_almost_equal
 from std.testing import TestSuite
 
+import numojo as nm
+from numojo.prelude import *
 
 def test_rand() raises:
     """Test random array generation with specified shape."""

--- a/tests/routines/test_random.mojo
+++ b/tests/routines/test_random.mojo
@@ -7,6 +7,7 @@ from std.testing import TestSuite
 import numojo as nm
 from numojo.prelude import *
 
+
 def test_rand() raises:
     """Test random array generation with specified shape."""
     var arr = nm.random.rand[nm.f64](3, 5, 2)

--- a/tests/routines/test_searching.mojo
+++ b/tests/routines/test_searching.mojo
@@ -4,6 +4,7 @@ from std.testing import TestSuite
 
 from numojo.prelude import *
 
+
 def test_argmax() raises:
     var np = Python.import_module("numpy")
 

--- a/tests/routines/test_searching.mojo
+++ b/tests/routines/test_searching.mojo
@@ -1,8 +1,8 @@
-from numojo.prelude import *
 from std.python import Python, PythonObject
 from utils_for_test import check, check_is_close, check_values_close
 from std.testing import TestSuite
 
+from numojo.prelude import *
 
 def test_argmax() raises:
     var np = Python.import_module("numpy")

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -4,6 +4,7 @@ from std.testing import TestSuite
 
 import numojo as nm
 
+
 def test_sort() raises:
     var np = Python.import_module("numpy")
     var A = nm.random.randn(10)

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -1,8 +1,8 @@
-import numojo as nm
 from std.python import Python, PythonObject
 from utils_for_test import check, check_is_close
 from std.testing import TestSuite
 
+import numojo as nm
 
 def test_sort() raises:
     var np = Python.import_module("numpy")

--- a/tests/routines/test_statistics.mojo
+++ b/tests/routines/test_statistics.mojo
@@ -1,10 +1,11 @@
-import numojo as nm
-from numojo.prelude import *
-from numojo.core.matrix import Matrix
 from std.python import Python, PythonObject
 from std.testing.testing import assert_raises, assert_true
 from utils_for_test import check, check_is_close
 from std.testing import TestSuite
+
+import numojo as nm
+from numojo.prelude import *
+from numojo.core.matrix import Matrix
 
 # ===-----------------------------------------------------------------------===#
 # Statistics

--- a/tests/routines/test_statistics.mojo
+++ b/tests/routines/test_statistics.mojo
@@ -73,12 +73,12 @@ def test_mean_median_var_std() raises:
         )
 
     assert_true(
-        np.all(np.isclose(nm.std(A), np.std(Anp), atol=PythonObject(0.001))),
+        np.all(np.isclose(nm.stddev(A), np.std(Anp), atol=PythonObject(0.001))),
         "`std` is broken",
     )
     for axis in range(3):
         check_is_close(
-            nm.std(A, axis),
+            nm.stddev(A, axis),
             np.std(Anp, axis),
             String("`std` is broken for axis {}").format(axis),
         )


### PR DESCRIPTION
## Upgrade to Mojo 1.0.0b1 + memory model refactor

### Summary

- Upgrades NuMojo to Mojo 1.0.0b1, fixing all breaking language and stdlib changes
- Refactors the memory model to make `__copyinit__` a true deep copy throughout
- Removes the redundant `deep_copy()` family of methods
- Renames standalone `std()` → `stddev()` to avoid conflict with the `std` stdlib module
- Switches CI from Ubuntu to macOS 14 (ARM)

---

### Language changes

- Replaced all `fn` keyword usages with `def` across the entire codebase. 
- Removed the `unified` keyword from all closure capture lists. The new syntax is just `{captures}` directly.
- Updated all call sites that passed stdlib SIMD methods (`SIMD.__add__`, `SIMD.lt`, `math.sin`, etc.) directly to backend functions expecting `capturing`. Replaced with local `@parameter` kernel closures, for example,
```mojo
  @parameter
  def kernel[dtype: DType, simd_w: Int](
      simd1: SIMD[dtype, simd_w], simd2: SIMD[dtype, simd_w]
  ) -> SIMD[dtype, simd_w]:
      return simd1 + simd2
  return HostExecutor.apply_binary[dtype, kernel](array1, array2)
```
- Fixed `from pkg import ...` no longer making pkg available as a name: added explicit `import ...` as alias statements and replaced all numojo.X.func() call sites with their aliases in ndarray.mojo, complex_ndarray.mojo, and matrix/base.mojo.

# Stdlib API changes
- UnsafePointer null construction `UnsafePointer[T]() → UnsafePointer[T, origin].unsafe_dangling()`
- UnsafePointer is no longer Boolable: replaced all if ptr: / if not ptr: guards with Int(ptr) == 0 / Int(ptr) != 0. (This is temporary as we will move to using Optional[UnsafePointer] in the following PR to ensure safety).
- `is_refcounted()` in DataContainer and HostStorage now checks self.ownership == Ownership.Managed instead of comparing against a null pointer
- Atomic imports moved from std.os.atomic (Consistency) to std.atomic (Ordering), and MONOTONIC → RELAXED throughout data_container.mojo and storage.mojo.
- `String.__len__()` deprecated → replaced `len(out)` with `out.byte_length()` in array formatting code in ndarray.mojo and complex_ndarray.mojo.
- Renamed standalone std() functions (standard deviation) to stddev() across statistics/, __init__ exports, and all call sites as std conflicts with the stdlib module name. Note: NDArray.std() and Matrix.std() methods are unchanged as method names don't conflict.

## Memory model refactor
- `DataContainer.__copyinit__` is now a deep copy (allocates new storage and memcpys data) instead of a shallow ref-counted copy. This makes `arr.copy()` produce an independent owned array everywhere, consistent with NumPy semantics.
- Removed `deep_copy()` methods from DataContainer, NDArray, ComplexNDArray, Matrix, HostStorage, and AcceleratorDataContainer - they are now redundant since `copy()` (i.e. __copyinit__) does the same thing
- All former .deep_copy() call sites updated to .copy()
- Shared views still use `.share() / .view()` explicitly. `DataContainer.share()` is unchanged and continues to increment the refcount without copying data.

## Test fix
- test_view_safety.mojo: updated `_make_1d_offset_view` and `_make_2d_offset_view` helpers to use parent.view() instead of parent.copy(), since .copy() now produces an independent buffer and writes to the view would not be reflected in the 

## Docstrings and warnings
- Fixed all module-level docstring summaries that triggered mojo doc warnings — replaced blank lines after the title with --- separator lines, following the established pattern in ndarray.mojo
- Removed ==== banner style in favour of consistent ---- separators
- Replaced deprecated String.__len__() usages (2 occurrences) with .byte_length()
- Replaced all Bool(ptr) on UnsafePointer usages in dlpack.mojo with Int(ptr) == 0 checks

## CI
- Switched GitHub Actions runner from ubuntu-22.04 to macos-14 (Apple Silicon ARM), matching the primary development and target platform

