### PR TITLE
[Port] Migrate NuMojo to Mojo 1.0.0b1 (modular 26.3)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -210,18 +210,18 @@ backend = {name = "pixi-build-mojo", version = "0.*"}
 name = "your_package_name"
 
 [package.host-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 
 [package.build-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [package.run-dependencies]
-modular = ">=25.7.0,<26"
+modular = "0.26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 
 [dependencies]
-modular = ">=25.7.0,<26"
+modular = "26.2.*"
 numojo = { git = "https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo", branch = "main"}
 ```
 

--- a/README.MD
+++ b/README.MD
@@ -68,7 +68,13 @@ For a detailed roadmap, please refer to the [docs/user-guide/roadmap.md](docs/us
 
 ## Usage
 
-Runnable examples are available in `examples/` (e.g., `examples/quickstart.mojo`).
+Runnable examples are available in `examples/` (e.g., `examples/quickstart.mojo`). Run them from the repository root with:
+
+```bash
+mojo run -I . examples/quickstart.mojo
+```
+
+> Note: when building an example into a standalone binary (`mojo build`), some Linux toolchains fail at the link step with `undefined reference to 'log10f@@GLIBC_2.43'`. If you hit this, pass the math library to the linker explicitly: `mojo build -I . -Xlinker -lm examples/quickstart.mojo`.
 
 An example of n-dimensional array (`NDArray` type) goes as follows.
 
@@ -92,7 +98,7 @@ def main() raises:
     var C = A @ B
 
     # Array inversion
-    var I = nm.inv(A)
+    var I = nm.linalg.inv(A)
 
     # Array slicing
     var A_slice = A[1:3, 4:19]
@@ -123,7 +129,7 @@ def main() raises:
     )
 
     # Matrix slicing
-    var A_slice = A[1:3, 4:19] # returns a copy, for getting a view use `A.get(Slice(1,3), Slice(4, 19))
+    var A_slice = A[1:3, 4:19] # returns a copy, for getting a view use `A.get(Slice(1,3), Slice(4, 19))`
     var B_slice = B[255, 103:241:2]
 
     # Get scalar from matrix
@@ -147,10 +153,10 @@ def main() raises:
     print(A.inv())
 
     # Solve linear algebra
-    print(nm.solve(A, B))
+    print(nm.linalg.solve(A, B))
 
     # Least square
-    print(nm.lstsq(A, C))
+    print(nm.linalg.lstsq(A, C))
 ```
 
 An example of `ComplexNDArray` is as follows:
@@ -182,7 +188,7 @@ def main() raises:
     # Get scalar from array
     var A_item = A[Item(291, 141)]
     # Set an element of the array
-    A[item(291, 141)] = complexscalar
+    A[Item(291, 141)] = complexscalar
 ```
 
 ## Installation

--- a/benchmark/benchmark_dlpack.mojo
+++ b/benchmark/benchmark_dlpack.mojo
@@ -1,7 +1,7 @@
 from numojo.prelude import *
 from numojo.core.memory.dlpack import from_dlpack
-from python import Python
-import benchmark
+from std.python import Python
+from std import benchmark
 
 
 def main() raises:

--- a/docs/getting-started/readme_jp.md
+++ b/docs/getting-started/readme_jp.md
@@ -90,13 +90,13 @@ def main() raises:
     var C = A @ B
 
     # 配列の逆行列
-    var I = nm.inv(A)
+    var I = nm.linalg.inv(A)
 
     # 配列のスライス
     var A_slice = A[1:3, 4:19]
 
     # 配列からスカラーを取得
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     var A_item_2 = A.item(291, 141)
 ```
 
@@ -145,10 +145,10 @@ def main() raises:
     print(A.inv())
 
     # 線形代数の求解
-    print(nm.solve(A, B))
+    print(nm.linalg.solve(A, B))
 
     # 最小二乗法
-    print(nm.lstsq(A, C))
+    print(nm.linalg.lstsq(A, C))
 ```
 
 `ComplexNDArray`の例は以下の通りです：
@@ -160,10 +160,10 @@ from numojo.prelude import *
 
 def main() raises:
     # 複素数スカラー 5 + 5j を作成
-    var complexscalar = ComplexSIMD[f32](re=5, im=5)
+    var complexscalar = CScalar[cf32](5, 5)
     # 複素数配列を作成
-    var A = nm.full[f32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
-    var B = nm.ones[f32](Shape(1000, 1000))                            # (1+1j)
+    var A = nm.full[cf32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
+    var B = nm.ones[cf32](Shape(1000, 1000))                            # (1+1j)
 
     # 配列を出力
     print(A)
@@ -175,10 +175,12 @@ def main() raises:
     var C = A * B
 
     # 配列からスカラーを取得
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     # 配列の要素を設定
-    A[item(291, 141)] = complexscalar
-```## インストール方法
+    A[Item(291, 141)] = complexscalar
+```
+
+## インストール方法
 
 NuMojoパッケージをインストールして使用するには、3つのアプローチがあります。
 

--- a/docs/getting-started/readme_kr.md
+++ b/docs/getting-started/readme_kr.md
@@ -90,13 +90,13 @@ def main() raises:
     var C = A @ B
 
     # 배열 역행렬
-    var I = nm.inv(A)
+    var I = nm.linalg.inv(A)
 
     # 배열 슬라이싱
     var A_slice = A[1:3, 4:19]
 
     # 배열에서 스칼라 가져오기
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     var A_item_2 = A.item(291, 141)
 ```
 
@@ -145,10 +145,10 @@ def main() raises:
     print(A.inv())
 
     # 선형 대수 풀이
-    print(nm.solve(A, B))
+    print(nm.linalg.solve(A, B))
 
     # 최소 제곱법
-    print(nm.lstsq(A, C))
+    print(nm.linalg.lstsq(A, C))
 ```
 
 `ComplexNDArray`의 예시는 다음과 같습니다:
@@ -160,10 +160,10 @@ from numojo.prelude import *
 
 def main() raises:
     # 복소수 스칼라 5 + 5j 생성
-    var complexscalar = ComplexSIMD[f32](re=5, im=5)
+    var complexscalar = CScalar[cf32](5, 5)
     # 복소수 배열 생성
-    var A = nm.full[f32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
-    var B = nm.ones[f32](Shape(1000, 1000))                            # (1+1j)
+    var A = nm.full[cf32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
+    var B = nm.ones[cf32](Shape(1000, 1000))                            # (1+1j)
 
     # 배열 출력
     print(A)
@@ -175,9 +175,9 @@ def main() raises:
     var C = A * B
 
     # 배열에서 스칼라 가져오기
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     # 배열의 요소 설정
-    A[item(291, 141)] = complexscalar
+    A[Item(291, 141)] = complexscalar
 ```
 
 ## 설치 방법

--- a/docs/getting-started/readme_zhs.md
+++ b/docs/getting-started/readme_zhs.md
@@ -75,14 +75,13 @@ def main() raises:
     var C = A @ B
 
     # 数组求逆
-    var I = nm.inv(A)
+    var I = nm.linalg.inv(A)
 
     # 数组切片
     var A_slice = A[1:3, 4:19]
-    var B_slice = B[255, 103:241:2]
 
     # 提取矩阵元素
-    var A_item = A.item(291, 141)
+    var A_item = A[Item(291, 141)]
     var A_item_2 = A.item(291, 141)
 ```
 
@@ -131,10 +130,10 @@ def main() raises:
     print(A.inv())
 
     # 求解线性代数方程
-    print(nm.solve(A, B))
+    print(nm.linalg.solve(A, B))
 
     # 最小二乘法
-    print(nm.lstsq(A, C))
+    print(nm.linalg.lstsq(A, C))
 ```
 
 `ComplexNDArray` 的示例如下：
@@ -146,10 +145,10 @@ from numojo.prelude import *
 
 def main() raises:
     # 创建复数标量 5 + 5j
-    var complexscalar = ComplexSIMD[f32](re=5, im=5)
+    var complexscalar = CScalar[cf32](5, 5)
     # 创建复数数组
-    var A = nm.full[f32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
-    var B = nm.ones[f32](Shape(1000, 1000))                            # (1+1j)
+    var A = nm.full[cf32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
+    var B = nm.ones[cf32](Shape(1000, 1000))                            # (1+1j)
 
     # 打印数组
     print(A)
@@ -161,9 +160,9 @@ def main() raises:
     var C = A * B
 
     # 从数组获取标量
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     # 设置数组元素
-    A[item(291, 141)] = complexscalar
+    A[Item(291, 141)] = complexscalar
 ```
 
 请在 [此文档](../user-guide/features.md) 中查询所有可用的函数。

--- a/docs/getting-started/readme_zht.md
+++ b/docs/getting-started/readme_zht.md
@@ -75,14 +75,13 @@ def main() raises:
     var C = A @ B
 
     # 數組求逆
-    var I = nm.inv(A)
+    var I = nm.linalg.inv(A)
 
     # 數組切片
     var A_slice = A[1:3, 4:19]
-    var B_slice = B[255, 103:241:2]
 
     # 提取矩陣元素
-    var A_item = A.at(291, 141)
+    var A_item = A[Item(291, 141)]
     var A_item_2 = A.item(291, 141)
 ```
 
@@ -131,10 +130,10 @@ def main() raises:
     print(A.inv())
 
     # 求解線性代數方程
-    print(nm.solve(A, B))
+    print(nm.linalg.solve(A, B))
 
     # 最小二乘法
-    print(nm.lstsq(A, C))
+    print(nm.linalg.lstsq(A, C))
 ```
 
 `ComplexNDArray` 的示例如下：
@@ -146,10 +145,10 @@ from numojo.prelude import *
 
 def main() raises:
     # 創建複數標量 5 + 5j
-    var complexscalar = ComplexSIMD[f32](re=5, im=5)
+    var complexscalar = CScalar[cf32](5, 5)
     # 創建複數數組
-    var A = nm.full[f32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
-    var B = nm.ones[f32](Shape(1000, 1000))                            # (1+1j)
+    var A = nm.full[cf32](Shape(1000, 1000), fill_value=complexscalar)  # (5+5j)
+    var B = nm.ones[cf32](Shape(1000, 1000))                            # (1+1j)
 
     # 打印數組
     print(A)
@@ -161,9 +160,9 @@ def main() raises:
     var C = A * B
 
     # 從數組獲取標量
-    var A_item = A[item(291, 141)]
+    var A_item = A[Item(291, 141)]
     # 設置數組元素
-    A[item(291, 141)] = complexscalar
+    A[Item(291, 141)] = complexscalar
 ```
 
 請在 [此文檔](../user-guide/features.md) 中查詢所有可用的函數。

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -11,7 +11,7 @@ This section collects user-facing documentation for NuMojo. Use it to discover a
 ## Looking for onboarding?
 
 - [Project README](../../README.MD): Installation and usage overview.
-- [Runnable Examples](../getting-started/runnable-examples.md): Small examples you can run locally.
+- [Runnable Examples](../../examples/): Small examples you can run locally (e.g. `mojo run -I . examples/quickstart.mojo` from the repository root).
 
 ## Developer references
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -125,9 +125,9 @@ from numojo.core.type_aliases import (
 # Objects
 from numojo.routines.constants import Constants
 
-comptime pi = numojo.routines.constants.Constants.pi
-comptime e = numojo.routines.constants.Constants.e
-comptime c = numojo.routines.constants.Constants.c
+comptime pi = Constants.pi
+comptime e = Constants.e
+comptime c = Constants.c
 
 # Functions
 # TODO Make explicit imports of each individual function in future

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -224,7 +224,6 @@ from numojo.routines.statistics import (
     mode,
     median,
     variance,
-    std,
 )
 
 from numojo.routines import bitwise

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -224,6 +224,7 @@ from numojo.routines.statistics import (
     mode,
     median,
     variance,
+    std_dev,
 )
 
 from numojo.routines import bitwise

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -6,8 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """
-NuMojo Top-Level Package (`numojo`)
-==================================
+NuMojo Top-Level Package (`numojo`).
 
 Central public surface for NuMojo that exposes the primary containers, dtype helpers, common errors,
 and a curated set of NumPy-inspired routines.

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Core (numojo.core)
+"""Core (numojo.core).
 
 This sub module provides the core types and utilities for NuMojo, including fundamental data structures
 like `NDArray` and `Matrix`, dtype aliases, memory layout definitions, error handling utilities, and complex number support.

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -13,9 +13,9 @@ It serves as the foundational layer upon which higher-level routines and algorit
 Fundamental types and utilities for NuMojo: arrays, matrices, memory layouts, data types, and error handling.
 """
 
-from .ndarray import NDArray
+from numojo.core.ndarray import NDArray
 
-from .type_aliases import (
+from numojo.core.type_aliases import (
     Shape,
     Strides,
     ComplexScalar,
@@ -23,20 +23,20 @@ from .type_aliases import (
     `1j`,
 )
 
-from .error import (
+from numojo.core.error import (
     terminate,
     NumojoError,
 )
 
-from .matrix import Matrix
+from numojo.core.matrix import Matrix
 
-from .layout import (
+from numojo.core.layout import (
     NDArrayShape,
     NDArrayStrides,
     Flags,
 )
 
-from .dtype import (
+from numojo.core.dtype import (
     i8,
     i16,
     i32,
@@ -79,25 +79,25 @@ from .dtype import (
     cinvalid,
 )
 
-from .complex import (
+from numojo.core.complex import (
     ComplexSIMD,
     ComplexNDArray,
 )
 
-from .memory import (
+from numojo.core.memory import (
     DataContainer,
     HostStorage,
     DeviceStorage,
     AcceleratorDataContainer,
 )
-from .accelerator import Device, cpu, cuda, mps, rocm
+from numojo.core.accelerator import Device, cpu, cuda, mps, rocm
 
-from .indexing import Item, IndexMethods, TraverseMethods, Validator
+from numojo.core.indexing import Item, IndexMethods, TraverseMethods, Validator
 
-import .dtype
-import .layout
-import .memory
-import .matrix
-import .complex
-import .traits
-import .accelerator
+import numojo.core.dtype
+import numojo.core.layout
+import numojo.core.memory
+import numojo.core.matrix
+import numojo.core.complex
+import numojo.core.traits
+import numojo.core.accelerator

--- a/numojo/core/accelerator/__init__.mojo
+++ b/numojo/core/accelerator/__init__.mojo
@@ -6,9 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """
-=====================================
-Accelerator (numojo.core.accelerator)
-=====================================
+Accelerator (numojo.core.accelerator).
 
 Accelerator (GPU) support namespace for NuMojo.
 """

--- a/numojo/core/accelerator/__init__.mojo
+++ b/numojo/core/accelerator/__init__.mojo
@@ -13,4 +13,4 @@ Accelerator (numojo.core.accelerator)
 Accelerator (GPU) support namespace for NuMojo.
 """
 
-from .device import Device, cpu, cuda, mps, rocm
+from numojo.core.accelerator.device import Device, cpu, cuda, mps, rocm

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Device (numojo.core.accelerator.device)
+"""Device (numojo.core.accelerator.device).
 
 This module defines the `Device` struct, which represents an execution device for array and matrix operations.
 It supports CPU and GPU devices, with GPU backends for NVIDIA CUDA, AMD ROCm, and Apple Metal.

--- a/numojo/core/complex/__init__.mojo
+++ b/numojo/core/complex/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Complex (numojo.core.complex)
+"""Complex (numojo.core.complex).
 
 Complex number support (SIMD complex types and complex NDArray).
 """

--- a/numojo/core/complex/__init__.mojo
+++ b/numojo/core/complex/__init__.mojo
@@ -10,5 +10,5 @@
 Complex number support (SIMD complex types and complex NDArray).
 """
 
-from .complex_simd import ComplexSIMD
-from .complex_ndarray import ComplexNDArray
+from numojo.core.complex.complex_simd import ComplexSIMD
+from numojo.core.complex.complex_ndarray import ComplexNDArray

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -421,26 +421,15 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     #         precision=2, edge_items=2, line_width=100, formatted_width=6
     #     )
 
-    @always_inline("nodebug")
-    def copy(self) raises -> Self:
-        """
-        Return a deep copy of self.
-        """
-        return Self(re=self._re.copy(), im=self._im.copy())
+    # Note (Mojo 1.0): no explicit `copy()` method — `Copyable` synthesizes a
+    # memberwise `copy()` that deep-copies `_re`/`_im` (each an NDArray whose
+    # own synthesized copy is deep). An explicit `copy()` here would be
+    # ambiguous with the synthesized one.
 
-    @always_inline("nodebug")
-    def __moveinit__(mut self, var existing: Self):
-        """
-        Move other into self.
-        """
-        self._re = existing._re^
-        self._im = existing._im^
-        self.ndim = existing.ndim
-        self.shape = existing.shape
-        self.size = existing.size
-        self.strides = existing.strides
-        self.flags = existing.flags
-        self.print_options = existing.print_options
+    # Move constructor is synthesized by `Movable` (plain memberwise move),
+    # matching NDArray. An explicit `__moveinit__` that transfers `_re`/`_im`
+    # with `^` is rejected in Mojo 1.0 because their buffers have a custom
+    # `__del__`, making a field-out-of-the-middle move of `existing` illegal.
 
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -75,6 +75,7 @@ import numojo.routines.logic.comparison as comparison
 # === numojo routines (math / bitwise / searching) ===
 # ===----------------------------------------------------------------------===#
 import numojo.routines.bitwise as bitwise
+import numojo.routines.manipulation as manipulation
 import numojo.routines.math.arithmetic as arithmetic
 import numojo.routines.math.rounding as rounding
 import numojo.routines.math.trig as trig
@@ -421,32 +422,25 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
     #     )
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def copy(self) raises -> Self:
         """
-        Copy copy into self.
+        Return a deep copy of self.
         """
-        self._re = copy._re.copy()
-        self._im = copy._im.copy()
-        self.ndim = copy.ndim
-        self.shape = copy.shape
-        self.size = copy.size
-        self.strides = copy.strides
-        self.flags = copy.flags
-        self.print_options = copy.print_options
+        return Self(re=self._re.copy(), im=self._im.copy())
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __moveinit__(mut self, var existing: Self):
         """
         Move other into self.
         """
-        self._re = take._re^
-        self._im = take._im^
-        self.ndim = take.ndim
-        self.shape = take.shape
-        self.size = take.size
-        self.strides = take.strides
-        self.flags = take.flags
-        self.print_options = take.print_options
+        self._re = existing._re^
+        self._im = existing._im^
+        self.ndim = existing.ndim
+        self.shape = existing.shape
+        self.size = existing.size
+        self.strides = existing.strides
+        self.flags = existing.flags
+        self.print_options = existing.print_options
 
     # ===-------------------------------------------------------------------===#
     # Indexing and slicing
@@ -3303,8 +3297,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             Array of the same data with a new shape.
         """
         var result: Self = ComplexNDArray[Self.cdtype](
-            re=numojo.reshape(self._re.copy(), shape=shape, order=order),
-            im=numojo.reshape(self._im.copy(), shape=shape, order=order),
+            re=manipulation.reshape(self._re.copy(), shape=shape, order=order),
+            im=manipulation.reshape(self._im.copy(), shape=shape, order=order),
         )
         result._re.flags = self._re.flags
         result._im.flags = self._im.flags
@@ -4365,7 +4359,7 @@ struct _ComplexNDArrayIter[
             return result^
 
         else:  # 0-D array
-            var result = numojo.creation._0darray[Self.cdtype](
+            var result = creation._0darray[Self.cdtype](
                 ComplexSIMD[Self.cdtype](self.re_ptr[index], self.im_ptr[index])
             )
             return result^

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-""""ComplexNDArray (numojo.core.complex.complex_ndarray)
+""""ComplexNDArray (numojo.core.complex.complex_ndarray).
 
 Complex NDArray support for NuMojo.
 
@@ -3023,9 +3023,9 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     + "\n"
                     + String(self.ndim)
                     + "D-array  Shape"
-                    + String(self.shape)
+                    + self.shape.__str__()
                     + "  Strides"
-                    + String(self.strides)
+                    + self.strides.__str__()
                     + "  DType: "
                     + _concise_dtype_str(Self.cdtype)
                     + "  C-cont: "
@@ -3147,7 +3147,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 out += padding + "]"
 
             # Greedy line wrapping
-            if len(out) > options.line_width:
+            if out.count_codepoints() > options.line_width:
                 var wrapped: String = String("")
                 var line_len: Int = 0
                 for c in out.codepoint_slices():

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""ComplexSIMD (numojo.core.complex.complex_simd)
+"""ComplexSIMD (numojo.core.complex.complex_simd).
 
 Implement the ComplexSIMD type and its operations.
 

--- a/numojo/core/dtype/__init__.mojo
+++ b/numojo/core/dtype/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Dtype (numojo.core.dtype)
+"""Dtype (numojo.core.dtype).
 
 Dtype aliases and dtype-related utilities used across NuMojo.
 """

--- a/numojo/core/dtype/__init__.mojo
+++ b/numojo/core/dtype/__init__.mojo
@@ -10,7 +10,7 @@
 Dtype aliases and dtype-related utilities used across NuMojo.
 """
 
-from .default_dtype import (
+from numojo.core.dtype.default_dtype import (
     i8,
     i16,
     i32,
@@ -32,7 +32,7 @@ from .default_dtype import (
     boolean,
 )
 
-from .complex_dtype import (
+from numojo.core.dtype.complex_dtype import (
     ComplexDType,
     ci8,
     ci16,

--- a/numojo/core/dtype/complex_dtype.mojo
+++ b/numojo/core/dtype/complex_dtype.mojo
@@ -8,7 +8,7 @@
 # Copyright (c) 2025, Modular Inc. All rights reserved.
 # Original source: https://github.com/modularml/mojo
 # ===----------------------------------------------------------------------=== #
-"""ComplexDType (numojo.core.dtype.complex_dtype)
+"""ComplexDType (numojo.core.dtype.complex_dtype).
 
 ComplexDType and related utilities for working with complex data types in NuMojo.
 """

--- a/numojo/core/dtype/default_dtype.mojo
+++ b/numojo/core/dtype/default_dtype.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Default datatype (numojo.core.dtype.default_dtype)
+"""Default datatype (numojo.core.dtype.default_dtype).
 
 Datatypes Module - Implements rust like aliases for datatypes
 """
@@ -57,6 +57,10 @@ def _concise_dtype_str(dtype: DType) -> String:
     """Returns a concise string representation of the data type."""
     if dtype == i8:
         return "i8"
+    elif dtype == i16:
+        return "i16"
+    elif dtype == i32:
+        return "i32"
     elif dtype == i64:
         return "i64"
     elif dtype == i128:

--- a/numojo/core/dtype/utility.mojo
+++ b/numojo/core/dtype/utility.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Data type utility functions (numojo.core.dtype.utility)
+"""Data type utility functions (numojo.core.dtype.utility).
 
 This module provides utility functions for checking properties of data types (DType) at both compile time and run time.
 """

--- a/numojo/core/indexing/__init__.mojo
+++ b/numojo/core/indexing/__init__.mojo
@@ -10,10 +10,10 @@
 Indexing-related helpers and types used by NuMojo core containers.
 """
 
-from .item import Item
-from .index_buffer import IndexBuffer
-from .offset import IndexMethods
-from .traversal import TraverseMethods
-from .validation import Validator
-from .slicing import InternalSlice
-from .utility import bool_to_numeric, to_numpy, newaxis
+from numojo.core.indexing.item import Item
+from numojo.core.indexing.index_buffer import IndexBuffer
+from numojo.core.indexing.offset import IndexMethods
+from numojo.core.indexing.traversal import TraverseMethods
+from numojo.core.indexing.validation import Validator
+from numojo.core.indexing.slicing import InternalSlice
+from numojo.core.indexing.utility import bool_to_numeric, to_numpy, newaxis

--- a/numojo/core/indexing/__init__.mojo
+++ b/numojo/core/indexing/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Indexing (numojo.core.indexing)
+"""Indexing (numojo.core.indexing).
 
 Indexing-related helpers and types used by NuMojo core containers.
 """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -60,7 +60,9 @@ struct IndexBuffer(
 
         self.ndim = size
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.element_type]](size)
             memset_zero(self.ptr, size)
@@ -85,7 +87,9 @@ struct IndexBuffer(
         Initialize an empty IndexBuffer.
         """
         self.ndim = 0
-        self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+        self.ptr = UnsafePointer[
+            Scalar[Self.element_type], Self._origin
+        ].unsafe_dangling()
 
     def __init__(out self, *values: Int):
         """
@@ -96,7 +100,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -114,7 +120,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -129,7 +137,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -144,7 +154,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -161,7 +173,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -176,7 +190,9 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
@@ -195,7 +211,9 @@ struct IndexBuffer(
         """
         self.ndim = copy.ndim
         if copy.ndim <= 0:
-            self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.element_type], Self._origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
             memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
@@ -214,7 +232,9 @@ struct IndexBuffer(
         """
         Deinitialize the IndexBuffer and free resources.
         """
-        if self.ndim > 0 and self.ptr:
+        # ptr is a non-null `unsafe_dangling()` sentinel when ndim <= 0 and a
+        # real allocation otherwise, so ndim is the only valid free guard.
+        if self.ndim > 0:
             self.ptr.free()
 
     # ===----------------------------------------------------------------------=== #

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -27,7 +27,6 @@ struct IndexBuffer(
     Equatable,
     ImplicitlyCopyable,
     Movable,
-    RegisterPassable,
     Sized,
     Writable,
 ):
@@ -185,19 +184,31 @@ struct IndexBuffer(
                 Scalar[Self.element_type](values[i])
             )
 
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
-        Copy-initialize an IndexBuffer from ancopy IndexBuffer.
+        Copy constructor (Mojo 1.0 lifecycle form; `Copyable` provides `.copy()`).
+
+        Performs a deep copy of the underlying buffer.
 
         Args:
-            copy: The copy IndexBuffer to copy from.
+            copy: IndexBuffer to copy from.
         """
         self.ndim = copy.ndim
         if copy.ndim <= 0:
             self.ptr = UnsafePointer[Scalar[Self.element_type], Self._origin]()
-            return
-        self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
-        memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
+        else:
+            self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
+            memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
+
+    def __init__(out self, *, deinit take: Self):
+        """
+        Move constructor (Mojo 1.0 lifecycle form). Transfers buffer ownership.
+
+        Args:
+            take: IndexBuffer to move from (consumed).
+        """
+        self.ptr = take.ptr
+        self.ndim = take.ndim
 
     def __del__(deinit self):
         """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -855,7 +855,7 @@ struct IndexBuffer(
             Sum of all elements in the IndexBuffer.
         """
         var total: Scalar[Self.element_type] = 0
-        # def closure[width: Int](i: Int) unified {mut total, read self}:
+        # def closure[width: Int](i: Int) {mut total, read self}:
         #     total += self.load[width](i).reduce_add()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):
@@ -870,7 +870,7 @@ struct IndexBuffer(
             Product of all elements in the IndexBuffer.
         """
         var total: Scalar[Self.element_type] = 1
-        # def closure[width: Int](i: Int) unified {mut total, read self}:
+        # def closure[width: Int](i: Int) {mut total, read self}:
         #     total += self.load[width](i).reduce_mul()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""IndexBuffer (numojo.core.indexing.index_buffer)
+"""IndexBuffer (numojo.core.indexing.index_buffer).
 
 Shared integer buffer backend for shape/strides/item.
 

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -161,15 +161,15 @@ struct Item(
         memset_zero(self._buf.ptr, ndim)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """Copy construct the Item.
 
-        Args:
-            copy: The Item to copy.
+        Returns:
+            A copy of the Item.
         """
-        self.ndim = copy.ndim
-        self._buf = IndexBuffer(size=self.ndim)
-        memcpy(dest=self._buf.ptr, src=copy._buf.ptr, count=copy.ndim)
+        var result = Self(ndim=self.ndim)
+        memcpy(dest=result._buf.ptr, src=self._buf.ptr, count=self.ndim)
+        return result^
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Item (numojo.core.indexing.item)
+"""Item (numojo.core.indexing.item).
 
 Implements Item type.
 

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -30,7 +30,6 @@ struct Item(
     Equatable,
     ImplicitlyCopyable,
     Movable,
-    RegisterPassable,
     Sized,
     Writable,
 ):
@@ -161,15 +160,25 @@ struct Item(
         memset_zero(self._buf.ptr, ndim)
 
     @always_inline("nodebug")
-    def copy(self) -> Self:
+    def __init__(out self, *, copy: Self):
         """Copy construct the Item.
 
-        Returns:
-            A copy of the Item.
+        Args:
+            copy: The Item to copy from.
         """
-        var result = Self(ndim=self.ndim)
-        memcpy(dest=result._buf.ptr, src=self._buf.ptr, count=self.ndim)
-        return result^
+        self.ndim = copy.ndim
+        self._buf = IndexBuffer(size=copy.ndim)
+        memcpy(dest=self._buf.ptr, src=copy._buf.ptr, count=copy.ndim)
+
+    @always_inline("nodebug")
+    def __init__(out self, *, deinit take: Self):
+        """Moves `take` into `self`.
+
+        Args:
+            take: The Item to move from.
+        """
+        self.ndim = take.ndim
+        self._buf = take._buf^
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods

--- a/numojo/core/indexing/offset.mojo
+++ b/numojo/core/indexing/offset.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Offset computation (numojo.core.indexing.offset)
+"""Offset computation (numojo.core.indexing.offset).
 
 Indexing offset calculation functions. These functions compute the flat index (offset)
 in memory for a given set of multi-dimensional indices and strides.

--- a/numojo/core/indexing/slicing.mojo
+++ b/numojo/core/indexing/slicing.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Slicing (numojo.core.indexing.slicing)
+"""Slicing (numojo.core.indexing.slicing).
 
 This module defines internal data structures and utilities for handling slicing operations in NuMojo.
 """

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Traversal (numojo.core.indexing.traversal)
+"""Traversal (numojo.core.indexing.traversal).
 
 Functions to traverse a multi-dimensional array.
 This module provides both recursive and iterative traversal methods,

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -14,6 +14,7 @@ which can be used for various indexing and slicing operations in NuMojo.
 
 from std.memory import UnsafePointer
 
+from numojo.core.ndarray import NDArray
 from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.indexing.offset import IndexMethods
 from numojo.core.error import NumojoError

--- a/numojo/core/indexing/utility.mojo
+++ b/numojo/core/indexing/utility.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Utility functions (numojo.core.indexing.utility)
+"""Utility functions (numojo.core.indexing.utility).
 
 Implements N-DIMENSIONAL ARRAY UTILITY FUNCTIONS
 

--- a/numojo/core/indexing/validation.mojo
+++ b/numojo/core/indexing/validation.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Validation (numojo.core.indexing.validation)
+"""Validation (numojo.core.indexing.validation).
 
 Contains utilities for validating indices, shapes, and axes for various indexing and reduction operations.
 """
@@ -75,7 +75,7 @@ struct Validator:
                     message="Cannot reshape array of size "
                     + String(current_size)
                     + " into shape "
-                    + String(new_shape),
+                    + new_shape.__str__(),
                     location="Validator.validate_reshape",
                 )
             )

--- a/numojo/core/layout/__init__.mojo
+++ b/numojo/core/layout/__init__.mojo
@@ -10,6 +10,6 @@
 Layout metadata types used by NuMojo arrays and matrices (shape, strides, and flags).
 """
 
-from .ndshape import NDArrayShape
-from .ndstrides import NDArrayStrides
-from .flags import Flags
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.layout.ndstrides import NDArrayStrides
+from numojo.core.layout.flags import Flags

--- a/numojo/core/layout/__init__.mojo
+++ b/numojo/core/layout/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Layout (numojo.core.layout)
+"""Layout (numojo.core.layout).
 
 Layout metadata types used by NuMojo arrays and matrices (shape, strides, and flags).
 """

--- a/numojo/core/layout/array_methods.mojo
+++ b/numojo/core/layout/array_methods.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Array methods (numojo.core.layout.array_methods)
+"""Array methods (numojo.core.layout.array_methods).
 
 This module defines the `NewAxis` struct, which is used to represent the insertion of new axes into array shapes,
 similar to the concept of `None` or `np.newaxis` in NumPy. The `NewAxis` struct can be used to indicate where

--- a/numojo/core/layout/flags.mojo
+++ b/numojo/core/layout/flags.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Flags (numojo.core.layout.flags)
+"""Flags (numojo.core.layout.flags).
 
 Implements Flags type to represent the memory layout information of NuMojo arrays.
 """

--- a/numojo/core/layout/flags.mojo
+++ b/numojo/core/layout/flags.mojo
@@ -154,20 +154,19 @@ struct Flags(ImplicitlyCopyable, RegisterPassable):
         self.WRITEABLE = writeable and owndata
         self.FORC = self.F_CONTIGUOUS or self.C_CONTIGUOUS
 
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """
-        Initializes the Flags object by copying the information from
-        ancopy Flags object.
+        Returns a copy of this Flags object.
 
-        Args:
-            copy: The Flags object to copy information from.
+        Returns:
+            A new Flags object with the same field values.
         """
-
-        self.C_CONTIGUOUS = copy.C_CONTIGUOUS
-        self.F_CONTIGUOUS = copy.F_CONTIGUOUS
-        self.OWNDATA = copy.OWNDATA
-        self.WRITEABLE = copy.WRITEABLE
-        self.FORC = copy.FORC
+        return Self(
+            c_contiguous=self.C_CONTIGUOUS,
+            f_contiguous=self.F_CONTIGUOUS,
+            owndata=self.OWNDATA,
+            writeable=self.WRITEABLE,
+        )
 
     # === ---------------------------------------------------------------- === #
     # Get and set dunder methods

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""NDArrayShape (numojo.core.layout.ndshape)
+"""NDArrayShape (numojo.core.layout.ndshape).
 
 Implements NDArrayShape type representing the shape of an NDArray.
 The shape is stored as a contiguous buffer of integers, with the number of dimensions (ndim) tracked separately.

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -24,7 +24,6 @@ struct NDArrayShape(
     Equatable,
     ImplicitlyCopyable,
     Movable,
-    RegisterPassable,
     Sized,
     Writable,
 ):
@@ -263,25 +262,28 @@ struct NDArrayShape(
                     self._buf.init_value(i, 1)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
-        Initializes the NDArrayShape from ancopy NDArrayShape.
-        A deep copy of the data buffer is conducted.
+        Copy constructor (Mojo 1.0 lifecycle form; `Copyable` provides `.copy()`).
+
+        Performs a deep copy of the underlying buffer.
 
         Args:
-            copy: Ancopy NDArrayShape to initialize from.
+            copy: NDArrayShape to copy from.
         """
         self.ndim = copy.ndim
-        if copy.ndim == 0:
-            self._buf = IndexBuffer(size=1)
-            self._buf.init_value(0, 0)
-        else:
-            self._buf = IndexBuffer(size=copy.ndim)
-            memcpy(
-                dest=self._buf.ptr,
-                src=copy._buf.ptr,
-                count=copy.ndim,
-            )
+        self._buf = copy._buf.copy()
+
+    @always_inline("nodebug")
+    def __init__(out self, *, deinit take: Self):
+        """
+        Move constructor (Mojo 1.0 lifecycle form).
+
+        Args:
+            take: NDArrayShape to move from (consumed).
+        """
+        self.ndim = take.ndim
+        self._buf = take._buf^
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods
@@ -584,12 +586,12 @@ struct NDArrayShape(
         Returns:
             A new shape with the given axes swapped.
         """
-        var res = self
+        var res = self.copy()
         var val1 = res[axis1]
         var val2 = res[axis2]
         res[axis1] = val2
         res[axis2] = val1
-        return res
+        return res^
 
     def extend(self, *values: Int) -> Self:
         """

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -22,7 +22,6 @@ struct NDArrayStrides(
     Equatable,
     ImplicitlyCopyable,
     Movable,
-    RegisterPassable,
     Sized,
     Writable,
 ):
@@ -322,25 +321,28 @@ struct NDArrayStrides(
                     self._buf.init_value(i, 0)
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
-        Initializes the NDArrayStrides from ancopy strides.
-        A deep-copy of the elements is conducted.
+        Copy constructor (Mojo 1.0 lifecycle form; `Copyable` provides `.copy()`).
+
+        Performs a deep copy of the underlying buffer.
 
         Args:
-            copy: Strides of the array.
+            copy: NDArrayStrides to copy from.
         """
         self.ndim = copy.ndim
-        if copy.ndim == 0:
-            self._buf = IndexBuffer(size=1)
-            self._buf.init_value(0, 0)
-        else:
-            self._buf = IndexBuffer(size=copy.ndim)
-            memcpy(
-                dest=self._buf.ptr,
-                src=copy._buf.ptr,
-                count=copy.ndim,
-            )
+        self._buf = copy._buf.copy()
+
+    @always_inline("nodebug")
+    def __init__(out self, *, deinit take: Self):
+        """
+        Move constructor (Mojo 1.0 lifecycle form).
+
+        Args:
+            take: NDArrayStrides to move from (consumed).
+        """
+        self.ndim = take.ndim
+        self._buf = take._buf^
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""NDArrayStrides (numojo.core.layout.ndstrides)
+"""NDArrayStrides (numojo.core.layout.ndstrides).
 
 Implements NDArrayStrides type. NDArrayStrides represents the strides of an NDArray,
 which is used to calculate the memory offset for each dimension when indexing into the array.

--- a/numojo/core/matrix/__init__.mojo
+++ b/numojo/core/matrix/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Matrix (numojo.core.matrix)
+"""Matrix (numojo.core.matrix).
 
 2D matrix types and APIs.
 """

--- a/numojo/core/matrix/__init__.mojo
+++ b/numojo/core/matrix/__init__.mojo
@@ -10,4 +10,4 @@
 2D matrix types and APIs.
 """
 
-from .base import Matrix
+from numojo.core.matrix.base import Matrix

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -4998,7 +4998,7 @@ struct _MEq(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a == b
+        return a.eq(b)
 
 
 struct _MNe(BinaryPredicate):
@@ -5006,7 +5006,7 @@ struct _MNe(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a != b
+        return a.ne(b)
 
 
 struct _MGt(BinaryPredicate):
@@ -5014,7 +5014,7 @@ struct _MGt(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a > b
+        return a.gt(b)
 
 
 struct _MGe(BinaryPredicate):
@@ -5022,7 +5022,7 @@ struct _MGe(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a >= b
+        return a.ge(b)
 
 
 struct _MLt(BinaryPredicate):
@@ -5030,7 +5030,7 @@ struct _MLt(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a < b
+        return a.lt(b)
 
 
 struct _MLe(BinaryPredicate):
@@ -5038,7 +5038,7 @@ struct _MLe(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a <= b
+        return a.le(b)
 
 
 # TODO: we can move the checks in these functions to the caller functions to avoid redundant checks.

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -2239,8 +2239,7 @@ struct Matrix[
         )
         comptime width = simd_width_of[Self.dtype]()
 
-        @parameter
-        def vec_pow[w: Int](i: Int) unified {mut result, read self, read rhs}:
+        def vec_pow[w: Int](i: Int) {mut result, read self, read rhs}:
             var vec = self._buf.ptr.load[width=w](i)
             result._buf.ptr.store(i, vec.__pow__(rhs))
 
@@ -2286,8 +2285,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_add[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a + b)
@@ -2315,8 +2313,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_add_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_add_scalar[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a + other)
 
@@ -2365,8 +2362,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_sub[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a - b)
@@ -2394,8 +2390,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_sub_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_sub_scalar[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a - other)
 
@@ -2444,8 +2439,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mul[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a * b)
@@ -2473,8 +2467,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mul_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mul_scalar[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a * other)
 
@@ -2523,8 +2516,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_div[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a / b)
@@ -2552,8 +2544,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_div_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_div_scalar[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a / other)
 
@@ -2665,8 +2656,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_floordiv[w: Int](i: Int) unified {mut self, read other}:
+            def vec_floordiv[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a // b)
@@ -2694,10 +2684,9 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
             def vec_floordiv_scalar[
                 w: Int
-            ](i: Int) unified {mut self, read other}:
+            ](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a // other)
 
@@ -2804,8 +2793,7 @@ struct Matrix[
         if self.is_c_contiguous() and other.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mod[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 var b = other._buf.ptr.load[width=w](other.offset + i)
                 self._buf.ptr.store(self.offset + i, a % b)
@@ -2833,8 +2821,7 @@ struct Matrix[
         if self.is_c_contiguous():
             comptime width = simd_width_of[Self.dtype]()
 
-            @parameter
-            def vec_mod_scalar[w: Int](i: Int) unified {mut self, read other}:
+            def vec_mod_scalar[w: Int](i: Int) {mut self, read other}:
                 var a = self._buf.ptr.load[width=w](self.offset + i)
                 self._buf.ptr.store(self.offset + i, a % other)
 
@@ -4308,8 +4295,7 @@ struct Matrix[
         var matrix = Matrix[datatype](shape, order)
         comptime width = simd_width_of[datatype]()
 
-        @parameter
-        def vec_fill[w: Int](i: Int) unified {mut matrix, read fill_value}:
+        def vec_fill[w: Int](i: Int) {mut matrix, read fill_value}:
             matrix._buf.ptr.store(i, SIMD[datatype, w](fill_value))
 
         vectorize[width](matrix.size, vec_fill)
@@ -4414,8 +4400,7 @@ struct Matrix[
         var result = Matrix[datatype](shape, order)
         comptime width = simd_width_of[datatype]()
 
-        @parameter
-        def vec_rand[w: Int](i: Int) unified {mut result}:
+        def vec_rand[w: Int](i: Int) {mut result}:
             var rand_vec = SIMD[datatype, w]()
             for j in range(w):
                 rand_vec[j] = random_float64(0, 1).cast[datatype]()
@@ -5022,8 +5007,7 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
-    @parameter
-    def vec_func[simd_width: Int](i: Int) unified {mut res, read A, read B}:
+    def vec_func[simd_width: Int](i: Int) {mut res, read A, read B}:
         res._buf.ptr.store(
             i,
             simd_func(
@@ -5062,8 +5046,7 @@ def _arithmetic_func_matrix_to_matrix[
 
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
-    @parameter
-    def vec_func[simd_width: Int](i: Int) unified {mut C, read A}:
+    def vec_func[simd_width: Int](i: Int) {mut C, read A}:
         C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
@@ -5130,8 +5113,7 @@ def _logic_func_matrix_matrix_to_matrix[
 
     # Use vectorized comparison for better performance
     # Process elements using input dtype width, then store results as bool
-    @parameter
-    def vec_compare[w: Int](i: Int) unified {mut C, read A, read B}:
+    def vec_compare[w: Int](i: Int) {mut C, read A, read B}:
         var a_vec = A._buf.ptr.load[width=w](i)
         var b_vec = B._buf.ptr.load[width=w](i)
         var result = simd_func[dtype, w](a_vec, b_vec)

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -33,6 +33,8 @@ from numojo.core.memory.data_container import DataContainer
 from numojo.core.traits.buffered import Buffered
 from numojo.routines.manipulation import broadcast_to, reorder_layout
 from numojo.routines.linalg.misc import issymmetric
+from numojo.routines import linalg, logic, math, statistics, searching, sorting
+from numojo.routines import UnaryKernel, BinaryKernel, BinaryPredicate
 
 
 # TODO: Currently the copyinit creates a ref counted view instead of a deep copy.
@@ -354,14 +356,14 @@ struct Matrix[
     # TODO: prevent copying from views to views or views to owning matrices right now.`where` clause isn't working here either for now, So we use constrained. Move to 'where` clause when it's stable.
     # TODO: Current copyinit creates an instance with same origin. This should be external origin. fix this so that we can use default `.copy()` method and remove `create_copy()` method.
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """
-        Initialize a new matrix by copying data from ancopy matrix.
+        Return a copy of the matrix with its own independent data buffer.
 
-        This method creates a deep copy of the `copy` matrix into `self`. It ensures that the copied matrix is independent of the source matrix, with its own memory allocation.
+        This method creates a copy of the matrix into a new instance. It ensures that the copied matrix is independent of the source matrix, with its own memory allocation.
 
-        Args:
-            copy: The source matrix to copy from. Must be an owning matrix.
+        Returns:
+            Matrix: A copy of the source matrix.
 
         Example:
             ```mojo
@@ -370,14 +372,17 @@ struct Matrix[
             var mat2 = mat1.copy()
             ```
         """
-        self.shape = (copy.shape[0], copy.shape[1])
-        self.strides = (copy.strides[0], copy.strides[1])
-        self.size = copy.size
-        self._buf = copy._buf.copy()
-        self.offset = copy.offset
-        self.flags = Flags(
-            copy.shape, copy.strides, owndata=True, writeable=True
+        var result = Self(
+            data=self._buf.copy(),
+            is_view=False,
+            shape=(self.shape[0], self.shape[1]),
+            strides=(self.strides[0], self.strides[1]),
+            offset=self.offset,
         )
+        result.flags = Flags(
+            self.shape, self.strides, owndata=True, writeable=True
+        )
+        return result^
 
     # NOTE: perhaps remove this?
     def deep_copy(self) -> Self:
@@ -432,27 +437,27 @@ struct Matrix[
         )
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __moveinit__(mut self, var existing: Self):
         """
-        Transfer ownership of resources from `other` to `self`.
+        Transfer ownership of resources from `existing` to `self`.
 
-        This method moves the data and metadata from the `other` matrix instance
-        into the current instance (`self`). After the move, the `other` instance
+        This method moves the data and metadata from the `existing` matrix instance
+        into the current instance (`self`). After the move, the `existing` instance
         is left in an invalid state and should not be used.
 
         Args:
-            take: The source matrix instance whose resources will be moved.
+            existing: The source matrix instance whose resources will be moved.
 
         Notes:
             - This operation is efficient as it avoids copying data.
-            - The `other` instance is deinitialized as part of this operation.
+            - The `existing` instance is deinitialized as part of this operation.
         """
-        self.shape = take.shape^
-        self.strides = take.strides^
-        self.size = take.size
-        self._buf = take._buf^
-        self.offset = take.offset
-        self.flags = take.flags^
+        self.shape = existing.shape^
+        self.strides = existing.strides^
+        self.size = existing.size
+        self._buf = existing._buf^
+        self.offset = existing.offset
+        self.flags = existing.flags^
 
     @always_inline("nodebug")
     def __del__(deinit self):
@@ -1949,17 +1954,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, _MAdd
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, _MAdd
             ](broadcast_to[Self.dtype](self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__add__
+                Self.dtype, _MAdd
             ](self, broadcast_to[Self.dtype](other, self.shape, self.order()))
 
     def __add__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2025,17 +2030,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, _MSub
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, _MSub
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__sub__
+                Self.dtype, _MSub
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __sub__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2101,17 +2106,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, _MMul
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, _MMul
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mul__
+                Self.dtype, _MMul
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __mul__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2179,17 +2184,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, _MDiv
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, _MDiv
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__truediv__
+                Self.dtype, _MDiv
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __truediv__(
@@ -2581,17 +2586,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, _MFloorDiv
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, _MFloorDiv
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__floordiv__
+                Self.dtype, _MFloorDiv
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __floordiv__(
@@ -2721,17 +2726,17 @@ struct Matrix[
             self.shape[1] == other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, _MMod
             ](self, other)
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, _MMod
             ](broadcast_to(self, other.shape, self.order()), other)
         else:
             return _arithmetic_func_matrix_matrix_to_matrix[
-                Self.dtype, SIMD.__mod__
+                Self.dtype, _MMod
             ](self, broadcast_to(other, self.shape, self.order()))
 
     def __mod__(self, other: Scalar[Self.dtype]) raises -> Matrix[Self.dtype]:
@@ -2855,17 +2860,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLt](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLt](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.lt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLt](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -2912,17 +2917,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLe](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLe](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.le](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MLe](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -2969,17 +2974,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGt](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGt](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.gt](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGt](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3026,17 +3031,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGe](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGe](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ge](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MGe](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3086,17 +3091,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MEq](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MEq](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.eq](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MEq](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3143,17 +3148,17 @@ struct Matrix[
         if (self.shape[0] == other.shape[0]) and (
             self.shape[1] == other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MNe](
                 self, other
             )
         elif (self.shape[0] < other.shape[0]) or (
             self.shape[1] < other.shape[1]
         ):
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MNe](
                 broadcast_to(self, other.shape, self.order()), other
             )
         else:
-            return _logic_func_matrix_matrix_to_matrix[Self.dtype, SIMD.ne](
+            return _logic_func_matrix_matrix_to_matrix[Self.dtype, _MNe](
                 self, broadcast_to(other, self.shape, self.order())
             )
 
@@ -3199,7 +3204,7 @@ struct Matrix[
             print(A @ B)
             ```
         """
-        return numojo.linalg.matmul(self, other)
+        return linalg.matmul(self, other)
 
     # # ===-------------------------------------------------------------------===#
     # # Core methods
@@ -3222,7 +3227,7 @@ struct Matrix[
             print(B.all())  # Outputs: False
             ```
         """
-        return numojo.logic.all(self)
+        return logic.all(self)
 
     def all(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3244,7 +3249,7 @@ struct Matrix[
             print(A.all(axis=1))  # Outputs: [[1], [0]]
             ```
         """
-        return numojo.logic.all[Self.dtype](self, axis=axis)
+        return logic.all[Self.dtype](self, axis=axis)
 
     def any(self) -> Scalar[Self.dtype]:
         """
@@ -3262,7 +3267,7 @@ struct Matrix[
             print(B.any())  # Outputs: True
             ```
         """
-        return numojo.logic.any(self)
+        return logic.any(self)
 
     def any(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3274,7 +3279,7 @@ struct Matrix[
         Returns:
             Matrix[dtype]: Matrix of boolean values for each slice along the axis.
         """
-        return numojo.logic.any(self, axis=axis)
+        return logic.any(self, axis=axis)
 
     def argmax(self) raises -> Scalar[DType.int]:
         """
@@ -3290,7 +3295,7 @@ struct Matrix[
             print(A.argmax())  # Outputs: 3
             ```
         """
-        return numojo.math.argmax(self)
+        return searching.argmax(self)
 
     def argmax(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3310,7 +3315,7 @@ struct Matrix[
             print(A.argmax(axis=1))  # Outputs: [[1], [2]]
             ```
         """
-        return numojo.math.argmax(self, axis=axis)
+        return searching.argmax(self, axis=axis)
 
     def argmin(self) raises -> Scalar[DType.int]:
         """
@@ -3326,7 +3331,7 @@ struct Matrix[
             print(A.argmin())  # Outputs: 1
             ```
         """
-        return numojo.math.argmin(self)
+        return searching.argmin(self)
 
     def argmin(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3346,7 +3351,7 @@ struct Matrix[
             print(A.argmin(axis=1))  # Outputs: [[1], [2]]
             ```
         """
-        return numojo.math.argmin(self, axis=axis)
+        return searching.argmin(self, axis=axis)
 
     def argsort(self) raises -> Matrix[DType.int]:
         """
@@ -3362,7 +3367,7 @@ struct Matrix[
             print(A.argsort())  # Outputs: [[1, 3, 0, 2]]
             ```
         """
-        return numojo.math.argsort(self)
+        return sorting.argsort(self)
 
     def argsort(self, axis: Int) raises -> Matrix[DType.int]:
         """
@@ -3382,7 +3387,7 @@ struct Matrix[
             print(A.argsort(axis=1))  # Outputs: [[1, 3, 0], [2, 0, 1]]
             ```
         """
-        return numojo.math.argsort(self, axis=axis)
+        return sorting.argsort(self, axis=axis)
 
     def astype[asdtype: DType](self) -> Matrix[asdtype]:
         """
@@ -3424,7 +3429,7 @@ struct Matrix[
             print(A.cumprod())
             ```
         """
-        return numojo.math.cumprod(self)
+        return math.cumprod(self)
 
     def cumprod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3444,7 +3449,7 @@ struct Matrix[
             print(A.cumprod(axis=1))
             ```
         """
-        return numojo.math.cumprod(self, axis=axis)
+        return math.cumprod(self, axis=axis)
 
     def cumsum(self) raises -> Matrix[Self.dtype]:
         """
@@ -3460,7 +3465,7 @@ struct Matrix[
             print(A.cumsum())
             ```
         """
-        return numojo.math.cumsum(self)
+        return math.cumsum(self)
 
     def cumsum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3480,7 +3485,7 @@ struct Matrix[
             print(A.cumsum(axis=1))
             ```
         """
-        return numojo.math.cumsum(self, axis=axis)
+        return math.cumsum(self, axis=axis)
 
     def fill(self, fill_value: Scalar[Self.dtype]):
         """
@@ -3544,7 +3549,7 @@ struct Matrix[
             print(A.inv())
             ```
         """
-        return numojo.linalg.inv(self)
+        return linalg.inv(self)
 
     def order(self) -> String:
         """
@@ -3658,7 +3663,7 @@ struct Matrix[
             print(A.max())
             ```
         """
-        return numojo.math.extrema.max(self)
+        return math.max(self)
 
     def max(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3678,7 +3683,7 @@ struct Matrix[
             print(A.max(axis=1))  # Max of each row
             ```
         """
-        return numojo.math.extrema.max(self, axis=axis)
+        return math.max(self, axis=axis)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -3696,7 +3701,7 @@ struct Matrix[
             print(A.mean())
             ```
         """
-        return numojo.statistics.mean[returned_dtype](self)
+        return statistics.mean[returned_dtype](self)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -3718,7 +3723,7 @@ struct Matrix[
             print(A.mean(axis=1))
             ```
         """
-        return numojo.statistics.mean[returned_dtype](self, axis=axis)
+        return statistics.mean[returned_dtype](self, axis=axis)
 
     def min(self) raises -> Scalar[Self.dtype]:
         """
@@ -3736,7 +3741,7 @@ struct Matrix[
             print(A.min())
             ```
         """
-        return numojo.math.extrema.min(self)
+        return math.min(self)
 
     def min(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3756,7 +3761,7 @@ struct Matrix[
             print(A.min(axis=1))  # Min of each row
             ```
         """
-        return numojo.math.extrema.min(self, axis=axis)
+        return math.min(self, axis=axis)
 
     def prod(self) -> Scalar[Self.dtype]:
         """
@@ -3772,7 +3777,7 @@ struct Matrix[
             print(A.prod())
             ```
         """
-        return numojo.math.prod(self)
+        return math.prod(self)
 
     def prod(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -3792,7 +3797,7 @@ struct Matrix[
             print(A.prod(axis=1))
             ```
         """
-        return numojo.math.prod(self, axis=axis)
+        return math.prod(self, axis=axis)
 
     def reshape(
         self, shape: Tuple[Int, Int], order: String = "C"
@@ -3943,7 +3948,7 @@ struct Matrix[
             print(B)  # Outputs a Matrix[Float64] with values [[1.12], [2.68], [3.14]]
             ```
         """
-        return numojo.math.rounding.round(self, decimals=decimals)
+        return math.round(self, decimals=decimals)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -3964,7 +3969,7 @@ struct Matrix[
             print(A.std())
             ```
         """
-        return numojo.statistics.std[returned_dtype](self, ddof=ddof)
+        return statistics.std_dev[returned_dtype](self, ddof=ddof)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -3987,7 +3992,7 @@ struct Matrix[
             print(A.std(axis=1))
             ```
         """
-        return numojo.statistics.std[returned_dtype](self, axis=axis, ddof=ddof)
+        return statistics.std_dev[returned_dtype](self, axis=axis, ddof=ddof)
 
     def sum(self) -> Scalar[Self.dtype]:
         """
@@ -4003,7 +4008,7 @@ struct Matrix[
             print(A.sum())
             ```
         """
-        return numojo.math.sum(self)
+        return math.sum(self)
 
     def sum(self, axis: Int) raises -> Matrix[Self.dtype]:
         """
@@ -4023,7 +4028,7 @@ struct Matrix[
             print(A.sum(axis=1))
             ```
         """
-        return numojo.math.sum(self, axis=axis)
+        return math.sum(self, axis=axis)
 
     def trace(self) raises -> Scalar[Self.dtype]:
         """
@@ -4041,7 +4046,7 @@ struct Matrix[
             print(A.trace())  # Outputs: 15.0
             ```
         """
-        return numojo.linalg.trace(self)
+        return linalg.trace(self)
 
     def issymmetric(self) -> Bool:
         """
@@ -4133,7 +4138,7 @@ struct Matrix[
             print(A.variance())
             ```
         """
-        return numojo.statistics.variance[returned_dtype](self, ddof=ddof)
+        return statistics.variance[returned_dtype](self, ddof=ddof)
 
     def variance[
         returned_dtype: DType = DType.float64
@@ -4156,7 +4161,7 @@ struct Matrix[
             print(A.variance(axis=1))
             ```
         """
-        return numojo.statistics.variance[returned_dtype](
+        return statistics.variance[returned_dtype](
             self, axis=axis, ddof=ddof
         )
 
@@ -4951,12 +4956,113 @@ struct _MatrixIter[
 # # ===-----------------------------------------------------------------------===#
 
 
+# ===------------------------------------------------------------------------===#
+# Kernel functors for Matrix element-wise ops
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see routines/operations/backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _MAdd(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a + b
+
+
+struct _MSub(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a - b
+
+
+struct _MMul(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a * b
+
+
+struct _MDiv(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a / b
+
+
+struct _MFloorDiv(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a // b
+
+
+struct _MMod(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a % b
+
+
+struct _MEq(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a == b
+
+
+struct _MNe(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a != b
+
+
+struct _MGt(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a > b
+
+
+struct _MGe(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a >= b
+
+
+struct _MLt(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a < b
+
+
+struct _MLe(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a <= b
+
+
 # TODO: we can move the checks in these functions to the caller functions to avoid redundant checks.
 def _arithmetic_func_matrix_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](
-        SIMD[type, simd_width], SIMD[type, simd_width]
-    ) -> SIMD[type, simd_width],
+    K: BinaryKernel,
 ](A: Matrix[dtype], B: Matrix[dtype]) raises -> Matrix[dtype]:
     """
     Perform element-wise arithmetic operation between two matrices using a SIMD function.
@@ -5008,9 +5114,9 @@ def _arithmetic_func_matrix_matrix_to_matrix[
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
     def vec_func[simd_width: Int](i: Int) {mut res, read A, read B}:
-        res._buf.ptr.store(
+        res._buf.ptr.store[width=simd_width](
             i,
-            simd_func(
+            K.apply[dtype, simd_width](
                 A._buf.ptr.load[width=simd_width](i),
                 B._buf.ptr.load[width=simd_width](i),
             ),
@@ -5022,9 +5128,7 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
 def _arithmetic_func_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](SIMD[type, simd_width]) -> SIMD[
-        type, simd_width
-    ],
+    K: UnaryKernel,
 ](A: Matrix[dtype]) -> Matrix[dtype]:
     """
     Apply a unary SIMD function element-wise to a matrix.
@@ -5047,7 +5151,7 @@ def _arithmetic_func_matrix_to_matrix[
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
     def vec_func[simd_width: Int](i: Int) {mut C, read A}:
-        C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
+        C._buf.ptr.store[width=simd_width](i, K.apply[dtype, simd_width](A._buf.ptr.load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
 
@@ -5056,9 +5160,7 @@ def _arithmetic_func_matrix_to_matrix[
 
 def _logic_func_matrix_matrix_to_matrix[
     dtype: DType,
-    simd_func: fn[type: DType, simd_width: Int](
-        SIMD[type, simd_width], SIMD[type, simd_width]
-    ) -> SIMD[DType.bool, simd_width],
+    K: BinaryPredicate,
 ](A: Matrix[dtype], B: Matrix[dtype]) raises -> Matrix[DType.bool]:
     """
     Perform element-wise logical comparison between two matrices using a SIMD function.
@@ -5116,7 +5218,7 @@ def _logic_func_matrix_matrix_to_matrix[
     def vec_compare[w: Int](i: Int) {mut C, read A, read B}:
         var a_vec = A._buf.ptr.load[width=w](i)
         var b_vec = B._buf.ptr.load[width=w](i)
-        var result = simd_func[dtype, w](a_vec, b_vec)
+        var result = K.apply[dtype, w](a_vec, b_vec)
 
         # Store bool results element by element to avoid width mismatch
         for j in range(w):

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Matrix (numojo.core.matrix)
+"""Matrix (numojo.core.matrix).
 
 This file implements the core 2D matrix type for the NuMojo numerical computing library. It provides efficient, flexible, and memory-safe matrix operations for scientific and engineering applications.
 
@@ -5051,7 +5051,7 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
     Parameters:
         dtype: The data type of the matrix elements.
-        simd_func: A SIMD function that takes two SIMD vectors and returns a SIMD vector, representing the desired arithmetic operation (e.g., addition, subtraction).
+        K: A SIMD kernel that takes two SIMD vectors and returns a SIMD vector, representing the desired arithmetic operation (e.g., addition, subtraction).
 
     Args:
         A: The first input matrix.
@@ -5117,7 +5117,7 @@ def _arithmetic_func_matrix_to_matrix[
 
     Parameters:
         dtype: The data type of the matrix elements.
-        simd_func: A SIMD function that takes a SIMD vector and returns a SIMD vector representing
+        K: A SIMD kernel that takes a SIMD vector and returns a SIMD vector, representing the desired unary operation.
 
     Args:
         A: Input matrix of type Matrix[dtype].
@@ -5149,7 +5149,7 @@ def _logic_func_matrix_matrix_to_matrix[
 
     Parameters:
         dtype: The data type of the input matrices.
-        simd_func: A SIMD function that takes two SIMD vectors of dtype and returns a SIMD vector of bools.
+        K: A SIMD kernel that takes two SIMD vectors of dtype and returns a SIMD vector of bools.
 
     Args:
         A: The first input matrix.

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -436,28 +436,10 @@ struct Matrix[
             offset=self.offset,
         )
 
-    @always_inline("nodebug")
-    def __moveinit__(mut self, var existing: Self):
-        """
-        Transfer ownership of resources from `existing` to `self`.
-
-        This method moves the data and metadata from the `existing` matrix instance
-        into the current instance (`self`). After the move, the `existing` instance
-        is left in an invalid state and should not be used.
-
-        Args:
-            existing: The source matrix instance whose resources will be moved.
-
-        Notes:
-            - This operation is efficient as it avoids copying data.
-            - The `existing` instance is deinitialized as part of this operation.
-        """
-        self.shape = existing.shape^
-        self.strides = existing.strides^
-        self.size = existing.size
-        self._buf = existing._buf^
-        self.offset = existing.offset
-        self.flags = existing.flags^
+    # Move constructor is synthesized by `Movable` (plain memberwise move),
+    # matching NDArray. An explicit `__moveinit__` that transfers fields with
+    # `^` is rejected in Mojo 1.0 because `_buf` has a custom `__del__`, which
+    # makes moving a field out of the middle of `existing` illegal.
 
     @always_inline("nodebug")
     def __del__(deinit self):

--- a/numojo/core/memory/__init__.mojo
+++ b/numojo/core/memory/__init__.mojo
@@ -10,6 +10,6 @@
 Low-level memory/storage utilities used by NuMojo core containers.
 """
 
-from .storage import HostStorage, DeviceStorage, AcceleratorDataContainer
-from .data_container import DataContainer
-from .dlpack import from_dlpack
+from numojo.core.memory.storage import HostStorage, DeviceStorage, AcceleratorDataContainer
+from numojo.core.memory.data_container import DataContainer
+from numojo.core.memory.dlpack import from_dlpack

--- a/numojo/core/memory/__init__.mojo
+++ b/numojo/core/memory/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Memory (numojo.core.memory)
+"""Memory (numojo.core.memory).
 
 Low-level memory/storage utilities used by NuMojo core containers.
 """

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -13,7 +13,7 @@ DataContainer manages memory ownership and reference counting for shared or exte
 """
 
 from std.memory import UnsafePointer, memcpy
-from std.os.atomic import Atomic, Consistency, fence
+from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 
 from numojo.core.error import NumojoError
@@ -221,7 +221,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = copy.ownership
 
         if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
     def deep_copy(self) -> Self:
         """
@@ -265,10 +265,10 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Consistency.RELEASE](1) != 1:
+        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
             return
 
-        fence[ordering=Consistency.ACQUIRE]()
+        fence[ordering=Ordering.ACQUIRE]()
         if self.ptr and self.size > 0:
             self.ptr.free()
         self._refcount.free()
@@ -434,7 +434,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Consistency.MONOTONIC]()
+        return self._refcount[].load[ordering=Ordering.RELAXED]()
 
     def share(mut self) raises -> DataContainer[Self.dtype]:
         """
@@ -456,7 +456,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = DataContainer[Self.dtype](
             ptr=self.ptr,

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -76,7 +76,9 @@ struct Ownership(ImplicitlyCopyable):
         writer.write(self.__str__())
 
 
-struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
+struct DataContainer[dtype: DType](
+    ImplicitlyCopyable & Movable & Sized & Writable
+):
     """
     Reference-counted container for a contiguous buffer of elements.
 
@@ -206,22 +208,22 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def __init__(out self, *, copy: Self):
         """
-        Copy constructor.
+        Copy constructor (Mojo 1.0 lifecycle form; `Copyable` provides `.copy()`).
 
-        Increments the reference count for managed containers.
+        Increments the reference count for managed containers and shares the
+        same underlying buffer.
 
         Args:
             copy: DataContainer to copy from.
         """
-        self.size = copy.size
+        if copy.is_refcounted():
+            _ = copy._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
         self.ptr = copy.ptr
+        self.size = copy.size
         self._refcount = copy._refcount
         self.ownership = copy.ownership
-
-        if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
     def deep_copy(self) -> Self:
         """
@@ -238,14 +240,14 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         return result^
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """
-        Move constructor.
+        Move constructor (Mojo 1.0 lifecycle form).
 
         Transfers ownership without changing the reference count.
 
         Args:
-            take: DataContainer to move from.
+            take: DataContainer to move from (consumed).
         """
         self.ptr = take.ptr
         self._refcount = take._refcount

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""DataContainer (numojo.core.memory.data_container)
+"""DataContainer (numojo.core.memory.data_container).
 
 A reference-counted container for contiguous data buffers, used for NDArray and Matrix.
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -91,7 +91,7 @@ struct DataContainer[dtype: DType](
 
     Fields:
         ptr: Pointer to the data array.
-        _refcount: Pointer to the atomic reference count (null for external).
+        _refcount: Optional pointer to the atomic reference count (None for external).
         ownership: Ownership status (Managed or External).
         size: Number of elements in the data array.
     """
@@ -102,8 +102,8 @@ struct DataContainer[dtype: DType](
     var ptr: UnsafePointer[Scalar[Self.dtype], Self.origin]
     """Pointer to the data array."""
 
-    var _refcount: UnsafePointer[Atomic[DType.uint64], Self.origin]
-    """Pointer to the atomic reference count."""
+    var _refcount: Optional[UnsafePointer[Atomic[DType.uint64], Self.origin]]
+    """Pointer to the atomic reference count (None for external containers)."""
 
     var ownership: Ownership
     """Ownership status of the container."""
@@ -119,9 +119,12 @@ struct DataContainer[dtype: DType](
         """
         Create an empty, managed DataContainer.
         """
-        self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
-        self._refcount = alloc[Atomic[DType.uint64]](1)
-        self._refcount[] = Atomic[DType.uint64](1)
+        self.ptr = UnsafePointer[
+            Scalar[Self.dtype], Self.origin
+        ].unsafe_dangling()
+        var refcount = alloc[Atomic[DType.uint64]](1)
+        refcount[] = Atomic[DType.uint64](1)
+        self._refcount = refcount
         self.ownership = Ownership.Managed
         self.size = 0
 
@@ -137,12 +140,15 @@ struct DataContainer[dtype: DType](
             abort("DataContainer: __init__() size must be non-negative")
 
         self.size = size
-        self._refcount = alloc[Atomic[DType.uint64]](1)
-        self._refcount[] = Atomic[DType.uint64](1)
+        var refcount = alloc[Atomic[DType.uint64]](1)
+        refcount[] = Atomic[DType.uint64](1)
+        self._refcount = refcount
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
@@ -167,17 +173,18 @@ struct DataContainer[dtype: DType](
         """
         if size < 0:
             abort("DataContainer: __init__() size must be non-negative")
-        if not ptr:
+        if Int(ptr) == 0:
             abort("DataContainer: __init__() ptr must be non-null")
         self.size = size
         if copy:
-            self._refcount = alloc[Atomic[DType.uint64]](1)
-            self._refcount[] = Atomic[DType.uint64](1)
+            var refcount = alloc[Atomic[DType.uint64]](1)
+            refcount[] = Atomic[DType.uint64](1)
+            self._refcount = refcount
             self.ptr = alloc[Scalar[Self.dtype]](size)
             memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[Atomic[DType.uint64], Self.origin]()
+            self._refcount = None
             self.ptr = ptr
             self.ownership = Ownership.External
 
@@ -187,7 +194,7 @@ struct DataContainer[dtype: DType](
         *,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
         size: Int,
-        refcount: UnsafePointer[Atomic[DType.uint64], Self.origin],
+        refcount: Optional[UnsafePointer[Atomic[DType.uint64], Self.origin]],
         ownership: Ownership,
     ):
         """Create a DataContainer that shares an existing buffer and refcount.
@@ -219,7 +226,9 @@ struct DataContainer[dtype: DType](
             copy: DataContainer to copy from.
         """
         if copy.is_refcounted():
-            _ = copy._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+            _ = copy._refcount.value()[].fetch_add[ordering=Ordering.RELAXED](
+                1
+            )
         self.ptr = copy.ptr
         self.size = copy.size
         self._refcount = copy._refcount
@@ -267,13 +276,17 @@ struct DataContainer[dtype: DType](
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
+        if self._refcount.value()[].fetch_sub[ordering=Ordering.RELEASE](
+            1
+        ) != 1:
             return
 
         fence[ordering=Ordering.ACQUIRE]()
-        if self.ptr and self.size > 0:
+        # ptr is a non-null `unsafe_dangling()` sentinel when size == 0 and a
+        # real allocation otherwise, so size is the only valid free guard.
+        if self.size > 0:
             self.ptr.free()
-        self._refcount.free()
+        self._refcount.value().free()
 
     # ===----------------------------------------------------------------------===#
     # Data Access Methods
@@ -422,9 +435,7 @@ struct DataContainer[dtype: DType](
         Returns:
             True if refcounting is enabled, False otherwise.
         """
-        return (
-            self._refcount != UnsafePointer[Atomic[DType.uint64], Self.origin]()
-        )
+        return self._refcount is not None
 
     @always_inline
     def ref_count(ref self) -> UInt64:
@@ -436,7 +447,7 @@ struct DataContainer[dtype: DType](
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Ordering.RELAXED]()
+        return self._refcount.value()[].load[ordering=Ordering.RELAXED]()
 
     def share(mut self) raises -> DataContainer[Self.dtype]:
         """
@@ -458,7 +469,7 @@ struct DataContainer[dtype: DType](
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+        _ = self._refcount.value()[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = DataContainer[Self.dtype](
             ptr=self.ptr,

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""DLPack (numojo.core.memory.dlpack)
+"""DLPack (numojo.core.memory.dlpack).
 
 This module implements the DLPack protocol for zero-copy tensor exchange
 between NuMojo and other array libraries (NumPy, PyTorch, JAX, etc.).

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -431,9 +431,11 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         )
 
     def __del__(deinit self):
-        if self.shape:
+        # Address comparisons (not Bool(ptr), removed in Mojo 1.0) because
+        # these pointers mirror the DLPack C ABI where NULL is meaningful.
+        if Int(self.shape) != 0:
             self.shape.free()
-        if self.strides:
+        if Int(self.strides) != 0:
             self.strides.free()
         # TODO: note sure if we should free it explicitly, gotta check this.
         _ = self.data_container^
@@ -448,11 +450,11 @@ def _dlpack_deleter_impl[
     dtype: DType
 ](managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]) -> None:
     """Type-specific deleter callback for DLManagedTensor."""
-    if not managed_tensor_ptr:
+    if Int(managed_tensor_ptr) == 0:
         return
 
     var ctx = managed_tensor_ptr[].manager_ctx
-    if ctx:
+    if Int(ctx) != 0:
         var metadata_ptr = ctx.bitcast[DLPackMetadata[dtype]]()
         metadata_ptr.destroy_pointee()
         metadata_ptr.free()
@@ -573,7 +575,7 @@ def _extract_dlpack_pointer(
 
     var p = result_obj.unsafe_get_as_pointer[DType.uint8]()
 
-    if not p:
+    if Int(p) == 0:
         raise Error(
             "_extract_dlpack_pointer: PyCapsule_GetPointer returned NULL"
             " - capsule may be invalid or already consumed"
@@ -635,7 +637,7 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
     var actual_capsule: PythonObject = capsule.__dlpack__()
     var managed_tensor_ptr = _extract_dlpack_pointer(actual_capsule)
 
-    if not managed_tensor_ptr:
+    if Int(managed_tensor_ptr) == 0:
         raise Error("from_dlpack: received null DLManagedTensor pointer")
 
     var dl_tensor = managed_tensor_ptr[].dl_tensor
@@ -662,7 +664,9 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
         shape[i] = Int(dl_tensor.shape[i])
 
     var strides: NDArrayStrides
-    if dl_tensor.strides:
+    # NULL strides is valid DLPack (means C-contiguous); compare the address
+    # since Bool(ptr) no longer models null in Mojo 1.0.
+    if Int(dl_tensor.strides) != 0:
         strides = NDArrayStrides(ndim=ndim, initialized=True)
         for i in range(ndim):
             strides[i] = Int(dl_tensor.strides[i])

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -396,11 +396,13 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         self.ndim = ndim
         self.data_container = data_container^
 
-    def __copyinit__(out self, copy: Self):
-        self.shape = copy.shape
-        self.strides = copy.strides
-        self.ndim = copy.ndim
-        self.data_container = copy.data_container.copy()
+    def copy(self) -> Self:
+        return Self(
+            shape=self.shape,
+            strides=self.strides,
+            ndim=self.ndim,
+            data_container=self.data_container.copy(),
+        )
 
     def __del__(deinit self):
         if self.shape:

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -311,11 +311,6 @@ struct DLTensor(ImplicitlyCopyable, Movable):
         self.byte_offset = byte_offset
 
 
-comptime DLManagedTensorDeleter = fn(
-    UnsafePointer[DLManagedTensor, MutAnyOrigin]
-) -> None
-
-
 # TODO: This is the old API, current API requires using DLManagedTensorVersioned which has a version field for future compatibility.
 # Need to update this to match the latest DLPack spec.
 struct DLManagedTensor(ImplicitlyCopyable, Movable):
@@ -342,18 +337,49 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
     """The underlying tensor."""
     var manager_ctx: UnsafePointer[NoneType, MutAnyOrigin]
     """Context pointer for the deleter (stores metadata, refcount, etc.)."""
-    var deleter: DLManagedTensorDeleter
-    """Cleanup function called when consumer is done."""
+    var deleter: UnsafePointer[NoneType, MutAnyOrigin]
+    """Raw address of the cleanup function called when consumer is done.
+
+    Mojo 1.0 note: a bare `fn(...) -> None` type can no longer be a concrete
+    struct-field type (it is treated as a dynamic trait). DLPack requires the
+    deleter to sit at a fixed offset in the C-ABI struct, so it is stored as a
+    raw address. Producers populate it via `DLManagedTensor.with_deleter`
+    (which takes the deleter as an inferred parameter and stores its address);
+    consumers read the field as an opaque pointer.
+    """
 
     def __init__(
         out self,
         dl_tensor: DLTensor,
         manager_ctx: UnsafePointer[NoneType, MutAnyOrigin],
-        deleter: DLManagedTensorDeleter,
+        deleter: UnsafePointer[NoneType, MutAnyOrigin],
     ):
         self.dl_tensor = dl_tensor.copy()
         self.manager_ctx = manager_ctx
         self.deleter = deleter
+
+    @staticmethod
+    def with_deleter[
+        deleter_fn: def(UnsafePointer[DLManagedTensor, MutAnyOrigin]) -> None,
+        //,
+    ](
+        dl_tensor: DLTensor,
+        manager_ctx: UnsafePointer[NoneType, MutAnyOrigin],
+        deleter: deleter_fn,
+    ) -> DLManagedTensor:
+        """Build a `DLManagedTensor`, storing the deleter as a raw address.
+
+        The deleter is accepted as an inferred parameter (the Mojo 1.0 idiom for
+        passing a named/parametric function as a value) and its address is
+        stored in the opaque `deleter` field.
+        """
+        var deleter_ptr = (
+            UnsafePointer(to=deleter)
+            .bitcast[NoneType]()
+            .unsafe_mut_cast[True]()
+            .as_any_origin()
+        )
+        return DLManagedTensor(dl_tensor, manager_ctx, deleter_ptr)
 
 
 # ===-------------------------------------------------------------------===#
@@ -503,7 +529,7 @@ def to_dlpack[
 
     var managed = alloc[DLManagedTensor](1)
     managed.init_pointee_move(
-        DLManagedTensor(
+        DLManagedTensor.with_deleter(
             dl_tensor,
             ctx.bitcast[NoneType](),
             _dlpack_deleter_impl[dtype],

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -57,8 +57,8 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     var ptr: UnsafePointer[Scalar[Self.dtype], Self.origin]
     """Pointer to the data array."""
 
-    var _refcount: UnsafePointer[Atomic[DType.uint64], Self.origin]
-    """Pointer to the atomic reference count (null for external containers)."""
+    var _refcount: Optional[UnsafePointer[Atomic[DType.uint64], Self.origin]]
+    """Pointer to the atomic reference count (None for external containers)."""
 
     var ownership: Ownership
     """Ownership status of the container (Managed or External)."""
@@ -73,9 +73,12 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
-        self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
-        self._refcount = alloc[Atomic[DType.uint64]](1)
-        self._refcount[] = Atomic[DType.uint64](1)
+        self.ptr = UnsafePointer[
+            Scalar[Self.dtype], Self.origin
+        ].unsafe_dangling()
+        var refcount = alloc[Atomic[DType.uint64]](1)
+        refcount[] = Atomic[DType.uint64](1)
+        self._refcount = refcount
         self.ownership = Ownership.Managed
         self.size = 0
 
@@ -93,12 +96,15 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             abort("HostStorage: __init__() size must be non-negative")
 
         self.size = size
-        self._refcount = alloc[Atomic[DType.uint64]](1)
-        self._refcount[] = Atomic[DType.uint64](1)
+        var refcount = alloc[Atomic[DType.uint64]](1)
+        refcount[] = Atomic[DType.uint64](1)
+        self._refcount = refcount
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[Scalar[Self.dtype], Self.origin]()
+            self.ptr = UnsafePointer[
+                Scalar[Self.dtype], Self.origin
+            ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](size)
 
@@ -123,18 +129,19 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if size < 0:
             abort("HostStorage: __init__() size must be non-negative")
-        if not ptr:
+        if Int(ptr) == 0:
             abort("HostStorage: __init__() ptr must be non-null")
 
         self.size = size
         if copy:
-            self._refcount = alloc[Atomic[DType.uint64]](1)
-            self._refcount[] = Atomic[DType.uint64](1)
+            var refcount = alloc[Atomic[DType.uint64]](1)
+            refcount[] = Atomic[DType.uint64](1)
+            self._refcount = refcount
             self.ptr = alloc[Scalar[Self.dtype]](size)
             memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[Atomic[DType.uint64], Self.origin]()
+            self._refcount = None
             self.ptr = ptr
             self.ownership = Ownership.External
 
@@ -144,7 +151,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         *,
         ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
         size: Int,
-        refcount: UnsafePointer[Atomic[DType.uint64], Self.origin],
+        refcount: Optional[UnsafePointer[Atomic[DType.uint64], Self.origin]],
         ownership: Ownership,
     ):
         """Create a HostStorage that shares an existing buffer and refcount.
@@ -175,7 +182,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             A new `HostStorage` sharing the same buffer.
         """
         if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+            _ = self._refcount.value()[].fetch_add[ordering=Ordering.RELAXED](
+                1
+            )
         return Self(ptr=self.ptr, size=self.size, refcount=self._refcount, ownership=self.ownership)
 
     @always_inline
@@ -207,13 +216,17 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
+        if self._refcount.value()[].fetch_sub[ordering=Ordering.RELEASE](
+            1
+        ) != 1:
             return
 
         fence[ordering=Ordering.ACQUIRE]()
-        if self.ptr and self.size > 0:
+        # ptr is a non-null `unsafe_dangling()` sentinel when size == 0 and a
+        # real allocation otherwise, so size is the only valid free guard.
+        if self.size > 0:
             self.ptr.free()
-        self._refcount.free()
+        self._refcount.value().free()
 
     # ===----------------------------------------------------------------------===#
     # Data Access
@@ -365,15 +378,12 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     def is_refcounted(ref self) -> Bool:
         """Return True if this container tracks a reference count.
 
-        External containers and containers whose refcount pointer is null
-        return False.
+        External containers (whose refcount is None) return False.
 
         Returns:
             Whether reference counting is active.
         """
-        return (
-            self._refcount != UnsafePointer[Atomic[DType.uint64], Self.origin]()
-        )
+        return self._refcount is not None
 
     @always_inline
     def ref_count(ref self) -> UInt64:
@@ -384,7 +394,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Ordering.RELAXED]()
+        return self._refcount.value()[].load[ordering=Ordering.RELAXED]()
 
     def deep_copy(self) -> Self:
         """Create an independent managed copy of this container.
@@ -423,7 +433,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+        _ = self._refcount.value()[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = HostStorage[Self.dtype](
             ptr=self.ptr,
@@ -684,7 +694,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
             abort(
                 "AcceleratorDataContainer: __init__() size must be non-negative"
             )
-        if not ptr:
+        if Int(ptr) == 0:
             abort("AcceleratorDataContainer: __init__() ptr must be non-null")
 
         self.size = size

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -505,16 +505,10 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         """
         return Self(buffer=self.buffer, size=self.size)
 
-    def __moveinit__(mut self, var existing: Self):
-        """Move constructor.
-
-        Transfers the buffer handle without copying.
-
-        Args:
-            existing: The source storage (consumed).
-        """
-        self.buffer = existing.buffer^
-        self.size = existing.size
+    # Move constructor is synthesized by `Movable` (plain memberwise move).
+    # An explicit `__moveinit__` transferring `buffer` with `^` is rejected in
+    # Mojo 1.0 because the buffer handle has a custom `__del__`, making a
+    # field-out-of-the-middle move of `existing` illegal.
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -718,18 +712,10 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         result.size = self.size
         return result^
 
-    @always_inline
-    def __moveinit__(mut self, var existing: Self):
-        """Move constructor.
-
-        Transfers all fields without touching reference counts.
-
-        Args:
-            existing: The source container (consumed).
-        """
-        self.host_storage = existing.host_storage^
-        self.device_storage = existing.device_storage^
-        self.size = existing.size
+    # Move constructor is synthesized by `Movable` (plain memberwise move).
+    # An explicit `__moveinit__` that transfers fields with `^` is rejected in
+    # Mojo 1.0 because `host_storage` has a custom `__del__`, which makes moving
+    # a field out of the middle of `existing` illegal.
 
     # ===----------------------------------------------------------------------===#
     # Data Access (CPU)

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -17,7 +17,7 @@ This module provides three storage structs:
   `HostStorage` and `DeviceStorage` at compile time based on a `Device` parameter.
 """
 from std.memory import UnsafePointer
-from std.os.atomic import Atomic, Consistency, fence
+from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
@@ -165,36 +165,32 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = ownership
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """Shallow-copy constructor.
 
         Copies the pointer and refcount, then atomically increments the
         reference count for managed containers.
 
-        Args:
-            copy: The source container.
+        Returns:
+            A new `HostStorage` sharing the same buffer.
         """
-        self.size = copy.size
-        self.ptr = copy.ptr
-        self._refcount = copy._refcount
-        self.ownership = copy.ownership
-
         if self.is_refcounted():
-            _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+            _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
+        return Self(ptr=self.ptr, size=self.size, refcount=self._refcount, ownership=self.ownership)
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __moveinit__(mut self, var existing: Self):
         """Move constructor.
 
         Transfers all fields without touching the reference count.
 
         Args:
-            take: The source container (consumed).
+            existing: The source container (consumed).
         """
-        self.ptr = take.ptr
-        self._refcount = take._refcount
-        self.ownership = take.ownership
-        self.size = take.size
+        self.ptr = existing.ptr
+        self._refcount = existing._refcount
+        self.ownership = existing.ownership
+        self.size = existing.size
 
     @always_inline
     def __del__(deinit self):
@@ -211,10 +207,10 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         if not self.is_refcounted():
             return
 
-        if self._refcount[].fetch_sub[ordering=Consistency.RELEASE](1) != 1:
+        if self._refcount[].fetch_sub[ordering=Ordering.RELEASE](1) != 1:
             return
 
-        fence[ordering=Consistency.ACQUIRE]()
+        fence[ordering=Ordering.ACQUIRE]()
         if self.ptr and self.size > 0:
             self.ptr.free()
         self._refcount.free()
@@ -388,7 +384,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         if not self.is_refcounted():
             return 0
-        return self._refcount[].load[ordering=Consistency.MONOTONIC]()
+        return self._refcount[].load[ordering=Ordering.RELAXED]()
 
     def deep_copy(self) -> Self:
         """Create an independent managed copy of this container.
@@ -427,7 +423,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
                 )
             )
 
-        _ = self._refcount[].fetch_add[ordering=Consistency.MONOTONIC](1)
+        _ = self._refcount[].fetch_add[ordering=Ordering.RELAXED](1)
 
         var result = HostStorage[Self.dtype](
             ptr=self.ptr,
@@ -498,28 +494,27 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         self.buffer = buffer
         self.size = size
 
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """Shallow-copy constructor.
 
         Copies the `DeviceBuffer` handle.  The GPU runtime determines
         whether the underlying memory is shared or duplicated.
 
-        Args:
-            copy: The source storage.
+        Returns:
+            A new `DeviceStorage` sharing the same buffer handle.
         """
-        self.buffer = copy.buffer
-        self.size = copy.size
+        return Self(buffer=self.buffer, size=self.size)
 
-    def __moveinit__(out self, deinit take: Self):
+    def __moveinit__(mut self, var existing: Self):
         """Move constructor.
 
         Transfers the buffer handle without copying.
 
         Args:
-            take: The source storage (consumed).
+            existing: The source storage (consumed).
         """
-        self.buffer = take.buffer^
-        self.size = take.size
+        self.buffer = existing.buffer^
+        self.size = existing.size
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -707,32 +702,34 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.device_storage = None
 
     @always_inline
-    def __copyinit__(out self, copy: Self):
+    def copy(self) -> Self:
         """Shallow-copy constructor.
 
         Shares the underlying storage.  For CPU containers this increments
         the `HostStorage` atomic refcount; for GPU containers this copies
         the `DeviceStorage` handle (automatic reference counting).
 
-        Args:
-            copy: The source container.
+        Returns:
+            A new `AcceleratorDataContainer` sharing the same underlying storage.
         """
-        self.host_storage = copy.host_storage.copy()
-        self.device_storage = copy.device_storage.copy()
-        self.size = copy.size
+        var result = Self()
+        result.host_storage = self.host_storage.copy()
+        result.device_storage = self.device_storage.copy()
+        result.size = self.size
+        return result^
 
     @always_inline
-    def __moveinit__(out self, deinit take: Self):
+    def __moveinit__(mut self, var existing: Self):
         """Move constructor.
 
         Transfers all fields without touching reference counts.
 
         Args:
-            take: The source container (consumed).
+            existing: The source container (consumed).
         """
-        self.host_storage = take.host_storage^
-        self.device_storage = take.device_storage^
-        self.size = take.size
+        self.host_storage = existing.host_storage^
+        self.device_storage = existing.device_storage^
+        self.size = existing.size
 
     # ===----------------------------------------------------------------------===#
     # Data Access (CPU)

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Storage (numojo.core.memory.storage)
+"""Storage (numojo.core.memory.storage).
 
 Backend storage containers for accelerator-aware data management.
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -80,6 +80,12 @@ import numojo.routines.bitwise as bitwise
 import numojo.routines.math.arithmetic as arithmetic
 import numojo.routines.math.rounding as rounding
 import numojo.routines.searching as searching
+import numojo.routines.linalg as linalg
+import numojo.routines.sorting as sorting
+import numojo.routines.math as math
+import numojo.routines.statistics as statistics
+import numojo.routines.manipulation as manipulation
+import numojo.routines.indexing as indexing
 
 comptime IndexTypes = Variant[Int, NewAxis, EllipsisType, Slice]
 """IndexTypes is used to represent the different kinds of indices that can be used for indexing and slicing operations on the NDArray.
@@ -315,25 +321,20 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = PrintOptions()
 
     @always_inline("nodebug")
-    def __copyinit__(out self, copy: Self):
-        """Copies `copy` into `self`.
-
-        Performs a deep copy. The new array owns its data.
-
-        Args:
-            copy: The NDArray to copy from.
-        """
-        self.ndim = copy.ndim
+    def __init__(out self, *, copy: Self):
+        """Returns a deep copy of this NDArray. The new array owns its data."""
+        var new_buf = copy._buf.copy()
         self.shape = copy.shape
-        self.size = copy.size
         self.strides = copy.strides
         self.offset = copy.offset
-        self._buf = copy._buf.copy()
+        self.ndim = copy.ndim
+        self.size = copy.size
+        self._buf = new_buf^
         self.flags = Flags(
             c_contiguous=copy.flags.C_CONTIGUOUS,
             f_contiguous=copy.flags.F_CONTIGUOUS,
             owndata=True,
-            writeable=True,
+            writeable=False,
         )
         self.print_options = copy.print_options
 
@@ -384,7 +385,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    def __moveinit__(out self, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Moves `take` into `self`.
 
         Args:
@@ -395,7 +396,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.size = take.size
         self.strides = take.strides
         self.offset = take.offset
-        self.flags = take.flags^
+        self.flags = take.flags
         self._buf = take._buf^
         self.print_options = take.print_options
 
@@ -673,9 +674,10 @@ struct NDArray[dtype: DType = DType.float64](
 
         # 1-D -> scalar (0-D array wrapper)
         if self.ndim == 1:
-            return creation._0darray[Self.dtype](
+            var r = creation._0darray[Self.dtype](
                 self._buf.ptr[self.offset + norm]
             )
+            return r^
 
         var out_shape = self.shape[1:]
         var alloc_order: String = "C"
@@ -929,7 +931,7 @@ struct NDArray[dtype: DType = DType.float64](
         var index: List[Int] = List[Int](length=ndims, fill=0)
 
         TraverseMethods.traverse_iterative[Self.dtype](
-            self,
+            self.copy(),
             narr,
             nshape,
             ncoefficients,
@@ -1066,7 +1068,7 @@ struct NDArray[dtype: DType = DType.float64](
         var index: List[Int] = List[Int](length=ndims, fill=0)
 
         TraverseMethods.traverse_iterative[Self.dtype](
-            self,
+            self.copy(),
             narr,
             nshape,
             ncoefficients,
@@ -1323,8 +1325,8 @@ struct NDArray[dtype: DType = DType.float64](
 
         var narr: Self
         if count_int == self.ndim:
-            narr = creation._0darray[Self.dtype](self._getitem(indices))
-            return narr^
+            var r0d = creation._0darray[Self.dtype](self._getitem(indices))
+            return r0d^
 
         if n_slices < self.ndim and not index_type_list[-1].is_ellipsis:
             for i in range(n_slices, self.ndim):
@@ -2394,7 +2396,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var val_c = val.contiguous()
         TraverseMethods.traverse_iterative_setter[Self.dtype](
-            val_c,
+            val_c^,
             self,
             nshape,
             ncoefficients,
@@ -3016,7 +3018,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.equal[Self.dtype](self, other)
+        var r = comparison.equal[Self.dtype](self.copy(), other.copy())
+        return r^
 
     @always_inline("nodebug")
     def __eq__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3028,7 +3031,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.equal[Self.dtype](self, other)
+        var r = comparison.equal[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __ne__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3040,7 +3044,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.not_equal[Self.dtype](self, other)
+        var r = comparison.not_equal[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __ne__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
@@ -3052,7 +3057,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.not_equal[Self.dtype](self, other)
+        var r = comparison.not_equal[Self.dtype](self.copy(), other.copy())
+        return r^
 
     @always_inline("nodebug")
     def __lt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3064,7 +3070,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.less[Self.dtype](self, other)
+        var r = comparison.less[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __lt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
@@ -3076,7 +3083,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.less[Self.dtype](self, other)
+        var r = comparison.less[Self.dtype](self.copy(), other.copy())
+        return r^
 
     @always_inline("nodebug")
     def __le__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3088,7 +3096,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.less_equal[Self.dtype](self, other)
+        var r = comparison.less_equal[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __le__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
@@ -3100,7 +3109,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.less_equal[Self.dtype](self, other)
+        var r = comparison.less_equal[Self.dtype](self.copy(), other.copy())
+        return r^
 
     @always_inline("nodebug")
     def __gt__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3112,7 +3122,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.greater[Self.dtype](self, other)
+        var r = comparison.greater[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __gt__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
@@ -3124,7 +3135,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.greater[Self.dtype](self, other)
+        var r = comparison.greater[Self.dtype](self.copy(), other.copy())
+        return r^
 
     @always_inline("nodebug")
     def __ge__(self, other: SIMD[Self.dtype, 1]) raises -> NDArray[DType.bool]:
@@ -3136,7 +3148,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.greater_equal[Self.dtype](self, other)
+        var r = comparison.greater_equal[Self.dtype](self.copy(), other)
+        return r^
 
     @always_inline("nodebug")
     def __ge__(self, other: NDArray[Self.dtype]) raises -> NDArray[DType.bool]:
@@ -3148,7 +3161,8 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of boolean values.
         """
-        return comparison.greater_equal[Self.dtype](self, other)
+        var r = comparison.greater_equal[Self.dtype](self.copy(), other.copy())
+        return r^
 
     # ===-------------------------------------------------------------------===#
     # ARITHMETIC OPERATORS
@@ -3157,19 +3171,22 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Enables `array + scalar`.
         """
-        return math.add[Self.dtype](self, other)
+        var r = math.add[Self.dtype](self.copy(), other)
+        return r^
 
     def __add__(self, other: Self) raises -> Self:
         """
         Enables `array + array`.
         """
-        return math.add[Self.dtype](self, other)
+        var r = math.add[Self.dtype](self.copy(), other.copy())
+        return r^
 
     def __radd__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar + array`.
         """
-        return math.add[Self.dtype](self, other)
+        var r = math.add[Self.dtype](self.copy(), other)
+        return r^
 
     # ===--- In-place helper methods (view-safe) ---===#
 
@@ -3286,19 +3303,22 @@ struct NDArray[dtype: DType = DType.float64](
         """
         Enables `array - scalar`.
         """
-        return math.sub[Self.dtype](self, other)
+        var r = math.sub[Self.dtype](self.copy(), other)
+        return r^
 
     def __sub__(self, other: Self) raises -> Self:
         """
         Enables `array - array`.
         """
-        return math.sub[Self.dtype](self, other)
+        var r = math.sub[Self.dtype](self.copy(), other.copy())
+        return r^
 
     def __rsub__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar - array`.
         """
-        return math.sub[Self.dtype](other, self)
+        var r = math.sub[Self.dtype](other, self.copy())
+        return r^
 
     def __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array -= scalar`. View-safe: modifies buffer in-place."""
@@ -3309,25 +3329,29 @@ struct NDArray[dtype: DType = DType.float64](
         self._inplace_array_op[SIMD.__sub__](other)
 
     def __matmul__(self, other: Self) raises -> Self:
-        return numojo.linalg.matmul(self, other)
+        var r = linalg.matmul(self.copy(), other.copy())
+        return r^
 
     def __mul__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
         Enables `array * scalar`.
         """
-        return math.mul[Self.dtype](self, other)
+        var r = math.mul[Self.dtype](self.copy(), other)
+        return r^
 
     def __mul__(self, other: Self) raises -> Self:
         """
         Enables `array * array`.
         """
-        return math.mul[Self.dtype](self, other)
+        var r = math.mul[Self.dtype](self.copy(), other.copy())
+        return r^
 
     def __rmul__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar * array`.
         """
-        return math.mul[Self.dtype](self, other)
+        var r = math.mul[Self.dtype](self.copy(), other)
+        return r^
 
     def __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array *= scalar`. View-safe: modifies buffer in-place."""
@@ -4000,7 +4024,7 @@ struct NDArray[dtype: DType = DType.float64](
             The indices of the sorted NDArray.
         """
 
-        return numojo.sorting.argsort(self)
+        return sorting.argsort(self)
 
     def argsort(mut self, axis: Int) raises -> NDArray[DType.int]:
         """Sorts the NDArray and returns the sorted indices. See
@@ -4010,7 +4034,7 @@ struct NDArray[dtype: DType = DType.float64](
             The indices of the sorted NDArray.
         """
 
-        return numojo.sorting.argsort(self, axis=axis)
+        return sorting.argsort(self, axis=axis)
 
     def astype[target: DType](self) raises -> NDArray[target]:
         """Converts the type of the array.
@@ -4039,7 +4063,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with the clipped values.
         """
 
-        return numojo.clip(self, a_min, a_max)
+        return math.clip(self, a_min, a_max)
 
     def compress(
         self, condition: NDArray[DType.bool], axis: Int
@@ -4066,7 +4090,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the condition contains no `True` values.
         """
 
-        return numojo.compress(condition=condition, a=self, axis=axis)
+        return indexing.compress(condition=condition, a=self, axis=axis)
 
     def compress(self, condition: NDArray[DType.bool]) raises -> Self:
         """Returns selected slices of an array along a given axis.
@@ -4089,7 +4113,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the condition contains no `True` values.
         """
 
-        return numojo.compress(condition=condition, a=self)
+        return indexing.compress(condition=condition, a=self)
 
     def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.
@@ -4177,7 +4201,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative product of all items.
         """
-        return numojo.math.cumprod[Self.dtype](self)
+        return math.cumprod[Self.dtype](self)
 
     def cumprod(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative product of the array along the given axis.
@@ -4188,7 +4212,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative product along the axis.
         """
-        return numojo.math.cumprod[Self.dtype](self.copy(), axis=axis)
+        return math.cumprod[Self.dtype](self.copy(), axis=axis)
 
     def cumsum(self) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of all items of an array. The array is
@@ -4197,7 +4221,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative sum of all items.
         """
-        return numojo.math.cumsum[Self.dtype](self)
+        return math.cumsum[Self.dtype](self)
 
     def cumsum(self, axis: Int) raises -> NDArray[Self.dtype]:
         """Returns the cumulative sum of the array along the given axis.
@@ -4208,7 +4232,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The cumulative sum along the axis.
         """
-        return numojo.math.cumsum[Self.dtype](self.copy(), axis=axis)
+        return math.cumsum[Self.dtype](self.copy(), axis=axis)
 
     def diagonal(self, offset: Int = 0) raises -> Self:
         """Returns specific diagonals.
@@ -4225,7 +4249,7 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the array is not 2D.
             Error: If the offset is beyond the shape of the array.
         """
-        return numojo.linalg.diagonal(self, offset=offset)
+        return linalg.diagonal(self, offset=offset)
 
     def fill(mut self, val: Scalar[Self.dtype]):
         """Fills all items of the array with the given value.
@@ -4542,7 +4566,7 @@ struct NDArray[dtype: DType = DType.float64](
             The max value.
         """
 
-        return numojo.math.max(self)
+        return math.max(self)
 
     def max(self, axis: Int) raises -> Self:
         """Finds the max value of an array along the axis. The number of
@@ -4557,7 +4581,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with reduced number of dimensions.
         """
 
-        return numojo.math.max(self, axis=axis)
+        return math.max(self, axis=axis)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -4567,7 +4591,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The mean of the array.
         """
-        return numojo.statistics.mean[returned_dtype](self)
+        return statistics.mean[returned_dtype](self)
 
     def mean[
         returned_dtype: DType = DType.float64
@@ -4580,7 +4604,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An NDArray.
         """
-        return numojo.statistics.mean[returned_dtype](self, axis)
+        return statistics.mean[returned_dtype](self, axis)
 
     def median[
         returned_dtype: DType = DType.float64
@@ -4614,7 +4638,7 @@ struct NDArray[dtype: DType = DType.float64](
             The min value.
         """
 
-        return numojo.math.min(self)
+        return math.min(self)
 
     def min(self, axis: Int) raises -> Self:
         """Finds the min value of an array along the axis. The number of
@@ -4629,7 +4653,7 @@ struct NDArray[dtype: DType = DType.float64](
             An array with reduced number of dimensions.
         """
 
-        return numojo.math.min(self, axis=axis)
+        return math.min(self, axis=axis)
 
     def nditer(self) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
         """Returns an iterator yielding the array elements according to the
@@ -4714,7 +4738,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             A scalar.
         """
-        return numojo.math.prod(self)
+        return math.prod(self)
 
     def prod(self, axis: Int) raises -> Self:
         """Computes the product of array elements over a given axis.
@@ -4726,7 +4750,7 @@ struct NDArray[dtype: DType = DType.float64](
             An NDArray.
         """
 
-        return numojo.math.prod(self, axis=axis)
+        return math.prod(self, axis=axis)
 
     # TODO: make it inplace?
     def reshape(
@@ -4741,7 +4765,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An array of the same data with a new shape.
         """
-        var result = numojo.reshape(self, shape=shape, order=order)
+        var result = manipulation.reshape(self, shape=shape, order=order)
         return result^
 
     def resize(mut self, shape: NDArrayShape) raises:
@@ -4844,7 +4868,7 @@ struct NDArray[dtype: DType = DType.float64](
                     location="NDArray.sort(axis: Int)",
                 )
             )
-        numojo.sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
+        sorting.sort_inplace(self, axis=normalized_axis, stable=stable)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -4908,7 +4932,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Defined in `numojo.routines.manipulation.transpose`.
         """
-        return numojo.routines.manipulation.transpose(self, axes)
+        return manipulation.transpose(self, axes)
 
     def T(self) raises -> Self:
         """Transposes the array when `axes` is not given.
@@ -4921,7 +4945,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Defined in `numojo.routines.manipulation.transpose`.
         """
-        return numojo.routines.manipulation.transpose(self.copy())
+        return manipulation.transpose(self.copy())
 
     def tolist(self) -> List[Scalar[Self.dtype]]:
         """Converts the NDArray to a 1-D list in row-major (C) order.
@@ -5003,7 +5027,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The trace of the ndarray.
         """
-        return numojo.linalg.trace[Self.dtype](self, offset, axis1, axis2)
+        return linalg.trace[Self.dtype](self, offset, axis1, axis2)
 
     # TODO: Remove the underscore in the method name when view is supported.
     # def _transpose(self) raises -> Self:
@@ -5287,7 +5311,7 @@ struct _NDArrayIter[
             return result^
 
         else:  # 0-D array
-            var result: NDArray[Self.dtype] = numojo.creation._0darray[
+            var result: NDArray[Self.dtype] = creation._0darray[
                 Self.dtype
             ](self._buf.ptr[self.offset + index])
             return result^

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1328,7 +1328,10 @@ struct NDArray[dtype: DType = DType.float64](
             var r0d = creation._0darray[Self.dtype](self._getitem(indices))
             return r0d^
 
-        if n_slices < self.ndim and not index_type_list[-1].is_ellipsis:
+        if (
+            n_slices < self.ndim
+            and not index_type_list[len(index_type_list) - 1].is_ellipsis
+        ):
             for i in range(n_slices, self.ndim):
                 slice_list.append(Slice(0, self.shape[i], 1))
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3193,8 +3193,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            @parameter
-            def vec_op[w: Int](i: Int) unified {mut self, read other}:
+            def vec_op[w: Int](i: Int) {mut self, read other}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3250,8 +3249,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            @parameter
-            def vec_op[w: Int](i: Int) unified {mut self, read other_c}:
+            def vec_op[w: Int](i: Int) {mut self, read other_c}:
                 self._buf.ptr.store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3378,10 +3376,9 @@ struct NDArray[dtype: DType = DType.float64](
         var p_c = p.contiguous()
         var result = NDArray[Self.dtype](self.shape)
 
-        @parameter
         def vectorized_pow[
             simd_width: Int
-        ](index: Int) unified {mut result, read src, read p_c}:
+        ](index: Int) {mut result, read src, read p_c}:
             result._buf.ptr.store(
                 index,
                 src._buf.ptr.load[width=simd_width](index)
@@ -3395,8 +3392,7 @@ struct NDArray[dtype: DType = DType.float64](
         """Enables `array **= int`. View-safe: modifies buffer in-place."""
         if self.is_c_contiguous():
 
-            @parameter
-            def vec_pow[w: Int](i: Int) unified {mut self, read p}:
+            def vec_pow[w: Int](i: Int) {mut self, read p}:
                 self._buf.ptr.store(
                     self.offset + i,
                     builtin_math.pow(
@@ -3419,10 +3415,9 @@ struct NDArray[dtype: DType = DType.float64](
     def _elementwise_pow(self, p: Int) raises -> Self:
         var src = self.contiguous()
 
-        @parameter
         def array_scalar_vectorize[
             simd_width: Int
-        ](index: Int) unified {mut src, read p} -> None:
+        ](index: Int) {mut src, read p} -> None:
             src._buf.ptr.store(
                 index,
                 builtin_math.pow(src._buf.ptr.load[width=simd_width](index), p),
@@ -3935,10 +3930,9 @@ struct NDArray[dtype: DType = DType.float64](
         var a = self.contiguous()
         var result: Bool = True
 
-        @parameter
         def vectorized_all[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             result = result and builtin_bool.all(
                 (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
             )
@@ -3962,10 +3956,9 @@ struct NDArray[dtype: DType = DType.float64](
         var a = self.contiguous()
         var result: Bool = False
 
-        @parameter
         def vectorized_any[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             result = result or builtin_bool.any(
                 (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
             )

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""NDArray (numojo.core.ndarray)
+"""NDArray (numojo.core.ndarray).
 
 This module implements the core `NDArray` type, which is the fundamental data structure for multi-dimensional arrays in NuMojo.
 It provides efficient storage, indexing, slicing, and basic operations on N-dimensional arrays. The `NDArray` is designed to be flexible and performant, supporting various memory layouts and data types.
@@ -3210,6 +3210,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Args:
             other: The scalar operand.
+            func_arg: The binary function to apply element-wise.
         """
 
         if self.is_c_contiguous():
@@ -3254,6 +3255,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Args:
             other: The array operand. Must have the same size as self.
+            func_arg: The binary function to apply element-wise.
 
         Raises:
             Error: If the arrays do not have the same size.
@@ -3576,9 +3578,9 @@ struct NDArray[dtype: DType = DType.float64](
                     + "\n"
                     + String(self.ndim)
                     + "D-array  Shape"
-                    + String(self.shape)
+                    + self.shape.__str__()
                     + "  Strides"
-                    + String(self.strides)
+                    + self.strides.__str__()
                     + "  DType: "
                     + _concise_dtype_str(self.dtype)
                     + "  C-cont: "
@@ -3826,7 +3828,7 @@ struct NDArray[dtype: DType = DType.float64](
                         out += separator
                 out += padding + "]"
 
-            if len(out) > options.line_width:
+            if out.count_codepoints() > options.line_width:
                 var wrapped: String = String("")
                 var line_len: Int = 0
                 for c in out.codepoint_slices():

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3191,10 +3191,11 @@ struct NDArray[dtype: DType = DType.float64](
     # ===--- In-place helper methods (view-safe) ---===#
 
     def _inplace_scalar_op[
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
-    ](mut self, other: SIMD[Self.dtype, 1]):
+        //,
+    ](mut self, other: SIMD[Self.dtype, 1], func_arg: func):
         """Apply a binary SIMD operation in-place: self[i] = func(self[i], s).
 
         This method is view-safe: it writes directly into the underlying
@@ -3210,10 +3211,10 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            def vec_op[w: Int](i: Int) {mut self, read other}:
+            def vec_op[w: Int](i: Int) {mut self, read other, read func_arg}:
                 self._buf.ptr.store(
                     self.offset + i,
-                    func[Self.dtype, w](
+                    func_arg[Self.dtype, w](
                         self._buf.ptr.load[width=w](self.offset + i),
                         SIMD[Self.dtype, w](other),
                     ),
@@ -3229,15 +3230,16 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[idx] = func[Self.dtype, 1](
+                self._buf.ptr[idx] = func_arg[Self.dtype, 1](
                     self._buf.ptr[idx], other
                 )
 
     def _inplace_array_op[
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
-    ](mut self, other: Self) raises:
+        //,
+    ](mut self, other: Self, func_arg: func) raises:
         """Apply a binary SIMD operation in-place: self[i] = func(self[i], o[i]).
 
         This method is view-safe: it writes directly into the underlying
@@ -3266,10 +3268,10 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            def vec_op[w: Int](i: Int) {mut self, read other_c}:
+            def vec_op[w: Int](i: Int) {mut self, read other_c, read func_arg}:
                 self._buf.ptr.store(
                     self.offset + i,
-                    func[Self.dtype, w](
+                    func_arg[Self.dtype, w](
                         self._buf.ptr.load[width=w](self.offset + i),
                         other_c._buf.ptr.load[width=w](i),
                     ),
@@ -3285,7 +3287,7 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[idx] = func[Self.dtype, 1](
+                self._buf.ptr[idx] = func_arg[Self.dtype, 1](
                     self._buf.ptr[idx], other_c._buf.ptr[i]
                 )
 
@@ -3293,11 +3295,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __iadd__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array += scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__add__](other)
+        self._inplace_scalar_op(other, SIMD.__add__)
 
     def __iadd__(mut self, other: Self) raises:
         """Enables `array += array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__add__](other)
+        self._inplace_array_op(other, SIMD.__add__)
 
     def __sub__(self, other: Scalar[Self.dtype]) raises -> Self:
         """
@@ -3322,11 +3324,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __isub__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array -= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__sub__](other)
+        self._inplace_scalar_op(other, SIMD.__sub__)
 
     def __isub__(mut self, other: Self) raises:
         """Enables `array -= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__sub__](other)
+        self._inplace_array_op(other, SIMD.__sub__)
 
     def __matmul__(self, other: Self) raises -> Self:
         var r = linalg.matmul(self.copy(), other.copy())
@@ -3355,11 +3357,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imul__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array *= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__mul__](other)
+        self._inplace_scalar_op(other, SIMD.__mul__)
 
     def __imul__(mut self, other: Self) raises:
         """Enables `array *= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__mul__](other)
+        self._inplace_array_op(other, SIMD.__mul__)
 
     def __abs__(self) -> Self:
         return abs(self)
@@ -3464,11 +3466,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __itruediv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array /= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__truediv__](s)
+        self._inplace_scalar_op(s, SIMD.__truediv__)
 
     def __itruediv__(mut self, other: Self) raises:
         """Enables `array /= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__truediv__](other)
+        self._inplace_array_op(other, SIMD.__truediv__)
 
     def __rtruediv__(self, s: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -3490,11 +3492,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __ifloordiv__(mut self, s: SIMD[Self.dtype, 1]) raises:
         """Enables `array //= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__floordiv__](s)
+        self._inplace_scalar_op(s, SIMD.__floordiv__)
 
     def __ifloordiv__(mut self, other: Self) raises:
         """Enables `array //= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__floordiv__](other)
+        self._inplace_array_op(other, SIMD.__floordiv__)
 
     def __rfloordiv__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -3516,11 +3518,11 @@ struct NDArray[dtype: DType = DType.float64](
 
     def __imod__(mut self, other: SIMD[Self.dtype, 1]) raises:
         """Enables `array %= scalar`. View-safe: modifies buffer in-place."""
-        self._inplace_scalar_op[SIMD.__mod__](other)
+        self._inplace_scalar_op(other, SIMD.__mod__)
 
     def __imod__(mut self, other: NDArray[Self.dtype]) raises:
         """Enables `array %= array`. View-safe: modifies buffer in-place."""
-        self._inplace_array_op[SIMD.__mod__](other)
+        self._inplace_array_op(other, SIMD.__mod__)
 
     def __rmod__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
@@ -4882,7 +4884,7 @@ struct NDArray[dtype: DType = DType.float64](
             ddof: The delta degree of freedom.
         """
 
-        return std[returned_dtype](self, ddof=ddof)
+        return statistics.std_dev[returned_dtype](self, ddof=ddof)
 
     def std[
         returned_dtype: DType = DType.float64
@@ -4897,7 +4899,7 @@ struct NDArray[dtype: DType = DType.float64](
             ddof: The delta degree of freedom.
         """
 
-        return std[returned_dtype](self, axis=axis, ddof=ddof)
+        return statistics.std_dev[returned_dtype](self, axis=axis, ddof=ddof)
 
     def sum(self) raises -> Scalar[Self.dtype]:
         """Returns the sum of all array elements.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -3325,7 +3325,7 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return math.mul[Self.dtype](self, other)
 
-    def __rmul__(mut self, other: SIMD[Self.dtype, 1]) raises -> Self:
+    def __rmul__(self, other: SIMD[Self.dtype, 1]) raises -> Self:
         """
         Enables `scalar * array`.
         """

--- a/numojo/core/traits/__init__.mojo
+++ b/numojo/core/traits/__init__.mojo
@@ -6,4 +6,4 @@ Traits (numojo.core.traits)
 Trait/protocol abstractions used across NuMojo core containers and internals.
 """
 
-from .backend import Backend
+from numojo.core.traits.backend import Backend

--- a/numojo/core/traits/__init__.mojo
+++ b/numojo/core/traits/__init__.mojo
@@ -1,7 +1,5 @@
 """
-=====================================
-Traits (numojo.core.traits)
-=====================================
+Traits (numojo.core.traits).
 
 Trait/protocol abstractions used across NuMojo core containers and internals.
 """

--- a/numojo/core/traits/backend.mojo
+++ b/numojo/core/traits/backend.mojo
@@ -76,7 +76,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        func: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             type, simd_w
         ],
     ](self, array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -97,7 +97,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_2_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
@@ -129,7 +129,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_array_1_scalar_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](
@@ -161,7 +161,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_1_scalar_1_array_in_one_array_out[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[type, simd_w],
     ](self, scalar: Scalar[dtype], array: NDArray[dtype]) raises -> NDArray[
@@ -189,7 +189,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_compare_2_arrays[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](
@@ -220,7 +220,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_compare_array_and_scalar[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](
+        func: def[type: DType, simd_w: Int](
             SIMD[type, simd_w], SIMD[type, simd_w]
         ) -> SIMD[DType.bool, simd_w],
     ](
@@ -251,7 +251,7 @@ trait Backend(ImplicitlyDestructible):
 
     def math_func_is[
         dtype: DType,
-        func: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
+        func: def[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
             DType.bool, simd_w
         ],
     ](self, array: NDArray[dtype]) raises -> NDArray[DType.bool]:

--- a/numojo/prelude.mojo
+++ b/numojo/prelude.mojo
@@ -6,8 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 """
-NuMojo Prelude (`numojo.prelude`)
-================================
+NuMojo Prelude (`numojo.prelude`).
 
 The prelude is the recommended “batteries-included” import for day-to-day use.
 

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Routines module (numojo.routines)
+"""Routines module (numojo.routines).
 
 This modules groups NumPy-like functionality by topic (math, linalg, statistics,
 creation, manipulation, etc.).

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -176,4 +176,12 @@ from .manipulation import (
 from .sorting import sort, argsort
 from .searching import argmax, argmin
 
-from .operations import HostExecutor
+from .operations import (
+    HostExecutor,
+    UnaryKernel,
+    BinaryKernel,
+    UnaryPredicate,
+    BinaryPredicate,
+    BinaryIntKernel,
+    TernaryKernel,
+)

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -122,7 +122,7 @@ from .math import (
     hypot_fma,
 )
 
-from .statistics import mean, mode, median, variance, std
+from .statistics import mean, mode, median, variance
 
 from .bitwise import invert
 

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -122,7 +122,7 @@ from numojo.routines.math import (
     hypot_fma,
 )
 
-from numojo.routines.statistics import mean, mode, median, variance
+from numojo.routines.statistics import mean, mode, median, variance, std_dev
 
 from numojo.routines.bitwise import invert
 

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -22,21 +22,21 @@ Notes / conventions:
   stable and widely used.
 """
 
-import .linalg
-import .logic
-import .math
-import .statistics
-import .bitwise
-import .creation
-import .indexing
-import .manipulation
-import .random
-import .sorting
-import .searching
-import .functional
-import .operations
+import numojo.routines.linalg
+import numojo.routines.logic
+import numojo.routines.math
+import numojo.routines.statistics
+import numojo.routines.bitwise
+import numojo.routines.creation
+import numojo.routines.indexing
+import numojo.routines.manipulation
+import numojo.routines.random
+import numojo.routines.sorting
+import numojo.routines.searching
+import numojo.routines.functional
+import numojo.routines.operations
 
-from .io import (
+from numojo.routines.io import (
     loadtxt,
     savetxt,
     load,
@@ -44,9 +44,9 @@ from .io import (
     set_printoptions,
 )
 
-from .linalg.misc import diagonal
+from numojo.routines.linalg.misc import diagonal
 
-from .logic import (
+from numojo.routines.logic import (
     greater,
     greater_equal,
     less,
@@ -60,7 +60,7 @@ from .logic import (
     all,
 )
 
-from .math import (
+from numojo.routines.math import (
     add,
     sub,
     mod,
@@ -122,11 +122,11 @@ from .math import (
     hypot_fma,
 )
 
-from .statistics import mean, mode, median, variance
+from numojo.routines.statistics import mean, mode, median, variance
 
-from .bitwise import invert
+from numojo.routines.bitwise import invert
 
-from .creation import (
+from numojo.routines.creation import (
     arange,
     linspace,
     logspace,
@@ -151,9 +151,9 @@ from .creation import (
     array,
 )
 
-from .indexing import `where`, compress, take_along_axis
+from numojo.routines.indexing import `where`, compress, take_along_axis
 
-from .functional import (
+from numojo.routines.functional import (
     apply_along_axis_reduce,
     apply_along_axis_reduce_to_int,
     apply_along_axis_reduce_with_dtype,
@@ -162,7 +162,7 @@ from .functional import (
     apply_along_axis_indices,
 )
 
-from .manipulation import (
+from numojo.routines.manipulation import (
     ndim,
     shape,
     size,
@@ -173,10 +173,10 @@ from .manipulation import (
     flip,
 )
 
-from .sorting import sort, argsort
-from .searching import argmax, argmin
+from numojo.routines.sorting import sort, argsort
+from numojo.routines.searching import argmax, argmin
 
-from .operations import (
+from numojo.routines.operations import (
     HostExecutor,
     UnaryKernel,
     BinaryKernel,

--- a/numojo/routines/bitwise.mojo
+++ b/numojo/routines/bitwise.mojo
@@ -10,8 +10,23 @@
 This module implements bit-wise operations on NDArrays, such as bitwise AND, OR, XOR, and NOT (invert).
 """
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel
 from numojo.core.ndarray import NDArray
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors for SIMD bitwise operators
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _Invert(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return ~x
+
 
 # ===------------------------------------------------------------------------===#
 # Bitwise operations
@@ -51,4 +66,4 @@ def invert[
         var result2 = invert(arr2) # result2 is [false, true, false
         ```
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__invert__](array)
+    return HostExecutor.apply_unary[dtype, _Invert](array)

--- a/numojo/routines/bitwise.mojo
+++ b/numojo/routines/bitwise.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Bit-wise operations module (`numojo.routines.bitwise`)
+"""Bit-wise operations module (`numojo.routines.bitwise`).
 
 This module implements bit-wise operations on NDArrays, such as bitwise AND, OR, XOR, and NOT (invert).
 """

--- a/numojo/routines/constants.mojo
+++ b/numojo/routines/constants.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Constants (numojo.routines.constants)
+"""Constants (numojo.routines.constants).
 
 This module defines physical and mathematical constants for use in numerical computations.
 The constants are defined as class attributes of the `Constants` class, which is designed to be immutable and efficient for compile-time evaluation.

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2195,10 +2195,9 @@ def astype[
 
     comptime if target == DType.bool:
 
-        @parameter
         def vectorized_astype[
             simd_width: Int
-        ](idx: Int) unified {mut result, read a} -> None:
+        ](idx: Int) {mut result, read a} -> None:
             (result.unsafe_ptr() + idx).strided_store[width=simd_width](
                 a._buf.ptr.load[width=simd_width](idx).cast[target](), 1
             )
@@ -2208,10 +2207,9 @@ def astype[
     else:
         comptime if target == DType.bool:
 
-            @parameter
             def vectorized_astypenb_from_b[
                 simd_width: Int
-            ](idx: Int) unified {mut result, read a} -> None:
+            ](idx: Int) {mut result, read a} -> None:
                 result._buf.ptr.store(
                     idx,
                     (a._buf.ptr + idx)
@@ -2223,10 +2221,9 @@ def astype[
 
         else:
 
-            @parameter
             def vectorized_astypenb[
                 simd_width: Int
-            ](idx: Int) unified {mut result, read a} -> None:
+            ](idx: Int) {mut result, read a} -> None:
                 result._buf.ptr.store(
                     idx, a._buf.ptr.load[width=simd_width](idx).cast[target]()
                 )

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Creation routines (numojo.routines.creation)
+"""Creation routines (numojo.routines.creation).
 
 # TODO (In order of priority)
 1) Implement axis argument for the NDArray creation functions

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2345,7 +2345,7 @@ def fromstring[
                 var number = atof(number_as_str).cast[dtype]()
                 data.append(number)  # Add the number to the data buffer
                 number_as_str = ""  # Clean the number cache
-                shape[-1] = shape[-1] + 1
+                shape[len(shape) - 1] = shape[len(shape) - 1] + 1
         if chr(Int(b)) == "]":
             level = level - 1
             if level < 0:

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -15,7 +15,7 @@ from std.memory import memcpy
 from std.sys import simd_width_of
 
 from numojo.core.layout import Flags, NDArrayShape, NDArrayStrides
-from numojo.routines.creation import arange
+from numojo.routines.creation import arange, _0darray
 from numojo.core.ndarray import NDArray
 
 # ===----------------------------------------------------------------------=== #
@@ -60,7 +60,7 @@ from numojo.core.ndarray import NDArray
 #     var res: NDArray[dtype]
 
 #     if a.ndim == 1:
-#         res = numojo.creation._0darray[dtype](0)
+#         res = _0darray[dtype](0)
 #         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
 #     else:
@@ -109,7 +109,7 @@ def apply_along_axis_reduce_to_int[
     var res: NDArray[DType.int]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[DType.int](0)
+        res = _0darray[DType.int](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
     else:
@@ -160,7 +160,7 @@ def apply_along_axis_reduce[
     var res: NDArray[dtype]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[dtype](0)
+        res = _0darray[dtype](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
 
     else:
@@ -222,7 +222,7 @@ def apply_along_axis_reduce_with_dtype[
     var res: NDArray[returned_dtype]
 
     if a.ndim == 1:
-        res = numojo.creation._0darray[returned_dtype](0)
+        res = _0darray[returned_dtype](0)
         (res._buf.ptr).init_pointee_copy(func1d[dtype, returned_dtype](a))
 
     else:

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Functional programming (numojo.routines.functional)
+"""Functional programming (numojo.routines.functional).
 
 This module implements functional programming utilities for NDArray operations, such as `apply_along_axis`.
 """
@@ -95,12 +95,13 @@ def apply_along_axis_reduce_to_int[
     When the array is 1-d, the returned array will be a 0-d array.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
 
     Returns:
         The NDArray with the function applied to the input NDArray by axis.
@@ -149,12 +150,13 @@ def apply_along_axis_reduce[
         Error when the array is 1-d.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
 
     Returns:
         The NDArray with the function applied to the input NDArray by axis.
@@ -211,13 +213,14 @@ def apply_along_axis_reduce_with_dtype[
     The function returns a different dtype than the input NDArray.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
         returned_dtype: The data type of the returned NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
 
     Returns:
         The NDArray with the function applied to the input NDArray by axis.
@@ -265,12 +268,13 @@ def apply_along_axis_preserve[
     The resulting array will have the same shape as the input array.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
 
     Returns:
         The NDArray with the function applied to the input NDArray by axis.
@@ -344,12 +348,13 @@ def apply_along_axis_inplace[
     The function is applied in-place to the input array.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
     """
 
     # The iterator along the axis
@@ -416,12 +421,13 @@ def apply_along_axis_indices[
     It can be used for, e.g., argsort.
 
     Parameters:
+        func1d: The type of the function to apply to the NDArray.
         dtype: The data type of the input NDArray elements.
-        func1d: The function to apply to the NDArray.
 
     Args:
         a: The NDArray to apply the function to.
         axis: The axis to apply the function to.
+        func1d_arg: The function to apply to the NDArray.
 
     Returns:
         The index array with the function applied to the input array by axis.

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -81,11 +81,14 @@ from numojo.core.ndarray import NDArray
 
 
 def apply_along_axis_reduce_to_int[
-    dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
+    func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
         DType.int
     ],
-](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
+    //,
+    dtype: DType,
+](a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> NDArray[
+    DType.int
+]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
     The returned data type is DType.int.
@@ -110,7 +113,7 @@ def apply_along_axis_reduce_to_int[
 
     if a.ndim == 1:
         res = _0darray[DType.int](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
+        (res._buf.ptr).init_pointee_copy(func1d_arg[dtype](a))
 
     else:
         res = NDArray[DType.int](a.shape.pop(axis=axis))
@@ -119,7 +122,7 @@ def apply_along_axis_reduce_to_int[
         def parallelized_func(i: Int):
             try:
                 (res._buf.ptr + i).init_pointee_copy(
-                    func1d[dtype](iterator.ith(i))
+                    func1d_arg[dtype](iterator.ith(i))
                 )
             except e:
                 print("Error in parallelized_func", e)
@@ -130,11 +133,12 @@ def apply_along_axis_reduce_to_int[
 
 
 def apply_along_axis_reduce[
-    dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
+    func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> Scalar[
         dtype_func
     ],
-](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+    //,
+    dtype: DType,
+](a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> NDArray[dtype]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
     When the array is 1-d, the returned array will be a 0-d array.
@@ -161,7 +165,7 @@ def apply_along_axis_reduce[
 
     if a.ndim == 1:
         res = _0darray[dtype](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
+        (res._buf.ptr).init_pointee_copy(func1d_arg[dtype](a))
 
     else:
         var new_shape = a.shape.pop(axis=axis)
@@ -170,13 +174,13 @@ def apply_along_axis_reduce[
 
         # for i in range(a.size // a.shape[axis]):
         #     var ith = iterator.ith(i)
-        #     var func_result = func1d[dtype](ith)
+        #     var func_result = func1d_arg[dtype](ith)
         #     res._buf.store(i, func_result)
 
         @parameter
         def parallelized_func(i: Int):
             try:
-                res._buf.store(i, func1d[dtype](iterator.ith(i)))
+                res._buf.store(i, func1d_arg[dtype](iterator.ith(i)))
             except e:
                 print("Error in parallelized_func", e)
             # try:
@@ -192,12 +196,15 @@ def apply_along_axis_reduce[
 
 
 def apply_along_axis_reduce_with_dtype[
-    dtype: DType,
-    returned_dtype: DType,
-    func1d: fn[dtype_func: DType, returned_dtype_func: DType](
+    func1d: def[dtype_func: DType, returned_dtype_func: DType](
         NDArray[dtype_func]
     ) raises -> Scalar[returned_dtype_func],
-](a: NDArray[dtype], axis: Int) raises -> NDArray[returned_dtype]:
+    //,
+    dtype: DType,
+    returned_dtype: DType,
+](a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> NDArray[
+    returned_dtype
+]:
     """
     Applies a function to a NDArray by axis and reduce that dimension.
     When the array is 1-d, the returned array will be a 0-d array.
@@ -223,7 +230,7 @@ def apply_along_axis_reduce_with_dtype[
 
     if a.ndim == 1:
         res = _0darray[returned_dtype](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype, returned_dtype](a))
+        (res._buf.ptr).init_pointee_copy(func1d_arg[dtype, returned_dtype](a))
 
     else:
         res = NDArray[returned_dtype](a.shape.pop(axis=axis))
@@ -232,7 +239,7 @@ def apply_along_axis_reduce_with_dtype[
         def parallelized_func(i: Int):
             try:
                 (res._buf.ptr + i).init_pointee_copy(
-                    func1d[dtype, returned_dtype](iterator.ith(i))
+                    func1d_arg[dtype, returned_dtype](iterator.ith(i))
                 )
             except e:
                 print("Error in parallelized_func", e)
@@ -247,11 +254,12 @@ def apply_along_axis_reduce_with_dtype[
 
 
 def apply_along_axis_preserve[
-    dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
+    func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
         dtype_func
     ],
-](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+    //,
+    dtype: DType,
+](a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> NDArray[dtype]:
     """
     Applies a function to a NDArray by axis without reducing that dimension.
     The resulting array will have the same shape as the input array.
@@ -278,7 +286,9 @@ def apply_along_axis_preserve[
         @parameter
         def parallelized_func_c(i: Int):
             try:
-                var elements: NDArray[dtype] = func1d[dtype](iterator.ith(i))
+                var elements: NDArray[dtype] = func1d_arg[dtype](
+                    iterator.ith(i)
+                )
                 memcpy(
                     dest=result._buf.ptr + i * elements.size,
                     src=elements._buf.ptr,
@@ -304,7 +314,7 @@ def apply_along_axis_preserve[
                 elements = indices_elements[1].copy()
                 # indices, elements = iterator.ith_with_offsets(i)
 
-                var res_along_axis: NDArray[dtype] = func1d[dtype](elements)
+                var res_along_axis: NDArray[dtype] = func1d_arg[dtype](elements)
 
                 for j in range(a.shape[axis]):
                     (result._buf.ptr + Int(indices[j])).init_pointee_copy(
@@ -325,9 +335,10 @@ def apply_along_axis_preserve[
 
 
 def apply_along_axis_inplace[
+    func1d: def[dtype_func: DType](mut NDArray[dtype_func]) raises -> None,
+    //,
     dtype: DType,
-    func1d: fn[dtype_func: DType](mut NDArray[dtype_func]) raises -> None,
-](mut a: NDArray[dtype], axis: Int) raises -> None:
+](mut a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> None:
     """
     Applies a function to a NDArray by axis without reducing that dimension.
     The function is applied in-place to the input array.
@@ -350,7 +361,7 @@ def apply_along_axis_inplace[
         def parallelized_func_c(i: Int):
             try:
                 var elements: NDArray[dtype] = iterator.ith(i)
-                func1d[dtype](elements)
+                func1d_arg[dtype](elements)
                 memcpy(
                     dest=a._buf.ptr + i * elements.size,
                     src=elements._buf.ptr,
@@ -375,7 +386,7 @@ def apply_along_axis_inplace[
                 indices = indices_elements[0].copy()
                 elements = indices_elements[1].copy()
 
-                func1d[dtype](elements)
+                func1d_arg[dtype](elements)
 
                 for j in range(a.shape[axis]):
                     (a._buf.ptr + Int(indices[j])).init_pointee_copy(
@@ -390,11 +401,14 @@ def apply_along_axis_inplace[
 
 
 def apply_along_axis_indices[
-    dtype: DType,
-    func1d: fn[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
+    func1d: def[dtype_func: DType](NDArray[dtype_func]) raises -> NDArray[
         DType.int
     ],
-](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
+    //,
+    dtype: DType,
+](a: NDArray[dtype], axis: Int, func1d_arg: func1d) raises -> NDArray[
+    DType.int
+]:
     """
     Applies a function to a NDArray by axis without reducing that dimension.
     The resulting array will have the same shape as the input array.
@@ -423,7 +437,7 @@ def apply_along_axis_indices[
         @parameter
         def parallelized_func_c(i: Int):
             try:
-                var elements: NDArray[DType.int] = func1d[dtype](
+                var elements: NDArray[DType.int] = func1d_arg[dtype](
                     iterator.ith(i)
                 )
                 memcpy(
@@ -450,7 +464,9 @@ def apply_along_axis_indices[
                 indices = indices_elements[0].copy()
                 elements = indices_elements[1].copy()
 
-                var res_along_axis: NDArray[DType.int] = func1d[dtype](elements)
+                var res_along_axis: NDArray[DType.int] = func1d_arg[dtype](
+                    elements
+                )
 
                 for j in range(a.shape[axis]):
                     (res._buf.ptr + Int(indices[j])).init_pointee_copy(

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Indexing routines (numojo.routines.indexing)
+"""Indexing routines (numojo.routines.indexing).
 
 - Generating index arrays
 - Indexing-like operations

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -20,6 +20,7 @@ from std.algorithm import vectorize
 from numojo.core.ndarray import NDArray
 from numojo.core.layout import NDArrayStrides
 from numojo.core.indexing import IndexMethods
+from numojo.routines.manipulation import broadcast_to
 
 # ===----------------------------------------------------------------------=== #
 # Generating index arrays
@@ -322,7 +323,7 @@ def take_along_axis[
         arr_shape_new[normalized_axis] = indices.shape[normalized_axis]
 
         try:
-            broadcasted_indices = numojo.broadcast_to(indices, arr_shape_new)
+            broadcasted_indices = broadcast_to(indices, arr_shape_new)
         except e:
             raise Error(
                 String(

--- a/numojo/routines/io/__init__.mojo
+++ b/numojo/routines/io/__init__.mojo
@@ -9,9 +9,9 @@
 
 This module provides functions for reading and writing arrays to and from files, as well as formatting options for printing arrays.
 """
-from .files import loadtxt, savetxt, load, save
+from numojo.routines.io.files import loadtxt, savetxt, load, save
 
-from .formatting import (
+from numojo.routines.io.formatting import (
     format_floating_scientific,
     PrintOptions,
     set_printoptions,

--- a/numojo/routines/io/__init__.mojo
+++ b/numojo/routines/io/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""I/O routines (numojo.routines.io)
+"""I/O routines (numojo.routines.io).
 
 This module provides functions for reading and writing arrays to and from files, as well as formatting options for printing arrays.
 """

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""File I/O (numojo.routines.io.files)
+"""File I/O (numojo.routines.io.files).
 
 This module provides functions for reading and writing arrays to and from files.
 """

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -13,7 +13,8 @@ from std.collections.optional import Optional
 from std.python import Python, PythonObject
 from std.memory import UnsafePointer, Span
 
-from numojo.routines.creation import fromstring
+from numojo.core.ndarray import NDArray
+from numojo.routines.creation import fromstring, array
 
 # We call into the numpy backend for now, this at least let's people go back and forth smoothly.
 # might consider implementing a funciton to write a .numojo file which can be read by both numpy and numojo.
@@ -50,7 +51,7 @@ def load[
         encoding=PythonObject(encoding),
         max_header_size=PythonObject(max_header_size),
     )
-    var array = numojo.array[dtype](data=data)
+    var array = array[dtype](data=data)
     return array^
 
 
@@ -255,7 +256,7 @@ def loadtxt[
         skiprows=PythonObject(skiprows),
         ndmin=PythonObject(ndmin),
     )
-    var array = numojo.array[dtype](data=data)
+    var array = array[dtype](data=data)
     return array^
 
 

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Formatting (numojo.routines.io.formatting)
+"""Formatting (numojo.routines.io.formatting).
 
 This module provides functions for formatting arrays and values for printing, including options for precision, scientific notation, and complex number formatting.
 """

--- a/numojo/routines/linalg/__init__.mojo
+++ b/numojo/routines/linalg/__init__.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Linear algebra routines (numojo.routines.linalg)
+"""Linear algebra routines (numojo.routines.linalg).
 
 This module provides functions for linear algebra operations, including matrix decompositions, norms, products, and solving linear systems etc.
 """

--- a/numojo/routines/linalg/__init__.mojo
+++ b/numojo/routines/linalg/__init__.mojo
@@ -9,8 +9,8 @@
 
 This module provides functions for linear algebra operations, including matrix decompositions, norms, products, and solving linear systems etc.
 """
-from .decompositions import lu_decomposition, qr, eig
-from .norms import det, trace
-from .products import cross, dot, matmul
-from .solving import inv, solve, lstsq
-from .misc import diagonal
+from numojo.routines.linalg.decompositions import lu_decomposition, qr, eig
+from numojo.routines.linalg.norms import det, trace
+from numojo.routines.linalg.products import cross, dot, matmul
+from numojo.routines.linalg.solving import inv, solve, lstsq
+from numojo.routines.linalg.misc import diagonal

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -28,10 +28,9 @@ def _compute_householder[
     comptime sqrt2: Scalar[dtype] = 1.4142135623730951
     var rRows = R.shape[0]
 
-    @parameter
     def load_store_vec[
         n_elements: Int
-    ](i: Int) unified {mut H, mut R, read work_index}:
+    ](i: Int) {mut H, mut R, read work_index}:
         var r_value = R._load[n_elements](i + work_index, work_index)
         H._store[n_elements](i + work_index, work_index, r_value)
         R._store[n_elements](i + work_index, work_index, 0.0)
@@ -40,10 +39,9 @@ def _compute_householder[
 
     var norm = Scalar[dtype](0)
 
-    @parameter
     def calculate_norm[
         width: Int
-    ](i: Int) unified {mut norm, read H, read work_index}:
+    ](i: Int) {mut norm, read H, read work_index}:
         norm += (H._load[width=width](i, work_index) ** 2).reduce_add()
 
     vectorize[simd_width](rRows, calculate_norm)
@@ -61,10 +59,9 @@ def _compute_householder[
 
     R._store(work_index, work_index, -1 / scaling_factor)
 
-    @parameter
     def scaling_factor_vec[
         simd_width: Int
-    ](i: Int) unified {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
@@ -76,10 +73,9 @@ def _compute_householder[
 
     scaling_factor = builtin_math.sqrt(1.0 / increment)
 
-    @parameter
     def scaling_factor_increment_vec[
         simd_width: Int
-    ](i: Int) unified {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, read work_index, read scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
@@ -103,20 +99,18 @@ def _apply_householder[
     for j in range(column_start, aCols):
         var dot: SIMD[dtype, 1] = 0.0
 
-        @parameter
         def calculate_norm[
             width: Int
-        ](i: Int) unified {mut dot, read H, read A, read work_index, read j}:
+        ](i: Int) {mut dot, read H, read A, read work_index, read j}:
             dot += (
                 H._load[width=width](i, work_index) * A._load[width=width](i, j)
             ).reduce_add()
 
         vectorize[simdwidth](aRows, calculate_norm)
 
-        @parameter
         def closure[
             width: Int
-        ](i: Int) unified {mut A, read H, read work_index, read j, read dot}:
+        ](i: Int) {mut A, read H, read work_index, read j, read dot}:
             val = A._load[width](i, j) - H._load[width](i, work_index) * dot
             A._store(i, j, val)
 

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Decompositions (numojo.routines.linalg.decompositions)
+"""Decompositions (numojo.routines.linalg.decompositions).
 
 This module provides functions for matrix decompositions, including LU decomposition, QR decomposition, and eigenvalue decomposition for symmetric matrices.
 """

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Miscellaneous Linear Algebra Routines (numojo.routines.linalg.misc)
+"""Miscellaneous Linear Algebra Routines (numojo.routines.linalg.misc).
 
 This module provides miscellaneous linear algebra routines, such as extracting diagonals and checking for symmetry.
 """

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Norms and other numbers (numojo.routines.linalg.norms)
+"""Norms and other numbers (numojo.routines.linalg.norms).
 
 This module provides functions for computing quantities related to linear algebra, such as determinants and traces.
 """

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -98,10 +98,9 @@ def dot[
     if array1.ndim == array2.ndim == 1:
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(array1.size))
 
-        @parameter
         def vectorized_dot[
             simd_width: Int
-        ](idx: Int) unified {mut result, read array1, read array2} -> None:
+        ](idx: Int) {mut result, read array1, read array2} -> None:
             result._buf.ptr.store(
                 idx,
                 array1._buf.ptr.load[width=simd_width](idx)
@@ -153,10 +152,9 @@ def matmul_tiled_unrolled_parallelized[
         def calc_tile[tile_x: Int, tile_y: Int](x: Int, y: Int):
             for k in range(y, y + tile_y):
 
-                @parameter
                 def dot[
                     simd_width: Int
-                ](n: Int) unified {
+                ](n: Int) {
                     mut result,
                     read A,
                     read B,
@@ -284,10 +282,9 @@ def matmul_2darray[
     def calculate_A_rows(m: Int):
         for k in range(t1):
 
-            @parameter
             def dot[
                 simd_width: Int
-            ](n: Int) unified {
+            ](n: Int) {
                 mut result, read A, read B, read t2, read t1, read k, read m
             } -> None:
                 result._buf.ptr.store(
@@ -434,10 +431,9 @@ def matmul[
         def calculate_resultresult(m: Int):
             for k in range(A.shape[1]):
 
-                @parameter
                 def dot[
                     simd_width: Int
-                ](n: Int) unified {
+                ](n: Int) {
                     mut result, read A, read B, read m, read k
                 } -> None:
                     result._store[simd_width](
@@ -459,10 +455,9 @@ def matmul[
         def calculate_FF(n: Int):
             for k in range(A.shape[1]):
 
-                @parameter
                 def dot_F[
                     simd_width: Int
-                ](m: Int) unified {
+                ](m: Int) {
                     mut result, read A, read B, read n, read k
                 } -> None:
                     result._store[simd_width](
@@ -485,10 +480,9 @@ def matmul[
             for n in range(B.shape[1]):
                 var sum: Scalar[dtype] = 0.0
 
-                @parameter
                 def dot_product[
                     simd_width: Int
-                ](k: Int) unified {
+                ](k: Int) {
                     mut sum, read A, read B, read m, read n
                 } -> None:
                     sum += (

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Matrix and vector products (numojo.routines.linalg.products)
+"""Matrix and vector products (numojo.routines.linalg.products).
 
 This module provides functions for computing products of vectors and matrices, such as cross product, dot product, and matrix multiplication.
 """

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Linear Algebra Solver (numojo.routines.linalg.solving)
+"""Linear Algebra Solver (numojo.routines.linalg.solving).
 
 Provides:
     - Solver of `Ax = y` using LU decomposition algorithm.

--- a/numojo/routines/logic/__init__.mojo
+++ b/numojo/routines/logic/__init__.mojo
@@ -9,7 +9,7 @@
 
 This module provides a collection of logic routines for numerical computations, including comparison operations, content checks, and truth evaluations.
 """
-from .comparison import (
+from numojo.routines.logic.comparison import (
     greater,
     greater_equal,
     less,
@@ -20,12 +20,12 @@ from .comparison import (
     isclose,
     array_equal,
 )
-from .contents import (
+from numojo.routines.logic.contents import (
     isinf,
     isfinite,
     isnan,
     isneginf,
     isposinf,
 )
-from .logical_ops import logical_and, logical_or, logical_not, logical_xor
-from .truth import any, all
+from numojo.routines.logic.logical_ops import logical_and, logical_or, logical_not, logical_xor
+from numojo.routines.logic.truth import any, all

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Comparison routines (numojo.routines.logic.comparison)
+"""Comparison routines (numojo.routines.logic.comparison).
 
 Implements comparison math routines for NDArrays and Matrices.
 """

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -32,7 +32,7 @@ struct _Gt(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a > b
+        return a.gt(b)
 
 
 struct _Ge(BinaryPredicate):
@@ -40,7 +40,7 @@ struct _Ge(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a >= b
+        return a.ge(b)
 
 
 struct _Lt(BinaryPredicate):
@@ -48,7 +48,7 @@ struct _Lt(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a < b
+        return a.lt(b)
 
 
 struct _Le(BinaryPredicate):
@@ -56,7 +56,7 @@ struct _Le(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a <= b
+        return a.le(b)
 
 
 struct _Eq(BinaryPredicate):
@@ -64,7 +64,7 @@ struct _Eq(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a == b
+        return a.eq(b)
 
 
 struct _Ne(BinaryPredicate):
@@ -72,7 +72,7 @@ struct _Ne(BinaryPredicate):
     def apply[type: DType, simd_w: Int](
         a: SIMD[type, simd_w], b: SIMD[type, simd_w]
     ) -> SIMD[DType.bool, simd_w]:
-        return a != b
+        return a.ne(b)
 
 
 # ===------------------------------------------------------------------------===#

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -12,13 +12,68 @@ Implements comparison math routines for NDArrays and Matrices.
 
 import std.math as math
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, BinaryPredicate
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 from numojo.core.error import NumojoError
 
 # TODO: define the allclose, isclose with correct behaviour for ComplexNDArray.
 # TODO: define array_equiv with correct broadcast semantics.
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors for SIMD comparison operators
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _Gt(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a > b
+
+
+struct _Ge(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a >= b
+
+
+struct _Lt(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a < b
+
+
+struct _Le(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a <= b
+
+
+struct _Eq(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a == b
+
+
+struct _Ne(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return a != b
+
 
 # ===------------------------------------------------------------------------===#
 # Simple Element-wise Comparisons
@@ -52,7 +107,7 @@ def greater[
         print(greater[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Gt](array1, array2)
 
 
 def greater[
@@ -81,7 +136,7 @@ def greater[
         print(greater[nm.f64](arr, 2.0))  # Output: [False, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.gt](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Gt](array1, scalar)
 
 
 def greater_equal[
@@ -111,7 +166,7 @@ def greater_equal[
         print(greater_equal[nm.f64](arr1, arr2))  # Output: [True, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Ge](array1, array2)
 
 
 def greater_equal[
@@ -140,7 +195,7 @@ def greater_equal[
         print(greater_equal[nm.f64](arr, 2.0))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ge](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Ge](array1, scalar)
 
 
 def less[
@@ -170,7 +225,7 @@ def less[
         print(less[nm.f64](arr1, arr2))  # Output: [False, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Lt](array1, array2)
 
 
 def less[
@@ -199,7 +254,7 @@ def less[
         print(less[nm.f64](arr, 2.0))  # Output: [True, False, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.lt](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Lt](array1, scalar)
 
 
 def less_equal[
@@ -229,7 +284,7 @@ def less_equal[
         print(less_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Le](array1, array2)
 
 
 def less_equal[
@@ -258,7 +313,7 @@ def less_equal[
         print(less_equal[nm.f64](arr, 2.0))  # Output: [True, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.le](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Le](array1, scalar)
 
 
 def equal[
@@ -288,7 +343,7 @@ def equal[
         print(equal[nm.f64](arr1, arr2))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Eq](array1, array2)
 
 
 def equal[
@@ -317,7 +372,7 @@ def equal[
         print(equal[nm.f64](arr, 2.0))  # Output: [False, True, False]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.eq](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Eq](array1, scalar)
 
 
 def not_equal[
@@ -347,7 +402,7 @@ def not_equal[
         print(not_equal[nm.f64](arr1, arr2))  # Output: [False, True, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ne](array1, array2)
+    return HostExecutor.apply_binary_predicate[dtype, _Ne](array1, array2)
 
 
 def not_equal[
@@ -376,7 +431,7 @@ def not_equal[
         print(not_equal[nm.f64](arr, 2.0))  # Output: [True, False, True]
         ```
     """
-    return HostExecutor.apply_binary_predicate[dtype, SIMD.ne](array1, scalar)
+    return HostExecutor.apply_binary_predicate[dtype, _Ne](array1, scalar)
 
 
 # ===------------------------------------------------------------------------===#

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -76,7 +76,7 @@ struct _IsNegInf(UnaryPredicate):
     ) -> SIMD[DType.bool, simd_w]:
         # Integers can never be -inf; only floats carry an infinity bit pattern.
         comptime if type.is_floating_point():
-            return x == SIMD[type, simd_w](neg_inf[type]())
+            return x.eq(SIMD[type, simd_w](neg_inf[type]()))
         else:
             return SIMD[DType.bool, simd_w](False)
 
@@ -88,7 +88,7 @@ struct _IsPosInf(UnaryPredicate):
     ) -> SIMD[DType.bool, simd_w]:
         # Integers can never be +inf; only floats carry an infinity bit pattern.
         comptime if type.is_floating_point():
-            return x == SIMD[type, simd_w](inf[type]())
+            return x.eq(SIMD[type, simd_w](inf[type]()))
         else:
             return SIMD[DType.bool, simd_w](False)
 

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Contents routines (numojo.routines.logic.contents)
+"""Contents routines (numojo.routines.logic.contents).
 
 Implements Checking routines: currently not SIMD due to bool bit packing issue
 """

--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -13,7 +13,7 @@ Implements Checking routines: currently not SIMD due to bool bit packing issue
 import std.math as math
 from std.utils.numerics import neg_inf, inf
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryPredicate
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 
@@ -38,6 +38,59 @@ from numojo.core.matrix import Matrix
 #     dtype: DType
 # ](array: NDArray[dtype]) -> NDArray[DType.bool]:
 #     return backend().math_func_is[dtype, math.is_odd](array)
+
+
+# ===------------------------------------------------------------------------===#
+# Unary predicate functors
+# ===------------------------------------------------------------------------===#
+
+
+struct _IsInf(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return math.isinf(x)
+
+
+struct _IsFinite(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return math.isfinite(x)
+
+
+struct _IsNan(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return math.isnan(x)
+
+
+struct _IsNegInf(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        # Integers can never be -inf; only floats carry an infinity bit pattern.
+        comptime if type.is_floating_point():
+            return x == SIMD[type, simd_w](neg_inf[type]())
+        else:
+            return SIMD[DType.bool, simd_w](False)
+
+
+struct _IsPosInf(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        # Integers can never be +inf; only floats carry an infinity bit pattern.
+        comptime if type.is_floating_point():
+            return x == SIMD[type, simd_w](inf[type]())
+        else:
+            return SIMD[DType.bool, simd_w](False)
 
 
 # ===------------------------------------------------------------------------===#
@@ -68,7 +121,7 @@ def isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isinf(arr))  # Output: [False, False, False, False, False]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isinf](array)
+    return HostExecutor.apply_unary_predicate[dtype, _IsInf](array)
 
 
 def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -94,7 +147,7 @@ def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isfinite(arr))  # Output: [True, True, True]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isfinite](array)
+    return HostExecutor.apply_unary_predicate[dtype, _IsFinite](array)
 
 
 def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -120,7 +173,7 @@ def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
             print(isnan(arr))  # Output: [False, False, False]
         ```
     """
-    return HostExecutor.apply_unary_predicate[dtype, math.isnan](array)
+    return HostExecutor.apply_unary_predicate[dtype, _IsNan](array)
 
 
 def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -147,12 +200,7 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         ```
     """
 
-    def is_neginf[
-        dtype: DType, simd_width: Int
-    ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
-        return x.eq(SIMD[dtype, simd_width](neg_inf[dtype]()))
-
-    return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
+    return HostExecutor.apply_unary_predicate[dtype, _IsNegInf](array)
 
 
 def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -179,12 +227,7 @@ def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         ```
     """
 
-    def is_posinf[
-        dtype: DType, simd_width: Int
-    ](x: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
-        return x.eq(SIMD[dtype, simd_width](inf[dtype]()))
-
-    return HostExecutor.apply_unary_predicate[dtype, is_posinf](array)
+    return HostExecutor.apply_unary_predicate[dtype, _IsPosInf](array)
 
 
 def isneginf[dtype: DType](matrix: Matrix[dtype]) raises -> Matrix[DType.bool]:

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Logical Operations Module (numojo.routines.logic.logical_ops)
+"""Logical Operations Module (numojo.routines.logic.logical_ops).
 
 This module implements element-wise logical operations for NDArray, ComplexNDArray, and Matrix types in the NuMojo library.
 """

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -10,12 +10,50 @@
 This module implements element-wise logical operations for NDArray, ComplexNDArray, and Matrix types in the NuMojo library.
 """
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, BinaryPredicate, UnaryPredicate
 from numojo.core.error import NumojoError
 
 # TODO: add `where` argument support to logical operations
 # FIXME: Make all SIMD vectorized operations once bool bit-packing issue is resolved.
 # TODO: Create backend for these operations.
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors for SIMD logical operators
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _And(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return SIMD[DType.bool, simd_w](a & b)
+
+
+struct _Or(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return SIMD[DType.bool, simd_w](a | b)
+
+
+struct _Xor(BinaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return SIMD[DType.bool, simd_w](a ^ b)
+
+
+struct _Not(UnaryPredicate):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]:
+        return SIMD[DType.bool, simd_w](~a)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -64,12 +102,7 @@ def logical_and[
             )
         )
 
-    def kernel[
-        dtype: DType, width: Int
-    ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
-        return SIMD[DType.bool, width](a & b)
-
-    return HostExecutor.apply_binary_predicate[dtype, kernel](a, b)
+    return HostExecutor.apply_binary_predicate[dtype, _And](a, b)
 
 
 def logical_or[
@@ -115,12 +148,7 @@ def logical_or[
             )
         )
 
-    def kernel[
-        dtype: DType, width: Int
-    ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
-        return SIMD[DType.bool, width](a | b)
-
-    return HostExecutor.apply_binary_predicate[dtype, kernel](a, b)
+    return HostExecutor.apply_binary_predicate[dtype, _Or](a, b)
 
 
 def logical_not[
@@ -153,12 +181,7 @@ def logical_not[
         ```
     """
 
-    def kernel[
-        dtype: DType, width: Int
-    ](a: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
-        return SIMD[DType.bool, width](~a)
-
-    return HostExecutor.apply_unary_predicate[dtype, kernel](a)
+    return HostExecutor.apply_unary_predicate[dtype, _Not](a)
 
 
 def logical_xor[
@@ -204,12 +227,7 @@ def logical_xor[
             )
         )
 
-    def kernel[
-        dtype: DType, width: Int
-    ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
-        return SIMD[DType.bool, width](a ^ b)
-
-    return HostExecutor.apply_binary_predicate[dtype, kernel](a, b)
+    return HostExecutor.apply_binary_predicate[dtype, _Xor](a, b)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 #  ===----------------------------------------------------------------------=== #
-"""Truth value testing (numojo.routines.logic.truth)
+"""Truth value testing (numojo.routines.logic.truth).
 
 This module implements the truth value testing functions, such as `all` and `any`, for both `NDArray` and `Matrix`.
 """

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -45,10 +45,9 @@ def all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](True)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    @parameter
     def closure[
         simd_width: Int
-    ](idx: Int) unified {mut result, read array} -> None:
+    ](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result & simd_data).reduce_and()
 
@@ -78,10 +77,9 @@ def any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](False)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    @parameter
     def closure[
         simd_width: Int
-    ](idx: Int) unified {mut result, read array} -> None:
+    ](idx: Int) {mut result, read array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result | simd_data).reduce_or()
 
@@ -107,8 +105,7 @@ def all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](1)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def closure[width: Int](i: Int) unified {mut res, read A}:
+    def closure[width: Int](i: Int) {mut res, read A}:
         res = (res & A._buf.ptr.load[width=width](i)).reduce_and()
 
     vectorize[width](A.size, closure)
@@ -127,8 +124,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) & A._load[width](i, j)
                 )
@@ -142,8 +138,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -171,8 +166,7 @@ def any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](0)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_and[width: Int](i: Int) unified {mut res, read A}:
+    def cal_and[width: Int](i: Int) {mut res, read A}:
         res = res | A._buf.ptr.load[width=width](i).reduce_or()
 
     vectorize[width](A.size, cal_and)
@@ -191,8 +185,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) | A._load[width](i, j)
                 )
@@ -206,8 +199,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Manipulation routines (numojo.routines.manipulation)
+"""Manipulation routines (numojo.routines.manipulation).
 
 This module implements routines that manipulate the shape and layout of arrays, such as reshaping, transposing, broadcasting, and flipping.
 """

--- a/numojo/routines/math/__init__.mojo
+++ b/numojo/routines/math/__init__.mojo
@@ -10,12 +10,12 @@
 Aggregates arithmetic, trigonometric, hyperbolic, and utility routines for NDArrays and Matrices.
 """
 
-from .arithmetic import add, sub, mod, mul, div, floor_div, fma, remainder
-from .differences import gradient, diff
-from .exponents import exp, exp2, expm1, log, log2, log10, log1p
-from .extrema import max, min, minimum, maximum
-from .floating import copysign
-from .hyper import (
+from numojo.routines.math.arithmetic import add, sub, mod, mul, div, floor_div, fma, remainder
+from numojo.routines.math.differences import gradient, diff
+from numojo.routines.math.exponents import exp, exp2, expm1, log, log2, log10, log1p
+from numojo.routines.math.extrema import max, min, minimum, maximum
+from numojo.routines.math.floating import copysign
+from numojo.routines.math.hyper import (
     arccosh,
     acosh,
     arcsinh,
@@ -26,9 +26,9 @@ from .hyper import (
     sinh,
     tanh,
 )
-from .misc import cbrt, clip, rsqrt, sqrt, scalb
-from .products import prod, cumprod
-from .rounding import (
+from numojo.routines.math.misc import cbrt, clip, rsqrt, sqrt, scalb
+from numojo.routines.math.products import prod, cumprod
+from numojo.routines.math.rounding import (
     round,
     tabs,
     tfloor,
@@ -38,8 +38,8 @@ from .rounding import (
     roundeven,
     nextafter,
 )
-from .sums import sum, cumsum
-from .trig import (
+from numojo.routines.math.sums import sum, cumsum
+from numojo.routines.math.trig import (
     arccos,
     acos,
     arcsin,

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -13,8 +13,71 @@ Implements addition, subtraction, multiplication, division, floor division, fuse
 from std.utils import Variant
 from std.builtin.simd import FastMathFlag
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, BinaryKernel, TernaryKernel
 from numojo.core.ndarray import NDArray
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors for SIMD arithmetic operators
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _Add(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a + b
+
+
+struct _Sub(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a - b
+
+
+struct _Mod(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a % b
+
+
+struct _Mul(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a * b
+
+
+struct _TrueDiv(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a / b
+
+
+struct _FloorDiv(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a // b
+
+
+struct _Fma(TernaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w], c: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return a.fma(b, c)
+
 
 # ===------------------------------------------------------------------------===#
 # Addition
@@ -40,7 +103,7 @@ def add[
     Returns:
         The element-wise sum of `array1` and`array2`.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Add](array1, array2)
 
 
 def add[
@@ -59,7 +122,7 @@ def add[
     Returns:
         The element-wise sum of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _Add](array, scalar)
 
 
 def add[
@@ -78,7 +141,7 @@ def add[
     Returns:
         The element-wise sum of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__add__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _Add](scalar, array)
 
 
 def add[
@@ -103,9 +166,9 @@ def add[
     var scalar_part: Scalar[dtype] = 0
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            array_list.append(values[i].take[NDArray[dtype]]())
+            array_list.append(values[i][NDArray[dtype]].copy())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part += values[i].take[Scalar[dtype]]()
+            scalar_part += values[i][Scalar[dtype]]
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:add(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
@@ -140,7 +203,7 @@ def sub[
     Returns:
         The element-wise difference of `array1` and`array2`.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Sub](array1, array2)
 
 
 def sub[
@@ -159,7 +222,7 @@ def sub[
     Returns:
         The element-wise difference of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _Sub](array, scalar)
 
 
 def sub[
@@ -178,7 +241,7 @@ def sub[
     Returns:
         The element-wise difference of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__sub__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _Sub](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -202,7 +265,7 @@ def mod[
     Returns:
         A NDArray equal to array1 % array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Mod](array1, array2)
 
 
 def mod[
@@ -221,7 +284,7 @@ def mod[
     Returns:
         A NDArray equal to array % scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _Mod](array, scalar)
 
 
 def mod[
@@ -240,7 +303,7 @@ def mod[
     Returns:
         A NDArray equal to scalar % array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _Mod](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -267,7 +330,7 @@ def mul[
     Returns:
         A NDArray equal to array1*array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Mul](array1, array2)
 
 
 def mul[
@@ -286,7 +349,7 @@ def mul[
     Returns:
         The element-wise product of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _Mul](array, scalar)
 
 
 def mul[
@@ -305,7 +368,7 @@ def mul[
     Returns:
         The element-wise product of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mul__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _Mul](scalar, array)
 
 
 def mul[
@@ -330,15 +393,15 @@ def mul[
     var scalar_part: Scalar[dtype] = 1
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            array_list.append(values[i].take[NDArray[dtype]]())
+            array_list.append(values[i][NDArray[dtype]].copy())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part *= values[i].take[Scalar[dtype]]()
+            scalar_part *= values[i][Scalar[dtype]]
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:mul(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
             " No arrays in arguments"
         )
-    var result_array: NDArray[dtype] = array_list[0].deep_copy()
+    var result_array: NDArray[dtype] = array_list[0].copy()
     for i in range(1, len(array_list)):
         result_array = mul[dtype](result_array, array_list[i])
     result_array = mul[dtype](result_array, scalar_part)
@@ -370,7 +433,7 @@ def div[
     Returns:
         A NDArray equal to array1/array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _TrueDiv](array1, array2)
 
 
 def div[
@@ -389,7 +452,7 @@ def div[
     Returns:
         The element-wise quotient of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _TrueDiv](array, scalar)
 
 
 def div[
@@ -408,7 +471,7 @@ def div[
     Returns:
         The element-wise quotient of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__truediv__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _TrueDiv](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -435,7 +498,7 @@ def floor_div[
     Returns:
         A NDArray equal to array1/array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _FloorDiv](array1, array2)
 
 
 def floor_div[
@@ -454,7 +517,7 @@ def floor_div[
     Returns:
         The element-wise quotient of array and scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _FloorDiv](array, scalar)
 
 
 def floor_div[
@@ -473,7 +536,7 @@ def floor_div[
     Returns:
         The element-wise quotient of scalar and array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__floordiv__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _FloorDiv](scalar, array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -506,7 +569,7 @@ def fma[
     """
     # TODO: Support passing through the FastMathFlag parameter
     # For now, FastMathFlag.CONTRACT is was default prior to this error.
-    return HostExecutor.apply_ternary[dtype, SIMD.fma[FastMathFlag.CONTRACT]](
+    return HostExecutor.apply_ternary[dtype, _Fma](
         array1, array2, array3
     )
 
@@ -533,7 +596,7 @@ def fma[
     Returns:
         A a new NDArray that is NDArray with the function func applied.
     """
-    return HostExecutor.apply_ternary[dtype, SIMD.fma[FastMathFlag.CONTRACT]](
+    return HostExecutor.apply_ternary[dtype, _Fma](
         array1, array2, simd
     )
 
@@ -562,7 +625,7 @@ def remainder[
     Returns:
         A NDArray equal to array1//array2.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Mod](array1, array2)
 
 
 def remainder[
@@ -581,7 +644,7 @@ def remainder[
     Returns:
         A NDArray equal to array//scalar.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](array, scalar)
+    return HostExecutor.apply_binary[dtype, _Mod](array, scalar)
 
 
 def remainder[
@@ -600,4 +663,4 @@ def remainder[
     Returns:
         A NDArray equal to scalar//array.
     """
-    return HostExecutor.apply_binary[dtype, SIMD.__mod__](scalar, array)
+    return HostExecutor.apply_binary[dtype, _Mod](scalar, array)

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -16,7 +16,89 @@ from std.algorithm import Static2DTileUnitFunc as Tile2DFunc
 from std.utils import Variant
 
 from numojo.core.ndarray import NDArray
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors
+# ===------------------------------------------------------------------------===#
+
+
+struct _Exp(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.exp(x)
+        else:
+            return x
+
+
+struct _Exp2(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.exp2(x)
+        else:
+            return x
+
+
+struct _Expm1(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.expm1(x)
+        else:
+            return x
+
+
+struct _Log(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.log(x)
+        else:
+            return x
+
+
+struct _Log2(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.log2(x)
+        else:
+            return x
+
+
+struct _Log10(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.log10(x)
+        else:
+            return x
+
+
+struct _Log1p(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.log1p(x)
+        else:
+            return x
+
 
 # ===------------------------------------------------------------------------===#
 # Exponential functions
@@ -49,7 +131,7 @@ def exp[
         var result = nm.exp(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.exp](array)
+    return HostExecutor.apply_unary[dtype, _Exp](array)
 
 
 def exp[
@@ -105,7 +187,7 @@ def exp2[
         var result = nm.exp2(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.exp2](array)
+    return HostExecutor.apply_unary[dtype, _Exp2](array)
 
 
 def exp2[
@@ -160,7 +242,7 @@ def expm1[
         var result = nm.expm1(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.expm1](array)
+    return HostExecutor.apply_unary[dtype, _Expm1](array)
 
 
 def expm1[
@@ -219,7 +301,7 @@ def log[
         var result = nm.log(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log](array)
+    return HostExecutor.apply_unary[dtype, _Log](array)
 
 
 def log[
@@ -274,7 +356,7 @@ def log2[
         var result = nm.log2(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log2](array)
+    return HostExecutor.apply_unary[dtype, _Log2](array)
 
 
 def log2[
@@ -327,7 +409,7 @@ def log10[
         var result = nm.log10(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log10](array)
+    return HostExecutor.apply_unary[dtype, _Log10](array)
 
 
 def log10[
@@ -382,7 +464,7 @@ def log1p[
         var result = nm.log1p(arr)
         ```
     """
-    return HostExecutor.apply_unary[dtype, math.log1p](array)
+    return HostExecutor.apply_unary[dtype, _Log1p](array)
 
 
 def log1p[

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -20,11 +20,32 @@ from std.sys import simd_width_of
 
 from numojo.core.matrix import Matrix
 from numojo.core.ndarray import NDArray
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, BinaryKernel
 from numojo.routines.creation import full
 from numojo.routines.sorting import binary_sort
 from numojo.routines.functional import apply_along_axis_reduce
 from numojo.routines.manipulation import ravel
+
+
+# ===-----------------------------------------------------------------------===#
+# Binary kernel functors
+# ===-----------------------------------------------------------------------===#
+
+
+struct _Max(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_max(a, b)
+
+
+struct _Min(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_min(a, b)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -574,7 +595,7 @@ def minimum[
         var m = nm.minimum(a, b)
         ```
     """
-    return HostExecutor.apply_binary[dtype, builtin_min](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Min](array1, array2)
 
 
 def maximum[
@@ -603,4 +624,4 @@ def maximum[
         var m = nm.maximum(a, b)
         ```
     """
-    return HostExecutor.apply_binary[dtype, builtin_max](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Max](array1, array2)

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -60,10 +60,9 @@ def extrema_1d[
 
     comptime if is_max:
 
-        @parameter
         def vectorize_max[
             simd_width: Int
-        ](offset: Int) unified {mut value, read a}:
+        ](offset: Int) {mut value, read a}:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
             if temp >= value:
                 value = temp
@@ -74,10 +73,9 @@ def extrema_1d[
 
     else:
 
-        @parameter
         def vectorize_min[
             simd_width: Int
-        ](offset: Int) unified {mut value, read a} -> None:
+        ](offset: Int) {mut value, read a} -> None:
             var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
             if temp < value:
                 value = temp

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -142,6 +142,13 @@ def extrema_1d_max[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
     return extrema_1d[is_max=True](a)
 
 
+def extrema_1d_min[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+    """
+    Find the min value in a 1-D array.
+    """
+    return extrema_1d[is_max=False](a)
+
+
 def max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     """
     Find the max value of an array along an axis.
@@ -176,8 +183,8 @@ def max[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
             )
         )
 
-    return apply_along_axis_reduce[dtype, func1d=extrema_1d_max](
-        a=a, axis=normalized_axis
+    return apply_along_axis_reduce[dtype](
+        a=a, axis=normalized_axis, func1d_arg=extrema_1d_max
     )
 
 
@@ -244,8 +251,8 @@ def min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
             )
         )
 
-    return apply_along_axis_reduce[func1d=extrema_1d[is_max=False]](
-        a=a, axis=normalized_axis
+    return apply_along_axis_reduce[dtype](
+        a=a, axis=normalized_axis, func1d_arg=extrema_1d_min
     )
 
 

--- a/numojo/routines/math/floating.mojo
+++ b/numojo/routines/math/floating.mojo
@@ -12,8 +12,21 @@ Implements floating-point specific helpers on NDArrays, such as `copysign`.
 
 import std.math as math
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, BinaryKernel
 from numojo.core.ndarray import NDArray
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors
+# ===------------------------------------------------------------------------===#
+
+
+struct _Copysign(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return math.copysign(a, b)
+
 
 # ===------------------------------------------------------------------------===#
 # Sign Copy
@@ -39,4 +52,4 @@ def copysign[
     Returns:
         A NDArray with the magnitude of `array2` and the sign of `array1`.
     """
-    return HostExecutor.apply_binary[dtype, math.copysign](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Copysign](array1, array2)

--- a/numojo/routines/math/hyper.mojo
+++ b/numojo/routines/math/hyper.mojo
@@ -12,12 +12,82 @@ Implements hyperbolic and inverse hyperbolic functions for NDArrays and Matrices
 
 import std.math as math
 
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 from numojo.core.matrix.base import _arithmetic_func_matrix_to_matrix
 
 # TODO: add dtype in backends and pass it here.
+
+# ===------------------------------------------------------------------------===#
+# Unary kernel functors
+# ===------------------------------------------------------------------------===#
+
+
+struct _Acosh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.acosh(x)
+        else:
+            return x
+
+
+struct _Asinh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.asinh(x)
+        else:
+            return x
+
+
+struct _Atanh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.atanh(x)
+        else:
+            return x
+
+
+struct _Cosh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.cosh(x)
+        else:
+            return x
+
+
+struct _Sinh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.sinh(x)
+        else:
+            return x
+
+
+struct _Tanh(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.tanh(x)
+        else:
+            return x
 
 # ===------------------------------------------------------------------------===#
 # Inverse Hyperbolic Trig (NDArray)
@@ -37,7 +107,7 @@ def acosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acosh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.acosh](array)
+    return HostExecutor.apply_unary[dtype, _Acosh](array)
 
 
 def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -53,7 +123,7 @@ def asinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asinh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.asinh](array)
+    return HostExecutor.apply_unary[dtype, _Asinh](array)
 
 
 def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -69,7 +139,7 @@ def atanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atanh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.atanh](array)
+    return HostExecutor.apply_unary[dtype, _Atanh](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -90,7 +160,7 @@ def arccosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (arccosh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Acosh](A)
 
 
 def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -106,7 +176,7 @@ def acosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic cosine (acosh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acosh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Acosh](A)
 
 
 def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -122,7 +192,7 @@ def arcsinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (arcsinh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Asinh](A)
 
 
 def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -138,7 +208,7 @@ def asinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic sine (asinh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asinh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Asinh](A)
 
 
 def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -154,7 +224,7 @@ def arctanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (arctanh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atanh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Atanh](A)
 
 
 def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -170,7 +240,7 @@ def atanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise inverse hyperbolic tangent (atanh) of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atanh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Atanh](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -191,7 +261,7 @@ def cosh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cosh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.cosh](array)
+    return HostExecutor.apply_unary[dtype, _Cosh](array)
 
 
 def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -207,7 +277,7 @@ def sinh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sinh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.sinh](array)
+    return HostExecutor.apply_unary[dtype, _Sinh](array)
 
 
 def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -223,7 +293,7 @@ def tanh[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tanh of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.tanh](array)
+    return HostExecutor.apply_unary[dtype, _Tanh](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -243,7 +313,7 @@ def cosh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cosh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.cosh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Cosh](A)
 
 
 def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -258,7 +328,7 @@ def sinh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sinh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.sinh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Sinh](A)
 
 
 def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -273,4 +343,4 @@ def tanh[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tanh of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.tanh](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Tanh](A)

--- a/numojo/routines/math/misc.mojo
+++ b/numojo/routines/math/misc.mojo
@@ -16,7 +16,18 @@ import std.math.math as stdlib_math
 from std.sys import simd_width_of
 
 from numojo.core.ndarray import NDArray
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel, BinaryKernel
+
+
+struct _Cbrt(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return stdlib_math.cbrt(x)
+        else:
+            return x
 
 
 # TODO: Implement same routines for Matrix.
@@ -33,7 +44,7 @@ def cbrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to array**(1/3).
     """
-    return HostExecutor.apply_unary[dtype, stdlib_math.cbrt](array)
+    return HostExecutor.apply_unary[dtype, _Cbrt](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -97,6 +108,17 @@ def _mt_rsqrt[
     return stdlib_math.sqrt(SIMD.__truediv__(SIMD[dtype, simd_width](1), value))
 
 
+struct _MtRsqrt(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return _mt_rsqrt(x)
+        else:
+            return x
+
+
 def rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     Element-wise reciprocal square root of NDArray.
@@ -110,7 +132,18 @@ def rsqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to 1/NDArray**(1/2).
     """
-    return HostExecutor.apply_unary[dtype, _mt_rsqrt](array)
+    return HostExecutor.apply_unary[dtype, _MtRsqrt](array)
+
+
+struct _Sqrt(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return stdlib_math.sqrt(x)
+        else:
+            return x
 
 
 def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -126,12 +159,23 @@ def sqrt[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to NDArray**(1/2).
     """
-    return HostExecutor.apply_unary[dtype, stdlib_math.sqrt](array)
+    return HostExecutor.apply_unary[dtype, _Sqrt](array)
 
 
 # ===------------------------------------------------------------------------===#
 # Scaling
 # ===------------------------------------------------------------------------===#
+
+
+struct _Scalb(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return stdlib_math.scalb(a, b)
+        else:
+            return a
 
 
 def scalb[
@@ -153,4 +197,4 @@ def scalb[
     Returns:
         A NDArray with values equal to scalb(array1, array2).
     """
-    return HostExecutor.apply_binary[dtype, stdlib_math.scalb](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Scalb](array1, array2)

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -49,8 +49,7 @@ def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
     var res = Scalar[dtype](1)
 
-    @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res *= A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -109,8 +108,7 @@ def prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](1)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res = res * A._buf.ptr.load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
@@ -141,8 +139,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            @parameter
-            def cal_vec_sum[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
                 B._store[width](
                     0, j, B._load[width](0, j) * A._load[width](i, j)
                 )
@@ -156,8 +153,7 @@ def prod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            @parameter
-            def cal_vec[width: Int](j: Int) unified {mut B, read A, read i}:
+            def cal_vec[width: Int](j: Int) {mut B, read A, read i}:
                 B._store(
                     i,
                     0,
@@ -296,10 +292,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     else:
         for j in range(result.shape[1]):
 
-            @parameter
             def copy_col[
                 width: Int
-            ](i: Int) unified {mut result, read A, read j}:
+            ](i: Int) {mut result, read A, read j}:
                 result._store[width](i, j, A._load[width](i, j))
 
             vectorize[width](A.shape[0], copy_col)
@@ -308,10 +303,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if A.is_c_contiguous():
             for i in range(1, A.shape[0]):
 
-                @parameter
                 def cal_vec_row[
                     width: Int
-                ](j: Int) unified {mut result, read i}:
+                ](j: Int) {mut result, read i}:
                     result._store[width](
                         i,
                         j,
@@ -336,10 +330,9 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         else:
             for j in range(1, A.shape[1]):
 
-                @parameter
                 def cal_vec_column[
                     width: Int
-                ](i: Int) unified {mut result, read j}:
+                ](i: Int) {mut result, read j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -16,7 +16,62 @@ from std.utils.numerics import nextafter as builtin_nextafter
 from numojo.core.ndarray import NDArray
 import numojo.core.matrix as matrix
 from numojo.core.matrix import Matrix
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel, BinaryKernel
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors for SIMD rounding/abs operators
+# (Mojo 1.0: a parametric `fn` value can't be a comptime param; pass a
+# trait-conforming functor type instead — see backend.mojo)
+# ===------------------------------------------------------------------------===#
+
+
+struct _Abs(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return abs(x)
+
+
+struct _Floor(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_math.floor(x)
+
+
+struct _Ceil(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_math.ceil(x)
+
+
+struct _Trunc(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_math.trunc(x)
+
+
+struct _Round(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_math.round(x)
+
+
+struct _NextAfter(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        return builtin_nextafter(a, b)
+
 
 # ===------------------------------------------------------------------------===#
 # Matrix Rounding
@@ -53,7 +108,7 @@ def tabs[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to abs(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__abs__](array)
+    return HostExecutor.apply_unary[dtype, _Abs](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -74,7 +129,7 @@ def tfloor[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to floor(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__floor__](array)
+    return HostExecutor.apply_unary[dtype, _Floor](array)
 
 
 def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -90,7 +145,7 @@ def tceil[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to ceil(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__ceil__](array)
+    return HostExecutor.apply_unary[dtype, _Ceil](array)
 
 
 def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -106,7 +161,7 @@ def ttrunc[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to trunc(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__trunc__](array)
+    return HostExecutor.apply_unary[dtype, _Trunc](array)
 
 
 def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -122,7 +177,7 @@ def tround[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         A NDArray equal to round(array).
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
+    return HostExecutor.apply_unary[dtype, _Round](array)
 
 
 def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -138,7 +193,7 @@ def roundeven[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise rounding of `array` to the nearest integer with ties to even.
     """
-    return HostExecutor.apply_unary[dtype, SIMD.__round__](array)
+    return HostExecutor.apply_unary[dtype, _Round](array)
 
 
 # def round_half_down[
@@ -208,4 +263,4 @@ def nextafter[
     Returns:
         The element-wise nextafter of `array1` toward `array2`.
     """
-    return HostExecutor.apply_binary[dtype, builtin_nextafter](array1, array2)
+    return HostExecutor.apply_binary[dtype, _NextAfter](array1, array2)

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -47,8 +47,7 @@ def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
     var result: Scalar[dtype] = Scalar[dtype](0)
 
-    @parameter
-    def cal_vec[width: Int](i: Int) unified {mut result, read A}:
+    def cal_vec[width: Int](i: Int) {mut result, read A}:
         result += A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -144,8 +143,7 @@ def sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](0)
     comptime width: Int = simd_width_of[dtype]()
 
-    @parameter
-    def cal_vec[width: Int](i: Int) unified {mut res, read A}:
+    def cal_vec[width: Int](i: Int) {mut res, read A}:
         res = res + A._buf.ptr.load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
@@ -180,8 +178,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
             @parameter
             def calc_columns(j: Int):
-                @parameter
-                def col_sum[width: Int](i: Int) unified {mut B, read j, read A}:
+                def col_sum[width: Int](i: Int) {mut B, read j, read A}:
                     B._store(
                         0,
                         j,
@@ -194,10 +191,9 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         else:
             for i in range(A.shape[0]):
 
-                @parameter
                 def cal_vec_sum[
                     width: Int
-                ](j: Int) unified {mut B, read i, read A}:
+                ](j: Int) {mut B, read i, read A}:
                     B._store[width](
                         0, j, B._load[width](0, j) + A._load[width](i, j)
                     )
@@ -213,8 +209,7 @@ def sum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
             @parameter
             def cal_rows(i: Int):
-                @parameter
-                def cal_vec[width: Int](j: Int) unified {mut B, read i, read A}:
+                def cal_vec[width: Int](j: Int) {mut B, read i, read A}:
                     B._store(
                         i,
                         0,
@@ -371,10 +366,9 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         if result.is_c_contiguous():
             for i in range(1, A.shape[0]):
 
-                @parameter
                 def cal_vec_sum_column[
                     width: Int
-                ](j: Int) unified {mut result, read i}:
+                ](j: Int) {mut result, read i}:
                     result._store[width](
                         i,
                         j,
@@ -399,10 +393,9 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
         else:
             for j in range(1, A.shape[1]):
 
-                @parameter
                 def cal_vec_sum_row[
                     width: Int
-                ](i: Int) unified {mut result, read j}:
+                ](i: Int) {mut result, read j}:
                     result._store[width](
                         i,
                         j,

--- a/numojo/routines/math/trig.mojo
+++ b/numojo/routines/math/trig.mojo
@@ -15,9 +15,101 @@ import std.math as math
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 from numojo.core.matrix.base import _arithmetic_func_matrix_to_matrix
-from numojo.routines import HostExecutor
+from numojo.routines import HostExecutor, UnaryKernel, BinaryKernel
 from numojo.routines.math.misc import sqrt
 from numojo.routines.math.arithmetic import fma
+
+# ===------------------------------------------------------------------------===#
+# Kernel functors
+# ===------------------------------------------------------------------------===#
+
+
+struct _Sin(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.sin(x)
+        else:
+            return x
+
+
+struct _Cos(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.cos(x)
+        else:
+            return x
+
+
+struct _Tan(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.tan(x)
+        else:
+            return x
+
+
+struct _Asin(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.asin(x)
+        else:
+            return x
+
+
+struct _Acos(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.acos(x)
+        else:
+            return x
+
+
+struct _Atan(UnaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.atan(x)
+        else:
+            return x
+
+
+struct _Atan2(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.atan2(a, b)
+        else:
+            return a
+
+
+struct _Hypot(BinaryKernel):
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]:
+        comptime if type.is_floating_point():
+            return math.hypot(a, b)
+        else:
+            return a
 
 # ===------------------------------------------------------------------------===#
 # Inverse Trig (NDArray)
@@ -37,7 +129,7 @@ def acos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise acos of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.acos](array)
+    return HostExecutor.apply_unary[dtype, _Acos](array)
 
 
 def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -53,7 +145,7 @@ def asin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise asin of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.asin](array)
+    return HostExecutor.apply_unary[dtype, _Asin](array)
 
 
 def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -69,7 +161,7 @@ def atan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise atan of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.atan](array)
+    return HostExecutor.apply_unary[dtype, _Atan](array)
 
 
 def atan2[
@@ -94,7 +186,7 @@ def atan2[
     References:
         https://en.wikipedia.org/wiki/Atan2.
     """
-    return HostExecutor.apply_binary[dtype, math.atan2](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Atan2](array1, array2)
 
 
 # ===------------------------------------------------------------------------===#
@@ -115,7 +207,7 @@ def arccos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Acos](A)
 
 
 def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -131,7 +223,7 @@ def acos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise acos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.acos](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Acos](A)
 
 
 def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -147,7 +239,7 @@ def arcsin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Asin](A)
 
 
 def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -163,7 +255,7 @@ def asin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise asin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.asin](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Asin](A)
 
 
 def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -179,7 +271,7 @@ def arctan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atan](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Atan](A)
 
 
 def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -195,7 +287,7 @@ def atan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise atan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.atan](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Atan](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -216,7 +308,7 @@ def cos[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise cos of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.cos](array)
+    return HostExecutor.apply_unary[dtype, _Cos](array)
 
 
 def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -232,7 +324,7 @@ def sin[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise sin of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.sin](array)
+    return HostExecutor.apply_unary[dtype, _Sin](array)
 
 
 def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
@@ -248,7 +340,7 @@ def tan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     Returns:
         The element-wise tan of `array`.
     """
-    return HostExecutor.apply_unary[dtype, math.tan](array)
+    return HostExecutor.apply_unary[dtype, _Tan](array)
 
 
 # ===------------------------------------------------------------------------===#
@@ -269,7 +361,7 @@ def cos[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise cos of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.cos](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Cos](A)
 
 
 def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -285,7 +377,7 @@ def sin[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise sin of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.sin](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Sin](A)
 
 
 def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
@@ -301,7 +393,7 @@ def tan[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     Returns:
         The element-wise tan of `A`.
     """
-    return _arithmetic_func_matrix_to_matrix[dtype, math.tan](A)
+    return _arithmetic_func_matrix_to_matrix[dtype, _Tan](A)
 
 
 # ===------------------------------------------------------------------------===#
@@ -328,7 +420,7 @@ def hypot[
     Returns:
         The element-wise hypotenuse of `array1` and `array2`.
     """
-    return HostExecutor.apply_binary[dtype, math.hypot](array1, array2)
+    return HostExecutor.apply_binary[dtype, _Hypot](array1, array2)
 
 
 def hypot_fma[

--- a/numojo/routines/operations/__init__.mojo
+++ b/numojo/routines/operations/__init__.mojo
@@ -9,7 +9,7 @@
 
 This module contains all the vectorized unary, binary, unary_predicate, binary_predicate operations.
 """
-from .backend import (
+from numojo.routines.operations.backend import (
     HostExecutor,
     UnaryKernel,
     BinaryKernel,

--- a/numojo/routines/operations/__init__.mojo
+++ b/numojo/routines/operations/__init__.mojo
@@ -9,4 +9,12 @@
 
 This module contains all the vectorized unary, binary, unary_predicate, binary_predicate operations.
 """
-from .backend import HostExecutor
+from .backend import (
+    HostExecutor,
+    UnaryKernel,
+    BinaryKernel,
+    UnaryPredicate,
+    BinaryPredicate,
+    BinaryIntKernel,
+    TernaryKernel,
+)

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -171,8 +171,7 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
-        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(i, kernel[dtype, simd_w](simd_data))
 
@@ -226,10 +225,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read array2}:
+        ](i: Int) {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
@@ -273,10 +271,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read scalar}:
+        ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
                 i, kernel[dtype, simd_w](simd_data1, scalar)
@@ -320,10 +317,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read scalar}:
+        ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
                 i, kernel[dtype, simd_w](scalar, simd_data1)
@@ -360,10 +356,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array, read intval}:
+        ](i: Int) {mut result_array, read array, read intval}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
 
             result_array._buf.ptr.store(
@@ -426,10 +421,9 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read array2}:
+        ](i: Int) {mut result_array, read array1, read array2}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
 
@@ -482,10 +476,9 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
         def closure[
             simd_w: Int
-        ](i: Int) unified {mut result_array, read array1, read scalar}:
+        ](i: Int) {mut result_array, read array1, read scalar}:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = SIMD[dtype, simd_w](scalar)
             bool_simd_store[simd_w](
@@ -524,8 +517,7 @@ struct HostExecutor:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
 
-        @parameter
-        def closure[simd_w: Int](i: Int) unified {mut result_array, read array}:
+        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
             bool_simd_store[simd_w](
                 result_array._buf.ptr,
@@ -590,10 +582,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simdwidth: Int
-        ](i: Int) unified {
+        ](i: Int) {
             mut result_array, read array1, read array2, read array3
         }:
             var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
@@ -652,10 +643,9 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        @parameter
         def closure[
             simdwidth: Int
-        ](i: Int) unified {
+        ](i: Int) {
             mut result_array, read array1, read array2, read scalar
         }:
             var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -18,6 +18,57 @@ from numojo.core.ndarray import NDArray
 from numojo.routines.creation import _0darray
 
 
+# ===------------------------------------------------------------------------===#
+# Kernel functor traits
+# (Mojo 1.0: a parametric `fn[type, simd_w](...)` value cannot be a compile-time
+# parameter — it boxes to `AnyTrait[def[...]]` and the call fails. Instead we pass
+# a *type* constrained by one of these traits whose `apply` method carries the
+# parametricity. Functor structs are empty, so this is zero runtime cost.)
+# ===------------------------------------------------------------------------===#
+
+
+trait UnaryKernel:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]: ...
+
+
+trait BinaryKernel:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]: ...
+
+
+trait UnaryPredicate:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        x: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]: ...
+
+
+trait BinaryPredicate:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w]
+    ) -> SIMD[DType.bool, simd_w]: ...
+
+
+trait BinaryIntKernel:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: Int
+    ) -> SIMD[type, simd_w]: ...
+
+
+trait TernaryKernel:
+    @staticmethod
+    def apply[type: DType, simd_w: Int](
+        a: SIMD[type, simd_w], b: SIMD[type, simd_w], c: SIMD[type, simd_w]
+    ) -> SIMD[type, simd_w]: ...
+
+
 # TODO: Add overloads for complexndarray.
 # TODO: Add NumojoError as argument so that the calling function can modify the error message with more context.
 # NOTE: We currently do all checks within these backend functions,
@@ -38,9 +89,7 @@ struct HostExecutor:
     def apply_unary[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
+        K: UnaryKernel,
     ](scalar: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
         """
         Applies a SIMD-compatible unary function to a SIMD value.
@@ -56,15 +105,13 @@ struct HostExecutor:
         Returns:
             A new SIMD value containing the result of applying the function.
         """
-        return kernel[dtype, simd_width](scalar)
+        return K.apply[dtype, simd_width](scalar)
 
     @staticmethod
     def apply_binary[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: BinaryKernel,
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
         dtype, simd_width
     ]:
@@ -83,15 +130,13 @@ struct HostExecutor:
         Returns:
             A new SIMD value containing the result of applying the function.
         """
-        return kernel[dtype, simd_width](simd1, simd2)
+        return K.apply[dtype, simd_width](simd1, simd2)
 
     @staticmethod
     def apply_unary_predicate[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
+        K: UnaryPredicate,
     ](simd: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
         """
         Applies a SIMD-compatible unary predicate to a SIMD value.
@@ -107,15 +152,13 @@ struct HostExecutor:
         Returns:
             A SIMD boolean value containing the predicate result.
         """
-        return kernel[dtype, simd_width](simd)
+        return K.apply[dtype, simd_width](simd)
 
     @staticmethod
     def apply_binary_predicate[
         dtype: DType,
         simd_width: Int,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        K: BinaryPredicate,
     ](simd1: SIMD[dtype, simd_width], simd2: SIMD[dtype, simd_width]) -> SIMD[
         DType.bool, simd_width
     ]:
@@ -134,14 +177,12 @@ struct HostExecutor:
         Returns:
             A SIMD boolean value containing the predicate result.
         """
-        return kernel[dtype, simd_width](simd1, simd2)
+        return K.apply[dtype, simd_width](simd1, simd2)
 
     @staticmethod
     def apply_unary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            type, simd_w
-        ],
+        K: UnaryKernel,
     ](array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible unary function to an NDArray.
@@ -158,13 +199,13 @@ struct HostExecutor:
         """
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array.is_c_contiguous():
-            return Self.apply_unary[dtype, kernel](array.contiguous())
+            return Self.apply_unary[dtype, K](array.contiguous())
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
             var result_array = _0darray(
-                val=kernel[dtype, 1]((array._buf.ptr + array.offset)[])
+                val=K.apply[dtype, 1]((array._buf.ptr + array.offset)[])
             )
             return result_array^
 
@@ -173,7 +214,7 @@ struct HostExecutor:
 
         def closure[simd_w: Int](i: Int) {mut result_array, read array}:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
-            result_array._buf.ptr.store(i, kernel[dtype, simd_w](simd_data))
+            result_array._buf.ptr.store(i, K.apply[dtype, simd_w](simd_data))
 
         vectorize[width](array.size, closure)
 
@@ -182,9 +223,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: BinaryKernel,
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to two NDArrays.
@@ -201,21 +240,21 @@ struct HostExecutor:
             A new NDArray containing the result of applying the function.
         """
         if not array1.is_c_contiguous() and not array2.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](
+            return Self.apply_binary[dtype, K](
                 array1.contiguous(), array2.contiguous()
             )
 
         if not array1.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](array1.contiguous(), array2)
+            return Self.apply_binary[dtype, K](array1.contiguous(), array2)
         if not array2.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](array1, array2.contiguous())
+            return Self.apply_binary[dtype, K](array1, array2.contiguous())
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array1.ndim == 0:
-            return Self.apply_binary[dtype, kernel](array1[], array2)
+            return Self.apply_binary[dtype, K](array1[], array2)
         if array2.ndim == 0:
-            return Self.apply_binary[dtype, kernel](array1, array2[])
+            return Self.apply_binary[dtype, K](array1, array2[])
 
         if array1.shape != array2.shape:
             raise Error(
@@ -231,7 +270,7 @@ struct HostExecutor:
             var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
             var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data1, simd_data2)
+                i, K.apply[dtype, simd_w](simd_data1, simd_data2)
             )
 
         vectorize[width](result_array.size, closure)
@@ -240,9 +279,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: BinaryKernel,
     ](array: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to an NDArray and a scalar.
@@ -260,12 +297,12 @@ struct HostExecutor:
         """
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](array.contiguous(), scalar)
+            return Self.apply_binary[dtype, K](array.contiguous(), scalar)
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
-            var result_array = _0darray(val=kernel[dtype, 1](array[], scalar))
+            var result_array = _0darray(val=K.apply[dtype, 1](array[], scalar))
             return result_array^
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
@@ -276,7 +313,7 @@ struct HostExecutor:
         ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data1, scalar)
+                i, K.apply[dtype, simd_w](simd_data1, scalar)
             )
 
         vectorize[width](result_array.size, closure)
@@ -285,9 +322,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: BinaryKernel,
     ](scalar: SIMD[dtype, 1], array: NDArray[dtype]) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to a scalar and an NDArray.
@@ -306,12 +341,12 @@ struct HostExecutor:
 
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](scalar, array.contiguous())
+            return Self.apply_binary[dtype, K](scalar, array.contiguous())
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
-            var result_array = _0darray(val=kernel[dtype, 1](scalar, array[]))
+            var result_array = _0darray(val=K.apply[dtype, 1](scalar, array[]))
             return result_array^
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
@@ -322,7 +357,7 @@ struct HostExecutor:
         ](i: Int) {mut result_array, read array, read scalar}:
             var simd_data1 = array._buf.ptr.load[width=simd_w](i)
             result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](scalar, simd_data1)
+                i, K.apply[dtype, simd_w](scalar, simd_data1)
             )
 
         vectorize[width](result_array.size, closure)
@@ -331,9 +366,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w], Int) -> SIMD[
-            type, simd_w
-        ],
+        K: BinaryIntKernel,
     ](array: NDArray[dtype], intval: Int) raises -> NDArray[dtype]:
         """
         Applies a SIMD-compatible binary function to an NDArray and an Int scalar.
@@ -351,7 +384,7 @@ struct HostExecutor:
         """
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array.is_c_contiguous():
-            return Self.apply_binary[dtype, kernel](array.contiguous(), intval)
+            return Self.apply_binary[dtype, K](array.contiguous(), intval)
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
@@ -362,7 +395,7 @@ struct HostExecutor:
             var simd_data = array._buf.ptr.load[width=simd_w](i)
 
             result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data, intval)
+                i, K.apply[dtype, simd_w](simd_data, intval)
             )
 
         vectorize[width](array.size, closure)
@@ -371,9 +404,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        K: BinaryPredicate,
     ](array1: NDArray[dtype], array2: NDArray[dtype]) raises -> NDArray[
         DType.bool
     ]:
@@ -392,24 +423,24 @@ struct HostExecutor:
             A new boolean NDArray containing the result of the predicate.
         """
         if not array1.is_c_contiguous() and not array2.is_c_contiguous():
-            return Self.apply_binary_predicate[dtype, kernel](
+            return Self.apply_binary_predicate[dtype, K](
                 array1.contiguous(), array2.contiguous()
             )
 
         # View safety guard: ensure inputs are C-contiguous before SIMD access.
         if not array1.is_c_contiguous():
-            return Self.apply_binary_predicate[dtype, kernel](
+            return Self.apply_binary_predicate[dtype, K](
                 array1.contiguous(), array2
             )
         if not array2.is_c_contiguous():
-            return Self.apply_binary_predicate[dtype, kernel](
+            return Self.apply_binary_predicate[dtype, K](
                 array1, array2.contiguous()
             )
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array2.ndim == 0:
-            return Self.apply_binary_predicate[dtype, kernel](array1, array2[])
+            return Self.apply_binary_predicate[dtype, K](array1, array2[])
 
         if array1.shape != array2.shape:
             raise Error(
@@ -430,7 +461,7 @@ struct HostExecutor:
             bool_simd_store[simd_w](
                 result_array._buf.ptr,
                 i,
-                kernel[dtype, simd_w](simd_data1, simd_data2),
+                K.apply[dtype, simd_w](simd_data1, simd_data2),
             )
 
         vectorize[width](array1.size, closure)
@@ -439,9 +470,7 @@ struct HostExecutor:
     @staticmethod
     def apply_binary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[DType.bool, simd_w],
+        K: BinaryPredicate,
     ](array1: NDArray[dtype], scalar: SIMD[dtype, 1]) raises -> NDArray[
         DType.bool
     ]:
@@ -461,14 +490,14 @@ struct HostExecutor:
         """
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array1.is_c_contiguous():
-            return Self.apply_binary_predicate[dtype, kernel](
+            return Self.apply_binary_predicate[dtype, K](
                 array1.contiguous(), scalar
             )
 
         # For 0darray (numojo scalar)
         # Treat it as a scalar and apply the function
         if array1.ndim == 0:
-            var result_array = _0darray(val=kernel[dtype, 1](array1[], scalar))
+            var result_array = _0darray(val=K.apply[dtype, 1](array1[], scalar))
             return result_array^
 
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](
@@ -484,7 +513,7 @@ struct HostExecutor:
             bool_simd_store[simd_w](
                 result_array.unsafe_ptr(),
                 i,
-                kernel[dtype, simd_w](simd_data1, simd_data2),
+                K.apply[dtype, simd_w](simd_data1, simd_data2),
             )
 
         vectorize[width](array1.size, closure)
@@ -493,9 +522,7 @@ struct HostExecutor:
     @staticmethod
     def apply_unary_predicate[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](SIMD[type, simd_w]) -> SIMD[
-            DType.bool, simd_w
-        ],
+        K: UnaryPredicate,
     ](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         """
         Applies a SIMD-compatible unary predicate to an NDArray, returning a boolean NDArray.
@@ -512,7 +539,7 @@ struct HostExecutor:
         """
         # View safety guard: ensure input is C-contiguous before SIMD access.
         if not array.is_c_contiguous():
-            return Self.apply_unary_predicate[dtype, kernel](array.contiguous())
+            return Self.apply_unary_predicate[dtype, K](array.contiguous())
 
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
@@ -522,7 +549,7 @@ struct HostExecutor:
             bool_simd_store[simd_w](
                 result_array._buf.ptr,
                 i,
-                kernel[dtype, simd_w](simd_data),
+                K.apply[dtype, simd_w](simd_data),
             )
 
         vectorize[width](array.size, closure)
@@ -531,9 +558,7 @@ struct HostExecutor:
     @staticmethod
     def apply_ternary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: TernaryKernel,
     ](
         array1: NDArray[dtype], array2: NDArray[dtype], array3: NDArray[dtype]
     ) raises -> NDArray[dtype]:
@@ -557,20 +582,20 @@ struct HostExecutor:
             and not array2.is_c_contiguous()
             and not array3.is_c_contiguous()
         ):
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1.contiguous(), array2.contiguous(), array3.contiguous()
             )
 
         if not array1.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1.contiguous(), array2, array3
             )
         if not array2.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1, array2.contiguous(), array3
             )
         if not array3.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1, array2, array3.contiguous()
             )
 
@@ -591,7 +616,7 @@ struct HostExecutor:
             var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
             var simd_data3 = array3._buf.ptr.load[width=simdwidth](i)
             result_array._buf.ptr.store(
-                i, kernel(simd_data1, simd_data2, simd_data3)
+                i, K.apply[dtype, simdwidth](simd_data1, simd_data2, simd_data3)
             )
 
         vectorize[width](array1.size, closure)
@@ -600,9 +625,7 @@ struct HostExecutor:
     @staticmethod
     def apply_ternary[
         dtype: DType,
-        kernel: fn[type: DType, simd_w: Int](
-            SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
-        ) -> SIMD[type, simd_w],
+        K: TernaryKernel,
     ](
         array1: NDArray[dtype], array2: NDArray[dtype], scalar: SIMD[dtype, 1]
     ) raises -> NDArray[dtype]:
@@ -622,16 +645,16 @@ struct HostExecutor:
             A new NDArray containing the result of applying the function.
         """
         if not array1.is_c_contiguous() and not array2.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1.contiguous(), array2.contiguous(), scalar
             )
 
         if not array1.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1.contiguous(), array2, scalar
             )
         if not array2.is_c_contiguous():
-            return Self.apply_ternary[dtype, kernel](
+            return Self.apply_ternary[dtype, K](
                 array1, array2.contiguous(), scalar
             )
 
@@ -651,7 +674,10 @@ struct HostExecutor:
             var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
             var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
             result_array._buf.ptr.store(
-                i, kernel(simd_data1, simd_data2, scalar)
+                i,
+                K.apply[dtype, simdwidth](
+                    simd_data1, simd_data2, SIMD[dtype, simdwidth](scalar)
+                ),
             )
 
         vectorize[width](array1.size, closure)

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -97,7 +97,7 @@ struct HostExecutor:
         Parameters:
             dtype: The element type.
             simd_width: The SIMD width of the input and output.
-            kernel: The SIMD-compatible function to apply.
+            K: The SIMD-compatible function to apply.
 
         Args:
             scalar: The input SIMD value.
@@ -121,7 +121,7 @@ struct HostExecutor:
         Parameters:
             dtype: The element type.
             simd_width: The SIMD width of the input and output.
-            kernel: The SIMD-compatible binary function to apply.
+            K: The SIMD-compatible binary function to apply.
 
         Args:
             simd1: The first input SIMD value.
@@ -144,7 +144,7 @@ struct HostExecutor:
         Parameters:
             dtype: The element type.
             simd_width: The SIMD width of the input and output.
-            kernel: The SIMD-compatible unary predicate function to apply.
+            K: The SIMD-compatible unary predicate function to apply.
 
         Args:
             simd: The input SIMD value.
@@ -168,7 +168,7 @@ struct HostExecutor:
         Parameters:
             dtype: The element type.
             simd_width: The SIMD width of the input and output (should be 1 for SIMD).
-            kernel: The SIMD-compatible binary predicate function to apply.
+            K: The SIMD-compatible binary predicate function to apply.
 
         Args:
             simd1: The first input SIMD value.
@@ -189,7 +189,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArray.
-            kernel: The SIMD-compatible function to apply.
+            K: The SIMD-compatible function to apply.
 
         Args:
             array: The input NDArray.
@@ -230,7 +230,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArrays.
-            kernel: The SIMD-compatible binary function to apply.
+            K: The SIMD-compatible binary function to apply.
 
         Args:
             array1: The first input NDArray.
@@ -286,7 +286,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArray.
-            kernel: The SIMD-compatible binary function to apply.
+            K: The SIMD-compatible binary function to apply.
 
         Args:
             array: The input NDArray.
@@ -329,7 +329,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArray.
-            kernel: The SIMD-compatible binary function to apply.
+            K: The SIMD-compatible binary function to apply.
 
         Args:
             scalar: The input scalar value.
@@ -373,7 +373,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArray.
-            kernel: The SIMD-compatible binary function to apply.
+            K: The SIMD-compatible binary function to apply.
 
         Args:
             array: The input NDArray.
@@ -413,7 +413,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the input NDArrays.
-            kernel: The SIMD-compatible binary predicate function to apply.
+            K: The SIMD-compatible binary predicate function to apply.
 
         Args:
             array1: The first input NDArray.
@@ -479,7 +479,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the input NDArray.
-            kernel: The SIMD-compatible binary predicate function to apply.
+            K: The SIMD-compatible binary predicate function to apply.
 
         Args:
             array1: The input NDArray.
@@ -529,7 +529,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the input NDArray.
-            kernel: The SIMD-compatible unary predicate function to apply.
+            K: The SIMD-compatible unary predicate function to apply.
 
         Args:
             array: The input NDArray.
@@ -567,7 +567,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the NDArrays.
-            kernel: The SIMD-compatible ternary function to apply.
+            K: The SIMD-compatible ternary function to apply.
 
         Args:
             array1: The first input NDArray.
@@ -634,7 +634,7 @@ struct HostExecutor:
 
         Parameters:
             dtype: The element type of the input NDArrays.
-            kernel: The SIMD-compatible ternary function to apply.
+            K: The SIMD-compatible ternary function to apply.
 
         Args:
             array1: The first input NDArray.

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -6,7 +6,7 @@
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
 
-"""Random (numojo.routines.random)
+"""Random (numojo.routines.random).
 
 Creates array of the given shape and populate it with random samples from
 a certain distribution.

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-""""Searching routines (numojo.routines.searching)
+""""Searching routines (numojo.routines.searching).
 
 This module implements searching routines for finding indices of extrema (argmax and argmin) in NDArrays and Matrices.
 """

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -169,8 +169,8 @@ def argmax[
             )
         )
 
-    return apply_along_axis_reduce_to_int[dtype, func1d=argmax_1d](
-        a=a, axis=normalized_axis
+    return apply_along_axis_reduce_to_int[dtype](
+        a=a, axis=normalized_axis, func1d_arg=argmax_1d
     )
 
 
@@ -322,8 +322,8 @@ def argmin[
             )
         )
 
-    return apply_along_axis_reduce_to_int[dtype, func1d=argmin_1d](
-        a=a, axis=normalized_axis
+    return apply_along_axis_reduce_to_int[dtype](
+        a=a, axis=normalized_axis, func1d_arg=argmin_1d
     )
 
 

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -163,7 +163,7 @@ def sort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     return B^
 
 
-def sort[dtype: DType](var A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
+def sort[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     """
     Sort the Matrix along the given axis.
     """

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -98,12 +98,12 @@ def sort[
             return quick_sort_1d(a)
 
     if stable:
-        return apply_along_axis_preserve[dtype, func1d=quick_sort_stable_1d](
-            a, axis=normalized_axis
+        return apply_along_axis_preserve[dtype](
+            a, axis=normalized_axis, func1d_arg=quick_sort_stable_1d
         )
     else:
-        return apply_along_axis_preserve[dtype, func1d=quick_sort_1d](
-            a, axis=normalized_axis
+        return apply_along_axis_preserve[dtype](
+            a, axis=normalized_axis, func1d_arg=quick_sort_1d
         )
 
 
@@ -140,12 +140,12 @@ def sort_inplace[
             quick_sort_inplace_1d(a)
 
     if stable:
-        apply_along_axis_inplace[dtype, func1d=quick_sort_stable_inplace_1d](
-            a, axis=normalized_axis
+        apply_along_axis_inplace[dtype](
+            a, axis=normalized_axis, func1d_arg=quick_sort_stable_inplace_1d
         )
     else:
-        apply_along_axis_inplace[dtype, func1d=quick_sort_inplace_1d](
-            a, axis=normalized_axis
+        apply_along_axis_inplace[dtype](
+            a, axis=normalized_axis, func1d_arg=quick_sort_inplace_1d
         )
 
 
@@ -274,8 +274,8 @@ def argsort[
     if (a.ndim == 1) and (normalized_axis == 0):
         return argsort_quick_sort_1d(a)
 
-    return apply_along_axis_indices[dtype, func1d=argsort_quick_sort_1d](
-        a, axis=normalized_axis
+    return apply_along_axis_indices[dtype](
+        a, axis=normalized_axis, func1d_arg=argsort_quick_sort_1d
     )
 
 

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -5,7 +5,7 @@
 # https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
 # https://llvm.org/LICENSE.txt
 # ===----------------------------------------------------------------------=== #
-"""Sorting routines (numojo.routines.sorting)
+"""Sorting routines (numojo.routines.sorting).
 
 This module implements sorting routines for NDArrays and Matrices, including `sort` and `argsort` functions.
 

--- a/numojo/routines/statistics/__init__.mojo
+++ b/numojo/routines/statistics/__init__.mojo
@@ -17,5 +17,5 @@ from .averages import (
     mode,
     median,
     variance,
-    std,
+    std_dev,
 )

--- a/numojo/routines/statistics/__init__.mojo
+++ b/numojo/routines/statistics/__init__.mojo
@@ -10,7 +10,7 @@
 Aggregates averages, modes, and dispersion helpers for NDArrays and Matrices.
 """
 
-from .averages import (
+from numojo.routines.statistics.averages import (
     mean,
     max,
     min,

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -99,8 +99,8 @@ def mean[
         )
 
     return apply_along_axis_reduce_with_dtype[
-        dtype, returned_dtype=returned_dtype, func1d=mean_1d
-    ](a=a, axis=normalized_axis)
+        dtype, returned_dtype=returned_dtype
+    ](a=a, axis=normalized_axis, func1d_arg=mean_1d)
 
 
 def mean[
@@ -228,8 +228,8 @@ def median[
             )
         )
     return apply_along_axis_reduce_with_dtype[
-        dtype, returned_dtype=returned_dtype, func1d=median_1d
-    ](a=a, axis=normalized_axis)
+        dtype, returned_dtype=returned_dtype
+    ](a=a, axis=normalized_axis, func1d_arg=median_1d)
 
 
 def mode_1d[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
@@ -308,8 +308,8 @@ def mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
             )
         )
 
-    return apply_along_axis_reduce[dtype, func1d=mode_1d](
-        a=a, axis=normalized_axis
+    return apply_along_axis_reduce[dtype](
+        a=a, axis=normalized_axis, func1d_arg=mode_1d
     )
 
 

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -313,7 +313,7 @@ def mode[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     )
 
 
-def std[
+def std_dev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -338,7 +338,7 @@ def std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-def std[
+def std_dev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: NDArray[dtype], axis: Int, ddof: Int = 0) raises -> NDArray[
     returned_dtype
@@ -380,7 +380,7 @@ def std[
     return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** 0.5
 
 
-def std[
+def std_dev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], ddof: Int = 0) raises -> Scalar[returned_dtype]:
     """
@@ -405,7 +405,7 @@ def std[
     return variance[returned_dtype](A, ddof=ddof) ** 0.5
 
 
-def std[
+def std_dev[
     dtype: DType, //, returned_dtype: DType = DType.float64
 ](A: Matrix[dtype], axis: Int, ddof: Int = 0) raises -> Matrix[returned_dtype]:
     """

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,13 +34,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [package.build-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [package.run-dependencies]
-modular = "26.2.*"
+modular = "0.26.2.*"
 
 [tasks]
 # compile the package and copy it to the tests folder

--- a/pixi.toml
+++ b/pixi.toml
@@ -69,7 +69,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
-modular = "26.2.*"
+modular = "==26.3.0"
 numpy = ">=2.4.2,<3"
 python = ">=3.14.3,<3.15"
 scipy = ">=1.17.0,<2"

--- a/tests/core/test_operations.mojo
+++ b/tests/core/test_operations.mojo
@@ -1,0 +1,16 @@
+import numojo as nm
+from numojo.prelude import *
+from std.testing.testing import assert_true
+from std.testing import TestSuite
+
+
+def test_ndarray_multiplication_commutes() raises:
+    var A = nm.ones[nm.f64](nm.Shape(2, 2))
+    var B = nm.ones[nm.f64](nm.Shape(2, 2))
+    var L = 2.0 * (A @ B)
+    var R = (A @ B) * 2.0
+    assert_true((L == R).all())
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/routines/test_functional.mojo
+++ b/tests/routines/test_functional.mojo
@@ -32,8 +32,8 @@ def test_apply_along_axis() raises:
 
     for i in range(a.ndim):
         check(
-            apply_along_axis_preserve[DType.float64, nm.sorting.quick_sort_1d](
-                a, axis=i
+            apply_along_axis_preserve[DType.float64](
+                a, axis=i, func1d_arg=nm.sorting.quick_sort_1d
             ),
             np.apply_along_axis(np.sort, axis=i, arr=anp),
             String(
@@ -41,8 +41,8 @@ def test_apply_along_axis() raises:
             ).format(i),
         )
         check(
-            apply_along_axis_preserve[DType.float64, nm.sorting.quick_sort_1d](
-                b, axis=i
+            apply_along_axis_preserve[DType.float64](
+                b, axis=i, func1d_arg=nm.sorting.quick_sort_1d
             ),
             np.apply_along_axis(np.sort, axis=i, arr=bnp),
             String(

--- a/tests/routines/test_indexing.mojo
+++ b/tests/routines/test_indexing.mojo
@@ -23,12 +23,12 @@ def test_compress() raises:
     var bnp = b.to_numpy()
 
     check(
-        numojo.indexing.compress(nm.array[boolean]("[0, 1, 1, 0]"), b),
+        nm.indexing.compress(nm.array[boolean]("[0, 1, 1, 0]"), b),
         np.compress(np.array(Python.list(0, 1, 1, 0)), bnp),
         "`compress` 1-d array is broken",
     )
     check(
-        numojo.indexing.compress(
+        nm.indexing.compress(
             nm.array[boolean]("[0,1,1,0,1,0,1,0,1,1,1]"), a
         ),
         np.compress(

--- a/tests/routines/test_io.mojo
+++ b/tests/routines/test_io.mojo
@@ -1,5 +1,6 @@
 from numojo.routines.io.files import load, save, loadtxt, savetxt
 from numojo import ones, full
+from numojo.prelude import *
 from std.python import Python
 from std import os
 from std.testing import TestSuite
@@ -7,7 +8,7 @@ from std.testing import TestSuite
 
 def test_save_and_load() raises:
     var np = Python.import_module("numpy")
-    var arr = ones[numojo.f32](numojo.Shape(10, 15))
+    var arr = ones[f32](Shape(10, 15))
     var fname = "test_save_load.npy"
     save(fname=fname, array=arr)
     # Load with numpy for cross-check
@@ -22,7 +23,7 @@ def test_save_and_load() raises:
 
 def test_savetxt_and_loadtxt() raises:
     var np = Python.import_module("numpy")
-    var arr = full[numojo.f32](numojo.Shape(10, 15), fill_value=5.0)
+    var arr = full[f32](Shape(10, 15), fill_value=5.0)
     var fname = "test_savetxt_loadtxt.txt"
     savetxt(fname, arr, fmt="%.2f")
     # Load with numpy for cross-check

--- a/tests/routines/test_statistics.mojo
+++ b/tests/routines/test_statistics.mojo
@@ -72,14 +72,16 @@ def test_mean_median_var_std() raises:
         )
 
     assert_true(
-        np.all(np.isclose(nm.std(A), np.std(Anp), atol=PythonObject(0.001))),
-        "`std` is broken",
+        np.all(
+            np.isclose(nm.std_dev(A), np.std(Anp), atol=PythonObject(0.001))
+        ),
+        "`std_dev` is broken",
     )
     for axis in range(3):
         check_is_close(
-            nm.std(A, axis),
+            nm.std_dev(A, axis),
             np.std(Anp, axis),
-            String("`std` is broken for axis {}").format(axis),
+            String("`std_dev` is broken for axis {}").format(axis),
         )
 
 


### PR DESCRIPTION
## Summary

Ports NuMojo from Mojo 0.26.2 to **Mojo 1.0.0b1** (modular 26.3). Starting point was ~510 build errors; the branch now builds with **0 errors**.

Tracking notes with the error-burndown history are in Tokarzewski/NuMojo#1.

## Key changes

- **Higher-order functions**: migrated kernel-as-parameter HOFs to the inferred-parameter form required by 1.0 (`backend.mojo`, `functional.mojo`, matrix base)
- **Lifecycle**: fixed `Copyable` `copy()` ambiguity, `moveinit` field-out-of-middle errors, and leaf lifecycle constructors
- **Cross-module type identity**: switched all package `__init__` files to absolute imports to resolve type-identity divergence between modules
- **SIMD**: completed element-wise comparison migration to the 1.0 API
- **DLPack**: fixed the deleter field for the new ABI (one remaining caveat noted below)
- **List**: negative-index fix
- Warning cleanup: docstring format/parameter names aligned with the real 1.0 signatures, `fn[...]` → `def[...]` in `Backend` trait function-type parameters, deprecated `String(shape)`/`len(out)` replaced with `shape.__str__()`/`out.count_codepoints()`

## Validation (Mojo 1.0.0b1, a9591de6, Linux/WSL)

- `mojo package numojo`: 0 errors, 30 warnings (all remaining warnings are the known `UnsafePointer` null-pointer-model deprecations in `storage.mojo`, `data_container.mojo`, `dlpack.mojo`, `index_buffer.mojo`)
- Test suite: all 22 test files under `tests/core/` and `tests/routines/` pass, plus the `-D F_CONTIGUOUS` re-run of `test_matrix.mojo` — 23/23 runs. (Ran `mojo run -I tests/` per file directly, mirroring `tests/test_all.sh`, since pixi wasn't available in the environment.)

## Known follow-ups (not blocking)

- Mechanical migration of the 30 `UnsafePointer` deprecation warnings (`Optional[UnsafePointer]` / `unsafe_dangling()`)
- DLPack deleter ABI caveat documented in the port notes
- `benchmark/`, `examples/`, and `docs/` trees not yet re-verified against 1.0

Happy to split this into smaller PRs if the maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)