### PR TITLE
[NDArray][Routines] Implement `nonzero` function

### DIFF
--- a/docs/developer-guide/style_example.mojo
+++ b/docs/developer-guide/style_example.mojo
@@ -26,8 +26,8 @@ def func[param: Copyable](arg1: param) -> param:
     Returns:
         Describe what is returned.
 
-    Notes: 
-        Any additional notes related to the function that user must know. 
+    Notes:
+        Any additional notes related to the function that user must know.
     """
     return arg1
 

--- a/docs/developer-guide/style_example.mojo
+++ b/docs/developer-guide/style_example.mojo
@@ -25,6 +25,9 @@ def func[param: Copyable](arg1: param) -> param:
 
     Returns:
         Describe what is returned.
+
+    Notes: 
+        Any additional notes related to the function that user must know. 
     """
     return arg1
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -258,7 +258,13 @@ from numojo.routines.creation import (
 )
 
 from numojo.routines import indexing
-from numojo.routines.indexing import `where`, compress, take_along_axis, take
+from numojo.routines.indexing import (
+    `where`,
+    compress,
+    take_along_axis,
+    take,
+    nonzero,
+)
 
 
 from numojo.routines import manipulation

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,12 +31,7 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import (
-    NDArrayShape,
-    NDArrayStrides,
-    Flags,
-    newaxis
-)
+from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
 
 from .dtype import (
     i8,

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,7 +31,12 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
+from .layout import (
+    NDArrayShape,
+    NDArrayStrides,
+    Flags,
+    newaxis
+)
 
 from .dtype import (
     i8,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -84,7 +84,7 @@ import numojo.routines.linalg as linalg
 import numojo.routines.sorting as sorting
 import numojo.routines.manipulation as manipulation
 import numojo.routines.statistics as statistics
-from numojo.routines.indexing import compress, take as _take
+from numojo.routines.indexing import compress, take as _take, nonzero as _nonzero
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
 import numojo.routines.math as numojo_math
@@ -4692,6 +4692,31 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         return compress(condition=condition, a=self)
+
+    def nonzero(self) raises -> List[NDArray[DType.int]]:
+        """Returns the indices of non-zero elements, one array per dimension.
+        Each array in the returned list contains the coordinates of non-zero
+        elements along that dimension, in C-order.
+
+        Returns:
+            A `List` of `ndim` 1-D integer arrays. The i-th array contains the
+            indices along dimension `i` of all non-zero elements.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+            var idx = a.nonzero()
+            print(idx[0])  # [0, 2, 4]
+
+            var b = nm.array[nm.i32]("[[1, 0], [0, 4]]")
+            var idx2 = b.nonzero()
+            print(idx2[0])  # [0, 1]
+            print(idx2[1])  # [0, 1]
+            ```
+        """
+        return _nonzero(self)
 
     def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -685,7 +685,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -84,7 +84,11 @@ import numojo.routines.linalg as linalg
 import numojo.routines.sorting as sorting
 import numojo.routines.manipulation as manipulation
 import numojo.routines.statistics as statistics
-from numojo.routines.indexing import compress, take as _take, nonzero as _nonzero
+from numojo.routines.indexing import (
+    compress,
+    take as _take,
+    nonzero as _nonzero,
+)
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
 import numojo.routines.math as numojo_math

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -685,6 +685,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
+
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -151,7 +151,7 @@ from .creation import (
     array,
 )
 
-from .indexing import `where`, compress, take_along_axis, take
+from .indexing import `where`, compress, take_along_axis, take, nonzero
 
 from .functional import (
     apply_along_axis_reduce,

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -561,3 +561,74 @@ def take[
 #     var shape: List[Scalar[DType.int]] = [Scalar[DType.int](len(indices))]
 #     var arr = _array_creation_from_list[dtype](indices, shape)
 #     return take(arr, indices, axis=0)
+
+
+# ===----------------------------------------------------------------------=== #
+# nonzero
+# ===----------------------------------------------------------------------=== #
+
+
+def nonzero[
+    dtype: DType,
+    //,
+](a: NDArray[dtype]) raises -> List[NDArray[DType.int]]:
+    """Returns the indices of elements that are non-zero.
+
+    Returns a list of 1-D index arrays, one per dimension of `a`. Each array
+    contains the coordinates of non-zero elements along that dimension. This
+    mirrors `numpy.nonzero(a)`.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Input array.
+
+    Returns:
+        A `List` of `ndim` 1-D integer arrays. The i-th array contains the
+        indices along dimension `i` of all non-zero elements.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+        var idx = nm.nonzero(a)
+        print(idx[0])  # [0, 2, 4]
+
+        var b = nm.array[nm.i32]("[[1, 0], [0, 4]]")
+        var idx2 = nm.nonzero(b)
+        print(idx2[0])  # [0, 1]  (row indices)
+        print(idx2[1])  # [0, 1]  (col indices)
+        ```
+        .
+    """
+    var a_c = a.contiguous()
+
+    var count: Int = 0
+    for i in range(a_c.size):
+        if a_c._buf.ptr[i] != 0:
+            count += 1
+
+    if count == 0:
+        raise Error(
+            String(
+                "\nError in `nonzero`: array has no non-zero elements."
+                " Empty index arrays are not supported."
+            )
+        )
+    var result = List[NDArray[DType.int]]()
+    for _ in range(a.ndim):
+        result.append(NDArray[DType.int](NDArrayShape(count)))
+
+    var out_idx = 0
+    for flat in range(a_c.size):
+        if a_c._buf.ptr[flat] != 0:
+            var rem = flat
+            for d in range(a.ndim - 1, -1, -1):
+                var coord = rem % a.shape[d]
+                rem //= a.shape[d]
+                result[d]._buf.ptr[out_idx] = Scalar[DType.int](coord)
+            out_idx += 1
+
+    return result^


### PR DESCRIPTION
This PR implements the `nonzero` function which does the following, 
```mojo
import numojo as nm
from numojo.prelude import *

def main() raises:
    # 1-D test
    var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
    var idx = a.nonzero()
    print("1-D nonzero indices:", idx[0])

    # 2-D test
    var b = nm.array[nm.i32]("[[1, 0], [0, 4]]")
    var idx2 = b.nonzero()
    print("2-D row indices:", idx2[0])
    print("2-D col indices:", idx2[1])
```