### PR TITLE
[NDArray] Extend boolean mask indexing to k-D masks

### DIFF
--- a/numojo/core/indexing/slicing.mojo
+++ b/numojo/core/indexing/slicing.mojo
@@ -12,6 +12,9 @@ This module defines internal data structures and utilities for handling slicing 
 
 from std.math import ceil
 
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.error import NumojoError
+
 
 # ===----------------------------------------------------------------------=== #
 # Internal Data Structure: IndexTypeInfo
@@ -205,3 +208,79 @@ struct InternalSlice(ImplicitlyCopyable):
         """
         var length = Int(ceil((self.end - self.start) / self.step))
         return (self.start, self.end, self.step, length)
+
+    @staticmethod
+    def adjust_list(
+        shape: NDArrayShape, slice_list: List[Slice]
+    ) raises -> List[InternalSlice]:
+        """Normalises a list of `Slice` objects against the given array shape.
+
+        For each slice, resolves defaults, wraps negative indices, clamps
+        out-of-bounds values, and validates that the step is non-zero.
+        Returns one `InternalSlice` per input slice with concrete start, end,
+        and step values ready for use in traversal.
+
+        Args:
+            shape: The array shape; `shape[i]` is the size of dimension `i`.
+            slice_list: Raw slices to normalise (one per dimension to process).
+
+        Returns:
+            A list of `InternalSlice` values parallel to `slice_list`.
+
+        Raises:
+            ValueError: If any slice has a step of zero.
+        """
+        var n_slices: Int = len(slice_list)
+        var slices = List[InternalSlice](capacity=n_slices)
+        for i in range(n_slices):
+            var dim_size = Int(shape[i])
+            var step = slice_list[i].step.or_else(1)
+
+            if step == 0:
+                raise Error(
+                    NumojoError(
+                        category="value",
+                        message=String(
+                            "Slice step cannot be zero (dimension {}). Use"
+                            " positive or negative non-zero step."
+                        ).format(i),
+                        location="InternalSlice.adjust_list",
+                    )
+                )
+
+            var start: Int
+            var end: Int
+            if step > 0:
+                start = 0
+                end = dim_size
+            else:
+                start = dim_size - 1
+                end = -1
+
+            var raw_start = slice_list[i].start.or_else(start)
+            if raw_start < 0:
+                raw_start += dim_size
+            if step > 0:
+                start = 0 if raw_start < 0 else (
+                    dim_size if raw_start > dim_size else raw_start
+                )
+            else:
+                start = -1 if raw_start < -1 else (
+                    dim_size - 1 if raw_start >= dim_size else raw_start
+                )
+
+            var raw_end = slice_list[i].end.or_else(end)
+            if raw_end < 0:
+                raw_end += dim_size
+            if step > 0:
+                end = 0 if raw_end < 0 else (
+                    dim_size if raw_end > dim_size else raw_end
+                )
+            else:
+                end = -1 if raw_end < -1 else (
+                    dim_size if raw_end > dim_size else raw_end
+                )
+
+            slices.append(InternalSlice(start=start, end=end, step=step))
+
+        return slices^

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -841,7 +841,9 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If `slice_list` is empty or contains invalid slices.
         """
         var n_slices: Int = len(slice_list)
-        var slices: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slice_list)
+        var slices: List[InternalSlice] = InternalSlice.adjust_list(
+            self.shape, slice_list
+        )
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
                 slices.append(InternalSlice(0, self.shape[i], 1))
@@ -977,7 +979,9 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         # adjust slice values for user provided slices
-        var slices: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slice_list)
+        var slices: List[InternalSlice] = InternalSlice.adjust_list(
+            self.shape, slice_list
+        )
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
                 slices.append(InternalSlice(0, self.shape[i], 1))
