### PR TITLE
[NDArray] Implement building blocks and AcceleratorNDArray 

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -55,6 +55,7 @@ comptime __version__: String = "V0.9.0"
 # ===----------------------------------------------------------------------=== #
 
 from numojo.core.ndarray import NDArray
+from numojo.core.accelerator_ndarray import AcceleratorNDArray
 from numojo.core.layout.ndshape import NDArrayShape
 from numojo.core.layout.ndstrides import NDArrayStrides
 from numojo.core.indexing.item import Item

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -14,6 +14,7 @@ Fundamental types and utilities for NuMojo: arrays, matrices, memory layouts, da
 """
 
 from .ndarray import NDArray
+from .accelerator_ndarray import AcceleratorNDArray
 
 from .type_aliases import (
     Shape,

--- a/numojo/core/accelerator/__init__.mojo
+++ b/numojo/core/accelerator/__init__.mojo
@@ -10,4 +10,12 @@
 Accelerator (GPU) support namespace for NuMojo.
 """
 
-from .device import Device, cpu, cuda, mps, rocm
+from .device import (
+    Device,
+    DeviceHandle,
+    DeviceSpec,
+    cpu,
+    cuda,
+    mps,
+    rocm,
+)

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -124,26 +124,6 @@ struct DeviceSpec(
         return not self.__eq__(other)
 
 
-struct CPUDeviceHandle(Copyable, Movable, Writable):
-    """Runtime-facing CPU handle.
-
-    CPU execution does not need a `DeviceContext`, but keeping an explicit
-    handle type lets storage and dispatch code treat CPU and GPU as concrete
-    runtime resources rather than overloading `Device`.
-    """
-
-    var spec: DeviceSpec
-
-    def __init__(out self):
-        self.spec = DeviceSpec()
-
-    def __str__(self) -> String:
-        return "CPUDeviceHandle(cpu)"
-
-    def write_to[W: Writer](self, mut writer: W):
-        writer.write(self.__str__())
-
-
 struct DeviceHandle[device: Device](Copyable, Movable, Writable):
     """GPU handle for a compile-time `Device`.
 
@@ -157,7 +137,7 @@ struct DeviceHandle[device: Device](Copyable, Movable, Writable):
     def __init__(out self) raises:
         comptime assert (
             Self._requires_gpu
-        ), "DeviceHandle is only for GPU devices. Use CPUDeviceHandle for CPU."
+        ), "DeviceHandle is only for GPU devices."
         if not Self.device.is_available():
             raise Error(
                 NumojoError(
@@ -170,6 +150,12 @@ struct DeviceHandle[device: Device](Copyable, Movable, Writable):
                 )
             )
         self.context = DeviceContext(Self.device.id)
+
+    def __init__(out self, var context: DeviceContext):
+        comptime assert (
+            Self._requires_gpu
+        ), "DeviceHandle is only for GPU devices."
+        self.context = context^
 
     def __init__(out self, *, copy: Self):
         self.context = copy.context.copy()

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -103,13 +103,13 @@ struct DeviceSpec(
             return 3
         return -1
 
-    def canonical(self) -> String:
+    def name(self) -> String:
         if self.backend == "cpu":
             return "cpu"
         return self.backend + ":" + String(self.id)
 
     def __str__(self) -> String:
-        return self.canonical()
+        return self.name()
 
     def __repr__(self) -> String:
         return self.__str__()
@@ -144,7 +144,7 @@ struct DeviceHandle[device: Device](Copyable, Movable, Writable):
                     category="value",
                     message=(
                         "Cannot create runtime handle for unavailable device: "
-                        + Self.device.canonical()
+                        + Self.device.device_name()
                     ),
                     location="DeviceHandle.__init__",
                 )
@@ -164,7 +164,7 @@ struct DeviceHandle[device: Device](Copyable, Movable, Writable):
         self.context = take.context^
 
     def __str__(self) -> String:
-        return "DeviceHandle(" + Self.device.canonical() + ", context=True)"
+        return "DeviceHandle(" + Self.device.device_name() + ", context=True)"
 
     def write_to[W: Writer](self, mut writer: W):
         writer.write(self.__str__())
@@ -494,13 +494,13 @@ struct Device(
         """
         return self.spec.backend_id()
 
-    def canonical(self) -> String:
+    def device_name(self) -> String:
         """Return device string.
 
         Returns:
             "cpu" for CPU devices and "<backend>:<id>" for GPU devices.
         """
-        return self.spec.canonical()
+        return self.spec.name()
 
     def same_backend(self, other: Self) -> Bool:
         """Check if two devices use the same execution backend."""

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -15,6 +15,7 @@ from std.sys.info import (
     has_amd_gpu_accelerator,
     has_apple_gpu_accelerator,
 )
+from std.gpu.host import DeviceContext
 
 from numojo.core.error import NumojoError
 
@@ -24,13 +25,184 @@ comptime rocm = Device.ROCM
 comptime mps = Device.MPS
 
 
+struct DeviceSpec(
+    Equatable,
+    ImplicitlyCopyable,
+    Movable,
+    Writable,
+):
+    """Device identity.
+
+    `DeviceSpec` only describes where data should live: CPU or a GPU backend plus device index.
+    """
+
+    var backend: String
+    """Canonical backend: "cpu", "cuda", "rocm", or "mps"."""
+    var id: Int
+    """Zero-based device index. CPU always uses id 0."""
+
+    def __init__(out self):
+        self.backend = "cpu"
+        self.id = 0
+
+    def __init__(out self, backend: String, id: Int) raises:
+        if backend == "cpu":
+            if id != 0:
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="CPU device id must be 0.",
+                        location="DeviceSpec.__init__",
+                    )
+                )
+            self.backend = "cpu"
+            self.id = 0
+            return
+
+        if backend != "cuda" and backend != "rocm" and backend != "mps":
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="Unsupported device backend: " + backend,
+                    location="DeviceSpec.__init__",
+                )
+            )
+
+        if id < 0:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="GPU device id must be non-negative.",
+                    location="DeviceSpec.__init__",
+                )
+            )
+
+        self.backend = backend
+        self.id = id
+
+    @staticmethod
+    def _unchecked_init(out spec: DeviceSpec, backend: String, id: Int):
+        spec = DeviceSpec()
+        spec.backend = backend
+        spec.id = id
+
+    def is_cpu(self) -> Bool:
+        return self.backend == "cpu"
+
+    def is_gpu(self) -> Bool:
+        return not self.is_cpu()
+
+    def backend_id(self) -> Int:
+        if self.backend == "cpu":
+            return 0
+        if self.backend == "cuda":
+            return 1
+        if self.backend == "rocm":
+            return 2
+        if self.backend == "mps":
+            return 3
+        return -1
+
+    def canonical(self) -> String:
+        if self.backend == "cpu":
+            return "cpu"
+        return self.backend + ":" + String(self.id)
+
+    def __str__(self) -> String:
+        return self.canonical()
+
+    def __repr__(self) -> String:
+        return self.__str__()
+
+    def write_to[W: Writer](self, mut writer: W):
+        writer.write(self.__str__())
+
+    def __eq__(self, other: Self) -> Bool:
+        return self.backend == other.backend and self.id == other.id
+
+    def __ne__(self, other: Self) -> Bool:
+        return not self.__eq__(other)
+
+
+struct CPUDeviceHandle(Copyable, Movable, Writable):
+    """Runtime-facing CPU handle.
+
+    CPU execution does not need a `DeviceContext`, but keeping an explicit
+    handle type lets storage and dispatch code treat CPU and GPU as concrete
+    runtime resources rather than overloading `Device`.
+    """
+
+    var spec: DeviceSpec
+
+    def __init__(out self):
+        self.spec = DeviceSpec()
+
+    def __str__(self) -> String:
+        return "CPUDeviceHandle(cpu)"
+
+    def write_to[W: Writer](self, mut writer: W):
+        writer.write(self.__str__())
+
+
+struct DeviceHandle[device: Device](Copyable, Movable, Writable):
+    """GPU handle for a compile-time `Device`.
+
+    This handle owns the runtime `DeviceContext` used by storage allocation and kernels.
+    """
+
+    comptime _requires_gpu = Self.device.type == "gpu"
+
+    var context: DeviceContext
+
+    def __init__(out self) raises:
+        comptime assert (
+            Self._requires_gpu
+        ), "DeviceHandle is only for GPU devices. Use CPUDeviceHandle for CPU."
+        if not Self.device.is_available():
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Cannot create runtime handle for unavailable device: "
+                        + Self.device.canonical()
+                    ),
+                    location="DeviceHandle.__init__",
+                )
+            )
+        self.context = DeviceContext(Self.device.id)
+
+    def __init__(out self, *, copy: Self):
+        self.context = copy.context.copy()
+
+    def __init__(out self, *, deinit take: Self):
+        self.context = take.context^
+
+    def __str__(self) -> String:
+        return "DeviceHandle(" + Self.device.canonical() + ", context=True)"
+
+    def write_to[W: Writer](self, mut writer: W):
+        writer.write(self.__str__())
+
+    def is_cpu(self) -> Bool:
+        return False
+
+    def is_gpu(self) -> Bool:
+        return True
+
+    def device_context(self) -> DeviceContext:
+        return self.context.copy()
+
+    def synchronize(self) raises:
+        self.context.synchronize()
+
+
 struct Device(
     Equatable,
     ImplicitlyCopyable,
     Movable,
     Writable,
 ):
