### PR TITLE
[ndarray] Fix layout-unsafe bool-mask getter/setter paths from PR #360

### DIFF
--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1594,7 +1594,7 @@ struct NDArray[dtype: DType = DType.float64](
                         message=String(
                             "Boolean mask shape {} does not match the leading"
                             " dimensions of array shape {}. Mask shape must"
-                            " equal self.shape[:{}}."
+                            " equal self.shape[:{}]."
                         ).format(mask.shape, self.shape, mask.ndim),
                         location=(
                             "NDArray.__getitem__(mask: NDArray[DType.bool])"
@@ -1631,40 +1631,28 @@ struct NDArray[dtype: DType = DType.float64](
             for i in range(k, self.ndim):
                 result_shape_list.append(self.shape[i])
             var result = NDArray[Self.dtype](NDArrayShape(result_shape_list))
+            var size_per_item = self._trailing_size(k)
 
-            # size of one sub-array = product(self.shape[k:])
-            var size_per_item = 1
-            for i in range(k, self.ndim):
-                size_per_item *= self.shape[i]
-
-            var self_c = self.contiguous()
+            # Walk the mask linearly; decode flat index → leading coords using
+            # mask shape (= self.shape[:k]); compute the strided offset into
+            # self via self.strides[:k]; gather the trailing block respecting
+            # self.strides[k:]. No `self.contiguous()` copy required.
+            var coords = List[Int](length=k, fill=0)
             var out_offset = 0
-
-            # Precompute C-order strides for the first k dims of self_c.
-            # stride[d] = product(self.shape[d+1:self.ndim])
-            # = product(self.shape[d+1:k]) * size_per_item
-            var src_strides = List[Int](capacity=k)
-            for d in range(k):
-                var s = size_per_item
-                for dd in range(d + 1, k):
-                    s *= self.shape[dd]
-                src_strides.append(s)
-
-            # Walk the mask linearly; decode flat index → k-D coords.
             for flat in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](flat):
-                    var src_offset = 0
-                    var remaining = flat
+                    var rem = flat
                     for d in range(k - 1, -1, -1):
-                        src_offset += (remaining % self.shape[d]) * src_strides[
-                            d
-                        ]
-                        remaining //= self.shape[d]
-
-                    memcpy(
-                        dest=result._buf.ptr + out_offset * size_per_item,
-                        src=self_c._buf.ptr + src_offset,
-                        count=size_per_item,
+                        var dim = Int(self.shape.unsafe_load(d))
+                        coords[d] = rem % dim
+                        rem //= dim
+                    var src_base = self.offset
+                    for d in range(k):
+                        src_base += coords[d] * Int(self.strides.unsafe_load(d))
+                    self._read_block_from_self(
+                        base=src_base,
+                        axis_start=k,
+                        dst_ptr=result._buf.ptr + out_offset * size_per_item,
                     )
                     out_offset += 1
 
@@ -2344,13 +2332,18 @@ struct NDArray[dtype: DType = DType.float64](
             return
 
         # CASE 2: 1-D mask matching first dimension — write scalar to every
-        # element of each selected axis-0 slice.
+        # element of each selected axis-0 slice (sub-array of shape
+        # self.shape[1:]). Uses self.strides[0] / self.strides[1:], so this
+        # works for any layout.
         if mask.ndim == 1 and mask.shape[0] == self.shape[0]:
-            var size_per_item = self.size // self.shape[0]
+            var stride0 = Int(self.strides.unsafe_load(0))
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
-                    for j in range(size_per_item):
-                        self.itemset(i * size_per_item + j, value)
+                    self._fill_block_in_self(
+                        base=self.offset + i * stride0,
+                        axis_start=1,
+                        value=value,
+                    )
             return
 
         # CASE 3: k-D mask (1 < k < self.ndim) matching self.shape[:k].
@@ -2372,26 +2365,20 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
             var k = mask.ndim
-            var size_per_item = 1
-            for i in range(k, self.ndim):
-                size_per_item *= self.shape[i]
-
-            var src_strides = List[Int](capacity=k)
-            for d in range(k):
-                var s = size_per_item
-                for dd in range(d + 1, k):
-                    s *= self.shape[dd]
-                src_strides.append(s)
-
+            var coords = List[Int](length=k, fill=0)
             for flat in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](flat):
-                    var base = 0
-                    var remaining = flat
+                    var rem = flat
                     for d in range(k - 1, -1, -1):
-                        base += (remaining % self.shape[d]) * src_strides[d]
-                        remaining //= self.shape[d]
-                    for j in range(size_per_item):
-                        self.itemset(base + j, value)
+                        var dim = Int(self.shape.unsafe_load(d))
+                        coords[d] = rem % dim
+                        rem //= dim
+                    var lead = self.offset
+                    for d in range(k):
+                        lead += coords[d] * Int(self.strides.unsafe_load(d))
+                    self._fill_block_in_self(
+                        base=lead, axis_start=k, value=value
+                    )
             return
 
         raise Error(
@@ -2988,8 +2975,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         Examples:
             ```mojo
-            import numojo as nm
-
+            from numojo.prelude import *
             var A = nm.arange[nm.f32](6).reshape(nm.Shape(2, 3))
             var mask = A > Float32(2.0)
             var vals = nm.array[nm.f32]("[10.0, 20.0, 30.0]")
@@ -3042,7 +3028,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # CASE 2: 1-D mask matching first dimension.
         if mask.ndim == 1 and mask.shape[0] == self.shape[0]:
-            var size_per_item = self.size // self.shape[0]
+            var size_per_item = self._trailing_size(1)
             var true_count = 0
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
@@ -3070,16 +3056,17 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
 
+            var stride0 = Int(self.strides.unsafe_load(0))
             var out_row = 0
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
                     var src_ptr = val_c._buf.ptr + (
                         out_row * size_per_item if val_is_per_index else 0
                     )
-                    memcpy(
-                        dest=self._buf.ptr + self.offset + i * size_per_item,
-                        src=src_ptr,
-                        count=size_per_item,
+                    self._write_block_into_self(
+                        base=self.offset + i * stride0,
+                        axis_start=1,
+                        src_ptr=src_ptr,
                     )
                     out_row += 1
             return
@@ -3104,9 +3091,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
 
             var k = mask.ndim
-            var size_per_item = 1
-            for i in range(k, self.ndim):
-                size_per_item *= self.shape[i]
+            var size_per_item = self._trailing_size(k)
 
             var true_count = 0
             for i in range(mask_c.size):
@@ -3121,7 +3106,7 @@ struct NDArray[dtype: DType = DType.float64](
                 and NDArrayShape(val_c.shape[1:]) == tail_shape
             )
 
-            if not val_is_single and not val_is_per_index and val_c.size != 1:
+            if not val_is_single and not val_is_per_index:
                 raise Error(
                     NumojoError(
                         category="shape",
@@ -3133,42 +3118,30 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
 
-            var src_strides = List[Int](capacity=k)
-            for d in range(k):
-                var s = size_per_item
-                for dd in range(d + 1, k):
-                    s *= self.shape[dd]
-                src_strides.append(s)
-
-            # Work on a contiguous copy, then write back unconditionally.
-            # This handles both C- and F-order destinations correctly.
-            var self_c = self.contiguous()
+            # Layout-safe write: decode each True flat index into k-D coords
+            # via mask shape, compute the leading byte offset using
+            # self.strides[:k], then dispatch the trailing block write through
+            # `_write_block_into_self`, which respects self.strides[k:] (so it
+            # works for C-contig, F-contig, and arbitrary strided views).
+            var coords = List[Int](length=k, fill=0)
             var out_row = 0
             for flat in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](flat):
-                    var dst_offset = 0
-                    var remaining = flat
+                    var rem = flat
                     for d in range(k - 1, -1, -1):
-                        dst_offset += (remaining % self.shape[d]) * src_strides[
-                            d
-                        ]
-                        remaining //= self.shape[d]
-
+                        var dim = Int(self.shape.unsafe_load(d))
+                        coords[d] = rem % dim
+                        rem //= dim
+                    var lead = self.offset
+                    for d in range(k):
+                        lead += coords[d] * Int(self.strides.unsafe_load(d))
                     var src_ptr = val_c._buf.ptr + (
                         out_row * size_per_item if val_is_per_index else 0
                     )
-                    memcpy(
-                        dest=self_c._buf.ptr + dst_offset,
-                        src=src_ptr,
-                        count=size_per_item,
+                    self._write_block_into_self(
+                        base=lead, axis_start=k, src_ptr=src_ptr
                     )
                     out_row += 1
-
-            memcpy(
-                dest=self._buf.ptr + self.offset,
-                src=self_c._buf.ptr,
-                count=self.size,
-            )
             return
 
         raise Error(
@@ -4346,6 +4319,134 @@ struct NDArray[dtype: DType = DType.float64](
             Pointer(to=self),
             dimension=0,
         )
+
+    # ===-------------------------------------------------------------------===#
+    # Internal layout-aware block I/O helpers used by boolean-mask getter/setter
+    # paths. These respect `self.strides` so they work for C-contig, F-contig,
+    # and arbitrary strided views.
+    # ===-------------------------------------------------------------------===#
+
+    def _trailing_is_contig(self, axis_start: Int) -> Bool:
+        """Returns True iff dims [axis_start, ndim) form a contiguous block in
+        self._buf (i.e. the trailing strides match a dense C-order layout)."""
+        var expected = 1
+        for d in range(self.ndim - 1, axis_start - 1, -1):
+            var s = Int(self.shape.unsafe_load(d))
+            if s > 1:
+                if Int(self.strides.unsafe_load(d)) != expected:
+                    return False
+                expected *= s
+        return True
+
+    def _trailing_size(self, axis_start: Int) -> Int:
+        var n = 1
+        for d in range(axis_start, self.ndim):
+            n *= Int(self.shape.unsafe_load(d))
+        return n
+
+    def _write_block_into_self(
+        mut self,
+        base: Int,
+        axis_start: Int,
+        src_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+    ) raises:
+        """Writes a C-contiguous source block of `prod(shape[axis_start:])`
+        elements into self at offset `base`, following `self.strides[axis_start:]`.
+        """
+        var n_trail = self.ndim - axis_start
+        if n_trail <= 0:
+            self._buf.ptr.store(base, src_ptr.load[width=1](0))
+            return
+        var size_per_item = self._trailing_size(axis_start)
+        if self._trailing_is_contig(axis_start):
+            memcpy(dest=self._buf.ptr + base, src=src_ptr, count=size_per_item)
+            return
+        var tcoords = List[Int](length=n_trail, fill=0)
+        var j = 0
+        while True:
+            var off = base
+            for d in range(n_trail):
+                off += tcoords[d] * Int(
+                    self.strides.unsafe_load(axis_start + d)
+                )
+            self._buf.ptr.store(off, src_ptr.load[width=1](j))
+            j += 1
+            var d = n_trail - 1
+            while d >= 0:
+                tcoords[d] += 1
+                if tcoords[d] < Int(self.shape.unsafe_load(axis_start + d)):
+                    break
+                tcoords[d] = 0
+                d -= 1
+            if d < 0:
+                break
+
+    def _fill_block_in_self(
+        mut self,
+        base: Int,
+        axis_start: Int,
+        value: Scalar[Self.dtype],
+    ) raises:
+        """Fills `prod(shape[axis_start:])` elements of self starting at offset
+        `base` with `value`, following `self.strides[axis_start:]`."""
+        var n_trail = self.ndim - axis_start
+        if n_trail <= 0:
+            self._buf.ptr.store(base, value)
+            return
+        var tcoords = List[Int](length=n_trail, fill=0)
+        while True:
+            var off = base
+            for d in range(n_trail):
+                off += tcoords[d] * Int(
+                    self.strides.unsafe_load(axis_start + d)
+                )
+            self._buf.ptr.store(off, value)
+            var d = n_trail - 1
+            while d >= 0:
+                tcoords[d] += 1
+                if tcoords[d] < Int(self.shape.unsafe_load(axis_start + d)):
+                    break
+                tcoords[d] = 0
+                d -= 1
+            if d < 0:
+                break
+
+    def _read_block_from_self(
+        self,
+        base: Int,
+        axis_start: Int,
+        dst_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+    ) raises:
+        """Reads `prod(shape[axis_start:])` elements from self starting at
+        offset `base` (following `self.strides[axis_start:]`) into the
+        C-contiguous destination block `dst_ptr`."""
+        var n_trail = self.ndim - axis_start
+        if n_trail <= 0:
+            dst_ptr.store(0, self._buf.ptr.load[width=1](base))
+            return
+        var size_per_item = self._trailing_size(axis_start)
+        if self._trailing_is_contig(axis_start):
+            memcpy(dest=dst_ptr, src=self._buf.ptr + base, count=size_per_item)
+            return
+        var tcoords = List[Int](length=n_trail, fill=0)
+        var j = 0
+        while True:
+            var off = base
+            for d in range(n_trail):
+                off += tcoords[d] * Int(
+                    self.strides.unsafe_load(axis_start + d)
+                )
+            dst_ptr.store(j, self._buf.ptr.load[width=1](off))
+            j += 1
+            var d = n_trail - 1
+            while d >= 0:
+                tcoords[d] += 1
+                if tcoords[d] < Int(self.shape.unsafe_load(axis_start + d)):
+                    break
+                tcoords[d] = 0
+                d -= 1
+            if d < 0:
+                break
 
     def _array_to_string(
         self,

--- a/tests/core/test_bool_mask_nd.mojo
+++ b/tests/core/test_bool_mask_nd.mojo
@@ -229,5 +229,231 @@ def test_setitem_exact_shape_ndarray_regression() raises:
     assert_equal(Int(a.item(1, 0)), 3)
 
 
+# ===-------------------------------------------------------------------=== #
+# Layout-safety: F-order and strided-view destinations.
+# These regression tests pin the behavior of the k-D / 1-D mask paths when
+# `self` is NOT C-contiguous. Previous implementations assumed C-order and
+# silently corrupted data for these cases.
+# ===-------------------------------------------------------------------=== #
+
+
+def test_getitem_2d_mask_on_3d_f_order() raises:
+    """K-D mask getter must read correct values when self is F-order."""
+    # Same logical values as the C-order test, but F-order storage.
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4), order="F")
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    var result = a[mask]
+
+    assert_equal(result.ndim, 2)
+    assert_equal(result.shape[0], 2)
+    assert_equal(result.shape[1], 4)
+    # a[0, 1, :] in logical (i,j,k) terms — values come from F-storage decode.
+    for k in range(4):
+        assert_equal(Int(result.item(0, k)), Int(a.item(0, 1, k)))
+        assert_equal(Int(result.item(1, k)), Int(a.item(1, 2, k)))
+
+
+def test_setitem_scalar_2d_mask_on_3d_f_order() raises:
+    """K-D scalar setter must write through F-order strides."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4), order="F")
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    # Snapshot untouched positions for the "no neighbor corruption" check.
+    var v_002 = Int(a.item(0, 0, 2))
+    var v_103 = Int(a.item(1, 0, 3))
+
+    a.set(mask, val=Scalar[nm.i32](-7))
+
+    # Selected sub-arrays are all -7
+    for k in range(4):
+        assert_equal(Int(a.item(0, 1, k)), -7)
+        assert_equal(Int(a.item(1, 2, k)), -7)
+    # Untouched positions still hold their original values (strides honored).
+    assert_equal(Int(a.item(0, 0, 2)), v_002)
+    assert_equal(Int(a.item(1, 0, 3)), v_103)
+
+
+def test_setitem_ndarray_2d_mask_on_3d_f_order_per_index() raises:
+    """K-D NDArray setter with per-index val must write through F-order."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4), order="F")
+    # Snapshot one untouched value to verify F-strides are respected.
+    var v_120 = Int(a.item(1, 2, 0))
+    # Override v_120 only if it's not in a selected slice; (1, 2, *) IS selected
+    # so use a different untouched probe.
+    var v_010 = Int(a.item(0, 1, 0))
+
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 0], True)
+    mask.itemset([1, 2], True)
+
+    # val shape (2, 4) — C-contig per design.
+    var val = nm.zeros[nm.i32](Shape(2, 4))
+    for k in range(4):
+        val.itemset(k, Scalar[nm.i32](10 + k))
+        val.itemset(4 + k, Scalar[nm.i32](20 + k))
+
+    a.set(mask, val=val)
+
+    for k in range(4):
+        assert_equal(Int(a.item(0, 0, k)), 10 + k)
+        assert_equal(Int(a.item(1, 2, k)), 20 + k)
+    # Untouched position untouched.
+    assert_equal(Int(a.item(0, 1, 0)), v_010)
+    _ = v_120
+
+
+def test_setitem_scalar_1d_mask_on_3d_f_order() raises:
+    """CASE 2 scalar setter (1-D mask, n-D self) must respect F-order."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(3, 2, 4), order="F")
+    # Snapshot row 1 values (will NOT be touched).
+    var snap = List[Int]()
+    for j in range(2):
+        for k in range(4):
+            snap.append(Int(a.item(1, j, k)))
+
+    var mask = nm.array[nm.boolean]("[1, 0, 1]")
+    a.set(mask, val=Scalar[nm.i32](42))
+
+    # Every element of rows 0 and 2 (across both trailing dims) is 42.
+    for j in range(2):
+        for k in range(4):
+            assert_equal(Int(a.item(0, j, k)), 42)
+            assert_equal(Int(a.item(2, j, k)), 42)
+    # Row 1 untouched.
+    var idx = 0
+    for j in range(2):
+        for k in range(4):
+            assert_equal(Int(a.item(1, j, k)), snap[idx])
+            idx += 1
+
+
+def test_setitem_ndarray_1d_mask_on_3d_f_order_single_subarray() raises:
+    """CASE 2 NDArray setter, single broadcast sub-array, F-order self."""
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(3, 2, 4), order="F")
+    var snap = List[Int]()
+    for j in range(2):
+        for k in range(4):
+            snap.append(Int(a.item(1, j, k)))
+
+    var mask = nm.array[nm.boolean]("[1, 0, 1]")
+    # val shape (2, 4) matches self.shape[1:].
+    var val = nm.arange[nm.i32](100, 108).reshape(Shape(2, 4))
+
+    a.set(mask, val=val)
+
+    for j in range(2):
+        for k in range(4):
+            assert_equal(Int(a.item(0, j, k)), 100 + j * 4 + k)
+            assert_equal(Int(a.item(2, j, k)), 100 + j * 4 + k)
+    var idx = 0
+    for j in range(2):
+        for k in range(4):
+            assert_equal(Int(a.item(1, j, k)), snap[idx])
+            idx += 1
+
+
+def test_setitem_scalar_2d_mask_on_strided_view() raises:
+    """K-D scalar setter into a strided view (slice with step) must not
+    corrupt the parent at positions that are not part of the view."""
+    # Parent: 4x3x4 C-contig, all zeros. View = parent[0:4:2, :, :], i.e.
+    # rows 0 and 2 of the parent. View shape = (2, 3, 4), stride[0] = 24.
+    var parent = nm.zeros[nm.i32](Shape(4, 3, 4))
+    # Sentinel values into the rows that should NOT be touched (rows 1 and 3).
+    for j in range(3):
+        for k in range(4):
+            parent.itemset([1, j, k], Scalar[nm.i32](-1))
+            parent.itemset([3, j, k], Scalar[nm.i32](-2))
+
+    var view = parent[Slice(0, 4, 2), Slice(0, 3), Slice(0, 4)]
+    assert_equal(view.shape[0], 2)
+    assert_equal(view.shape[1], 3)
+    assert_equal(view.shape[2], 4)
+
+    # 2-D mask of shape (2, 3): True at (0, 1) and (1, 2).
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    view.set(mask, val=Scalar[nm.i32](7))
+
+    # Within the view, written positions are 7; others zero.
+    for j in range(3):
+        for k in range(4):
+            if j == 1:
+                assert_equal(Int(view.item(0, j, k)), 7)
+            else:
+                assert_equal(Int(view.item(0, j, k)), 0)
+            if j == 2:
+                assert_equal(Int(view.item(1, j, k)), 7)
+            else:
+                assert_equal(Int(view.item(1, j, k)), 0)
+
+    # Critical: the skipped parent rows must still hold their sentinel values.
+    for j in range(3):
+        for k in range(4):
+            assert_equal(Int(parent.item(1, j, k)), -1)
+            assert_equal(Int(parent.item(3, j, k)), -2)
+
+
+def test_setitem_ndarray_2d_mask_on_strided_view_per_index() raises:
+    """K-D NDArray setter with per-index val into a strided view."""
+    var parent = nm.zeros[nm.i32](Shape(4, 3, 4))
+    for j in range(3):
+        for k in range(4):
+            parent.itemset([1, j, k], Scalar[nm.i32](-1))
+            parent.itemset([3, j, k], Scalar[nm.i32](-2))
+
+    var view = parent[Slice(0, 4, 2), Slice(0, 3), Slice(0, 4)]
+
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 0], True)
+    mask.itemset([1, 2], True)
+
+    # val shape (2, 4) — row 0 → [10..13], row 1 → [20..23]
+    var val = nm.zeros[nm.i32](Shape(2, 4))
+    for k in range(4):
+        val.itemset(k, Scalar[nm.i32](10 + k))
+        val.itemset(4 + k, Scalar[nm.i32](20 + k))
+
+    view.set(mask, val=val)
+
+    for k in range(4):
+        assert_equal(Int(view.item(0, 0, k)), 10 + k)
+        assert_equal(Int(view.item(1, 2, k)), 20 + k)
+    # Other view positions still zero.
+    assert_equal(Int(view.item(0, 1, 0)), 0)
+    assert_equal(Int(view.item(1, 0, 0)), 0)
+    # Skipped parent rows still hold sentinels.
+    for j in range(3):
+        for k in range(4):
+            assert_equal(Int(parent.item(1, j, k)), -1)
+            assert_equal(Int(parent.item(3, j, k)), -2)
+
+
+def test_getitem_2d_mask_on_strided_view() raises:
+    """K-D mask getter on a strided view must gather from the correct
+    parent positions, not from `view.contiguous()`'s buffer."""
+    var parent = nm.arange[nm.i32](0, 48).reshape(Shape(4, 3, 4))
+    var view = parent[Slice(0, 4, 2), Slice(0, 3), Slice(0, 4)]
+    # view[i, j, k] should equal parent[2*i, j, k].
+
+    var mask = nm.zeros[nm.boolean](Shape(2, 3))
+    mask.itemset([0, 1], True)
+    mask.itemset([1, 2], True)
+
+    var result = view[mask]
+
+    for k in range(4):
+        # view[0, 1, k] == parent[0, 1, k] == 0*12 + 1*4 + k = 4+k
+        assert_equal(Int(result.item(0, k)), 4 + k)
+        # view[1, 2, k] == parent[2, 2, k] == 2*12 + 2*4 + k = 32+k
+        assert_equal(Int(result.item(1, k)), 32 + k)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
PR #360 added k-D boolean-mask indexing but assumed C-contiguous storage. For F-order arrays and strided views, the k-D NDArray setter writes into a `self.contiguous()` copy and then blindly `memcpy` it back, which transposed values on F-order targets and overwrote parent data outside a strided view. The getter and scalar setter paths had the same C-order-only assumption. PR 360 also had a typo in its k-D mask shape-mismatch error (`self.shape[:{}}`.) that made String.format itself raise, hiding the real diagnostic.

This change replaces the contiguous round-trip with three small stride-aware helpers (`_read_block_from_self`, `_write_block_into_self`, `_fill_block_in_self`) that walk the trailing dimensions using self.strides, taking a fast memcpy path only when the trailing block is genuinely dense. All k-D and 1-D mask getter/setter paths now compute leading offsets from `self.offset` and `self.strides[:k]`, so they work for C-contiguous, F-contiguous, and arbitrary strided views. The misleading size-1 shortcut in the NDArray-setter validation was removed, and the format-string typo was fixed.

Eight regression tests were added covering F-order arrays and strided views for the getter, scalar setter, and NDArray setter, asserting both correct results and that positions outside the selection keep their original values.