@@ -2459,7 +2463,9 @@ struct NDArray[dtype: DType = DType.float64](
         var ndims: Int = 0
         var count: Int = 0
         var spec: List[Int] = List[Int]()
-        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slices)
+        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(
+            self.shape, slices
+        )
         for i in range(n_slices):
             if (
                 slice_list[i].start >= self.shape[i]
@@ -2663,7 +2669,9 @@ struct NDArray[dtype: DType = DType.float64](
             val: The scalar value to write to every selected position.
         """
         var n_slices: Int = len(slices)
-        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slices)
+        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(
+            self.shape, slices
+        )
 
         for i in range(n_slices, self.ndim):
             slice_list.append(InternalSlice(0, self.shape[i], 1))

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1539,8 +1539,8 @@ struct NDArray[dtype: DType = DType.float64](
             return result^
 
         # CASE 2:
-        # if array shape is not equal to mask shape,
-        # return items from the 0-th dimension of the array where mask is True
+        # 1-D mask whose length matches self.shape[0]:
+        # return axis-0 slices where mask is True → shape (true_count, *self.shape[1:])
         elif mask.ndim == 1 and mask.shape[0] == self.shape[0]:
             var self_c = self.contiguous()
             var len_of_result = 0
@@ -1569,19 +1569,112 @@ struct NDArray[dtype: DType = DType.float64](
                     offset += 1
 
             return result^
+
+        # CASE 3:
+        # k-D mask (1 < k < self.ndim) whose shape matches self.shape[:k]:
+        # each True position selects one sub-array of shape self.shape[k:]
+        # → result shape is (true_count, *self.shape[k:])
+        elif mask.ndim > 1 and mask.ndim < self.ndim:
+            # Verify mask shape matches leading dims of self.
+            var shape_match = True
+            for i in range(mask.ndim):
+                if mask.shape[i] != self.shape[i]:
+                    shape_match = False
+                    break
+            if not shape_match:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "Boolean mask shape {} does not match the leading"
+                            " dimensions of array shape {}. Mask shape must"
+                            " equal self.shape[:{}}."
+                        ).format(mask.shape, self.shape, mask.ndim),
+                        location=(
+                            "NDArray.__getitem__(mask: NDArray[DType.bool])"
+                        ),
+                    )
+                )
+
+            var k = mask.ndim
+            var mask_c = mask.contiguous()
+
+            # Count True entries in the mask.
+            var true_count = 0
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    true_count += 1
+
+            if true_count == 0:
+                raise Error(
+                    NumojoError(
+                        category="index",
+                        message=(
+                            "Boolean mask has no True entries. Empty array"
+                            " results are not supported yet."
+                        ),
+                        location=(
+                            "NDArray.__getitem__(mask: NDArray[DType.bool])"
+                        ),
+                    )
+                )
+
+            # Build result shape: (true_count, *self.shape[k:])
+            var result_shape_list = List[Int](capacity=1 + self.ndim - k)
+            result_shape_list.append(true_count)
+            for i in range(k, self.ndim):
+                result_shape_list.append(self.shape[i])
+            var result = NDArray[Self.dtype](NDArrayShape(result_shape_list))
+
+            # size of one sub-array = product(self.shape[k:])
+            var size_per_item = 1
+            for i in range(k, self.ndim):
+                size_per_item *= self.shape[i]
+
+            var self_c = self.contiguous()
+            var out_offset = 0
+
+            # Precompute C-order strides for the first k dims of self_c.
+            # stride[d] = product(self.shape[d+1:self.ndim])
+            # = product(self.shape[d+1:k]) * size_per_item
+            var src_strides = List[Int](capacity=k)
+            for d in range(k):
+                var s = size_per_item
+                for dd in range(d + 1, k):
+                    s *= self.shape[dd]
+                src_strides.append(s)
+
+            # Walk the mask linearly; decode flat index → k-D coords.
+            for flat in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](flat):
+                    var src_offset = 0
+                    var remaining = flat
+                    for d in range(k - 1, -1, -1):
+                        src_offset += (remaining % self.shape[d]) * src_strides[
+                            d
+                        ]
+                        remaining //= self.shape[d]
+
+                    memcpy(
+                        dest=result._buf.ptr + out_offset * size_per_item,
+                        src=self_c._buf.ptr + src_offset,
+                        count=size_per_item,
+                    )
+                    out_offset += 1
+
+            return result^
+
         else:
             raise Error(
                 NumojoError(
                     category="shape",
                     message=String(
                         "Boolean mask shape {} is not compatible with array"
-                        " shape {}. Currently supported: (1) exact shape match"
-                        " for element-wise masking, (2) 1-D mask with length"
-                        " matching first dimension. Broadcasting is not"
-                        " supported currently. Ensure mask shape matches array"
-                        " shape for element-wise masking, or use 1-D mask with"
-                        " length {} for first-dimension indexing."
-                    ).format(mask.shape, self.shape, self.shape[0]),
+                        " shape {}. Supported: (1) exact shape match for"
+                        " element-wise masking, (2) 1-D mask matching first"
+                        " dimension, (3) k-D mask matching first k dimensions"
+                        " (1 < k < ndim)."
+                    ).format(mask.shape, self.shape),
                     location="NDArray.__getitem__(mask: NDArray[DType.bool])",
                 )
             )
@@ -1973,27 +2066,39 @@ struct NDArray[dtype: DType = DType.float64](
 
     # ===-------------------------------------------------------------------===#
     # Setter dunders and other setter methods
-
-    # Basic Setter Methods
-    # def _setitem(self, *indices: Int, val: Scalar[dtype])                      # Direct unsafe setter
-    # def __setitem__(mut self, idx: Int, val: Self) raises                      # Set by single index
-    # def __setitem__(mut self, index: Item, val: Scalar[dtype]) raises          # Set by coordinate list
-    # def __setitem__(mut self, mask: NDArray[DType.bool], value: Scalar[dtype]) # Set by boolean mask
-
-    # Slice-based Setters
-    # def __setitem__(mut self, *slices: Slice, val: Self) raises                # Set by variable slices
-    # def __setitem__(mut self, slices: List[Slice], val: Self) raises           # Set by list of slices
-    # def __setitem__(mut self, *slices: Variant[Slice, Int], val: Self) raises  # Set by mix of slices/ints
-
-    # Index-based Setters
-    # def __setitem__(self, indices: NDArray[DType.int], val: NDArray) raises  # Set by index array
-    # def __setitem__(mut self, mask: NDArray[DType.bool], val: NDArray[dtype])  # Set by boolean mask array
-
-    # Helper Methods
-    # def itemset(mut self, index: Variant[Int, List[Int]], item: Scalar[dtype]) # Set single item
-    # def store(self, var index: Int, val: Scalar[dtype]) raises               # Store with bounds checking
-    # def store[width: Int](mut self, index: Int, val: SIMD[dtype, width])       # Store SIMD value
-    # def store[width: Int = 1](mut self, *indices: Int, val: SIMD[dtype, width])# Store SIMD at coordinates
+    #
+    # NOTE: Mojo cannot resolve __setitem__ overloads where the RHS type
+    # (Scalar vs NDArray) differs but the index type is the same variadic.
+    # Those setters are exposed as `set()` instead, with `val` as a
+    # keyword-only argument (after `*`), so callers use `arr.set(..., val=v)`.
+    #
+    # Unsafe/internal setter
+    # def _setitem(self, *indices: Int, val: Scalar[dtype])
+    #
+    # __setitem__ overloads (a[...] = val syntax works for all of these)
+    # def __setitem__(mut self, idx: Int, val: Self)
+    # def __setitem__(mut self, index: Item, val: Scalar[dtype])
+    # def __setitem__(mut self, *slices: Slice, val: Self)
+    # def __setitem__(mut self, slices: List[Slice], val: Self)
+    # def __setitem__(mut self, *slices: Variant[Slice, Int], val: Self)
+    # def __setitem__(mut self, indices: NDArray[DType.int], val: NDArray)
+    #
+    # set() overloads (use arr.set(..., val=v) — Mojo cannot resolve these
+    # as __setitem__ due to ambiguity with the NDArray overloads above)
+    # def set(mut self, mask: NDArray[DType.bool], *, val: Scalar[dtype])
+    # def set(mut self, mask: NDArray[DType.bool], *, val: NDArray[dtype])
+    # def set(mut self, *slices: Slice, val: Scalar[dtype])
+    # def set(mut self, *slices: Variant[Slice, Int], val: Scalar[dtype])
+    #
+    # Internal scalar-fill backend (called by the set() slice overloads)
+    # def _setitem_slice_scalar(mut self, slices: List[Slice], val: Scalar)
+    #
+    # Item helpers
+    # def itemset(mut self, index: Int, item: Scalar[dtype])
+    # def itemset(mut self, indices: List[Int], item: Scalar[dtype])
+    # def store(mut self, index: Int, val: Scalar[dtype])
+    # def store[width](mut self, index: Int, val: SIMD[dtype, width])
+    # def store[width=1](mut self, *indices: Int, val: SIMD[dtype, width])
     # ===-------------------------------------------------------------------===#
 
     def _setitem(self, *indices: Int, val: Scalar[Self.dtype]):
@@ -2194,49 +2299,105 @@ struct NDArray[dtype: DType = DType.float64](
         var idx: Int = IndexMethods.get_1d_index(index, self.strides)
         self._buf.ptr.store(self.offset + idx, val)
 
-    # only works if array is called as array.__setitem__(), mojo compiler doesn't parse it implicitly
-    def __setitem__(
-        mut self, mask: NDArray[DType.bool], value: Scalar[Self.dtype]
+    def set(
+        mut self, mask: NDArray[DType.bool], *, val: Scalar[Self.dtype]
     ) raises:
-        """Sets the value of the array at the indices where the mask is `True`.
+        """Sets elements where `mask` is `True` to a scalar value.
+
+        Supports three mask shapes:
+        - Exact shape match: writes to every True element.
+        - 1-D mask of length `shape[0]`: fills each selected axis-0 slice.
+        - k-D mask matching `shape[:k]`: fills each selected k-dimensional block.
 
         Args:
-            mask: The boolean mask array.
-            value: The value to set.
+            mask: Boolean mask array.
+            val: The scalar value to write at every True position.
 
-        Raises:
-            Error: If the mask and the array do not have the same shape.
+        Notes:
+            Use `arr.set(mask, val=scalar)` rather than `arr[mask] = scalar`
+            — Mojo cannot distinguish the scalar from the NDArray overload at
+            the `__setitem__` level.
 
         Examples:
-
-        ```console
-        >>> import numojo
-        >>> var A = numojo.random.rand[numojo.i16](2, 2, 2)
-        >>> var mask = A > 0.5
-        >>> A[mask] = 10
-        ```.
+            ```mojo
+            var A = nm.arange[nm.f32](6)
+            var mask = A > nm.f32(2.0)
+            A.set(mask, val=nm.f32(0.0))
+            ```
         """
-        if (
-            mask.shape != self.shape
-        ):  # this behavious could be removed potentially
-            raise Error(
-                NumojoError(
-                    category="shape",
-                    message=String(
-                        "Mask shape {} does not match array shape {}. Provide a"
-                        " boolean mask with exactly the same shape ({})."
-                    ).format(mask.shape, self.shape, self.shape),
-                    location=(
-                        "NDArray.__setitem__(mask: NDArray[DType.bool], val:"
-                        " Scalar[dtype])"
-                    ),
-                )
-            )
-
+        var value = val
         var mask_c = mask.contiguous()
-        for i in range(mask_c.size):
-            if mask_c._buf.ptr.load[width=1](i):
-                self.itemset(i, value)
+
+        # CASE 1: exact shape match — write scalar at every True position.
+        if mask.shape == self.shape:
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    self.itemset(i, value)
+            return
+
+        # CASE 2: 1-D mask matching first dimension — write scalar to every
+        # element of each selected axis-0 slice.
+        if mask.ndim == 1 and mask.shape[0] == self.shape[0]:
+            var size_per_item = self.size // self.shape[0]
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    for j in range(size_per_item):
+                        self.itemset(i * size_per_item + j, value)
+            return
+
+        # CASE 3: k-D mask (1 < k < self.ndim) matching self.shape[:k].
+        if mask.ndim > 1 and mask.ndim < self.ndim:
+            var shape_match = True
+            for i in range(mask.ndim):
+                if mask.shape[i] != self.shape[i]:
+                    shape_match = False
+                    break
+            if not shape_match:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "Boolean mask shape {} does not match the leading"
+                            " dimensions of array shape {}."
+                        ).format(mask.shape, self.shape),
+                        location="NDArray.set(mask, value: Scalar)",
+                    )
+                )
+            var k = mask.ndim
+            var size_per_item = 1
+            for i in range(k, self.ndim):
+                size_per_item *= self.shape[i]
+
+            var src_strides = List[Int](capacity=k)
+            for d in range(k):
+                var s = size_per_item
+                for dd in range(d + 1, k):
+                    s *= self.shape[dd]
+                src_strides.append(s)
+
+            for flat in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](flat):
+                    var base = 0
+                    var remaining = flat
+                    for d in range(k - 1, -1, -1):
+                        base += (remaining % self.shape[d]) * src_strides[d]
+                        remaining //= self.shape[d]
+                    for j in range(size_per_item):
+                        self.itemset(base + j, value)
+            return
+
+        raise Error(
+            NumojoError(
+                category="shape",
+                message=String(
+                    "Boolean mask shape {} is not compatible with array shape"
+                    " {}. Supported: (1) exact shape match, (2) 1-D mask"
+                    " matching first dimension, (3) k-D mask matching first k"
+                    " dimensions (1 < k < ndim)."
+                ).format(mask.shape, self.shape),
+                location="NDArray.set(mask, value: Scalar)",
+            )
+        )
 
     def __setitem__(mut self, *slices: Slice, val: Self) raises:
         """Sets the elements of the array at the slices with the given array.
@@ -2493,9 +2654,8 @@ struct NDArray[dtype: DType = DType.float64](
     ) raises:
         """Internal backend: fill every element in a slice region with a scalar.
 