-    """Represents an execution device for array and matrix operations.
+    """Represents an execution device for array operations.
 
     A `Device` identifies where computation should run, analogous to
     `torch.device` in PyTorch. Each device has a type ("cpu" or "gpu"),
@@ -49,6 +221,9 @@ struct Device(
         var cpu = Device("cpu")
         ```
     """
+
+    var spec: DeviceSpec
+    """Device identity."""
 
     var type: String
     """Device type: "cpu" or "gpu"."""
@@ -76,6 +251,7 @@ struct Device(
 
     def __init__(out self):
         """Initialize a default CPU device."""
+        self.spec = DeviceSpec()
         self.type = "cpu"
         self.name = ""
         self.id = 0
@@ -92,16 +268,12 @@ struct Device(
         Raises:
             Error on invalid device string format.
         """
-        var parsed = Device.parse_device_string(text)
-        self.type = parsed.type
-        self.name = parsed.name
-        self.id = parsed.id
+        self = Device.parse_device_string(text)
 
-    def __init__(out self, type: String, name: String, id: Int):
+    def __init__(out self, type: String, name: String, id: Int) raises:
         """Initialize a device with explicit type, name, and index.
 
-        Validates the arguments and falls back to CPU if the requested
-        GPU backend is not available on the current system.
+        Validates the arguments and raises on invalid or unavailable devices.
 
         Args:
             type: Device type, must be "cpu" or "gpu".
@@ -109,48 +281,99 @@ struct Device(
             id: Zero-based device index (must be 0 for CPU, >= 0 for GPU).
         """
         if type != "cpu" and type != "gpu":
-            print("Invalid device type '" + type + "'. Defaulting to CPU.")
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="Invalid device type: " + type,
+                    location="Device.__init__",
+                )
+            )
 
         if type == "gpu" and name == "":
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="GPU device backend name cannot be empty.",
+                    location="Device.__init__",
+                )
+            )
 
         if type == "cpu":
             if name != "":
-                print("CPU device name must be empty. Defaulting to CPU.")
-                self = Device._cpu_fallback()
-                return
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="CPU device name must be empty.",
+                        location="Device.__init__",
+                    )
+                )
             if id != 0:
-                print("CPU device id must be 0. Defaulting to CPU.")
-                self = Device._cpu_fallback()
-                return
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="CPU device id must be 0.",
+                        location="Device.__init__",
+                    )
+                )
+            self.spec = DeviceSpec("cpu", 0)
             self.type = "cpu"
             self.name = ""
             self.id = 0
             return
 
         if name != "cuda" and name != "rocm" and name != "mps":
-            print("Invalid GPU backend '" + name + "'. Defaulting to CPU.")
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="Invalid GPU backend: " + name,
+                    location="Device.__init__",
+                )
+            )
 
         if id < 0:
-            print("GPU device id must be non-negative. Defaulting to CPU.")
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="GPU device id must be non-negative.",
+                    location="Device.__init__",
+                )
+            )
 
         if name == "cuda" and not has_nvidia_gpu_accelerator():
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "CUDA device requested but no CUDA accelerator is"
+                        " available."
+                    ),
+                    location="Device.__init__",
+                )
+            )
         if name == "rocm" and not has_amd_gpu_accelerator():
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "ROCm device requested but no ROCm accelerator is"
+                        " available."
+                    ),
+                    location="Device.__init__",
+                )
+            )
         if name == "mps" and not has_apple_gpu_accelerator():
-            self = Device._cpu_fallback()
-            return
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "MPS device requested but no MPS accelerator is"
+                        " available."
+                    ),
+                    location="Device.__init__",
+                )
+            )
 
+        self.spec = DeviceSpec(name, id)
         self.type = type
         self.name = name
         self.id = id
@@ -161,6 +384,9 @@ struct Device(
     ):
         """Create a device without any validation. For internal/comptime use."""
         device = Device()
+        device.spec = DeviceSpec._unchecked_init(
+            backend="cpu" if type == "cpu" else name, id=id
+        )
         device.type = type
         device.name = name
         device.id = id
@@ -169,6 +395,13 @@ struct Device(
     def _cpu_fallback() -> Device:
         """Return a default CPU device."""
         return Device()
+
+    @staticmethod
+    def from_spec(spec: DeviceSpec) raises -> Device:
+        """Validate and construct a `Device` from a canonical spec."""
+        if spec.is_cpu():
+            return Device.CPU
+        return Device(type="gpu", name=spec.backend, id=spec.id)
 
     # ===------------------------------------------------------------------=== #
     # Trait implementations
@@ -267,6 +500,30 @@ struct Device(
         """
         return self.type == "gpu"
 
+    def backend_id(self) -> Int:
+        """Return a backend identifier.
+
+        Returns:
+            0 for CPU, 1 for CUDA, 2 for ROCm, 3 for MPS, and -1 for unknown.
+        """
+        return self.spec.backend_id()
+
+    def canonical(self) -> String:
+        """Return device string.
+
+        Returns:
+            "cpu" for CPU devices and "<backend>:<id>" for GPU devices.
+        """
+        return self.spec.canonical()
+
+    def same_backend(self, other: Self) -> Bool:
+        """Check if two devices use the same execution backend."""
+        return self.spec.backend == other.spec.backend
+
+    def is_default_index(self) -> Bool:
+        """Check if this device uses index 0."""
+        return self.id == 0
+
     def is_available(self) -> Bool:
         """Check if this device is available on the current system.
 
@@ -289,7 +546,7 @@ struct Device(
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    def default_device() -> Device:
+    def default_device() raises -> Device:
         """Return the best available device: GPU if present, otherwise CPU.
 
         Returns:
@@ -377,13 +634,16 @@ struct Device(
             text: The device string to parse.
 
         Returns:
-            The parsed `Device`. Falls back to `Device.CPU` for
-            unrecognized or invalid strings.
+            The parsed and validated `Device`.
 
         Raises:
-            Error when "gpu" is specified but no GPU backend is available.
+            Error for invalid strings, unavailable GPU backends, or invalid
+            device indices.
         """
-        if text == "cpu" or text.startswith("cpu:"):
+        if text == "cpu":
+            return Device.CPU
+
+        if text == "cpu:0":
             return Device.CPU
 
         var backend: String = ""
@@ -401,13 +661,25 @@ struct Device(
                 id_str += ch
 
         if backend == "":
-            return Device.CPU
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="Device string cannot be empty.",
+                    location="Device.parse_device_string",
+                )
+            )
 
         if backend == "gpu":
             backend = Device.available_gpu()
 
         if seen_colon and id_str == "":
-            return Device.CPU
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message="Device index is missing after ':'.",
+                    location="Device.parse_device_string",
+                )
+            )
 
         if id_str != "":
             var sign: Int = 1
@@ -419,19 +691,43 @@ struct Device(
                     sign = -1
                     continue
                 if Int(b) < ord("0") or Int(b) > ord("9"):
-                    return Device.CPU
+                    raise Error(
+                        NumojoError(
+                            category="value",
+                            message="Device index must be an integer.",
+                            location="Device.parse_device_string",
+                        )
+                    )
                 has_digit = True
                 id = id * 10 + (Int(b) - ord("0"))
             if not has_digit:
-                return Device.CPU
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="Device index must contain at least one digit.",
+                        location="Device.parse_device_string",
+                    )
+                )
             id = id * sign
             if id < 0:
-                return Device.CPU
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="Device index must be non-negative.",
+                        location="Device.parse_device_string",
+                    )
+                )
 
         if backend == "cuda" or backend == "rocm" or backend == "mps":
             return Device(type="gpu", name=backend, id=id)
 
-        return Device.CPU
+        raise Error(
+            NumojoError(
+                category="value",
+                message="Unsupported device string: " + text,
+                location="Device.parse_device_string",
+            )
+        )
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -1,0 +1,878 @@
+# ===----------------------------------------------------------------------=== #
+# NuMojo: Accelerator NDArray
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+"""AcceleratorNDArray (numojo.core.accelerator_ndarray)
+--------------------------------------------------------
+Device-aware NDArray that stores data in `AcceleratorDataContainer`.
+"""
+
+from std.memory import UnsafePointer
+from numojo.core.error import NumojoError
+from numojo.core.layout.flags import Flags
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.layout.ndstrides import NDArrayStrides
+from numojo.core.indexing.item import Item
+from numojo.core.indexing.offset import IndexMethods
+from numojo.core.memory.storage import AcceleratorDataContainer
+from numojo.core.accelerator.device import Device
+from numojo.core.ndarray import NDArray
+from numojo.core.dtype.default_dtype import _concise_dtype_str
+
+
+struct AcceleratorNDArray[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](
+    Copyable,
+    Movable,
+    Sized,
+    Writable,
+):
+    """Device-aware N-dimensional array.
+
+    Parameters:
+        dtype: Element dtype.
+        device: Target device (`Device.CPU`, `Device.CUDA`, `Device.ROCM`,
+            `Device.MPS`).
+    """
+
+    var _buf: AcceleratorDataContainer[Self.dtype, Self.device]
+    var ndim: Int
+    var shape: NDArrayShape
+    var size: Int
+    var strides: NDArrayStrides
+    var offset: Int
+    var flags: Flags
+
+    # ===------------------------------------------------------------------=== #
+    # Lifecycle
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline("nodebug")
+    def __init__(out self):
+        self._buf = AcceleratorDataContainer[Self.dtype, Self.device]()
+        self.ndim = 0
+        self.shape = NDArrayShape()
+        self.size = 0
+        self.strides = NDArrayStrides()
+        self.offset = 0
+        self.flags = Flags(
+            c_contiguous=True,
+            f_contiguous=True,
+            owndata=False,
+            writeable=False,
+        )
+
+    @always_inline("nodebug")
+    def __init__(out self, shape: NDArrayShape, order: String = "C") raises:
+        self.ndim = shape.ndim
+        self.shape = shape
+        self.size = shape.size()
+        self.strides = NDArrayStrides(shape, order=order)
+        self.offset = 0
+        self._buf = AcceleratorDataContainer[Self.dtype, Self.device](self.size)
+        self.flags = Flags(
+            self.shape, self.strides, owndata=True, writeable=True
+        )
+
+    @always_inline("nodebug")
+    def __init__(out self, shape: List[Int], order: String = "C") raises:
+        self = Self(shape=NDArrayShape(shape), order=order)
+
+    @always_inline("nodebug")
+    def __init__(out self, *shape: Int, order: String = "C") raises:
+        self = Self(shape=NDArrayShape(shape), order=order)
+
+    @always_inline("nodebug")
+    def __init__(
+        out self,
+        shape: NDArrayShape,
+        strides: NDArrayStrides,
+        offset: Int,
+        flags: Flags,
+    ) raises:
+        self.ndim = shape.ndim
+        self.shape = shape
+        self.size = shape.size()
+        self.strides = strides
+        self.offset = offset
+        self._buf = AcceleratorDataContainer[Self.dtype, Self.device](self.size)
+        self.flags = flags
+
+    @always_inline("nodebug")
+    def __init__(
+        out self,
+        var data: AcceleratorDataContainer[Self.dtype, Self.device],
+        *,
+        is_view: Bool,
+        shape: NDArrayShape,
+        strides: NDArrayStrides,
+        offset: Int,
+        size: Int,
+    ) raises:
+        self._buf = data^
+        self.ndim = shape.ndim
+        self.shape = shape
+        self.size = size
+        self.strides = strides
+        self.offset = offset
+        self.flags = Flags(shape, strides, owndata=not is_view, writeable=True)
+
+    @always_inline("nodebug")
+    def __init__(out self, *, copy: Self):
+        self.ndim = copy.ndim
+        self.shape = copy.shape
+        self.size = copy.size
+        self.strides = copy.strides
+        self.offset = copy.offset
+        self.flags = copy.flags
+        self._buf = copy._buf.copy()
+
+    @always_inline("nodebug")
+    def __init__(out self, *, deinit take: Self):
+        self.ndim = take.ndim
+        self.shape = take.shape
+        self.size = take.size
+        self.strides = take.strides
+        self.offset = take.offset
+        self.flags = take.flags
+        self._buf = take._buf^
+
+    @always_inline("nodebug")
+    def view(self) raises -> Self:
+        """Create a metadata-only view sharing the same storage."""
+        return self._make_view(
+            shape=self.shape,
+            strides=self.strides,
+            offset=self.offset,
+            size=self.size,
+        )
+
+    @always_inline("nodebug")
+    def _make_view(
+        self,
+        shape: NDArrayShape,
+        strides: NDArrayStrides,
+        offset: Int,
+        size: Int,
+    ) raises -> Self:
+        var shared = self._buf.share()
+        return Self(
+            shared^,
+            is_view=True,
+            shape=shape,
+            strides=strides,
+            offset=offset,
+            size=size,
+        )
+
+    # ===------------------------------------------------------------------=== #
+    # Representation
+    # ===------------------------------------------------------------------=== #
+
+    def _as_cpu_ndarray_for_display(self) raises -> NDArray[Self.dtype]:
+        var out = NDArray[Self.dtype](self.shape)
+        for i in range(self.size):
+            out.itemset(i, self.item(i))
+        return out^
+
+    def __str__(self) -> String:
+        var res: String
+        try:
+            if self.ndim == 0:
+                res = (
+                    String(self.item(0))
+                    + "  (0darray["
+                    + _concise_dtype_str(self.dtype)
+                    + "], use `[]` or `.item()` to unpack)"
+                )
+            else:
+                comptime if Self.device.type == "cpu":
+                    res = self._as_cpu_ndarray_for_display().__str__()
+                else:
+                    var host = self.to_host()
+                    res = host._as_cpu_ndarray_for_display().__str__()
+                var order = String("non-contiguous")
+                if self.flags.C_CONTIGUOUS:
+                    order = "C"
+                elif self.flags.F_CONTIGUOUS:
+                    order = "F"
+                res += (
+                    "\n"
+                    + String(self.ndim)
+                    + "D-array  Shape: "
+                    + self.shape.__str__()
+                    + "  Strides: "
+                    + self.strides.__str__()
+                    + "  DType: "
+                    + _concise_dtype_str(self.dtype)
+                    + "  order: "
+                    + order
+                    + "  own data: "
+                    + String(self.flags.OWNDATA)
+                    + "  device: "
+                    + Self.device.device_name()
+                )
+        except e:
+            res = String("Cannot convert array to string.\n") + String(e)
+        return res
+
+    def __repr__(self) -> String:
+        return self.__str__()
+
+    def write_to[W: Writer](self, mut writer: W):
+        writer.write(self.__str__())
+
+    def __len__(self) -> Int:
+        if self.ndim == 0:
+            return 1
+        return Int(self.shape.unsafe_load(0))
+
+    # ===------------------------------------------------------------------=== #
+    # Device helpers
+    # ===------------------------------------------------------------------=== #
+
+    @parameter
+    def is_cpu(self) -> Bool:
+        return Self.device.type == "cpu"
+
+    @parameter
+    def is_gpu(self) -> Bool:
+        return Self.device.type == "gpu"
+
+    def unsafe_ptr(
+        ref self,
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+        Self.device.type == "cpu"
+    ):
+        return self._buf.host_storage.unsafe_value().ptr + self.offset
+
+    def num_elements(self) -> Int:
+        return self.size
+
+    # ===------------------------------------------------------------------=== #
+    # Indexing and scalar access
+    # ===------------------------------------------------------------------=== #
+
+    @always_inline("nodebug")
+    def normalize(self, index: Int, dim: Int) -> Int:
+        return index if index >= 0 else index + dim
+
+    @always_inline("nodebug")
+    def _flat_offset(self, flat_index: Int) raises -> Int:
+        var idx = self.normalize(flat_index, self.size)
+        if idx < 0 or idx >= self.size:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Flat index {} out of range for size {}."
+                    ).format(flat_index, self.size),
+                    location="AcceleratorNDArray._flat_offset",
+                )
+            )
+        if self.flags.C_CONTIGUOUS or self.ndim <= 1:
+            return self.offset + idx
+
+        var rem = idx
+        var coords = Item(ndim=self.ndim)
+        for d in range(self.ndim - 1, -1, -1):
+            coords[d] = rem % self.shape[d]
+            rem //= self.shape[d]
+        return self.offset + IndexMethods.get_1d_index(coords, self.strides)
+
+    def item(self, flat_index: Int) raises -> Scalar[Self.dtype]:
+        comptime if Self.device.type == "cpu":
+            var off = self._flat_offset(flat_index)
+            return self._buf[off]
+        else:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Direct host-side item access is not available for GPU"
+                        " arrays. Call `.to_host()` first."
+                    ),
+                    location="AcceleratorNDArray.item(flat_index)",
+                )
+            )
+
+    def item(self, *indices: Int) raises -> Scalar[Self.dtype]:
+        if len(indices) != self.ndim:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String("Expected {} indices but got {}.").format(
+                        self.ndim, len(indices)
+                    ),
+                    location="AcceleratorNDArray.item(*indices)",
+                )
+            )
+
+        var coords = Item(ndim=self.ndim)
+        for i in range(self.ndim):
+            var n = self.normalize(indices[i], self.shape[i])
+            if n < 0 or n >= self.shape[i]:
+                raise Error(
+                    NumojoError(
+                        category="index",
+                        message=String(
+                            "Index {} out of range for axis {} with size {}."
+                        ).format(indices[i], i, self.shape[i]),
+                        location="AcceleratorNDArray.item(*indices)",
+                    )
+                )
+            coords[i] = n
+
+        comptime if Self.device.type == "cpu":
+            return self._buf[
+                self.offset + IndexMethods.get_1d_index(coords, self.strides)
+            ]
+        else:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Direct host-side item access is not available for GPU"
+                        " arrays. Call `.to_host()` first."
+                    ),
+                    location="AcceleratorNDArray.item(*indices)",
+                )
+            )
+
+    def itemset(mut self, flat_index: Int, value: Scalar[Self.dtype]) raises:
+        comptime if Self.device.type == "cpu":
+            var off = self._flat_offset(flat_index)
+            self._buf[off] = value
+        else:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Direct host-side itemset is not available for GPU"
+                        " arrays. Call `.to_host()`, modify, then"
+                        " `.to_device()`."
+                    ),
+                    location="AcceleratorNDArray.itemset(flat_index)",
+                )
+            )
+
+    def __getitem__(self) raises -> Scalar[Self.dtype]:
+        if self.ndim != 0 and self.size != 1:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=(
+                        "Use `a[]` only for 0-D or size-1 arrays. Use `item()`"
+                        " or regular indexing for other shapes."
+                    ),
+                    location="AcceleratorNDArray.__getitem__()",
+                )
+            )
+        return self.item(0)
+
+    def __getitem__(self, index: Item) raises -> Scalar[Self.dtype]:
+        if index.__len__() != self.ndim:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Expected {} indices in Item but got {}."
+                    ).format(self.ndim, index.__len__()),
+                    location="AcceleratorNDArray.__getitem__(index: Item)",
+                )
+            )
+        var normalized = Item(ndim=self.ndim)
+        for i in range(self.ndim):
+            var n = self.normalize(index[i], self.shape[i])
+            if n < 0 or n >= self.shape[i]:
+                raise Error(
+                    NumojoError(
+                        category="index",
+                        message=String(
+                            "Index {} out of range for axis {} with size {}."
+                        ).format(index[i], i, self.shape[i]),
+                        location="AcceleratorNDArray.__getitem__(index: Item)",
+                    )
+                )
+            normalized[i] = n
+
+        comptime if Self.device.type == "cpu":
+            var off = self.offset + IndexMethods.get_1d_index(
+                normalized, self.strides
+            )
+            return self._buf[off]
+        else:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Direct host-side item access is not available for GPU"
+                        " arrays. Call `.to_host()` first."
+                    ),
+                    location="AcceleratorNDArray.__getitem__(index: Item)",
+                )
+            )
+
+    def __getitem__(self, idx: Int) raises -> Self:
+        if self.ndim == 0:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message="Cannot index a 0-D array with an integer index.",
+                    location="AcceleratorNDArray.__getitem__(idx: Int)",
+                )
+            )
+
+        var norm = self.normalize(idx, self.shape[0])
+        if norm < 0 or norm >= self.shape[0]:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Index {} out of range for axis 0 with size {}."
+                    ).format(idx, self.shape[0]),
+                    location="AcceleratorNDArray.__getitem__(idx: Int)",
+                )
+            )
+
+        var new_offset = self.offset + norm * self.strides[0]
+        if self.ndim == 1:
+            return self._make_view(
+                shape=NDArrayShape(),
+                strides=NDArrayStrides(),
+                offset=new_offset,
+                size=1,
+            )
+
+        var new_shape = self.shape.pop(0)
+        var new_strides = self.strides.pop(0)
+        var new_size = self.size // self.shape[0]
+        return self._make_view(
+            shape=new_shape,
+            strides=new_strides,
+            offset=new_offset,
+            size=new_size,
+        )
+
+    def __getitem__(self, var *slices: Slice) raises -> Self:
+        if self.ndim == 0:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message="Cannot slice a 0-D array.",
+                    location="AcceleratorNDArray.__getitem__(*slices: Slice)",
+                )
+            )
+
+        var n_slices = len(slices)
+        if n_slices > self.ndim:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Too many slices: got {}, but array ndim is {}."
+                    ).format(n_slices, self.ndim),
+                    location="AcceleratorNDArray.__getitem__(*slices: Slice)",
+                )
+            )
+
+        var new_shape = List[Int](capacity=self.ndim)
+        var new_strides = List[Int](capacity=self.ndim)
+        var new_offset = self.offset
+        var new_size = 1
+
+        for axis in range(self.ndim):
+            var s = slices[axis] if axis < n_slices else Slice(
+                0, self.shape[axis], 1
+            )
+
+            var step = s.step.or_else(1)
+            if step == 0:
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message="Slice step cannot be zero.",
+                        location=(
+                            "AcceleratorNDArray.__getitem__(*slices: Slice)"
+                        ),
+                    )
+                )
+
+            var dim = self.shape[axis]
+            var start: Int
+            var end: Int
+
+            if step > 0:
+                start = s.start.or_else(0)
+                end = s.end.or_else(dim)
+            else:
+                start = s.start.or_else(dim - 1)
+                end = s.end.or_else(-1)
+
+            if start < 0:
+                start += dim
+            if end < 0:
+                end += dim
+
+            if step > 0:
+                if start < 0:
+                    start = 0
+                if start > dim:
+                    start = dim
+                if end < 0:
+                    end = 0
+                if end > dim:
+                    end = dim
+            else:
+                if start < -1:
+                    start = -1
+                if start >= dim:
+                    start = dim - 1
+                if end < -1:
+                    end = -1
+                if end >= dim:
+                    end = dim - 1
+
+            var slice_len: Int
+            if step > 0:
+                slice_len = max((end - start + step - 1) // step, 0)
+            else:
+                slice_len = max((start - end + (-step) - 1) // (-step), 0)
+
+            if slice_len == 0:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=(
+                            "Empty slices are not supported yet in"
+                            " AcceleratorNDArray basic slicing."
+                        ),
+                        location=(
+                            "AcceleratorNDArray.__getitem__(*slices: Slice)"
+                        ),
+                    )
+                )
+
+            new_offset += start * self.strides[axis]
+            new_shape.append(slice_len)
+            new_strides.append(self.strides[axis] * step)
+            new_size *= slice_len
+
+        return self._make_view(
+            shape=NDArrayShape(new_shape),
+            strides=NDArrayStrides(strides=new_strides),
+            offset=new_offset,
+            size=new_size,
+        )
+
+    def __setitem__(mut self, index: Item, value: Scalar[Self.dtype]) raises:
+        if index.__len__() != self.ndim:
+            raise Error(
+                NumojoError(
+                    category="index",
+                    message=String(
+                        "Expected {} indices in Item but got {}."
+                    ).format(self.ndim, index.__len__()),
+                    location=(
+                        "AcceleratorNDArray.__setitem__(index: Item, value)"
+                    ),
+                )
+            )
+        var coords = List[Int](capacity=self.ndim)
+        for i in range(self.ndim):
+            coords.append(index[i])
+
+        comptime if Self.device.type == "cpu":
+            var normalized = Item(ndim=self.ndim)
+            for i in range(self.ndim):
+                var n = self.normalize(coords[i], self.shape[i])
+                if n < 0 or n >= self.shape[i]:
+                    raise Error(
+                        NumojoError(
+                            category="index",
+                            message=String(
+                                "Index {} out of range for axis {} with"
+                                " size {}."
+                            ).format(coords[i], i, self.shape[i]),
+                            location=(
+                                "AcceleratorNDArray.__setitem__(index: Item,"
+                                " value)"
+                            ),
+                        )
+                    )
+                normalized[i] = n
+            var off = self.offset + IndexMethods.get_1d_index(
+                normalized, self.strides
+            )
+            self._buf[off] = value
+        else:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "Direct host-side itemset is not available for GPU"
+                        " arrays. Call `.to_host()`, modify, then"
+                        " `.to_device()`."
+                    ),
+                    location=(
+                        "AcceleratorNDArray.__setitem__(index: Item, value)"
+                    ),
+                )
+            )
+
+    # ===------------------------------------------------------------------=== #
+    # Host/Device transfer
+    # ===------------------------------------------------------------------=== #
+
+    def deep_copy(self) raises -> Self:
+        var out = Self(shape=self.shape)
+        out.strides = self.strides
+        out.offset = self.offset
+        out.flags = self.flags
+
+        comptime if Self.device.type == "cpu":
+            var src_ptr = self._buf.host_storage.unsafe_value().ptr
+            var dst_ptr = out._buf.host_storage.unsafe_value().ptr
+            for i in range(self.size):
+                dst_ptr[i] = src_ptr[i]
+        else:
+            self._buf.device_storage.unsafe_value().get_buffer().enqueue_copy_to(
+                out._buf.device_storage.unsafe_value().get_buffer()
+            )
+            self._buf.device_storage.unsafe_value().get_buffer().context().synchronize()
+        return out^
+
+    def to_host(self) raises -> AcceleratorNDArray[Self.dtype, Device.CPU]:
+        var out = AcceleratorNDArray[Self.dtype, Device.CPU](shape=self.shape)
+        out.strides = self.strides
+        out.offset = self.offset
+        out.flags = self.flags
+
+        comptime if Self.device.type == "cpu":
+            var src_ptr = self._buf.host_storage.unsafe_value().ptr
+            var dst_ptr = out._buf.host_storage.unsafe_value().ptr
+            for i in range(self.size):
+                dst_ptr[i] = src_ptr[i]
+        else:
+            self._buf.device_storage.unsafe_value().get_buffer().enqueue_copy_to(
+                out._buf.host_storage.unsafe_value().ptr
+            )
+            self._buf.device_storage.unsafe_value().get_buffer().context().synchronize()
+
+        return out^
+
+    def to_device[
+        target: Device
+    ](self,) raises -> AcceleratorNDArray[Self.dtype, target]:
+        comptime if target.type == "cpu":
+            var host = self.to_host()
+            var out = AcceleratorNDArray[Self.dtype, target](shape=host.shape)
+            out.strides = host.strides
+            out.offset = host.offset
+            out.flags = host.flags
+            var src_ptr = host._buf.host_storage.unsafe_value().ptr
+            var dst_ptr = out._buf.host_storage.unsafe_value().ptr
+            for i in range(host.size):
+                dst_ptr[i] = src_ptr[i]
+            return out^
+        else:
+            var host = self.to_host()
+            var out = AcceleratorNDArray[Self.dtype, target](shape=host.shape)
+            out.strides = host.strides
+            out.offset = host.offset
+            out.flags = host.flags
+            out._buf.device_storage.unsafe_value().get_buffer().enqueue_copy_from(
+                host._buf.host_storage.unsafe_value().ptr
+            )
+            out._buf.device_storage.unsafe_value().get_buffer().context().synchronize()
+            return out^
+
+    def to[
+        target: Device
+    ](self,) raises -> AcceleratorNDArray[Self.dtype, target]:
+        return self.to_device[target]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Creation routines
+# ===----------------------------------------------------------------------=== #
+
+
+def empty[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: NDArrayShape, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an uninitialized accelerator array on `device`."""
+    return AcceleratorNDArray[dtype, device](shape=shape, order=order)
+
+
+def empty[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: List[Int], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an uninitialized accelerator array on `device`."""
+    return empty[dtype, device](NDArrayShape(shape), order=order)
+
+
+def empty[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an uninitialized accelerator array on `device`."""
+    return empty[dtype, device](NDArrayShape(shape), order=order)
+
+
+def full[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](
+    shape: NDArrayShape,
+    fill_value: Scalar[dtype],
+    order: String = "C",
+) raises -> AcceleratorNDArray[dtype, device]:
+    """Create an accelerator array filled with `fill_value`."""
+    comptime if device.type == "cpu":
+        var out = AcceleratorNDArray[dtype, device](shape=shape, order=order)
+        for i in range(out.size):
+            out.itemset(i, fill_value)
+        return out^
+    else:
+        var host = full[dtype, Device.CPU](shape, fill_value, order=order)
+        return host.to[device]()
+
+
+def full[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](
+    shape: List[Int],
+    fill_value: Scalar[dtype],
+    order: String = "C",
+) raises -> AcceleratorNDArray[dtype, device]:
+    """Create an accelerator array filled with `fill_value`."""
+    return full[dtype, device](NDArrayShape(shape), fill_value, order=order)
+
+
+def zeros[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: NDArrayShape, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with zeros."""
+    return full[dtype, device](shape, Scalar[dtype](0), order=order)
+
+
+def zeros[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: List[Int], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with zeros."""
+    return zeros[dtype, device](NDArrayShape(shape), order=order)
+
+
+def zeros[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with zeros."""
+    return zeros[dtype, device](NDArrayShape(shape), order=order)
+
+
+def ones[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: NDArrayShape, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with ones."""
+    return full[dtype, device](shape, Scalar[dtype](1), order=order)
+
+
+def ones[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](shape: List[Int], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with ones."""
+    return ones[dtype, device](NDArrayShape(shape), order=order)
+
+
+def ones[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an accelerator array filled with ones."""
+    return ones[dtype, device](NDArrayShape(shape), order=order)
+
+
+def empty_like[
+    dtype: DType, device: Device
+](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create an uninitialized accelerator array with `a`'s shape and device."""
+    return empty[dtype, device](a.shape, order=order)
+
+
+def zeros_like[
+    dtype: DType, device: Device
+](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create a zeros accelerator array with `a`'s shape and device."""
+    return zeros[dtype, device](a.shape, order=order)
+
+
+def ones_like[
+    dtype: DType, device: Device
+](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
+    dtype, device
+]:
+    """Create a ones accelerator array with `a`'s shape and device."""
+    return ones[dtype, device](a.shape, order=order)
+
+
+def full_like[
+    dtype: DType, device: Device
+](
+    a: AcceleratorNDArray[dtype, device],
+    fill_value: Scalar[dtype],
+    order: String = "C",
+) raises -> AcceleratorNDArray[dtype, device]:
+    """Create a filled accelerator array with `a`'s shape and device."""
+    return full[dtype, device](a.shape, fill_value, order=order)
+
+
+def arange[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](
+    start: Scalar[dtype],
+    stop: Scalar[dtype],
+    step: Scalar[dtype] = Scalar[dtype](1),
+) raises -> AcceleratorNDArray[dtype, device]:
+    """Create an accelerator array with evenly spaced values."""
+    var num = Int((stop - start) / step)
+    comptime if device.type == "cpu":
+        var out = AcceleratorNDArray[dtype, device](Shape(num))
+        for i in range(num):
+            out.itemset(i, start + step * Scalar[dtype](i))
+        return out^
+    else:
+        var host = AcceleratorNDArray[dtype, Device.CPU](Shape(num))
+        for i in range(num):
+            host.itemset(i, start + step * Scalar[dtype](i))
+        return host.to[device]()
+
+
+def arange[
+    dtype: DType = DType.float64, device: Device = Device.CPU
+](stop: Scalar[dtype]) raises -> AcceleratorNDArray[dtype, device]:
+    """Create an accelerator array with values from zero to `stop`."""
+    return arange[dtype, device](Scalar[dtype](0), stop, Scalar[dtype](1))

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -722,9 +722,7 @@ def empty[
 
 def empty[
     dtype: DType = DType.float64, device: Device = Device.CPU
-](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[dtype, device]:
     """Create an uninitialized accelerator array on `device`."""
     return empty[dtype, device](NDArrayShape(shape), order=order)
 
@@ -778,9 +776,7 @@ def zeros[
 
 def zeros[
     dtype: DType = DType.float64, device: Device = Device.CPU
-](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[dtype, device]:
     """Create an accelerator array filled with zeros."""
     return zeros[dtype, device](NDArrayShape(shape), order=order)
 
@@ -805,36 +801,34 @@ def ones[
 
 def ones[
     dtype: DType = DType.float64, device: Device = Device.CPU
-](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](*shape: Int, order: String = "C") raises -> AcceleratorNDArray[dtype, device]:
     """Create an accelerator array filled with ones."""
     return ones[dtype, device](NDArrayShape(shape), order=order)
 
 
 def empty_like[
     dtype: DType, device: Device
-](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](
+    a: AcceleratorNDArray[dtype, device], order: String = "C"
+) raises -> AcceleratorNDArray[dtype, device]:
     """Create an uninitialized accelerator array with `a`'s shape and device."""
     return empty[dtype, device](a.shape, order=order)
 
 
 def zeros_like[
     dtype: DType, device: Device
-](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](
+    a: AcceleratorNDArray[dtype, device], order: String = "C"
+) raises -> AcceleratorNDArray[dtype, device]:
     """Create a zeros accelerator array with `a`'s shape and device."""
     return zeros[dtype, device](a.shape, order=order)
 
 
 def ones_like[
     dtype: DType, device: Device
-](a: AcceleratorNDArray[dtype, device], order: String = "C") raises -> AcceleratorNDArray[
-    dtype, device
-]:
+](
+    a: AcceleratorNDArray[dtype, device], order: String = "C"
+) raises -> AcceleratorNDArray[dtype, device]:
     """Create a ones accelerator array with `a`'s shape and device."""
     return ones[dtype, device](a.shape, order=order)
 

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -24,7 +24,7 @@ from std.sys.info import has_accelerator
 from std.memory import memcpy
 from std.gpu.host import DeviceBuffer, DeviceContext
 
-from numojo.core.accelerator import Device
+from numojo.core.accelerator import Device, DeviceHandle
 from numojo.core.accelerator.device import is_accelerator_available
 from numojo.core.memory.data_container import Ownership
 from numojo.core.error import NumojoError
@@ -70,6 +70,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # Constructors and Destructor
     # ===----------------------------------------------------------------------===#
 
+    # TODO: Replace UnsafePointer with Optional[UnsafePointer] for ptr. 
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
@@ -170,21 +171,25 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
 
     @always_inline
     def __init__(out self, *, copy: Self):
-        """Shallow-copy constructor.
+        """Deep-copy constructor.
 
-        Copies the pointer and refcount, then atomically increments the
-        reference count for managed containers.
+        Matches `DataContainer`: allocate owned storage and copy the data.
+        Use `share()` for a shallow shared handle.
 
         Args:
             copy: The source container.
         """
         self.size = copy.size
-        self.ptr = copy.ptr
-        self._refcount = copy._refcount
-        self.ownership = copy.ownership
-
-        if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+        self.ownership = Ownership.Managed
+        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount[] = Atomic[DType.uint64](1)
+        if copy.size == 0:
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
+        else:
+            self.ptr = alloc[Scalar[Self.dtype]](copy.size)
+            memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
     def __init__(out self, *, deinit take: Self):
@@ -212,6 +217,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if self.ownership == Ownership.External:
             return
 
+        # I think this branch might be redundant, check it. 
         if not self.is_refcounted():
             return
 
@@ -235,6 +241,16 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
 
         Returns:
             A reference to `self.ptr`.
+        """
+        return self.ptr
+
+    @always_inline
+    def get_ptr(
+        ref self,
+    ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
+        """Return a reference to the raw data pointer.
+
+        This mirrors `DataContainer.get_ptr()`.
         """
         return self.ptr
 
@@ -392,7 +408,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             return 0
         return self._refcount[].load[ordering=Ordering.RELAXED]()
 
-    def share(mut self) raises -> HostStorage[Self.dtype]:
+    def share(self) raises -> HostStorage[Self.dtype]:
         """Create a new handle that shares this container's data and refcount.
 
         The reference count is atomically incremented so both the original
@@ -446,6 +462,9 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
     var buffer: DeviceBuffer[Self.dtype]
     """The GPU-side data buffer."""
 
+    var handle: DeviceHandle[Self.device]
+    """Runtime handle that owns the device context used for this storage."""
+
     var size: Int
     """Number of elements in the buffer."""
 
@@ -465,35 +484,44 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         comptime assert is_accelerator_available[
             Self.device
         ](), "NuMojo: No GPU accelerator available."
-        # TODO: Use a device-specific or cached DeviceContext instead of
-        # the default one, so the correct backend is selected.
-        self.buffer = DeviceContext().enqueue_create_buffer[Self.dtype](size)
+        self.handle = DeviceHandle[Self.device]()
+        var context = self.handle.device_context()
+        self.buffer = context.enqueue_create_buffer[Self.dtype](size)
         self.size = size
 
     def __init__(
         out self,
         buffer: DeviceBuffer[Self.dtype],
         size: Int,
-    ):
+    ) raises:
         """Wrap an existing `DeviceBuffer`.
 
         Args:
             buffer: An already-allocated device buffer.
             size: Number of elements accessible in `buffer`.
         """
+        var context = buffer.context()
+        self.handle = DeviceHandle[Self.device](context^)
         self.buffer = buffer
         self.size = size
 
     def __init__(out self, *, copy: Self):
-        """Shallow-copy constructor.
+        """Deep-copy constructor.
 
-        Copies the `DeviceBuffer` handle.  The GPU runtime determines
-        whether the underlying memory is shared or duplicated.
+        Allocates a new buffer on the same device context and copies all data.
+        Use `share()` for a shallow shared handle.
 
         Args:
             copy: The source storage.
         """
-        self.buffer = copy.buffer
+        self.handle = copy.handle.copy()
+        try:
+            var context = self.handle.device_context()
+            self.buffer = context.enqueue_create_buffer[Self.dtype](copy.size)
+            copy.buffer.enqueue_copy_to(self.buffer)
+            context.synchronize()
+        except e:
+            abort("DeviceStorage: deep copy failed: " + String(e))
         self.size = copy.size
 
     def __init__(out self, *, deinit take: Self):
@@ -504,6 +532,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         Args:
             take: The source storage (consumed).
         """
+        self.handle = take.handle^
         self.buffer = take.buffer^
         self.size = take.size
 
@@ -567,6 +596,11 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
             An `UnsafePointer` to the first element on the device.
         """
         return self.buffer.unsafe_ptr()
+
+    def share(self) raises -> DeviceStorage[Self.dtype, Self.device]:
+        """Create a shallow handle sharing this device buffer."""
+        var shared_buffer = self.buffer.copy()
+        return DeviceStorage[Self.dtype, Self.device](shared_buffer^, self.size)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -690,12 +724,29 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.device_storage = None
 
     @always_inline
-    def __init__(out self, *, copy: Self):
-        """Shallow-copy constructor.
+    def __init__(
+        out self, var host_storage: HostStorage[Self.dtype]
+    ) where Self.device.type == "cpu":
+        """Create a CPU container from an existing `HostStorage` handle."""
+        self.size = host_storage.size
+        self.host_storage = host_storage^
+        self.device_storage = None
 
-        Shares the underlying storage.  For CPU containers this increments
-        the `HostStorage` atomic refcount; for GPU containers this copies
-        the `DeviceStorage` handle (automatic reference counting).
+    @always_inline
+    def __init__(
+        out self, var device_storage: DeviceStorage[Self.dtype, Self.device]
+    ) where Self.device.type == "gpu":
+        """Create a GPU container from an existing `DeviceStorage` handle."""
+        self.size = device_storage.size
+        self.host_storage = None
+        self.device_storage = device_storage^
+
+    @always_inline
+    def __init__(out self, *, copy: Self):
+        """Deep-copy constructor.
+
+        Copies the active backend container. Use `share()` for a shallow
+        shared handle.
 
         Args:
             copy: The source container.
@@ -873,9 +924,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     # Reference Counting and Sharing
     # ===----------------------------------------------------------------------===#
 
-    def share(
-        mut self,
-    ) raises -> AcceleratorDataContainer[Self.dtype, Self.device]:
+    def share(self) raises -> AcceleratorDataContainer[Self.dtype, Self.device]:
         """Create a new handle that shares this container's storage.
 
         For CPU containers the `HostStorage` refcount is atomically
@@ -888,20 +937,14 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Raises:
             Error: If the active storage is missing or cannot be shared.
         """
-        var result = AcceleratorDataContainer[Self.dtype, Self.device]()
-        result.size = self.size
-
         comptime if Self.device.type == "cpu":
             var shared = self.host_storage.unsafe_value().share()
-            result.host_storage = shared^
-            result.device_storage = None
+            return AcceleratorDataContainer[Self.dtype, Self.device](shared^)
         elif Self.device.type == "gpu":
-            result.device_storage = self.device_storage.copy()
-            result.host_storage = None
+            var shared = self.device_storage.unsafe_value().share()
+            return AcceleratorDataContainer[Self.dtype, Self.device](shared^)
         else:
             raise Error("Unsupported device type for sharing")
-
-        return result^
 
     # ===----------------------------------------------------------------------===#
     # Device-Specific Access

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -70,7 +70,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     # Constructors and Destructor
     # ===----------------------------------------------------------------------===#
 
-    # TODO: Replace UnsafePointer with Optional[UnsafePointer] for ptr. 
+    # TODO: Replace UnsafePointer with Optional[UnsafePointer] for ptr.
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
@@ -217,7 +217,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if self.ownership == Ownership.External:
             return
 
-        # I think this branch might be redundant, check it. 
+        # I think this branch might be redundant, check it.
         if not self.is_refcounted():
             return
 

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -34,6 +34,7 @@ import numojo as nm
 from numojo.core.indexing.item import Item
 from numojo.core.matrix import Matrix
 from numojo.core.ndarray import NDArray
+from numojo.core.accelerator_ndarray import AcceleratorNDArray
 from numojo.core.layout import NDArrayShape
 from numojo.core.complex.complex_simd import (
     ComplexSIMD,

--- a/tests/core/test_accelerator_creation.mojo
+++ b/tests/core/test_accelerator_creation.mojo
@@ -1,0 +1,54 @@
+from numojo.core.accelerator.device import Device
+from numojo.core.accelerator_ndarray import (
+    arange,
+    full,
+    ones,
+    ones_like,
+    zeros,
+    zeros_like,
+)
+from numojo.prelude import Shape, f32
+from std.testing import TestSuite
+from std.testing.testing import assert_equal
+
+
+def test_zeros_cpu() raises:
+    var a = zeros[f32, Device.CPU](Shape(2, 3))
+    assert_equal(a.shape[0], 2)
+    assert_equal(a.shape[1], 3)
+    assert_equal(a.item(0, 0), 0.0)
+    assert_equal(a.item(1, 2), 0.0)
+    assert_equal(a.device.device_name(), "cpu")
+
+
+def test_ones_cpu() raises:
+    var a = ones[f32, Device.CPU](Shape(2, 2))
+    assert_equal(a.item(0, 0), 1.0)
+    assert_equal(a.item(1, 1), 1.0)
+
+
+def test_full_cpu() raises:
+    var a = full[f32, Device.CPU](Shape(2, 2), 7.0)
+    assert_equal(a.item(0, 0), 7.0)
+    assert_equal(a.item(1, 1), 7.0)
+
+
+def test_arange_cpu() raises:
+    var a = arange[f32, Device.CPU](0.0, 5.0, 1.0)
+    assert_equal(a.shape[0], 5)
+    assert_equal(a.item(0), 0.0)
+    assert_equal(a.item(4), 4.0)
+
+
+def test_like_cpu() raises:
+    var base = full[f32, Device.CPU](Shape(2, 2), 3.0)
+    var z = zeros_like[f32, Device.CPU](base)
+    var o = ones_like[f32, Device.CPU](base)
+    assert_equal(z.shape[0], 2)
+    assert_equal(z.shape[1], 2)
+    assert_equal(z.item(0, 0), 0.0)
+    assert_equal(o.item(1, 1), 1.0)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_device.mojo
+++ b/tests/core/test_device.mojo
@@ -1,6 +1,15 @@
-from numojo.core.accelerator.device import Device
+from numojo.core.accelerator.device import (
+    Device,
+    DeviceHandle,
+    DeviceSpec,
+)
 from std.testing.testing import assert_true, assert_equal
 from std.testing import TestSuite
+from std.sys.info import (
+    has_amd_gpu_accelerator,
+    has_apple_gpu_accelerator,
+    has_nvidia_gpu_accelerator,
+)
 
 
 def test_default_init() raises:
@@ -45,41 +54,58 @@ def test_cpu_explicit_init() raises:
     assert_equal(d.id, 0, "explicit cpu init id")
 
 
-def test_invalid_type_falls_back_to_cpu() raises:
-    var d = Device(type="tpu", name="", id=0)
-    assert_equal(d.type, "cpu", "invalid type fallback type")
-    assert_equal(d.name, "", "invalid type fallback name")
-    assert_equal(d.id, 0, "invalid type fallback id")
+def test_invalid_type_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="tpu", name="", id=0)
+    except e:
+        raised = True
+    assert_true(raised, "invalid type should raise")
 
 
-def test_gpu_empty_name_falls_back_to_cpu() raises:
-    var d = Device(type="gpu", name="", id=0)
-    assert_equal(d.type, "cpu", "gpu empty name fallback type")
-    assert_equal(d.name, "", "gpu empty name fallback name")
+def test_gpu_empty_name_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="gpu", name="", id=0)
+    except e:
+        raised = True
+    assert_true(raised, "gpu empty name should raise")
 
 
-def test_cpu_with_nonzero_id_falls_back() raises:
-    var d = Device(type="cpu", name="", id=5)
-    assert_equal(d.type, "cpu", "cpu nonzero id fallback type")
-    assert_equal(d.id, 0, "cpu nonzero id fallback id")
+def test_cpu_with_nonzero_id_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="cpu", name="", id=5)
+    except e:
+        raised = True
+    assert_true(raised, "cpu nonzero id should raise")
 
 
-def test_cpu_with_name_falls_back() raises:
-    var d = Device(type="cpu", name="something", id=0)
-    assert_equal(d.type, "cpu", "cpu with name fallback type")
-    assert_equal(d.name, "", "cpu with name fallback name")
+def test_cpu_with_name_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="cpu", name="something", id=0)
+    except e:
+        raised = True
+    assert_true(raised, "cpu with name should raise")
 
 
-def test_invalid_gpu_backend_falls_back() raises:
-    var d = Device(type="gpu", name="vulkan", id=0)
-    assert_equal(d.type, "cpu", "invalid gpu backend fallback type")
-    assert_equal(d.name, "", "invalid gpu backend fallback name")
+def test_invalid_gpu_backend_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="gpu", name="vulkan", id=0)
+    except e:
+        raised = True
+    assert_true(raised, "invalid gpu backend should raise")
 
 
-def test_negative_gpu_id_falls_back() raises:
-    var d = Device(type="gpu", name="cuda", id=-1)
-    assert_equal(d.type, "cpu", "negative gpu id fallback type")
-    assert_equal(d.name, "", "negative gpu id fallback name")
+def test_negative_gpu_id_raises() raises:
+    var raised = False
+    try:
+        _ = Device(type="gpu", name="cuda", id=-1)
+    except e:
+        raised = True
+    assert_true(raised, "negative gpu id should raise")
 
 
 def test_parse_cpu_string() raises:
@@ -94,39 +120,59 @@ def test_parse_cpu_string_variant() raises:
     assert_equal(d.type, "cpu", "parse 'cpu:0' type")
 
 
-def test_parse_empty_falls_back() raises:
-    var d = Device.parse_device_string("")
-    assert_equal(d.type, "cpu", "parse empty string type")
+def test_parse_empty_raises() raises:
+    var raised = False
+    try:
+        _ = Device.parse_device_string("")
+    except e:
+        raised = True
+    assert_true(raised, "parse empty string should raise")
 
 
-def test_parse_garbage_falls_back() raises:
-    var d = Device.parse_device_string("foobar")
-    assert_equal(d.type, "cpu", "parse garbage type")
-    assert_equal(d.name, "", "parse garbage name")
+def test_parse_garbage_raises() raises:
+    var raised = False
+    try:
+        _ = Device.parse_device_string("foobar")
+    except e:
+        raised = True
+    assert_true(raised, "parse garbage should raise")
 
 
-def test_parse_colon_no_id_falls_back() raises:
-    var d = Device.parse_device_string("cuda:")
-    assert_equal(d.type, "cpu", "parse 'cuda:' fallback type")
+def test_parse_colon_no_id_raises() raises:
+    var raised = False
+    try:
+        _ = Device.parse_device_string("cuda:")
+    except e:
+        raised = True
+    assert_true(raised, "parse 'cuda:' should raise")
 
 
-def test_parse_negative_id_falls_back() raises:
-    var d = Device.parse_device_string("cuda:-1")
-    assert_equal(d.type, "cpu", "parse negative id fallback type")
+def test_parse_negative_id_raises() raises:
+    var raised = False
+    try:
+        _ = Device.parse_device_string("cuda:-1")
+    except e:
+        raised = True
+    assert_true(raised, "parse negative id should raise")
 
 
-def test_parse_non_numeric_id_falls_back() raises:
-    var d = Device.parse_device_string("cuda:abc")
-    assert_equal(d.type, "cpu", "parse non-numeric id fallback type")
+def test_parse_non_numeric_id_raises() raises:
+    var raised = False
+    try:
+        _ = Device.parse_device_string("cuda:abc")
+    except e:
+        raised = True
+    assert_true(raised, "parse non-numeric id should raise")
 
 
 def test_parse_string_containing_cpu_not_matched() raises:
     """Ensure that strings like 'mycpu' or 'notcpu' are not matched as CPU."""
-    var d = Device.parse_device_string("mycpu")
-    assert_equal(d.type, "cpu", "parse 'mycpu' fallback type")
-    assert_equal(d.name, "", "parse 'mycpu' fallback name")
-    # 'mycpu' is not a valid backend, so it should fall back to CPU
-    # but importantly, it should NOT be matched by the "cpu" in text check
+    var raised = False
+    try:
+        _ = Device.parse_device_string("mycpu")
+    except e:
+        raised = True
+    assert_true(raised, "parse 'mycpu' should raise")
 
 
 def test_default_init_is_cpu() raises:
@@ -142,6 +188,8 @@ def test_unchecked_init() raises:
     assert_equal(d.type, "gpu", "_unchecked_init type")
     assert_equal(d.name, "cuda", "_unchecked_init name")
     assert_equal(d.id, 3, "_unchecked_init id")
+    assert_equal(d.spec.backend, "cuda", "_unchecked_init spec backend")
+    assert_equal(d.spec.id, 3, "_unchecked_init spec id")
 
 
 def test_unchecked_init_arbitrary() raises:
@@ -245,6 +293,39 @@ def test_default_device_is_valid_type() raises:
 def test_available_devices_contains_cpu() raises:
     var listing = Device.available_devices()
     assert_true("cpu" in listing, "available_devices contains cpu")
+
+
+def test_device_spec_cpu() raises:
+    var spec = DeviceSpec("cpu", 0)
+    assert_true(spec.is_cpu(), "cpu spec is_cpu")
+    assert_equal(spec.name(), "cpu", "cpu spec name")
+    assert_equal(spec.backend_id(), 0, "cpu spec backend id")
+
+
+def test_device_spec_gpu_identity() raises:
+    var spec = DeviceSpec._unchecked_init(backend="cuda", id=2)
+    assert_true(spec.is_gpu(), "cuda spec is_gpu")
+    assert_equal(spec.name(), "cuda:2", "cuda spec name")
+    assert_equal(spec.backend_id(), 1, "cuda spec backend id")
+
+
+def test_gpu_device_handle_when_available() raises:
+    comptime if has_nvidia_gpu_accelerator():
+        var handle = DeviceHandle[Device.CUDA]()
+        assert_true(handle.is_gpu(), "cuda handle is_gpu")
+        assert_equal(
+            String(handle),
+            "DeviceHandle(cuda:0, context=True)",
+            "cuda handle string",
+        )
+    elif has_amd_gpu_accelerator():
+        var handle = DeviceHandle[Device.ROCM]()
+        assert_true(handle.is_gpu(), "rocm handle is_gpu")
+    elif has_apple_gpu_accelerator():
+        var handle = DeviceHandle[Device.MPS]()
+        assert_true(handle.is_gpu(), "mps handle is_gpu")
+    else:
+        assert_true(True, "no gpu available; gpu handle test skipped")
 
 
 def main() raises:


### PR DESCRIPTION
## Summary
This PR tightens core accelerator array semantics, implements a basic `AcceleratorNDArray`, adds creation routines for `AcceleratorNDArray`.

### What changed
- **Device layer**
  - Added `DeviceSpec` for identity.
  - Added GPU-only `DeviceHandle[device]` owning `DeviceContext` (to prevent context creation in every method).
  - Renamed device string API for clarity:
    - `DeviceSpec.name()`
    - `Device.device_name()`

- **Storage layer**
  - `HostStorage(copy=...)` now **deep-copies** (matches `DataContainer` behavior).
  - `DeviceStorage(copy=...)` now **deep-copies** device-to-device.
  - Added `DeviceStorage.share()` for shallow sharing.
  - `DeviceStorage(buffer, size)` now uses `buffer.context()` so wrapped buffers keep their original context.

- **AcceleratorNDArray**
A basic `AcceleratorNDArray` is implemented that tries to mimic methods of `NDArray`. It now supports core lifecycle setup, CPU/GPU storage plumbing, readable printing with device info, scalar get/set, basic slicing/views with shared storage, and host/device transfer paths. This gives us a solid base to continue moving toward a single default device-agnostic NDArray in the future once `AcceleratorNDArray` matures.

  - Added dedicated view constructor using shared storage + metadata.
  - Refactored `_make_view()` to use constructor-based init.
  - Added free creation routines:
    - `empty`, `zeros`, `ones`, `full`, `arange`
    - `empty_like`, `zeros_like`, `ones_like`, `full_like`

### NDArray example
```mojo
import numojo as nm
from numojo.prelude import *
from std.sys.info import has_nvidia_gpu_accelerator
from numojo.core.accelerator.device import Device
from numojo.core.accelerator_ndarray import zeros, full, arange

def main() raises:
    # CPU creation
    var a = zeros[nm.f32, Device.CPU](Shape(2, 3))
    var b = full[nm.f32, Device.CPU](Shape(2, 3), 7.0)
    var c = arange[nm.f32, Device.CPU](0.0, 6.0, 1.0).reshape(Shape(2, 3))

    # CPU view semantics
    var row = c[1]
    row[Item(0)] = 99.0  # updates parent
    print("CPU c:")
    print(c)

    # GPU transfer + print + roundtrip
    comptime if has_apple_gpu_accelerator():
        var g = c.to[Device.MPS]()
        print("On GPU:")
        print(g)

        var back = g.to_host()
        print("Back on CPU:")
        print(back)
    else:
        print("MPS not available on this build; skipping GPU demo.")
```