### PR TITLE
[NDArray][Routines] Implement 'take' function

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -258,7 +258,7 @@ from numojo.routines.creation import (
 )
 
 from numojo.routines import indexing
-from numojo.routines.indexing import `where`, compress, take_along_axis
+from numojo.routines.indexing import `where`, compress, take_along_axis, take
 
 
 from numojo.routines import manipulation

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,12 +31,7 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import (
-    NDArrayShape,
-    NDArrayStrides,
-    Flags,
-    newaxis
-)
+from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
 
 from .dtype import (
     i8,

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,7 +31,12 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
+from .layout import (
+    NDArrayShape,
+    NDArrayStrides,
+    Flags,
+    newaxis
+)
 
 from .dtype import (
     i8,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -84,7 +84,7 @@ import numojo.routines.linalg as linalg
 import numojo.routines.sorting as sorting
 import numojo.routines.manipulation as manipulation
 import numojo.routines.statistics as statistics
-from numojo.routines.indexing import compress
+from numojo.routines.indexing import compress, take as _take
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
 import numojo.routines.math as numojo_math
@@ -4828,6 +4828,65 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If the offset is beyond the shape of the array.
         """
         return linalg.diagonal(self, offset=offset)
+
+    def take(self, indices: NDArray[DType.int], axis: Int) raises -> Self:
+        """Takes elements from the array along an axis.
+
+        Output shape is `self.shape[:axis] + indices.shape + self.shape[axis+1:]`.
+
+        Args:
+            indices: Indices to select along the axis. May be any shape.
+                Negative indices are normalised.
+            axis: Axis along which to select. Negative values count from the
+                end.
+
+        Returns:
+            Array of shape `self.shape[:axis] + indices.shape +
+            self.shape[axis+1:]`.
+
+        Raises:
+            Error: If `axis` is out of bounds.
+            Error: If any index is out of bounds for the given axis.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+            print(a.take(nm.array[nm.int]("[2, 0, 1]"), axis=0))
+            # [[8, 9, 10, 11], [0, 1, 2, 3], [4, 5, 6, 7]]
+
+            print(a.take(nm.array[nm.int]("[1, 3]"), axis=1))
+            # [[1, 3], [5, 7], [9, 11]]
+            ```
+        """
+        return _take(self, indices, axis)
+
+    def take(self, indices: NDArray[DType.int]) raises -> Self:
+        """Takes elements from the flattened array by linear indices.
+
+        Equivalent to `self.flatten().take(indices, axis=0)`. Output shape
+        matches `indices.shape`.
+
+        Args:
+            indices: Linear indices into the flattened array. May be any shape.
+
+        Returns:
+            Array with the same shape as `indices`.
+
+        Raises:
+            Error: If any index is out of bounds for the flattened array.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+            print(a.take(nm.array[nm.int]("[0, 5, 11]")))
+            # [0, 5, 11]
+            ```
+        """
+        return _take(self, indices)
 
     def fill(mut self, val: Scalar[Self.dtype]):
         """Fills all items of the array with the given value.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -685,7 +685,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -685,7 +685,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,
@@ -2326,8 +2325,8 @@ struct NDArray[dtype: DType = DType.float64](
             import numojo as nm
 
             var A = nm.arange[nm.f32](6)
-            var mask = A > nm.f32(2.0)
-            A.set(mask, val=nm.f32(0.0))
+            var mask = A > Float32(2.0)
+            A.set(mask, val=Float32(0.0))
             ```
         """
         var value = val
@@ -2417,12 +2416,12 @@ struct NDArray[dtype: DType = DType.float64](
             Error: If any of the slices is out of bound.
 
         Examples:
+            ```mojo
+            import numojo
 
-        ```console
-        >>> import numojo
-        >>> var A = numojo.random.rand[numojo.i16](2, 2, 2)
-        >>> A[1:3, 2:4] = numojo.random.rand[numojo.i16](2, 2)
-        ```.
+            var A = numojo.random.rand[numojo.i16](2, 2, 2)
+            A[1:3, 2:4] = numojo.random.rand[numojo.i16](2, 2)
+            ```.
         """
         var slice_list: List[Slice] = List[Slice]()
         for i in range(slices.__len__()):
@@ -2572,6 +2571,8 @@ struct NDArray[dtype: DType = DType.float64](
 
         Examples:
             ```mojo
+            import numojo as nm
+
             var a = nm.arange[nm.i32](16).reshape(nm.Shape(4, 4))
             var patch = nm.full[nm.i32](nm.Shape(2), fill_value=7)
             a.set(1, Slice(1, 3), val=patch)  # row 1, cols 1-2
@@ -2986,7 +2987,7 @@ struct NDArray[dtype: DType = DType.float64](
             import numojo as nm
 
             var A = nm.arange[nm.f32](6).reshape(nm.Shape(2, 3))
-            var mask = A > nm.f32(2.0)
+            var mask = A > Float32(2.0)
             var vals = nm.array[nm.f32]("[10.0, 20.0, 30.0]")
             A.set(mask, val=vals)
             ```

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -685,6 +685,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
+
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -151,7 +151,7 @@ from .creation import (
     array,
 )
 
-from .indexing import `where`, compress, take_along_axis
+from .indexing import `where`, compress, take_along_axis, take
 
 from .functional import (
     apply_along_axis_reduce,

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -388,7 +388,9 @@ def take[
     a: NDArray[dtype],
     indices: NDArray[DType.int],
     axis: Int,
-) raises -> NDArray[dtype]:
+) raises -> NDArray[
+    dtype
+]:
     """Takes elements from an array along an axis.
 
     Output shape is `a.shape[:axis] + indices.shape + a.shape[axis+1:]`.
@@ -473,7 +475,9 @@ def take[
             if norm_idx < 0:
                 norm_idx += axis_size
 
-            var src_base = outer * axis_size * inner_size + norm_idx * inner_size
+            var src_base = (
+                outer * axis_size * inner_size + norm_idx * inner_size
+            )
             var dst_base = outer * n_idx * inner_size + i * inner_size
             memcpy(
                 dest=result._buf.ptr + dst_base,
@@ -487,10 +491,7 @@ def take[
 def take[
     dtype: DType,
     //,
-](
-    a: NDArray[dtype],
-    indices: NDArray[DType.int],
-) raises -> NDArray[dtype]:
+](a: NDArray[dtype], indices: NDArray[DType.int],) raises -> NDArray[dtype]:
     """Takes elements from a flattened array by linear indices.
 
     Equivalent to `take(a.flatten(), indices, axis=0)`. The output shape

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -22,6 +22,7 @@ from numojo.core.ndarray import NDArray
 from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.indexing import IndexMethods
 import numojo.routines.manipulation as manipulation
+from numojo.routines.creation import array as _array_creation_from_list
 
 # ===----------------------------------------------------------------------=== #
 # Generating index arrays
@@ -522,3 +523,41 @@ def take[
     """
     var flat = manipulation.ravel(a)
     return take(flat, indices, axis=0)
+
+
+# TODO: Add this after Scalar[DType.int] and Int are merged in Mojo. a
+# def take[
+#     dtype: DType,
+#     //,
+# ](a: NDArray[dtype], indices: List[Scalar[DType.int]],) raises -> NDArray[dtype]:
+#     """Takes elements from a flattened array by linear indices.
+
+#     Equivalent to `take(a.flatten(), indices, axis=0)`. The output shape
+#     matches `indices.shape`.
+
+#     Parameters:
+#         dtype: Data type of the source array.
+
+#     Args:
+#         a: Source array (flattened before indexing).
+#         indices: List of linear indices into the flattened source (1D).
+
+#     Returns:
+#         Array with the same shape as `indices`.
+
+#     Raises:
+#         Error: If any index is out of bounds for the flattened array.
+
+#     Examples:
+#         ```mojo
+#         import numojo as nm
+
+#         var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+#         print(nm.indexing.take(a, nm.array[nm.int]("[0, 5, 11]")))
+#         # [0, 5, 11]
+#         ```
+#         .
+#     """
+#     var shape: List[Scalar[DType.int]] = [Scalar[DType.int](len(indices))]
+#     var arr = _array_creation_from_list[dtype](indices, shape)
+#     return take(arr, indices, axis=0)

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -19,8 +19,9 @@ from std.algorithm import vectorize
 
 from numojo import broadcast_to
 from numojo.core.ndarray import NDArray
-from numojo.core.layout import NDArrayStrides
+from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.indexing import IndexMethods
+import numojo.routines.manipulation as manipulation
 
 # ===----------------------------------------------------------------------=== #
 # Generating index arrays
@@ -373,3 +374,150 @@ def take_along_axis[
                 )
 
     return result^
+
+
+# ===----------------------------------------------------------------------=== #
+# take
+# ===----------------------------------------------------------------------=== #
+
+
+def take[
+    dtype: DType,
+    //,
+](
+    a: NDArray[dtype],
+    indices: NDArray[DType.int],
+    axis: Int,
+) raises -> NDArray[dtype]:
+    """Takes elements from an array along an axis.
+
+    Output shape is `a.shape[:axis] + indices.shape + a.shape[axis+1:]`.
+    Negative indices into `a` along the axis are normalised. Negative `axis`
+    values are also normalised.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Source array.
+        indices: Indices of values to take along the axis.
+        axis: Axis along which to select. Negative values count from the end.
+
+    Returns:
+        Array of shape `a.shape[:axis] + indices.shape + a.shape[axis+1:]`.
+
+    Raises:
+        Error: If `axis` is out of bounds.
+        Error: If any index is out of bounds for the given axis.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+
+        print(nm.indexing.take(a, nm.array[nm.int]("[2, 0, 1]"), axis=0))
+        # shape (3, 4): rows 2, 0, 1
+        #
+        print(nm.indexing.take(a, nm.array[nm.int]("[1, 3]"), axis=1))
+        # shape (3, 2): cols 1, 3
+        ```
+        .
+    """
+    var norm_axis = axis
+    if norm_axis < 0:
+        norm_axis = a.ndim + norm_axis
+    if norm_axis < 0 or norm_axis >= a.ndim:
+        raise Error(
+            String(
+                "\nError in `take`: axis {} is out of bounds for array with"
+                " {} dimensions."
+            ).format(axis, a.ndim)
+        )
+
+    # a.shape[:axis] + indices.shape + a.shape[axis+1:]
+    var out_shape_list = List[Int]()
+    for d in range(norm_axis):
+        out_shape_list.append(a.shape[d])
+    for d in range(indices.ndim):
+        out_shape_list.append(indices.shape[d])
+    for d in range(norm_axis + 1, a.ndim):
+        out_shape_list.append(a.shape[d])
+
+    var result = NDArray[dtype](NDArrayShape(out_shape_list))
+
+    # Sizes product(a.shape[:axis]) + indices.size + product(a.shape[axis+1:])
+    var outer_size = 1
+    for d in range(norm_axis):
+        outer_size *= a.shape[d]
+    var n_idx = indices.size
+    var inner_size = 1
+    for d in range(norm_axis + 1, a.ndim):
+        inner_size *= a.shape[d]
+
+    var axis_size = a.shape[norm_axis]
+    var indices_c = indices.contiguous()
+    var a_c = a.contiguous()
+
+    for outer in range(outer_size):
+        for i in range(n_idx):
+            var raw = Int(indices_c._buf.ptr[i])
+            if raw < -axis_size or raw >= axis_size:
+                raise Error(
+                    String(
+                        "\nError in `take`: index {} is out of bounds for"
+                        " axis {} with size {}."
+                    ).format(raw, norm_axis, axis_size)
+                )
+            var norm_idx = raw
+            if norm_idx < 0:
+                norm_idx += axis_size
+
+            var src_base = outer * axis_size * inner_size + norm_idx * inner_size
+            var dst_base = outer * n_idx * inner_size + i * inner_size
+            memcpy(
+                dest=result._buf.ptr + dst_base,
+                src=a_c._buf.ptr + src_base,
+                count=inner_size,
+            )
+
+    return result^
+
+
+def take[
+    dtype: DType,
+    //,
+](
+    a: NDArray[dtype],
+    indices: NDArray[DType.int],
+) raises -> NDArray[dtype]:
+    """Takes elements from a flattened array by linear indices.
+
+    Equivalent to `take(a.flatten(), indices, axis=0)`. The output shape
+    matches `indices.shape`.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Source array (flattened before indexing).
+        indices: Linear indices into the flattened source. May be any shape.
+
+    Returns:
+        Array with the same shape as `indices`.
+
+    Raises:
+        Error: If any index is out of bounds for the flattened array.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+        print(nm.indexing.take(a, nm.array[nm.int]("[0, 5, 11]")))
+        # [0, 5, 11]
+        ```
+        .
+    """
+    var flat = manipulation.ravel(a)
+    return take(flat, indices, axis=0)


### PR DESCRIPTION
This PR implements support for `take` function which works in the following manner, 

```mojo
import numojo as nm
from numojo.prelude import *

def main() raises:
    var a = nm.arange[nm.i32](12).reshape(Shape(3, 4))
    print("a =")
    print(a)

    # take along axis 0: select rows 2, 0, 1
    var idx0 = nm.array[int]("[2, 0, 1]")
    print("take(a, [2,0,1], axis=0):")
    print(a.take(idx0, axis=0))

    # take along axis 1: select cols 1, 3
    var idx1 = nm.array[int]("[1, 3]")
    print("take(a, [1,3], axis=1):")
    print(a.take(idx1, axis=1))

    # flat take
    var idxf = nm.array[int]("[0, 5, 11]")
    print("take(a, [0,5,11]) flat:")
    print(a.take(idxf))

    # negative index
    var idxn = nm.array[int]("[-1]")
    print("take(a, [-1], axis=0) (last row):")
    print(a.take(idxn, axis=0))

    # free function
    print("nm.take(a, [2,0,1], axis=0):")
    print(nm.take(a, idx0, axis=0))
```