-        Called by the user-facing `__setitem__(*Slice, scalar=)` and
-        `__setitem__(*Variant[Slice,Int], scalar=)` overloads after they
-        normalise their arguments into a `List[Slice]`.
+        Called by `set(*Slice, val=)` and `set(*Variant[Slice,Int], val=)`
+        after they normalise their arguments into a `List[Slice]`.
 
         Args:
             slices: One `Slice` per array dimension (trailing dims already
@@ -2540,62 +2700,54 @@ struct NDArray[dtype: DType = DType.float64](
                     break
                 coords[d] = 0
 
-    def __setitem__(
-        mut self, *slices: Slice, scalar: Scalar[Self.dtype]
-    ) raises:
+    def set(mut self, *slices: Slice, val: Scalar[Self.dtype]) raises:
         """Sets all elements in the slice region to a scalar value.
 
-        Delegates to `_setitem_slice_scalar` after packing slices into a list.
-
-        Note: the trailing keyword is named `scalar` (not `val`) to avoid
-        ambiguity with the `*slices: Slice, val: Self` overload during Mojo
-        overload resolution.
-
         Args:
-            slices: Variadic slices, one per dimension (trailing dims default
-                to the full range).
-            scalar: The scalar value to broadcast into every selected position.
+            slices: Variadic slices, one per dimension. Trailing dimensions
+                default to the full range.
+            val: The scalar value to broadcast into every selected position.
+
+        Notes:
+            Use `arr.set(s1, s2, val=scalar)` rather than `arr[s1, s2] = scalar`
+            — Mojo cannot distinguish the scalar from the NDArray overload at
+            the `__setitem__` level.
 
         Examples:
             ```mojo
-            import numojo as nm
-
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
-            a.__setitem__(Slice(1,3), Slice(1,3), scalar=99)
+            a.set(Slice(1, 3), Slice(1, 3), val=99)
             ```
         """
         var slice_list = List[Slice](capacity=slices.__len__())
         for i in range(slices.__len__()):
             slice_list.append(slices[i])
-        self._setitem_slice_scalar(slice_list, scalar)
+        self._setitem_slice_scalar(slice_list, val)
 
-    def __setitem__(
-        mut self, *slices: Variant[Slice, Int], scalar: Scalar[Self.dtype]
+    def set(
+        mut self, *slices: Variant[Slice, Int], val: Scalar[Self.dtype]
     ) raises:
         """Sets elements selected by mixed integer/slice indices to a scalar.
 
-        Handles two cases:
-        - All entries are integers (full coordinate) → direct single-element
-          write via `_setitem`, no allocation.
-        - Mixed or slice-only → normalise integers to unit-length slices and
-          delegate to `__setitem__(List[Slice], Scalar)` for the region fill.
-
-        Note: the trailing keyword is named `scalar` (not `val`) to avoid
-        ambiguity with the `*slices: Variant[Slice, Int], val: Self` overload
-        during Mojo overload resolution.
+        Integer entries select a single position in the corresponding dimension;
+        slice entries select a range. All-integer arguments write one element
+        directly. Mixed or slice-only arguments fill every selected position.
 
         Args:
             slices: Variadic mix of `Slice` and `Int` index entries.
-            scalar: The scalar value to write.
+            val: The scalar value to write.
+
+        Notes:
+            Use `arr.set(..., val=scalar)` rather than `arr[...] = scalar`
+            — Mojo cannot distinguish the scalar from the NDArray overload at
+            the `__setitem__` level.
 
         Examples:
             ```mojo
-            import numojo as nm
-
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
-            a.__setitem__(1, 2, scalar=99)           # single element
-            a.__setitem__(1, Slice(2,4), scalar=0)   # one row, partial column
-            a.__setitem__(Slice(1,3), Slice(2,4), scalar=7)  # sub-matrix
+            a.set(1, 2, val=99)                     # single element
+            a.set(1, Slice(2, 4), val=0)            # row 1, cols 2-3
+            a.set(Slice(1, 3), Slice(2, 4), val=7)  # sub-matrix
             ```
         """
         var n = slices.__len__()
@@ -2608,8 +2760,7 @@ struct NDArray[dtype: DType = DType.float64](
                         " dimensions."
                     ).format(n, self.ndim),
                     location=(
-                        "NDArray.__setitem__(*slices: Variant[Slice, Int],"
-                        " scalar: Scalar)"
+                        "NDArray.set(*slices: Variant[Slice, Int], val: Scalar)"
                     ),
                 )
             )
@@ -2618,9 +2769,6 @@ struct NDArray[dtype: DType = DType.float64](
         var count_int: Int = 0
         var coords = List[Int]()
 
-        # Track which array dimension each entry maps to (Int and Slice both
-        # consume one dimension; the loop index equals the array dim here
-        # because Variant[Slice,Int] carries no NewAxis).
         for i in range(n):
             if slices[i].isa[Int]():
                 var idx = slices[i][Int]
@@ -2639,8 +2787,8 @@ struct NDArray[dtype: DType = DType.float64](
                                 self.shape[i],
                             ),
                             location=(
-                                "NDArray.__setitem__(*slices: Variant[Slice,"
-                                " Int], scalar: Scalar)"
+                                "NDArray.set(*slices: Variant[Slice, Int], val:"
+                                " Scalar)"
                             ),
                         )
                     )
@@ -2652,16 +2800,14 @@ struct NDArray[dtype: DType = DType.float64](
             else:
                 slice_list.append(slices[i][Slice])
 
-        # Fast path: every dimension was given an integer → single element.
         if count_int == self.ndim:
-            self.itemset(coords.copy(), scalar)
+            self.itemset(coords.copy(), val)
             return
 
-        # Pad trailing dimensions.
         for i in range(n, self.ndim):
             slice_list.append(Slice(0, self.shape[i], 1))
 
-        self._setitem_slice_scalar(slice_list, scalar)
+        self._setitem_slice_scalar(slice_list, val)
 
     def __setitem__(
         mut self, index: NDArray[DType.int], val: NDArray[Self.dtype]
@@ -2831,87 +2977,218 @@ struct NDArray[dtype: DType = DType.float64](
                 )
                 self.__setitem__(idx=idx, val=slice)
 
-    def __setitem__(
-        mut self, mask: NDArray[DType.bool], val: NDArray[Self.dtype]
+    def set(
+        mut self, mask: NDArray[DType.bool], *, val: NDArray[Self.dtype]
     ) raises:
-        """Sets the value of the array at the indices where the mask is `True`.
+        """Sets elements where `mask` is `True` from an NDArray value.
+
+        Supported `val` shapes (same three mask cases as the scalar overload):
+        - Exact-shape mask: elementwise, size-1 broadcast, or compact 1-D.
+        - 1-D mask of length `shape[0]`: single sub-array or per-index array.
+        - k-D mask matching `shape[:k]`: single sub-array or per-index array.
 
         Args:
-            mask: The boolean mask array.
-            val: The value to set.
+            mask: Boolean mask array.
+            val: The NDArray value(s) to write.
 
-        Raises:
-            Error: If the mask and the array do not have the same shape.
+        Notes:
+            Use `arr.set(mask, val=values)` rather than `arr[mask] = values`
+            — Mojo cannot distinguish the scalar from the NDArray overload at
+            the `__setitem__` level.
 
         Examples:
-
-        ```console
-        >>> import numojo
-        >>> var A = numojo.random.rand[numojo.i16](2, 2, 2)
-        >>> var mask = A > 0.5
-        >>> A[mask] = 10
-        ```.
+            ```mojo
+            var A = nm.arange[nm.f32](6).reshape(nm.Shape(2, 3))
+            var mask = A > nm.f32(2.0)
+            var vals = nm.array[nm.f32]("[10.0, 20.0, 30.0]")
+            A.set(mask, val=vals)
+            ```
         """
-        if (
-            mask.shape != self.shape
-        ):  # this behavious could be removed potentially
+        var mask_c = mask.contiguous()
+        var val_c = val.contiguous()
+
+        # CASE 1: exact shape match — elementwise assignment or scalar broadcast.
+        if mask.shape == self.shape:
+            if val_c.shape == self.shape:
+                for i in range(mask_c.size):
+                    if mask_c._buf.ptr.load[width=1](i):
+                        self.itemset(i, val_c._buf.ptr.load[width=1](i))
+                return
+
+            if val_c.size == 1:
+                var scalar_val = val_c._buf.ptr.load[width=1](val_c.offset)
+                for i in range(mask_c.size):
+                    if mask_c._buf.ptr.load[width=1](i):
+                        self.itemset(i, scalar_val)
+                return
+
+            var true_count = 0
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    true_count += 1
+
+            if val_c.ndim == 1 and val_c.size == true_count:
+                var j = 0
+                for i in range(mask_c.size):
+                    if mask_c._buf.ptr.load[width=1](i):
+                        self.itemset(i, val_c._buf.ptr.load[width=1](j))
+                        j += 1
+                return
+
             raise Error(
                 NumojoError(
                     category="shape",
                     message=String(
-                        "Shape of mask does not match the shape of array. The"
-                        " mask shape is {}. The array shape is {}."
-                    ).format(mask.shape, self.shape),
-                    location=(
-                        "NDArray.__setitem__(mask: NDArray[DType.bool], val:"
-                        " NDArray)"
-                    ),
+                        "Invalid value shape {} for boolean mask assignment"
+                        " with {} selected elements. Expected value shape {}"
+                        " (elementwise), a scalar/size-1 array, or 1-D shape"
+                        " [{}]."
+                    ).format(val.shape, true_count, self.shape, true_count),
+                    location="NDArray.set(mask, val: NDArray)",
                 )
             )
 
-        var mask_c = mask.contiguous()
-        var val_c = val.contiguous()
-
-        # Elementwise (val matches self) and scalar broadcast paths do not
-        # need to count selected elements; only the compact 1-D path does.
-        if val_c.shape == self.shape:
+        # CASE 2: 1-D mask matching first dimension.
+        if mask.ndim == 1 and mask.shape[0] == self.shape[0]:
+            var size_per_item = self.size // self.shape[0]
+            var true_count = 0
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
-                    self.itemset(i, val_c._buf.ptr.load[width=1](i))
+                    true_count += 1
+
+            # val must be either a single sub-array (shape self.shape[1:])
+            # or (true_count, *self.shape[1:]).
+            var tail_shape = self.shape.pop(0)
+            var val_is_single = val_c.shape == tail_shape
+            var val_is_per_index = (
+                val_c.ndim == self.ndim
+                and val_c.shape[0] == true_count
+                and val_c.shape.pop(0) == tail_shape
+            )
+
+            if not val_is_single and not val_is_per_index:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "Invalid value shape {} for 1-D mask assignment."
+                            " Expected {} (single sub-array) or [{}, ...{}]."
+                        ).format(val.shape, tail_shape, true_count, tail_shape),
+                        location="NDArray.set(mask, val: NDArray)",
+                    )
+                )
+
+            var out_row = 0
+            for i in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](i):
+                    var src_ptr = val_c._buf.ptr + (
+                        out_row * size_per_item if val_is_per_index else 0
+                    )
+                    memcpy(
+                        dest=self._buf.ptr + self.offset + i * size_per_item,
+                        src=src_ptr,
+                        count=size_per_item,
+                    )
+                    out_row += 1
             return
 
-        if val_c.size == 1:
-            var scalar_val = val_c._buf.ptr.load[width=1](val_c.offset)
+        # CASE 3: k-D mask (1 < k < self.ndim) matching self.shape[:k].
+        if mask.ndim > 1 and mask.ndim < self.ndim:
+            var shape_match = True
+            for i in range(mask.ndim):
+                if mask.shape[i] != self.shape[i]:
+                    shape_match = False
+                    break
+            if not shape_match:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "Boolean mask shape {} does not match the leading"
+                            " dimensions of array shape {}."
+                        ).format(mask.shape, self.shape),
+                        location="NDArray.set(mask, val: NDArray)",
+                    )
+                )
+
+            var k = mask.ndim
+            var size_per_item = 1
+            for i in range(k, self.ndim):
+                size_per_item *= self.shape[i]
+
+            var true_count = 0
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
-                    self.itemset(i, scalar_val)
-            return
+                    true_count += 1
 
-        var true_count = 0
-        for i in range(mask_c.size):
-            if mask_c._buf.ptr.load[width=1](i):
-                true_count += 1
+            var tail_shape = NDArrayShape(self.shape[k:])
+            var val_is_single = val_c.shape == tail_shape
+            var val_is_per_index = (
+                val_c.ndim == self.ndim - k + 1
+                and val_c.shape[0] == true_count
+                and NDArrayShape(val_c.shape[1:]) == tail_shape
+            )
 
-        if val_c.ndim == 1 and val_c.size == true_count:
-            var j = 0
-            for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
-                    self.itemset(i, val_c._buf.ptr.load[width=1](j))
-                    j += 1
+            if not val_is_single and not val_is_per_index and val_c.size != 1:
+                raise Error(
+                    NumojoError(
+                        category="shape",
+                        message=String(
+                            "Invalid value shape {} for k-D mask assignment"
+                            " ({} selected sub-arrays of shape {})."
+                        ).format(val.shape, true_count, tail_shape),
+                        location="NDArray.set(mask, val: NDArray)",
+                    )
+                )
+
+            var src_strides = List[Int](capacity=k)
+            for d in range(k):
+                var s = size_per_item
+                for dd in range(d + 1, k):
+                    s *= self.shape[dd]
+                src_strides.append(s)
+
+            # Work on a contiguous copy, then write back unconditionally.
+            # This handles both C- and F-order destinations correctly.
+            var self_c = self.contiguous()
+            var out_row = 0
+            for flat in range(mask_c.size):
+                if mask_c._buf.ptr.load[width=1](flat):
+                    var dst_offset = 0
+                    var remaining = flat
+                    for d in range(k - 1, -1, -1):
+                        dst_offset += (remaining % self.shape[d]) * src_strides[
+                            d
+                        ]
+                        remaining //= self.shape[d]
+
+                    var src_ptr = val_c._buf.ptr + (
+                        out_row * size_per_item if val_is_per_index else 0
+                    )
+                    memcpy(
+                        dest=self_c._buf.ptr + dst_offset,
+                        src=src_ptr,
+                        count=size_per_item,
+                    )
+                    out_row += 1
+
+            memcpy(
+                dest=self._buf.ptr + self.offset,
+                src=self_c._buf.ptr,
+                count=self.size,
+            )
             return
 
         raise Error(
             NumojoError(
                 category="shape",
                 message=String(
-                    "Invalid value shape {} for boolean mask assignment with {}"
-                    " selected elements. Expected value shape {} (elementwise),"
-                    " a scalar/size-1 array, or 1-D shape [{}]."
-                ).format(val.shape, true_count, self.shape, true_count),
-                location=(
-                    "NDArray.__setitem__(mask: NDArray[DType.bool], val:"
-                    " NDArray)"
-                ),
+                    "Boolean mask shape {} is not compatible with array shape"
+                    " {}. Supported: (1) exact shape match, (2) 1-D mask"
+                    " matching first dimension, (3) k-D mask matching first k"
+                    " dimensions (1 < k < ndim)."
+                ).format(mask.shape, self.shape),
+                location="NDArray.set(mask, val: NDArray)",
             )
         )
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -841,7 +841,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If `slice_list` is empty or contains invalid slices.
         """
         var n_slices: Int = len(slice_list)
-        var slices: List[InternalSlice] = self._adjust_slice(slice_list)
+        var slices: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slice_list)
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
                 slices.append(InternalSlice(0, self.shape[i], 1))
@@ -977,7 +977,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         # adjust slice values for user provided slices
-        var slices: List[InternalSlice] = self._adjust_slice(slice_list)
+        var slices: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slice_list)
         if n_slices < self.ndim:
             for i in range(n_slices, self.ndim):
                 slices.append(InternalSlice(0, self.shape[i], 1))
@@ -2459,7 +2459,7 @@ struct NDArray[dtype: DType = DType.float64](
         var ndims: Int = 0
         var count: Int = 0
         var spec: List[Int] = List[Int]()
-        var slice_list: List[InternalSlice] = self._adjust_slice(slices)
+        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slices)
         for i in range(n_slices):
             if (
                 slice_list[i].start >= self.shape[i]
@@ -2663,7 +2663,7 @@ struct NDArray[dtype: DType = DType.float64](
             val: The scalar value to write to every selected position.
         """
         var n_slices: Int = len(slices)
-        var slice_list: List[InternalSlice] = self._adjust_slice(slices)
+        var slice_list: List[InternalSlice] = InternalSlice.adjust_list(self.shape, slices)
 
         for i in range(n_slices, self.ndim):
             slice_list.append(InternalSlice(0, self.shape[i], 1))
@@ -4354,82 +4354,6 @@ struct NDArray[dtype: DType = DType.float64](
             Pointer(to=self),
             dimension=0,
         )
-
-    def _adjust_slice(
-        self, slice_list: List[Slice]
-    ) raises -> List[InternalSlice]:
-        """Adjusts slice values to handle all possible slicing scenarios
-        including:
-
-        - Negative indices (Python-style wrapping).
-        - Out-of-bounds clamping.
-        - Negative steps (reverse slicing).
-        - Empty slices.
-        - Default start/end values based on step direction.
-        """
-        var n_slices: Int = len(slice_list)
-        var slices = List[InternalSlice](capacity=self.ndim)
-        for i in range(n_slices):
-            var dim_size = self.shape[i]
-            var step = slice_list[i].step.or_else(1)
-
-            if step == 0:
-                raise Error(
-                    NumojoError(
-                        category="value",
-                        message=String(
-                            "Slice step cannot be zero (dimension {}). Use"
-                            " positive or negative non-zero step."
-                        ).format(i),
-                        location="NDArray._adjust_slice",
-                    )
-                )
-
-            # defaults
-            var start: Int
-            var end: Int
-            if step > 0:
-                start = 0
-                end = dim_size
-            else:
-                start = dim_size - 1
-                end = -1
-
-            # start
-            var raw_start = slice_list[i].start.or_else(start)
-            if raw_start < 0:
-                raw_start += dim_size
-            if step > 0:
-                start = 0 if raw_start < 0 else (
-                    dim_size if raw_start > dim_size else raw_start
-                )
-            else:
-                start = -1 if raw_start < -1 else (
-                    dim_size - 1 if raw_start >= dim_size else raw_start
-                )
-
-            # end
-            var raw_end = slice_list[i].end.or_else(end)
-            if raw_end < 0:
-                raw_end += dim_size
-            if step > 0:
-                end = 0 if raw_end < 0 else (
-                    dim_size if raw_end > dim_size else raw_end
-                )
-            else:
-                end = -1 if raw_end < -1 else (
-                    dim_size if raw_end > dim_size else raw_end
-                )
-
-            slices.append(
-                InternalSlice(
-                    start=start,
-                    end=end,
-                    step=step,
-                )
-            )
-
-        return slices^
 
     def _array_to_string(
         self,

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -173,6 +173,7 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
+
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -173,7 +173,6 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         dtype: DType, simd_width: Int
     ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
-
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 

--- a/tests/core/test_array_indexing_and_slicing.mojo
+++ b/tests/core/test_array_indexing_and_slicing.mojo
@@ -333,7 +333,7 @@ def test_mask_setitem_compact_values() raises:
     var a = nm.arange[nm.i32](0, 6, step=1).reshape(Shape(2, 3))
     var mask = nm.array[boolean]("[[1,0,1],[0,1,0]]")
     var vals = nm.array[nm.i32]("[50, 60, 70]")
-    a[mask] = vals
+    a.set(mask, val=vals)
 
     # True positions in row-major order: (0,0), (0,2), (1,1)
     assert_equal(Int(a.item(0, 0)), 50)

--- a/tests/core/test_bool_mask_nd.mojo
+++ b/tests/core/test_bool_mask_nd.mojo
@@ -1,0 +1,260 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+# Tests for Step 5 and Step 6:
+#
+# Step 5 — __getitem__(mask: NDArray[DType.bool]):
+#   Added CASE 3: k-D mask (1 < k < ndim) whose shape matches self.shape[:k].
+#   Result shape: (true_count, *self.shape[k:])
+#
+# Step 6 — __setitem__(mask, value/val):
+#   Both scalar and NDArray overloads now support the same three cases as
+#   the getter: exact shape, 1-D leading, k-D leading.
+#
+# Existing CASE 1 and CASE 2 are tested in test_bool_masks.mojo and
+# test_array_indexing_and_slicing.mojo; we only add CASE 3 tests here
+# plus quick regression checks for CASE 1 and 2 to confirm they still work.
+
+
+# ===== Step 5: __getitem__ CASE 3 — k-D mask =====
+
+
+def test_getitem_2d_mask_on_3d_array() raises:
+    """2-D mask on 3-D array selects sub-arrays of shape (shape[2],)."""
+    # a shape (2, 3, 4):  a[i,j,k] = i*12 + j*4 + k
+    # mask shape (2, 3): True at (0,1) and (1,2)
+    #: result shape (2, 4): rows a[0,1,:] and a[1,2,:]
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    var result = a[mask]
+
+    assert_equal(result.ndim, 2)
+    assert_equal(result.shape[0], 2)
+    assert_equal(result.shape[1], 4)
+    # First selected sub-array: a[0,1,:] = [4,5,6,7]
+    assert_equal(Int(result.item(0, 0)), 4)
+    assert_equal(Int(result.item(0, 1)), 5)
+    assert_equal(Int(result.item(0, 2)), 6)
+    assert_equal(Int(result.item(0, 3)), 7)
+    # Second selected sub-array: a[1,2,:] = [20,21,22,23]
+    assert_equal(Int(result.item(1, 0)), 20)
+    assert_equal(Int(result.item(1, 1)), 21)
+    assert_equal(Int(result.item(1, 2)), 22)
+    assert_equal(Int(result.item(1, 3)), 23)
+
+
+def test_getitem_2d_mask_single_true() raises:
+    """2-D mask with only one True: result shape (1, trailing_dims)."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([1, 0], True)
+
+    var result = a[mask]
+
+    assert_equal(result.shape[0], 1)
+    assert_equal(result.shape[1], 4)
+    # a[1,0,:] = [12,13,14,15]
+    assert_equal(Int(result.item(0, 0)), 12)
+    assert_equal(Int(result.item(0, 3)), 15)
+
+
+def test_getitem_2d_mask_all_true() raises:
+    """2-D mask all True: result has all sub-arrays in row-major order."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    var mask = nm.ones[nm.boolean](Shape(2, 3))
+
+    var result = a[mask]
+
+    assert_equal(result.shape[0], 6)
+    assert_equal(result.shape[1], 4)
+    # Row-major order: (0,0),(0,1),(0,2),(1,0),(1,1),(1,2)
+    assert_equal(Int(result.item(0, 0)), 0)  # a[0,0,0]
+    assert_equal(Int(result.item(2, 0)), 8)  # a[0,2,0]
+    assert_equal(Int(result.item(3, 0)), 12)  # a[1,0,0]
+    assert_equal(Int(result.item(5, 3)), 23)  # a[1,2,3]
+
+
+def test_getitem_2d_mask_no_true() raises:
+    """2-D mask all False: raises because empty arrays are not supported."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+
+    var raised = False
+    try:
+        var _ = a[mask]
+    except:
+        raised = True
+    assert_true(raised, "all-False k-D mask should raise")
+
+
+def test_getitem_2d_mask_on_4d_array() raises:
+    """2-D mask on 4-D array: result shape (count, shape[2], shape[3])."""
+    # a shape (2, 2, 3, 3): a[i,j,k,l] = i*18 + j*9 + k*3 + l
+    var a = nm.arange[nm.i32](0, 36).reshape(Shape(2, 2, 3, 3))
+    var mask = nm.zeros[nm.boolean](Shape(2, 2))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 1], True)
+
+    var result = a[mask]
+
+    assert_equal(result.ndim, 3)
+    assert_equal(result.shape[0], 2)
+    assert_equal(result.shape[1], 3)
+    assert_equal(result.shape[2], 3)
+    # a[0,1,:,:]: starts at offset 0*18+1*9 = 9
+    assert_equal(Int(result.item(0, 0, 0)), 9)
+    assert_equal(Int(result.item(0, 2, 2)), 17)
+    # a[1,1,:,:]: starts at offset 1*18+1*9 = 27
+    assert_equal(Int(result.item(1, 0, 0)), 27)
+    assert_equal(Int(result.item(1, 2, 2)), 35)
+
+
+# Regression: CASE 1 and CASE 2 still work after adding CASE 3
+
+
+def test_getitem_exact_shape_mask_regression() raises:
+    """CASE 1 still works: exact shape mask: flattened 1-D result."""
+    var a = nm.arange[nm.i32](0, 6)
+    var mask = nm.array[nm.boolean]("[1,0,1,1,0,1]")
+    var result = a[mask]
+    assert_equal(result.ndim, 1)
+    assert_equal(result.shape[0], 4)
+    assert_equal(Int(result.item(0)), 0)
+    assert_equal(Int(result.item(1)), 2)
+    assert_equal(Int(result.item(3)), 5)
+
+
+def test_getitem_1d_mask_on_2d_regression() raises:
+    """CASE 2 still works: 1-D mask on 2-D array selects axis-0 rows."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var mask = nm.array[nm.boolean]("[0,1,0]")
+    var result = a[mask]
+    assert_equal(result.shape[0], 1)
+    assert_equal(result.shape[1], 4)
+    assert_equal(Int(result.item(0, 0)), 4)
+    assert_equal(Int(result.item(0, 3)), 7)
+
+
+# ===== Step 6: __setitem__ CASE 3 — k-D mask (scalar and NDArray val) =====
+
+
+def test_setitem_scalar_2d_mask_on_3d() raises:
+    """Scalar setitem: 2-D mask on 3-D array zeros selected sub-arrays."""
+    # a shape (2, 3, 4), mask True at (0,1) and (1,2)
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    a.set(mask, val=Scalar[nm.i32](0))
+
+    # a[0,1,:] should be 0
+    for k in range(4):
+        assert_equal(Int(a.item(0, 1, k)), 0)
+    # a[1,2,:] should be 0
+    for k in range(4):
+        assert_equal(Int(a.item(1, 2, k)), 0)
+    # Unmasked positions unchanged
+    assert_equal(Int(a.item(0, 0, 0)), 0)  # original value 0
+    assert_equal(Int(a.item(0, 2, 3)), 11)
+    assert_equal(Int(a.item(1, 0, 0)), 12)
+    assert_equal(Int(a.item(1, 1, 3)), 19)
+
+
+def test_setitem_scalar_2d_mask_non_zero_value() raises:
+    """Scalar setitem: 2-D mask writes a non-zero scalar."""
+    var a = nm.zeros[nm.i32](Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 0], True)
+    mask.itemset([1, 1], True)
+
+    a.set(mask, val=Scalar[nm.i32](99))
+
+    for k in range(4):
+        assert_equal(Int(a.item(0, 0, k)), 99)
+        assert_equal(Int(a.item(1, 1, k)), 99)
+    # Untouched
+    assert_equal(Int(a.item(0, 1, 0)), 0)
+    assert_equal(Int(a.item(1, 0, 0)), 0)
+
+
+def test_setitem_ndarray_2d_mask_single_subarray() raises:
+    """NDArray setitem: 2-D mask, val is a single sub-array broadcast."""
+    # Broadcast one (4,) row to all selected (2) positions
+    var a = nm.zeros[nm.i32](Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    var val = nm.arange[nm.i32](10, 14).reshape(Shape(4))
+    a.set(mask, val=val)
+
+    # Both selected sub-arrays get [10,11,12,13]
+    for k in range(4):
+        assert_equal(Int(a.item(0, 1, k)), 10 + k)
+        assert_equal(Int(a.item(1, 2, k)), 10 + k)
+    # Untouched
+    assert_equal(Int(a.item(0, 0, 0)), 0)
+    assert_equal(Int(a.item(1, 0, 0)), 0)
+
+
+def test_setitem_ndarray_2d_mask_per_index_val() raises:
+    """NDArray setitem: 2-D mask, val has shape (true_count, *trailing)."""
+    var a = nm.zeros[nm.i32](Shape(2, 3, 4))
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 0], True)
+    mask.itemset([1, 2], True)
+
+    # val shape (2, 4): row 0: [10..13], row 1: [20..23]
+    var val = nm.zeros[nm.i32](Shape(2, 4))
+    for k in range(4):
+        val.itemset(k, Scalar[nm.i32](10 + k))
+        val.itemset(4 + k, Scalar[nm.i32](20 + k))
+
+    a.set(mask, val=val)
+
+    for k in range(4):
+        assert_equal(Int(a.item(0, 0, k)), 10 + k)
+        assert_equal(Int(a.item(1, 2, k)), 20 + k)
+    # Untouched
+    assert_equal(Int(a.item(0, 1, 0)), 0)
+    assert_equal(Int(a.item(1, 0, 0)), 0)
+
+
+# Regression: CASE 1 and 2 setitem still work
+
+
+def test_setitem_exact_shape_scalar_regression() raises:
+    """CASE 1 scalar setitem still works after refactor."""
+    var a = nm.arange[nm.i32](0, 6)
+    var mask = nm.array[nm.boolean]("[0,1,0,1,0,0]")
+    a.set(mask, val=Scalar[nm.i32](99))
+    assert_equal(Int(a.item(0)), 0)
+    assert_equal(Int(a.item(1)), 99)
+    assert_equal(Int(a.item(2)), 2)
+    assert_equal(Int(a.item(3)), 99)
+    assert_equal(Int(a.item(5)), 5)
+
+
+def test_setitem_exact_shape_ndarray_regression() raises:
+    """CASE 1 NDArray setitem (compact 1-D val) still works after refactor."""
+    var a = nm.arange[nm.i32](0, 6).reshape(Shape(2, 3))
+    var mask = nm.array[nm.boolean]("[[1,0,1],[0,1,0]]")
+    var vals = nm.array[nm.i32]("[50, 60, 70]")
+    a.set(mask, val=vals)
+    assert_equal(Int(a.item(0, 0)), 50)
+    assert_equal(Int(a.item(0, 2)), 60)
+    assert_equal(Int(a.item(1, 1)), 70)
+    assert_equal(Int(a.item(0, 1)), 1)
+    assert_equal(Int(a.item(1, 0)), 3)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_bool_mask_nd.mojo
+++ b/tests/core/test_bool_mask_nd.mojo
@@ -4,6 +4,7 @@ from std.testing.testing import assert_equal, assert_true
 import numojo as nm
 from numojo.prelude import *
 
+
 def test_getitem_2d_mask_on_3d_array() raises:
     """2-D mask on 3-D array selects sub-arrays of shape (shape[2],)."""
     # a shape (2, 3, 4):  a[i,j,k] = i*12 + j*4 + k
@@ -97,7 +98,6 @@ def test_getitem_2d_mask_on_4d_array() raises:
     assert_equal(Int(result.item(1, 2, 2)), 35)
 
 
-
 def test_getitem_exact_shape_mask_regression() raises:
     """CASE 1 still works: exact shape mask: flattened 1-D result."""
     var a = nm.arange[nm.i32](0, 6)
@@ -176,7 +176,7 @@ def test_setitem_ndarray_2d_mask_single_subarray() raises:
     for k in range(4):
         assert_equal(Int(a.item(0, 1, k)), 10 + k)
         assert_equal(Int(a.item(1, 2, k)), 10 + k)
-    
+
     assert_equal(Int(a.item(0, 0, 0)), 0)
     assert_equal(Int(a.item(1, 0, 0)), 0)
 
@@ -199,7 +199,7 @@ def test_setitem_ndarray_2d_mask_per_index_val() raises:
     for k in range(4):
         assert_equal(Int(a.item(0, 0, k)), 10 + k)
         assert_equal(Int(a.item(1, 2, k)), 20 + k)
-    
+
     assert_equal(Int(a.item(0, 1, 0)), 0)
     assert_equal(Int(a.item(1, 0, 0)), 0)
 

--- a/tests/core/test_bool_mask_nd.mojo
+++ b/tests/core/test_bool_mask_nd.mojo
@@ -4,25 +4,6 @@ from std.testing.testing import assert_equal, assert_true
 import numojo as nm
 from numojo.prelude import *
 
-
-# Tests for Step 5 and Step 6:
-#
-# Step 5 — __getitem__(mask: NDArray[DType.bool]):
-#   Added CASE 3: k-D mask (1 < k < ndim) whose shape matches self.shape[:k].
-#   Result shape: (true_count, *self.shape[k:])
-#
-# Step 6 — __setitem__(mask, value/val):
-#   Both scalar and NDArray overloads now support the same three cases as
-#   the getter: exact shape, 1-D leading, k-D leading.
-#
-# Existing CASE 1 and CASE 2 are tested in test_bool_masks.mojo and
-# test_array_indexing_and_slicing.mojo; we only add CASE 3 tests here
-# plus quick regression checks for CASE 1 and 2 to confirm they still work.
-
-
-# ===== Step 5: __getitem__ CASE 3 — k-D mask =====
-
-
 def test_getitem_2d_mask_on_3d_array() raises:
     """2-D mask on 3-D array selects sub-arrays of shape (shape[2],)."""
     # a shape (2, 3, 4):  a[i,j,k] = i*12 + j*4 + k
@@ -116,8 +97,6 @@ def test_getitem_2d_mask_on_4d_array() raises:
     assert_equal(Int(result.item(1, 2, 2)), 35)
 
 
-# Regression: CASE 1 and CASE 2 still work after adding CASE 3
-
 
 def test_getitem_exact_shape_mask_regression() raises:
     """CASE 1 still works: exact shape mask: flattened 1-D result."""
@@ -140,9 +119,6 @@ def test_getitem_1d_mask_on_2d_regression() raises:
     assert_equal(result.shape[1], 4)
     assert_equal(Int(result.item(0, 0)), 4)
     assert_equal(Int(result.item(0, 3)), 7)
-
-
-# ===== Step 6: __setitem__ CASE 3 — k-D mask (scalar and NDArray val) =====
 
 
 def test_setitem_scalar_2d_mask_on_3d() raises:
@@ -180,7 +156,7 @@ def test_setitem_scalar_2d_mask_non_zero_value() raises:
     for k in range(4):
         assert_equal(Int(a.item(0, 0, k)), 99)
         assert_equal(Int(a.item(1, 1, k)), 99)
-    # Untouched
+
     assert_equal(Int(a.item(0, 1, 0)), 0)
     assert_equal(Int(a.item(1, 0, 0)), 0)
 
@@ -200,7 +176,7 @@ def test_setitem_ndarray_2d_mask_single_subarray() raises:
     for k in range(4):
         assert_equal(Int(a.item(0, 1, k)), 10 + k)
         assert_equal(Int(a.item(1, 2, k)), 10 + k)
-    # Untouched
+    
     assert_equal(Int(a.item(0, 0, 0)), 0)
     assert_equal(Int(a.item(1, 0, 0)), 0)
 
@@ -223,12 +199,9 @@ def test_setitem_ndarray_2d_mask_per_index_val() raises:
     for k in range(4):
         assert_equal(Int(a.item(0, 0, k)), 10 + k)
         assert_equal(Int(a.item(1, 2, k)), 20 + k)
-    # Untouched
+    
     assert_equal(Int(a.item(0, 1, 0)), 0)
     assert_equal(Int(a.item(1, 0, 0)), 0)
-
-
-# Regression: CASE 1 and 2 setitem still work
 
 
 def test_setitem_exact_shape_scalar_regression() raises:

--- a/tests/core/test_setitem_scalar.mojo
+++ b/tests/core/test_setitem_scalar.mojo
@@ -7,12 +7,9 @@ from numojo.prelude import *
 from utils_for_test import check
 
 
-# Mojo's __setitem__ overload resolution with variadic+keyword args requires:
-#   - List[Slice] scalar: pass the list positionally, `val=` keyword works.
-#   - *Slice scalar: use explicit `.__setitem__(s1, s2, ..., scalar=v)`.
-#   - *Variant[Slice,Int] scalar: use explicit `.__setitem__(i, s, scalar=v)`.
-# The `scalar` keyword name was chosen (instead of `val`) to avoid shadowing
-# the existing `val: Self` overloads at the Mojo compiler level.
+# Scalar assignment uses arr.set(..., val=scalar) since Mojo cannot resolve
+# __setitem__ overloads that differ only in the RHS type (Scalar vs NDArray).
+# List[Slice] backend is called directly via _setitem_slice_scalar().
 
 
 # ===== Step 3: __setitem__(List[Slice], val: Scalar) =====
@@ -146,7 +143,7 @@ def test_setitem_variadic_slice_scalar_2d() raises:
     sl.append(Slice(1, 3))
     a._setitem_slice_scalar(sl, Scalar[nm.i32](77))
 
-    b.__setitem__(Slice(1, 3), Slice(1, 3), scalar=Scalar[nm.i32](77))
+    b.set(Slice(1, 3), Slice(1, 3), val=Scalar[nm.i32](77))
 
     for i in range(4):
         for j in range(4):
@@ -162,7 +159,7 @@ def test_setitem_variadic_slice_scalar_2d() raises:
 def test_setitem_variadic_slice_scalar_1d() raises:
     """*Slice scalar: 1D slice fill."""
     var a = nm.arange[nm.i32](0, 8, step=1)
-    a.__setitem__(Slice(2, 6), scalar=Scalar[nm.i32](5))
+    a.set(Slice(2, 6), val=Scalar[nm.i32](5))
 
     assert_equal(Int(a.item(0)), 0)
     assert_equal(Int(a.item(1)), 1)
@@ -175,7 +172,7 @@ def test_setitem_variadic_slice_scalar_1d() raises:
 def test_setitem_variadic_slice_scalar_implicit_trailing() raises:
     """*Slice scalar: single slice on 2D array, trailing dim implicit full."""
     var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
-    a.__setitem__(Slice(0, 2), scalar=Scalar[nm.i32](9))
+    a.set(Slice(0, 2), val=Scalar[nm.i32](9))
 
     for c in range(4):
         assert_equal(Int(a.item(0, c)), 9)
@@ -191,7 +188,7 @@ def test_setitem_variadic_slice_scalar_implicit_trailing() raises:
 def test_setitem_mixed_single_element_2d() raises:
     """All-Int fast path: single element write on 2D array."""
     var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
-    a.__setitem__(1, 2, scalar=Scalar[nm.i32](99))
+    a.set(1, 2, val=Scalar[nm.i32](99))
 
     assert_equal(Int(a.item(1, 2)), 99)
     assert_equal(Int(a.item(1, 1)), 5)
@@ -203,7 +200,7 @@ def test_setitem_mixed_single_element_2d() raises:
 def test_setitem_mixed_single_element_3d() raises:
     """All-Int fast path: single element write on 3D array."""
     var a = nm.arange[nm.i32](0, 24, step=1).reshape(Shape(2, 3, 4))
-    a.__setitem__(0, 1, 2, scalar=Scalar[nm.i32](77))
+    a.set(0, 1, 2, val=Scalar[nm.i32](77))
 
     assert_equal(Int(a.item(0, 1, 2)), 77)
     assert_equal(Int(a.item(0, 0, 0)), 0)
@@ -213,7 +210,7 @@ def test_setitem_mixed_single_element_3d() raises:
 def test_setitem_mixed_int_slice_row() raises:
     """Int + Slice: select row by int, column range by slice."""
     var a = nm.arange[nm.i32](0, 16, step=1).reshape(Shape(4, 4))
-    a.__setitem__(1, Slice(1, 3), scalar=Scalar[nm.i32](55))
+    a.set(1, Slice(1, 3), val=Scalar[nm.i32](55))
 
     assert_equal(Int(a.item(1, 1)), 55)
     assert_equal(Int(a.item(1, 2)), 55)
@@ -226,7 +223,7 @@ def test_setitem_mixed_int_slice_row() raises:
 def test_setitem_mixed_slice_int_col() raises:
     """Slice + Int: select row range by slice, column by int."""
     var a = nm.arange[nm.i32](0, 16, step=1).reshape(Shape(4, 4))
-    a.__setitem__(Slice(1, 3), 2, scalar=Scalar[nm.i32](33))
+    a.set(Slice(1, 3), 2, val=Scalar[nm.i32](33))
 
     assert_equal(Int(a.item(1, 2)), 33)
     assert_equal(Int(a.item(2, 2)), 33)
@@ -239,7 +236,7 @@ def test_setitem_mixed_slice_int_col() raises:
 def test_setitem_mixed_negative_int() raises:
     """Negative integer index is normalised correctly."""
     var a = nm.arange[nm.i32](0, 12, step=1).reshape(Shape(3, 4))
-    a.__setitem__(-1, 2, scalar=Scalar[nm.i32](88))
+    a.set(-1, 2, val=Scalar[nm.i32](88))
 
     assert_equal(Int(a.item(2, 2)), 88)
     assert_equal(Int(a.item(0, 2)), 2)
@@ -250,7 +247,7 @@ def test_setitem_mixed_negative_int() raises:
 def test_setitem_mixed_int_only_1d() raises:
     """All-Int fast path on 1D array."""
     var a = nm.arange[nm.i32](0, 6, step=1)
-    a.__setitem__(3, scalar=Scalar[nm.i32](99))
+    a.set(3, val=Scalar[nm.i32](99))
 
     assert_equal(Int(a.item(3)), 99)
     assert_equal(Int(a.item(2)), 2)
@@ -260,7 +257,7 @@ def test_setitem_mixed_int_only_1d() raises:
 def test_setitem_mixed_partial_indices_3d() raises:
     """Two ints on 3D: trailing dim filled implicitly as full range."""
     var a = nm.arange[nm.i32](0, 24, step=1).reshape(Shape(2, 3, 4))
-    a.__setitem__(0, 1, scalar=Scalar[nm.i32](11))
+    a.set(0, 1, val=Scalar[nm.i32](11))
 
     for k in range(4):
         assert_equal(
@@ -275,7 +272,7 @@ def test_setitem_mixed_partial_indices_3d() raises:
 def test_setitem_mixed_does_not_corrupt_neighbours() raises:
     """Single-element write must not corrupt adjacent elements."""
     var a = nm.zeros[nm.i32](Shape(4, 4))
-    a.__setitem__(1, 2, scalar=Scalar[nm.i32](7))
+    a.set(1, 2, val=Scalar[nm.i32](7))
 
     for r in range(4):
         for c in range(4):
@@ -292,7 +289,7 @@ def test_setitem_mixed_agrees_with_list_slice_scalar() raises:
     var a = nm.arange[nm.i32](0, 16, step=1).reshape(Shape(4, 4))
     var b = nm.arange[nm.i32](0, 16, step=1).reshape(Shape(4, 4))
 
-    a.__setitem__(1, Slice(1, 3), scalar=Scalar[nm.i32](55))
+    a.set(1, Slice(1, 3), val=Scalar[nm.i32](55))
 
     var sl = List[Slice]()
     sl.append(Slice(1, 2))

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -1052,7 +1052,7 @@ def _make_1d_offset_view(
     """
     var view = parent.view()
     view.offset = offset
-    view.size = size 
+    view.size = size
     view.shape = NDArrayShape(size)
     view.ndim = 1
     view.strides = NDArrayStrides(shape=view.shape)

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -1255,7 +1255,7 @@ def test_offset_view_mask_setter() raises:
             idx.append(i)
             mask.itemset(idx^, Scalar[DType.bool](False))
 
-    view.__setitem__(mask, Scalar[nm.f64](-1.0))
+    view.set(mask, val=Scalar[nm.f64](-1.0))
 
     # view[6] (parent[10]) and view[7] (parent[11]) should be -1
     assert_true(view.item(6) == -1.0, "mask setter view[6]")

--- a/tests/core/test_view_safety.mojo
+++ b/tests/core/test_view_safety.mojo
@@ -1052,7 +1052,7 @@ def _make_1d_offset_view(
     """
     var view = parent.view()
     view.offset = offset
-    view.size = size
+    view.size = size 
     view.shape = NDArrayShape(size)
     view.ndim = 1
     view.strides = NDArrayStrides(shape=view.shape)


### PR DESCRIPTION
## Summary
- `__getitem__` with k-D boolean masks - previously only supported exact-shape masks (returns flattened 1-D) and 1-D masks (selects axis-0 slices). Added: when mask.ndim == k and mask.shape == self.shape[:k], the mask indexes the first k dimensions and returns an array of shape (true_count, *self.shape[k:]). Raises if true_count == 0 since zero-size dimensions are not yet supported.

- `set(mask, val=)` with k-D masks - both the scalar overload `set(mask, val: Scalar)` and the NDArray overload `set(mask, val: NDArray)` now support the same three cases as the getter. The NDArray overload also accepts a single broadcast sub-array or a per-entry array of shape (true_count, *self.shape[k:]). These must be called with keyword arguments `(val=...)` to prevent overload conflicts. eg: `a.set(1, Slice(1, 3), val=55.0)` 

- _adjust_slice moved to slicing.mojo.

- Array print format bug fixed.

## New tests
- tests/core/test_bool_mask_nd.mojo