### PR TITLE
[Accelerator] Add basic arithmetic ops for AcceleratorNDArray

### DIFF
--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,12 +31,7 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import (
-    NDArrayShape,
-    NDArrayStrides,
-    Flags,
-    newaxis
-)
+from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
 
 from .dtype import (
     i8,

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,7 +31,12 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
+from .layout import (
+    NDArrayShape,
+    NDArrayStrides,
+    Flags,
+    newaxis
+)
 
 from .dtype import (
     i8,

--- a/numojo/core/accelerator/kernels/__init__.mojo
+++ b/numojo/core/accelerator/kernels/__init__.mojo
@@ -10,4 +10,11 @@
 GPU kernel functions for `AcceleratorNDArray` operation dispatch.
 """
 
-from .binary_ops import add_kernel, launch_add
+from .binary_ops import (
+    ADD,
+    SUB,
+    MUL,
+    DIV,
+    binary_op_kernel,
+    launch_binary_op,
+)

--- a/numojo/core/accelerator/kernels/__init__.mojo
+++ b/numojo/core/accelerator/kernels/__init__.mojo
@@ -1,0 +1,13 @@
+# ===----------------------------------------------------------------------=== #
+# NuMojo: Accelerator kernels submodule
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+"""Accelerator kernels (numojo.core.accelerator.kernels)
+----------------------------------------------------------------
+GPU kernel functions for `AcceleratorNDArray` operation dispatch.
+"""
+
+from .binary_ops import add_kernel, launch_add

--- a/numojo/core/accelerator/kernels/__init__.mojo
+++ b/numojo/core/accelerator/kernels/__init__.mojo
@@ -18,3 +18,4 @@ from .binary_ops import (
     binary_op_kernel,
     launch_binary_op,
 )
+from .unary_ops import neg_kernel, launch_neg

--- a/numojo/core/accelerator/kernels/binary_ops.mojo
+++ b/numojo/core/accelerator/kernels/binary_ops.mojo
@@ -14,19 +14,38 @@ on contiguous `AcceleratorNDArray` buffers.
 from std.gpu import thread_idx, block_idx, block_dim
 from std.gpu.host import DeviceContext
 
+comptime ADD = 0
+comptime SUB = 1
+comptime MUL = 2
+comptime DIV = 3
 
-def add_kernel[
-    dtype: DType
+
+@always_inline
+def _binary_op[
+    dtype: DType, op_code: Int
+](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
+    comptime if op_code == ADD:
+        return a + b
+    elif op_code == SUB:
+        return a - b
+    elif op_code == MUL:
+        return a * b
+    else:
+        return a / b
+
+
+def binary_op_kernel[
+    dtype: DType, op_code: Int
 ](
     result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
-    """GPU kernel: `result[i] = a[i] + b[i]` for contiguous buffers."""
+    """GPU kernel: `result[i] = op(a[i], b[i])` for contiguous buffers."""
     var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
     if i < size:
-        result[i] = a[i] + b[i]
+        result[i] = _binary_op[dtype, op_code](a[i], b[i])
 
 
 def launch_config(size: Int) -> Tuple[Int, Int]:
@@ -40,8 +59,8 @@ def launch_config(size: Int) -> Tuple[Int, Int]:
     return (max(1, num_blocks), threads_per_block)
 
 
-def launch_add[
-    dtype: DType
+def launch_binary_op[
+    dtype: DType, op_code: Int
 ](
     context: DeviceContext,
     result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
@@ -50,11 +69,13 @@ def launch_add[
     size: Int,
     sync: Bool = True,
 ) raises:
-    """Launch the GPU add kernel over `size` contiguous elements."""
+    """Launch the GPU binary-op kernel over `size` contiguous elements."""
     var grid_dim: Int
     var block_dim: Int
     grid_dim, block_dim = launch_config(size)
-    context.enqueue_function[add_kernel[dtype], add_kernel[dtype]](
+    context.enqueue_function[
+        binary_op_kernel[dtype, op_code], binary_op_kernel[dtype, op_code]
+    ](
         result,
         a,
         b,

--- a/numojo/core/accelerator/kernels/binary_ops.mojo
+++ b/numojo/core/accelerator/kernels/binary_ops.mojo
@@ -1,0 +1,66 @@
+# ===----------------------------------------------------------------------=== #
+# NuMojo: Accelerator binary op kernels
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+"""Binary op GPU kernels (numojo.core.accelerator.kernels.binary_ops)
+-----------------------------------------------------------------
+GPU kernel functions and launch helpers for elementwise binary operations
+on contiguous `AcceleratorNDArray` buffers.
+"""
+
+from std.gpu import thread_idx, block_idx, block_dim
+from std.gpu.host import DeviceContext
+
+
+def add_kernel[
+    dtype: DType
+](
+    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int,
+):
+    """GPU kernel: `result[i] = a[i] + b[i]` for contiguous buffers."""
+    var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
+    if i < size:
+        result[i] = a[i] + b[i]
+
+
+def launch_config(size: Int) -> Tuple[Int, Int]:
+    """Compute (grid_dim, block_dim) for a one-thread-per-element launch.
+
+    Returns:
+        A tuple of (number of blocks, threads per block).
+    """
+    comptime threads_per_block = 256
+    var num_blocks = (size + threads_per_block - 1) // threads_per_block
+    return (max(1, num_blocks), threads_per_block)
+
+
+def launch_add[
+    dtype: DType
+](
+    context: DeviceContext,
+    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int,
+    sync: Bool = True,
+) raises:
+    """Launch the GPU add kernel over `size` contiguous elements."""
+    var grid_dim: Int
+    var block_dim: Int
+    grid_dim, block_dim = launch_config(size)
+    context.enqueue_function[add_kernel[dtype], add_kernel[dtype]](
+        result,
+        a,
+        b,
+        size,
+        grid_dim=grid_dim,
+        block_dim=block_dim,
+    )
+    if sync:
+        context.synchronize()

--- a/numojo/core/accelerator/kernels/unary_ops.mojo
+++ b/numojo/core/accelerator/kernels/unary_ops.mojo
@@ -1,0 +1,54 @@
+# ===----------------------------------------------------------------------=== #
+# NuMojo: Accelerator unary op kernels
+# Distributed under the Apache 2.0 License with LLVM Exceptions.
+# See LICENSE and the LLVM License for more information.
+# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE
+# https://llvm.org/LICENSE.txt
+# ===----------------------------------------------------------------------=== #
+"""Unary op GPU kernels (numojo.core.accelerator.kernels.unary_ops)
+-----------------------------------------------------------------
+GPU kernel functions and launch helpers for elementwise unary operations
+on contiguous `AcceleratorNDArray` buffers.
+"""
+
+from std.gpu import thread_idx, block_idx, block_dim
+from std.gpu.host import DeviceContext
+
+from .binary_ops import launch_config
+
+
+def neg_kernel[
+    dtype: DType
+](
+    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int,
+):
+    """GPU kernel: `result[i] = -a[i]` for contiguous buffers."""
+    var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
+    if i < size:
+        result[i] = -a[i]
+
+
+def launch_neg[
+    dtype: DType
+](
+    context: DeviceContext,
+    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    size: Int,
+    sync: Bool = True,
+) raises:
+    """Launch the GPU negation kernel over `size` contiguous elements."""
+    var grid_dim: Int
+    var block_dim: Int
+    grid_dim, block_dim = launch_config(size)
+    context.enqueue_function[neg_kernel[dtype], neg_kernel[dtype]](
+        result,
+        a,
+        size,
+        grid_dim=grid_dim,
+        block_dim=block_dim,
+    )
+    if sync:
+        context.synchronize()

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -808,6 +808,45 @@ struct AcceleratorNDArray[
         """Elementwise division. See `_binary_op` for constraints."""
         return self._binary_op[kernels.DIV, "division"](other)
 
+    def __neg__(self) raises -> Self:
+        """Elementwise negation. Requires a densely contiguous array (no
+        broadcasting or strided views yet).
+
+        Raises:
+            Error: If the array is not contiguous.
+        """
+        if not self.flags.C_CONTIGUOUS:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "AcceleratorNDArray.__neg__ currently requires a"
+                        " C-contiguous array."
+                    ),
+                    location="AcceleratorNDArray.__neg__",
+                )
+            )
+
+        var out = Self(shape=self.shape)
+
+        comptime if Self.device.type == "cpu":
+            comptime assert Self.device.type == "cpu"
+            var dst = out.unsafe_ptr()
+            var src = self.unsafe_ptr()
+            for i in range(self.size):
+                dst[i] = -src[i]
+        else:
+            comptime assert Self.device.type == "gpu"
+            var context = self.device_context()
+            kernels.launch_neg[Self.dtype](
+                context,
+                out.unsafe_device_ptr(),
+                self.unsafe_device_ptr(),
+                self.size,
+            )
+
+        return out^
+
 
 # ===----------------------------------------------------------------------=== #
 # Creation routines

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -721,9 +721,18 @@ struct AcceleratorNDArray[
     # Elementwise operations
     # ===------------------------------------------------------------------=== #
 
-    def __add__(self, other: Self) raises -> Self:
-        """Elementwise addition. Both operands must be on the same device
-        and densely contiguous (no broadcasting or strided views yet).
+    def _binary_op[
+        op_code: Int, op_name: StaticString
+    ](self, other: Self) raises -> Self:
+        """Shared dispatch for elementwise binary operators.
+
+        Both operands must be on the same device and densely contiguous
+        (no broadcasting or strided views yet).
+
+        Parameters:
+            op_code: One of `kernels.ADD`, `kernels.SUB`, `kernels.MUL`,
+                `kernels.DIV`.
+            op_name: Human-readable operator name, used in error messages.
 
         Raises:
             Error: If shapes differ, or either operand is not contiguous.
@@ -733,38 +742,47 @@ struct AcceleratorNDArray[
                 NumojoError(
                     category="shape",
                     message=String(
-                        "Shapes {} and {} do not match for addition."
-                    ).format(self.shape, other.shape),
-                    location="AcceleratorNDArray.__add__",
+                        "Shapes {} and {} do not match for {}."
+                    ).format(self.shape, other.shape, op_name),
+                    location="AcceleratorNDArray._binary_op",
                 )
             )
+        # TODO: Relax this constraint later.
         if not self.flags.C_CONTIGUOUS or not other.flags.C_CONTIGUOUS:
             raise Error(
                 NumojoError(
                     category="value",
-                    message=(
-                        "AcceleratorNDArray.__add__ currently requires both"
+                    message=String(
+                        "AcceleratorNDArray {} currently requires both"
                         " operands to be C-contiguous."
-                    ),
-                    location="AcceleratorNDArray.__add__",
+                    ).format(op_name),
+                    location="AcceleratorNDArray._binary_op",
                 )
             )
 
         var out = Self(shape=self.shape)
 
-        comptime if (Self.device.type == "cpu" and other.device.type == "cpu"):
+        comptime if Self.device.type == "cpu":
             comptime assert Self.device.type == "cpu"
             var dst = out.unsafe_ptr()
             var src1 = self.unsafe_ptr()
             var src2 = other.unsafe_ptr()
-            for i in range(self.size):
-                dst[i] = src1[i] + src2[i]
+            comptime if op_code == kernels.ADD:
+                for i in range(self.size):
+                    dst[i] = src1[i] + src2[i]
+            elif op_code == kernels.SUB:
+                for i in range(self.size):
+                    dst[i] = src1[i] - src2[i]
+            elif op_code == kernels.MUL:
+                for i in range(self.size):
+                    dst[i] = src1[i] * src2[i]
+            else:
+                for i in range(self.size):
+                    dst[i] = src1[i] / src2[i]
         else:
-            comptime assert (
-                Self.device.type == "gpu" and other.device.type == "gpu"
-            )
+            comptime assert Self.device.type == "gpu"
             var context = self.device_context()
-            kernels.launch_add[Self.dtype](
+            kernels.launch_binary_op[Self.dtype, op_code](
                 context,
                 out.unsafe_device_ptr(),
                 self.unsafe_device_ptr(),
@@ -773,6 +791,22 @@ struct AcceleratorNDArray[
             )
 
         return out^
+
+    def __add__(self, other: Self) raises -> Self:
+        """Elementwise addition. See `_binary_op` for constraints."""
+        return self._binary_op[kernels.ADD, "addition"](other)
+
+    def __sub__(self, other: Self) raises -> Self:
+        """Elementwise subtraction. See `_binary_op` for constraints."""
+        return self._binary_op[kernels.SUB, "subtraction"](other)
+
+    def __mul__(self, other: Self) raises -> Self:
+        """Elementwise multiplication. See `_binary_op` for constraints."""
+        return self._binary_op[kernels.MUL, "multiplication"](other)
+
+    def __truediv__(self, other: Self) raises -> Self:
+        """Elementwise division. See `_binary_op` for constraints."""
+        return self._binary_op[kernels.DIV, "division"](other)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -11,6 +11,7 @@ Device-aware NDArray that stores data in `AcceleratorDataContainer`.
 """
 
 from std.memory import UnsafePointer
+from std.gpu.host import DeviceContext
 from numojo.core.error import NumojoError
 from numojo.core.layout.flags import Flags
 from numojo.core.layout.ndshape import NDArrayShape
@@ -19,6 +20,7 @@ from numojo.core.indexing.item import Item
 from numojo.core.indexing.offset import IndexMethods
 from numojo.core.memory.storage import AcceleratorDataContainer
 from numojo.core.accelerator.device import Device
+import numojo.core.accelerator.kernels as kernels
 from numojo.core.ndarray import NDArray
 from numojo.core.dtype.default_dtype import _concise_dtype_str
 
@@ -249,6 +251,25 @@ struct AcceleratorNDArray[
         Self.device.type == "cpu"
     ):
         return self._buf.host_storage.unsafe_value().ptr + self.offset
+
+    def unsafe_device_ptr(
+        ref self,
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+        Self.device.type == "gpu"
+    ):
+        """Return the raw device pointer to the buffer's data.
+
+        Returns:
+            An `UnsafePointer` to the first element of the underlying
+            device buffer (not the logical view start).
+        """
+        return self._buf.device_storage.unsafe_value().unsafe_ptr()
+
+    def device_context(
+        self,
+    ) -> DeviceContext where (Self.device.type == "gpu"):
+        """Return the `DeviceContext` backing this array's GPU storage."""
+        return self._buf.device_storage.unsafe_value().handle.device_context()
 
     def num_elements(self) -> Int:
         return self.size
@@ -695,6 +716,61 @@ struct AcceleratorNDArray[
         target: Device
     ](self,) raises -> AcceleratorNDArray[Self.dtype, target]:
         return self.to_device[target]()
+
+    # ===------------------------------------------------------------------=== #
+    # Elementwise operations
+    # ===------------------------------------------------------------------=== #
+
+    def __add__(self, other: Self) raises -> Self:
+        """Elementwise addition. Both operands must be on the same device
+        and densely contiguous (no broadcasting or strided views yet).
+
+        Raises:
+            Error: If shapes differ, or either operand is not contiguous.
+        """
+        if self.shape != other.shape:
+            raise Error(
+                NumojoError(
+                    category="shape",
+                    message=String(
+                        "Shapes {} and {} do not match for addition."
+                    ).format(self.shape, other.shape),
+                    location="AcceleratorNDArray.__add__",
+                )
+            )
+        if not self.flags.C_CONTIGUOUS or not other.flags.C_CONTIGUOUS:
+            raise Error(
+                NumojoError(
+                    category="value",
+                    message=(
+                        "AcceleratorNDArray.__add__ currently requires both"
+                        " operands to be C-contiguous."
+                    ),
+                    location="AcceleratorNDArray.__add__",
+                )
+            )
+
+        var out = Self(shape=self.shape)
+
+        comptime if (Self.device.type == "cpu" and other.device.type == "cpu"):
+            comptime assert Self.device.type == "cpu"
+            var dst = out.unsafe_ptr()
+            var src1 = self.unsafe_ptr()
+            var src2 = other.unsafe_ptr()
+            for i in range(self.size):
+                dst[i] = src1[i] + src2[i]
+        else:
+            comptime assert (Self.device.type == "gpu" and other.device.type == "gpu")
+            var context = self.device_context()
+            kernels.launch_add[Self.dtype](
+                context,
+                out.unsafe_device_ptr(),
+                self.unsafe_device_ptr(),
+                other.unsafe_device_ptr(),
+                self.size,
+            )
+
+        return out^
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -267,7 +267,7 @@ struct AcceleratorNDArray[
 
     def device_context(
         self,
-    ) -> DeviceContext where (Self.device.type == "gpu"):
+    ) -> DeviceContext where Self.device.type == "gpu":
         """Return the `DeviceContext` backing this array's GPU storage."""
         return self._buf.device_storage.unsafe_value().handle.device_context()
 
@@ -760,7 +760,9 @@ struct AcceleratorNDArray[
             for i in range(self.size):
                 dst[i] = src1[i] + src2[i]
         else:
-            comptime assert (Self.device.type == "gpu" and other.device.type == "gpu")
+            comptime assert (
+                Self.device.type == "gpu" and other.device.type == "gpu"
+            )
             var context = self.device_context()
             kernels.launch_add[Self.dtype](
                 context,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -31,6 +31,7 @@ Iterators of `NDArray`:
 # Stdlib
 # ===----------------------------------------------------------------------===#
 from std.algorithm import parallelize, vectorize
+from std.sys.info import num_performance_cores
 import std.builtin.bool as builtin_bool
 import std.math as builtin_math
 from std.collections.optional import Optional
@@ -4854,20 +4855,37 @@ struct NDArray[dtype: DType = DType.float64](
                 src=self._buf.ptr + self.offset,
                 count=self.size,
             )
+        elif self.ndim == 0:
+            result._buf.ptr[0] = self._buf.ptr[self.offset]
         else:
-            # Stride-aware copy for non-contiguous views
-            for i in range(self.size):
-                var remainder = i
-                var item = Item(ndim=self.ndim)
-                for dim in range(self.ndim - 1, -1, -1):
-                    (item._buf.ptr + dim).init_pointee_copy(
-                        Scalar[DType.int](remainder % self.shape[dim])
-                    )
-                    remainder = remainder // self.shape[dim]
-                var src_offset = self.offset + IndexMethods.get_1d_index(
-                    item, self.strides
-                )
-                result._buf.ptr[i] = self._buf.ptr[src_offset]
+            # Stride-aware copy for non-contiguous views.
+            var last_dim = self.ndim - 1
+            var last_extent = Int(self.shape[last_dim])
+            var last_stride = Int(self.strides[last_dim])
+            var num_rows = self.size // last_extent
+            comptime width = simd_width_of[Self.dtype]()
+
+            for row in range(num_rows):
+                var remainder = row
+                var base_offset = self.offset
+                for dim in range(last_dim - 1, -1, -1):
+                    var idx = remainder % Int(self.shape[dim])
+                    remainder = remainder // Int(self.shape[dim])
+                    base_offset += idx * Int(self.strides[dim])
+
+                var dest_base = row * last_extent
+
+                def closure[
+                    simd_w: Int
+                ](
+                    i: Int
+                ) {mut result, read self, base_offset, dest_base, last_stride}:
+                    var simd_data = (
+                        self._buf.ptr + base_offset + i * last_stride
+                    ).strided_load[width=simd_w](last_stride)
+                    result._buf.ptr.store(dest_base + i, simd_data)
+
+                vectorize[width](last_extent, closure)
 
         return result^
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -689,7 +689,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -689,6 +689,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
+
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4877,9 +4877,9 @@ struct NDArray[dtype: DType = DType.float64](
 
                 def closure[
                     simd_w: Int
-                ](
-                    i: Int
-                ) {mut result, read self, base_offset, dest_base, last_stride}:
+                ](i: Int) {
+                    mut result, read self, base_offset, dest_base, last_stride
+                }:
                     var simd_data = (
                         self._buf.ptr + base_offset + i * last_stride
                     ).strided_load[width=simd_w](last_stride)

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -48,9 +48,9 @@ def _num_tasks_for(size: Int, simd_width: Int) -> Int:
 def _apply_unary_chunk[
     dtype: DType,
     width: Int,
-    kernel: def[type: DType, simd_w: Int](
-        SIMD[type, simd_w]
-    ) capturing -> SIMD[type, simd_w],
+    kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) capturing -> SIMD[
+        type, simd_w
+    ],
 ](
     src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
@@ -223,9 +223,9 @@ def _apply_binary_predicate_scalar_chunk[
 def _apply_unary_predicate_chunk[
     dtype: DType,
     width: Int,
-    kernel: def[type: DType, simd_w: Int](
-        SIMD[type, simd_w]
-    ) capturing -> SIMD[DType.bool, simd_w],
+    kernel: def[type: DType, simd_w: Int](SIMD[type, simd_w]) capturing -> SIMD[
+        DType.bool, simd_w
+    ],
 ](
     src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
@@ -532,11 +532,6 @@ struct HostExecutor:
             return Self.apply_binary[dtype, kernel](array1, array2[])
 
         if array1.shape != array2.shape:
-            # Shapes differ: broadcast both operands (zero-copy views) to
-            # their common shape, then fall through to the equal-shape path.
-            # Broadcast views are never C-contiguous (stride 0 dims), so the
-            # guards above will materialize them via `.contiguous()` on the
-            # recursive call below.
             var common_shape = array1.shape.broadcast(array2.shape)
             return Self.apply_binary[dtype, kernel](
                 broadcast_to(array1, common_shape),
@@ -608,9 +603,9 @@ struct HostExecutor:
 
         var num_tasks = _num_tasks_for(result_array.size, width)
         if num_tasks == 1:
-            _apply_binary_scalar_chunk[dtype, width, kernel, scalar_first=False](
-                src, dst, scalar, 0, result_array.size
-            )
+            _apply_binary_scalar_chunk[
+                dtype, width, kernel, scalar_first=False
+            ](src, dst, scalar, 0, result_array.size)
         else:
             var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
 
@@ -872,9 +867,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array1.size)
                 if end > start:
-                    _apply_binary_predicate_scalar_chunk[
-                        dtype, width, kernel
-                    ](src, dst, scalar, start, end)
+                    _apply_binary_predicate_scalar_chunk[dtype, width, kernel](
+                        src, dst, scalar, start, end
+                    )
 
             parallelize[worker](num_tasks)
 

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -195,9 +195,7 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array}:
+        def apply_chunk(start: Int, end: Int) {mut result_array, read array}:
             def closure[
                 simd_w: Int
             ](i: Int) {mut result_array, read array, start}:
@@ -688,9 +686,7 @@ struct HostExecutor:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
 
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array}:
+        def apply_chunk(start: Int, end: Int) {mut result_array, read array}:
             def closure[
                 simd_w: Int
             ](i: Int) {mut result_array, read array, start}:
@@ -779,9 +775,7 @@ struct HostExecutor:
         ) {mut result_array, read array1, read array2, read array3}:
             def closure[
                 simdwidth: Int
-            ](
-                i: Int
-            ) {
+            ](i: Int) {
                 mut result_array,
                 read array1,
                 read array2,
@@ -871,9 +865,9 @@ struct HostExecutor:
         ) {mut result_array, read array1, read array2, read scalar}:
             def closure[
                 simdwidth: Int
-            ](
-                i: Int
-            ) {mut result_array, read array1, read array2, read scalar, start}:
+            ](i: Int) {
+                mut result_array, read array1, read array2, read scalar, start
+            }:
                 var simd_data1 = array1._buf.ptr.load[width=simdwidth](
                     start + i
                 )

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -10,13 +10,36 @@
 Defines vectorized backend structures and reusable SIMD math primitives consumed by the math submodules.
 """
 
-from std.algorithm.functional import vectorize
+from std.algorithm.functional import parallelize, vectorize
 from std.sys import simd_width_of
+from std.sys.info import num_performance_cores
 from std.builtin.simd import FastMathFlag
 
 from numojo.core.ndarray import NDArray
 from numojo.routines.creation import _0darray
 from numojo.routines.manipulation import broadcast_to
+
+comptime MIN_SIMD_WIDTHS_PER_TASK = 8
+"""Minimum number of SIMD-widths of work each parallel task should get before
+splitting across cores is worth the thread-dispatch overhead. This is a heuristic
+that can be tuned.
+"""
+
+
+@always_inline
+def _num_tasks_for(size: Int, simd_width: Int) -> Int:
+    """
+    Decide how many parallel tasks to split `size` elements into.
+
+    Returns 1 (i.e. no parallelism) when there isn't enough work per task
+    to justify the overhead of spawning threads.
+    """
+    var min_chunk = simd_width * MIN_SIMD_WIDTHS_PER_TASK
+    var max_tasks_by_size = size // min_chunk
+    if max_tasks_by_size <= 1:
+        return 1
+    var cores = num_performance_cores()
+    return min(cores, max_tasks_by_size)
 
 
 # TODO: Add overloads for complexndarray.
@@ -172,11 +195,33 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
-            var simd_data = array._buf.ptr.load[width=simd_w](i)
-            result_array._buf.ptr.store(i, kernel[dtype, simd_w](simd_data))
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array, start}:
+                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
+                result_array._buf.ptr.store(
+                    start + i, kernel[dtype, simd_w](simd_data)
+                )
 
-        vectorize[width](array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array.size)
+        else:
+            var chunk_size = (array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
 
         return result_array^
 
@@ -233,16 +278,35 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array1, read array2}:
-            var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
-            var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
-            result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data1, simd_data2)
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array1, read array2}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array1, read array2, start}:
+                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
+                var simd_data2 = array2._buf.ptr.load[width=simd_w](start + i)
+                result_array._buf.ptr.store(
+                    start + i, kernel[dtype, simd_w](simd_data1, simd_data2)
+                )
 
-        vectorize[width](result_array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(result_array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, result_array.size)
+        else:
+            var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, result_array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -433,19 +497,38 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array1, read array2}:
-            var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
-            var simd_data2 = array2._buf.ptr.load[width=simd_w](i)
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array1, read array2}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array1, read array2, start}:
+                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
+                var simd_data2 = array2._buf.ptr.load[width=simd_w](start + i)
 
-            bool_simd_store[simd_w](
-                result_array._buf.ptr,
-                i,
-                kernel[dtype, simd_w](simd_data1, simd_data2),
-            )
+                bool_simd_store[simd_w](
+                    result_array._buf.ptr,
+                    start + i,
+                    kernel[dtype, simd_w](simd_data1, simd_data2),
+                )
 
-        vectorize[width](array1.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array1.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array1.size)
+        else:
+            var chunk_size = (array1.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array1.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -42,6 +42,283 @@ def _num_tasks_for(size: Int, simd_width: Int) -> Int:
     return min(cores, max_tasks_by_size)
 
 
+# NOTE: These chunk-application helpers are top-level (non-nested) functions
+# on purpose. This is to prevent the mojo compiler crash from nested clsoure funcs.
+@always_inline
+def _apply_unary_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w]
+    ) capturing -> SIMD[type, simd_w],
+](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        dst.store(i, kernel[dtype, width](src.load[width=width](i)))
+        i += width
+    while i < end:
+        dst.store(i, kernel[dtype, 1](src.load[width=1](i)))
+        i += 1
+
+
+@always_inline
+def _apply_binary_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[type, simd_w],
+](
+    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        dst.store(
+            i,
+            kernel[dtype, width](
+                src1.load[width=width](i), src2.load[width=width](i)
+            ),
+        )
+        i += width
+    while i < end:
+        dst.store(
+            i,
+            kernel[dtype, 1](src1.load[width=1](i), src2.load[width=1](i)),
+        )
+        i += 1
+
+
+@always_inline
+def _apply_binary_scalar_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[type, simd_w],
+    *,
+    scalar_first: Bool,
+](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    scalar: Scalar[dtype],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        var data = src.load[width=width](i)
+        comptime if scalar_first:
+            dst.store(i, kernel[dtype, width](scalar, data))
+        else:
+            dst.store(i, kernel[dtype, width](data, scalar))
+        i += width
+    while i < end:
+        var data = src.load[width=1](i)
+        comptime if scalar_first:
+            dst.store(i, kernel[dtype, 1](scalar, data))
+        else:
+            dst.store(i, kernel[dtype, 1](data, scalar))
+        i += 1
+
+
+@always_inline
+def _apply_binary_int_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], Int
+    ) capturing -> SIMD[type, simd_w],
+](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    intval: Int,
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        dst.store(i, kernel[dtype, width](src.load[width=width](i), intval))
+        i += width
+    while i < end:
+        dst.store(i, kernel[dtype, 1](src.load[width=1](i), intval))
+        i += 1
+
+
+@always_inline
+def _apply_binary_predicate_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[DType.bool, simd_w],
+](
+    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        bool_simd_store[width](
+            dst,
+            i,
+            kernel[dtype, width](
+                src1.load[width=width](i), src2.load[width=width](i)
+            ),
+        )
+        i += width
+    while i < end:
+        bool_simd_store[1](
+            dst,
+            i,
+            kernel[dtype, 1](src1.load[width=1](i), src2.load[width=1](i)),
+        )
+        i += 1
+
+
+@always_inline
+def _apply_binary_predicate_scalar_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[DType.bool, simd_w],
+](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    scalar: Scalar[dtype],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        bool_simd_store[width](
+            dst,
+            i,
+            kernel[dtype, width](
+                src.load[width=width](i), SIMD[dtype, width](scalar)
+            ),
+        )
+        i += width
+    while i < end:
+        bool_simd_store[1](
+            dst,
+            i,
+            kernel[dtype, 1](src.load[width=1](i), SIMD[dtype, 1](scalar)),
+        )
+        i += 1
+
+
+@always_inline
+def _apply_unary_predicate_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w]
+    ) capturing -> SIMD[DType.bool, simd_w],
+](
+    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        bool_simd_store[width](
+            dst, i, kernel[dtype, width](src.load[width=width](i))
+        )
+        i += width
+    while i < end:
+        bool_simd_store[1](dst, i, kernel[dtype, 1](src.load[width=1](i)))
+        i += 1
+
+
+@always_inline
+def _apply_ternary_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[type, simd_w],
+](
+    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src3: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        dst.store(
+            i,
+            kernel(
+                src1.load[width=width](i),
+                src2.load[width=width](i),
+                src3.load[width=width](i),
+            ),
+        )
+        i += width
+    while i < end:
+        dst.store(
+            i,
+            kernel(
+                src1.load[width=1](i),
+                src2.load[width=1](i),
+                src3.load[width=1](i),
+            ),
+        )
+        i += 1
+
+
+@always_inline
+def _apply_ternary_scalar_chunk[
+    dtype: DType,
+    width: Int,
+    kernel: def[type: DType, simd_w: Int](
+        SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
+    ) capturing -> SIMD[type, simd_w],
+](
+    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    scalar: Scalar[dtype],
+    start: Int,
+    end: Int,
+):
+    var i = start
+    while i + width <= end:
+        dst.store(
+            i,
+            kernel(
+                src1.load[width=width](i),
+                src2.load[width=width](i),
+                SIMD[dtype, width](scalar),
+            ),
+        )
+        i += width
+    while i < end:
+        dst.store(
+            i,
+            kernel(
+                src1.load[width=1](i),
+                src2.load[width=1](i),
+                SIMD[dtype, 1](scalar),
+            ),
+        )
+        i += 1
+
+
 # TODO: Add overloads for complexndarray.
 # TODO: Add NumojoError as argument so that the calling function can modify the error message with more context.
 # NOTE: We currently do all checks within these backend functions,
@@ -194,21 +471,12 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(start: Int, end: Int) {mut result_array, read array}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array, start}:
-                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
-                result_array._buf.ptr.store(
-                    start + i, kernel[dtype, simd_w](simd_data)
-                )
-
-            vectorize[width](end - start, closure)
-
         var num_tasks = _num_tasks_for(array.size, width)
+        var src = array.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
+
         if num_tasks == 1:
-            apply_chunk(0, array.size)
+            _apply_unary_chunk[dtype, width, kernel](src, dst, 0, array.size)
         else:
             var chunk_size = (array.size + num_tasks - 1) // num_tasks
 
@@ -217,7 +485,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_unary_chunk[dtype, width, kernel](
+                        src, dst, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -275,24 +545,15 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array1, read array2}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array1, read array2, start}:
-                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
-                var simd_data2 = array2._buf.ptr.load[width=simd_w](start + i)
-                result_array._buf.ptr.store(
-                    start + i, kernel[dtype, simd_w](simd_data1, simd_data2)
-                )
-
-            vectorize[width](end - start, closure)
+        var src1 = array1.unsafe_ptr()
+        var src2 = array2.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(result_array.size, width)
         if num_tasks == 1:
-            apply_chunk(0, result_array.size)
+            _apply_binary_chunk[dtype, width, kernel](
+                src1, src2, dst, 0, result_array.size
+            )
         else:
             var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
 
@@ -301,7 +562,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, result_array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_chunk[dtype, width, kernel](
+                        src1, src2, dst, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -340,23 +603,14 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array, read scalar}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array, read scalar, start}:
-                var simd_data1 = array._buf.ptr.load[width=simd_w](start + i)
-                result_array._buf.ptr.store(
-                    start + i, kernel[dtype, simd_w](simd_data1, scalar)
-                )
-
-            vectorize[width](end - start, closure)
+        var src = array.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(result_array.size, width)
         if num_tasks == 1:
-            apply_chunk(0, result_array.size)
+            _apply_binary_scalar_chunk[dtype, width, kernel, scalar_first=False](
+                src, dst, scalar, 0, result_array.size
+            )
         else:
             var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
 
@@ -365,7 +619,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, result_array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_scalar_chunk[
+                        dtype, width, kernel, scalar_first=False
+                    ](src, dst, scalar, start, end)
 
             parallelize[worker](num_tasks)
 
@@ -405,23 +661,14 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array, read scalar}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array, read scalar, start}:
-                var simd_data1 = array._buf.ptr.load[width=simd_w](start + i)
-                result_array._buf.ptr.store(
-                    start + i, kernel[dtype, simd_w](scalar, simd_data1)
-                )
-
-            vectorize[width](end - start, closure)
+        var src = array.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(result_array.size, width)
         if num_tasks == 1:
-            apply_chunk(0, result_array.size)
+            _apply_binary_scalar_chunk[dtype, width, kernel, scalar_first=True](
+                src, dst, scalar, 0, result_array.size
+            )
         else:
             var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
 
@@ -430,7 +677,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, result_array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_scalar_chunk[
+                        dtype, width, kernel, scalar_first=True
+                    ](src, dst, scalar, start, end)
 
             parallelize[worker](num_tasks)
 
@@ -463,24 +712,14 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array, read intval}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array, read intval, start}:
-                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
-
-                result_array._buf.ptr.store(
-                    start + i, kernel[dtype, simd_w](simd_data, intval)
-                )
-
-            vectorize[width](end - start, closure)
+        var src = array.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array.size)
+            _apply_binary_int_chunk[dtype, width, kernel](
+                src, dst, intval, 0, array.size
+            )
         else:
             var chunk_size = (array.size + num_tasks - 1) // num_tasks
 
@@ -489,7 +728,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_int_chunk[dtype, width, kernel](
+                        src, dst, intval, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -551,27 +792,15 @@ struct HostExecutor:
             array1.shape
         )
         comptime width = simd_width_of[DType.bool]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array1, read array2}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array1, read array2, start}:
-                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
-                var simd_data2 = array2._buf.ptr.load[width=simd_w](start + i)
-
-                bool_simd_store[simd_w](
-                    result_array._buf.ptr,
-                    start + i,
-                    kernel[dtype, simd_w](simd_data1, simd_data2),
-                )
-
-            vectorize[width](end - start, closure)
+        var src1 = array1.unsafe_ptr()
+        var src2 = array2.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array1.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array1.size)
+            _apply_binary_predicate_chunk[dtype, width, kernel](
+                src1, src2, dst, 0, array1.size
+            )
         else:
             var chunk_size = (array1.size + num_tasks - 1) // num_tasks
 
@@ -580,7 +809,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array1.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_predicate_chunk[dtype, width, kernel](
+                        src1, src2, dst, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -625,26 +856,14 @@ struct HostExecutor:
             array1.shape
         )
         comptime width = simd_width_of[DType.bool]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array1, read scalar}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array1, read scalar, start}:
-                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
-                var simd_data2 = SIMD[dtype, simd_w](scalar)
-                bool_simd_store[simd_w](
-                    result_array.unsafe_ptr(),
-                    start + i,
-                    kernel[dtype, simd_w](simd_data1, simd_data2),
-                )
-
-            vectorize[width](end - start, closure)
+        var src = array1.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array1.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array1.size)
+            _apply_binary_predicate_scalar_chunk[dtype, width, kernel](
+                src, dst, scalar, 0, array1.size
+            )
         else:
             var chunk_size = (array1.size + num_tasks - 1) // num_tasks
 
@@ -653,7 +872,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array1.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_binary_predicate_scalar_chunk[
+                        dtype, width, kernel
+                    ](src, dst, scalar, start, end)
 
             parallelize[worker](num_tasks)
 
@@ -685,23 +906,14 @@ struct HostExecutor:
 
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
-
-        def apply_chunk(start: Int, end: Int) {mut result_array, read array}:
-            def closure[
-                simd_w: Int
-            ](i: Int) {mut result_array, read array, start}:
-                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
-                bool_simd_store[simd_w](
-                    result_array._buf.ptr,
-                    start + i,
-                    kernel[dtype, simd_w](simd_data),
-                )
-
-            vectorize[width](end - start, closure)
+        var src = array.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array.size)
+            _apply_unary_predicate_chunk[dtype, width, kernel](
+                src, dst, 0, array.size
+            )
         else:
             var chunk_size = (array.size + num_tasks - 1) // num_tasks
 
@@ -710,7 +922,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_unary_predicate_chunk[dtype, width, kernel](
+                        src, dst, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -769,37 +983,16 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array1, read array2, read array3}:
-            def closure[
-                simdwidth: Int
-            ](i: Int) {
-                mut result_array,
-                read array1,
-                read array2,
-                read array3,
-                start,
-            }:
-                var simd_data1 = array1._buf.ptr.load[width=simdwidth](
-                    start + i
-                )
-                var simd_data2 = array2._buf.ptr.load[width=simdwidth](
-                    start + i
-                )
-                var simd_data3 = array3._buf.ptr.load[width=simdwidth](
-                    start + i
-                )
-                result_array._buf.ptr.store(
-                    start + i, kernel(simd_data1, simd_data2, simd_data3)
-                )
-
-            vectorize[width](end - start, closure)
+        var src1 = array1.unsafe_ptr()
+        var src2 = array2.unsafe_ptr()
+        var src3 = array3.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array1.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array1.size)
+            _apply_ternary_chunk[dtype, width, kernel](
+                src1, src2, src3, dst, 0, array1.size
+            )
         else:
             var chunk_size = (array1.size + num_tasks - 1) // num_tasks
 
@@ -808,7 +1001,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array1.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_ternary_chunk[dtype, width, kernel](
+                        src1, src2, src3, dst, start, end
+                    )
 
             parallelize[worker](num_tasks)
 
@@ -859,30 +1054,15 @@ struct HostExecutor:
 
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
-
-        def apply_chunk(
-            start: Int, end: Int
-        ) {mut result_array, read array1, read array2, read scalar}:
-            def closure[
-                simdwidth: Int
-            ](i: Int) {
-                mut result_array, read array1, read array2, read scalar, start
-            }:
-                var simd_data1 = array1._buf.ptr.load[width=simdwidth](
-                    start + i
-                )
-                var simd_data2 = array2._buf.ptr.load[width=simdwidth](
-                    start + i
-                )
-                result_array._buf.ptr.store(
-                    start + i, kernel(simd_data1, simd_data2, scalar)
-                )
-
-            vectorize[width](end - start, closure)
+        var src1 = array1.unsafe_ptr()
+        var src2 = array2.unsafe_ptr()
+        var dst = result_array.unsafe_ptr()
 
         var num_tasks = _num_tasks_for(array1.size, width)
         if num_tasks == 1:
-            apply_chunk(0, array1.size)
+            _apply_ternary_scalar_chunk[dtype, width, kernel](
+                src1, src2, dst, scalar, 0, array1.size
+            )
         else:
             var chunk_size = (array1.size + num_tasks - 1) // num_tasks
 
@@ -891,7 +1071,9 @@ struct HostExecutor:
                 var start = tid * chunk_size
                 var end = min(start + chunk_size, array1.size)
                 if end > start:
-                    apply_chunk(start, end)
+                    _apply_ternary_scalar_chunk[dtype, width, kernel](
+                        src1, src2, dst, scalar, start, end
+                    )
 
             parallelize[worker](num_tasks)
 

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -343,15 +343,34 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array, read scalar}:
-            var simd_data1 = array._buf.ptr.load[width=simd_w](i)
-            result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data1, scalar)
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array, read scalar}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array, read scalar, start}:
+                var simd_data1 = array._buf.ptr.load[width=simd_w](start + i)
+                result_array._buf.ptr.store(
+                    start + i, kernel[dtype, simd_w](simd_data1, scalar)
+                )
 
-        vectorize[width](result_array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(result_array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, result_array.size)
+        else:
+            var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, result_array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -389,15 +408,34 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array, read scalar}:
-            var simd_data1 = array._buf.ptr.load[width=simd_w](i)
-            result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](scalar, simd_data1)
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array, read scalar}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array, read scalar, start}:
+                var simd_data1 = array._buf.ptr.load[width=simd_w](start + i)
+                result_array._buf.ptr.store(
+                    start + i, kernel[dtype, simd_w](scalar, simd_data1)
+                )
 
-        vectorize[width](result_array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(result_array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, result_array.size)
+        else:
+            var chunk_size = (result_array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, result_array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -428,16 +466,35 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array, read intval}:
-            var simd_data = array._buf.ptr.load[width=simd_w](i)
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array, read intval}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array, read intval, start}:
+                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
 
-            result_array._buf.ptr.store(
-                i, kernel[dtype, simd_w](simd_data, intval)
-            )
+                result_array._buf.ptr.store(
+                    start + i, kernel[dtype, simd_w](simd_data, intval)
+                )
 
-        vectorize[width](array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array.size)
+        else:
+            var chunk_size = (array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -571,18 +628,37 @@ struct HostExecutor:
         )
         comptime width = simd_width_of[DType.bool]()
 
-        def closure[
-            simd_w: Int
-        ](i: Int) {mut result_array, read array1, read scalar}:
-            var simd_data1 = array1._buf.ptr.load[width=simd_w](i)
-            var simd_data2 = SIMD[dtype, simd_w](scalar)
-            bool_simd_store[simd_w](
-                result_array.unsafe_ptr(),
-                i,
-                kernel[dtype, simd_w](simd_data1, simd_data2),
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array1, read scalar}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array1, read scalar, start}:
+                var simd_data1 = array1._buf.ptr.load[width=simd_w](start + i)
+                var simd_data2 = SIMD[dtype, simd_w](scalar)
+                bool_simd_store[simd_w](
+                    result_array.unsafe_ptr(),
+                    start + i,
+                    kernel[dtype, simd_w](simd_data1, simd_data2),
+                )
 
-        vectorize[width](array1.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array1.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array1.size)
+        else:
+            var chunk_size = (array1.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array1.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -612,15 +688,36 @@ struct HostExecutor:
         var result_array: NDArray[DType.bool] = NDArray[DType.bool](array.shape)
         comptime width = simd_width_of[DType.bool]()
 
-        def closure[simd_w: Int](i: Int) {mut result_array, read array}:
-            var simd_data = array._buf.ptr.load[width=simd_w](i)
-            bool_simd_store[simd_w](
-                result_array._buf.ptr,
-                i,
-                kernel[dtype, simd_w](simd_data),
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array}:
+            def closure[
+                simd_w: Int
+            ](i: Int) {mut result_array, read array, start}:
+                var simd_data = array._buf.ptr.load[width=simd_w](start + i)
+                bool_simd_store[simd_w](
+                    result_array._buf.ptr,
+                    start + i,
+                    kernel[dtype, simd_w](simd_data),
+                )
 
-        vectorize[width](array.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array.size)
+        else:
+            var chunk_size = (array.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -677,17 +774,50 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simdwidth: Int
-        ](i: Int) {mut result_array, read array1, read array2, read array3}:
-            var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
-            var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
-            var simd_data3 = array3._buf.ptr.load[width=simdwidth](i)
-            result_array._buf.ptr.store(
-                i, kernel(simd_data1, simd_data2, simd_data3)
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array1, read array2, read array3}:
+            def closure[
+                simdwidth: Int
+            ](
+                i: Int
+            ) {
+                mut result_array,
+                read array1,
+                read array2,
+                read array3,
+                start,
+            }:
+                var simd_data1 = array1._buf.ptr.load[width=simdwidth](
+                    start + i
+                )
+                var simd_data2 = array2._buf.ptr.load[width=simdwidth](
+                    start + i
+                )
+                var simd_data3 = array3._buf.ptr.load[width=simdwidth](
+                    start + i
+                )
+                result_array._buf.ptr.store(
+                    start + i, kernel(simd_data1, simd_data2, simd_data3)
+                )
 
-        vectorize[width](array1.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array1.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array1.size)
+        else:
+            var chunk_size = (array1.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array1.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
     @staticmethod
@@ -736,16 +866,41 @@ struct HostExecutor:
         var result_array: NDArray[dtype] = NDArray[dtype](array1.shape)
         comptime width = simd_width_of[dtype]()
 
-        def closure[
-            simdwidth: Int
-        ](i: Int) {mut result_array, read array1, read array2, read scalar}:
-            var simd_data1 = array1._buf.ptr.load[width=simdwidth](i)
-            var simd_data2 = array2._buf.ptr.load[width=simdwidth](i)
-            result_array._buf.ptr.store(
-                i, kernel(simd_data1, simd_data2, scalar)
-            )
+        def apply_chunk(
+            start: Int, end: Int
+        ) {mut result_array, read array1, read array2, read scalar}:
+            def closure[
+                simdwidth: Int
+            ](
+                i: Int
+            ) {mut result_array, read array1, read array2, read scalar, start}:
+                var simd_data1 = array1._buf.ptr.load[width=simdwidth](
+                    start + i
+                )
+                var simd_data2 = array2._buf.ptr.load[width=simdwidth](
+                    start + i
+                )
+                result_array._buf.ptr.store(
+                    start + i, kernel(simd_data1, simd_data2, scalar)
+                )
 
-        vectorize[width](array1.size, closure)
+            vectorize[width](end - start, closure)
+
+        var num_tasks = _num_tasks_for(array1.size, width)
+        if num_tasks == 1:
+            apply_chunk(0, array1.size)
+        else:
+            var chunk_size = (array1.size + num_tasks - 1) // num_tasks
+
+            @parameter
+            def worker(tid: Int):
+                var start = tid * chunk_size
+                var end = min(start + chunk_size, array1.size)
+                if end > start:
+                    apply_chunk(start, end)
+
+            parallelize[worker](num_tasks)
+
         return result_array^
 
 

--- a/tests/core/test_accelerator_operations.mojo
+++ b/tests/core/test_accelerator_operations.mojo
@@ -62,6 +62,13 @@ def test_div_cpu_distinct_values() raises:
         assert_equal(c.item(i), ab[0].item(i) / ab[1].item(i), "cpu div distinct")
 
 
+def test_neg_cpu_distinct_values() raises:
+    var ab = _make_distinct_operands()
+    var c = -ab[0]
+    for i in range(6):
+        assert_equal(c.item(i), -ab[0].item(i), "cpu neg distinct")
+
+
 def test_add_cpu_shape_mismatch_raises() raises:
     var a = full[DType.float32, Device.CPU](Shape(4), 1.0)
     var b = full[DType.float32, Device.CPU](Shape(5), 1.0)
@@ -73,7 +80,7 @@ def test_add_cpu_shape_mismatch_raises() raises:
     assert_true(raised, "shape mismatch should raise")
 
 
-def _run_gpu_binary_op_test[device: Device]() raises:
+def _run_gpu_elementwise_op_test[device: Device]() raises:
     var ab = _make_distinct_operands()
     var a_gpu = ab[0].to[device]()
     var b_gpu = ab[1].to[device]()
@@ -82,6 +89,7 @@ def _run_gpu_binary_op_test[device: Device]() raises:
     var sub_host = (a_gpu - b_gpu).to_host()
     var mul_host = (a_gpu * b_gpu).to_host()
     var div_host = (a_gpu / b_gpu).to_host()
+    var neg_host = (-a_gpu).to_host()
 
     for i in range(6):
         var av = ab[0].item(i)
@@ -90,15 +98,16 @@ def _run_gpu_binary_op_test[device: Device]() raises:
         assert_equal(sub_host.item(i), av - bv, "gpu sub matches cpu")
         assert_equal(mul_host.item(i), av * bv, "gpu mul matches cpu")
         assert_equal(div_host.item(i), av / bv, "gpu div matches cpu")
+        assert_equal(neg_host.item(i), -av, "gpu neg matches cpu")
 
 
-def test_binary_ops_gpu_match_cpu_when_available() raises:
+def test_elementwise_ops_gpu_match_cpu_when_available() raises:
     comptime if has_nvidia_gpu_accelerator():
-        _run_gpu_binary_op_test[Device.CUDA]()
+        _run_gpu_elementwise_op_test[Device.CUDA]()
     elif has_amd_gpu_accelerator():
-        _run_gpu_binary_op_test[Device.ROCM]()
+        _run_gpu_elementwise_op_test[Device.ROCM]()
     elif has_apple_gpu_accelerator():
-        _run_gpu_binary_op_test[Device.MPS]()
+        _run_gpu_elementwise_op_test[Device.MPS]()
     else:
         assert_true(True, "no gpu available; gpu binary op tests skipped")
 

--- a/tests/core/test_accelerator_operations.mojo
+++ b/tests/core/test_accelerator_operations.mojo
@@ -22,10 +22,12 @@ def test_add_cpu_uniform() raises:
         assert_equal(c.item(i), 7.0, "cpu add uniform")
 
 
-def _make_distinct_operands() raises -> Tuple[
-    AcceleratorNDArray[DType.float32, Device.CPU],
-    AcceleratorNDArray[DType.float32, Device.CPU],
-]:
+def _make_distinct_operands() raises -> (
+    Tuple[
+        AcceleratorNDArray[DType.float32, Device.CPU],
+        AcceleratorNDArray[DType.float32, Device.CPU],
+    ]
+):
     var a = zeros[DType.float32, Device.CPU](Shape(6))
     var b = zeros[DType.float32, Device.CPU](Shape(6))
     for i in range(6):
@@ -38,28 +40,36 @@ def test_add_cpu_distinct_values() raises:
     var ab = _make_distinct_operands()
     var c = ab[0] + ab[1]
     for i in range(6):
-        assert_equal(c.item(i), ab[0].item(i) + ab[1].item(i), "cpu add distinct")
+        assert_equal(
+            c.item(i), ab[0].item(i) + ab[1].item(i), "cpu add distinct"
+        )
 
 
 def test_sub_cpu_distinct_values() raises:
     var ab = _make_distinct_operands()
     var c = ab[0] - ab[1]
     for i in range(6):
-        assert_equal(c.item(i), ab[0].item(i) - ab[1].item(i), "cpu sub distinct")
+        assert_equal(
+            c.item(i), ab[0].item(i) - ab[1].item(i), "cpu sub distinct"
+        )
 
 
 def test_mul_cpu_distinct_values() raises:
     var ab = _make_distinct_operands()
     var c = ab[0] * ab[1]
     for i in range(6):
-        assert_equal(c.item(i), ab[0].item(i) * ab[1].item(i), "cpu mul distinct")
+        assert_equal(
+            c.item(i), ab[0].item(i) * ab[1].item(i), "cpu mul distinct"
+        )
 
 
 def test_div_cpu_distinct_values() raises:
     var ab = _make_distinct_operands()
     var c = ab[0] / ab[1]
     for i in range(6):
-        assert_equal(c.item(i), ab[0].item(i) / ab[1].item(i), "cpu div distinct")
+        assert_equal(
+            c.item(i), ab[0].item(i) / ab[1].item(i), "cpu div distinct"
+        )
 
 
 def test_neg_cpu_distinct_values() raises:

--- a/tests/core/test_accelerator_operations.mojo
+++ b/tests/core/test_accelerator_operations.mojo
@@ -3,7 +3,7 @@ Tests for `AcceleratorNDArray` elementwise operation dispatch.
 """
 
 from numojo.core.accelerator.device import Device
-from numojo.core.accelerator_ndarray import full, zeros
+from numojo.core.accelerator_ndarray import AcceleratorNDArray, full, zeros
 from numojo.core.layout.ndshape import NDArrayShape as Shape
 from std.testing.testing import assert_true, assert_equal
 from std.testing import TestSuite
@@ -22,17 +22,44 @@ def test_add_cpu_uniform() raises:
         assert_equal(c.item(i), 7.0, "cpu add uniform")
 
 
-def test_add_cpu_distinct_values() raises:
+def _make_distinct_operands() raises -> Tuple[
+    AcceleratorNDArray[DType.float32, Device.CPU],
+    AcceleratorNDArray[DType.float32, Device.CPU],
+]:
     var a = zeros[DType.float32, Device.CPU](Shape(6))
     var b = zeros[DType.float32, Device.CPU](Shape(6))
     for i in range(6):
-        a.itemset(i, Float32(i))
-        b.itemset(i, Float32(100 * i))
-    var c = a + b
+        a.itemset(i, Float32(i + 1))
+        b.itemset(i, Float32(2 * (i + 1)))
+    return (a^, b^)
+
+
+def test_add_cpu_distinct_values() raises:
+    var ab = _make_distinct_operands()
+    var c = ab[0] + ab[1]
     for i in range(6):
-        assert_equal(
-            c.item(i), Float32(i) + Float32(100 * i), "cpu add distinct"
-        )
+        assert_equal(c.item(i), ab[0].item(i) + ab[1].item(i), "cpu add distinct")
+
+
+def test_sub_cpu_distinct_values() raises:
+    var ab = _make_distinct_operands()
+    var c = ab[0] - ab[1]
+    for i in range(6):
+        assert_equal(c.item(i), ab[0].item(i) - ab[1].item(i), "cpu sub distinct")
+
+
+def test_mul_cpu_distinct_values() raises:
+    var ab = _make_distinct_operands()
+    var c = ab[0] * ab[1]
+    for i in range(6):
+        assert_equal(c.item(i), ab[0].item(i) * ab[1].item(i), "cpu mul distinct")
+
+
+def test_div_cpu_distinct_values() raises:
+    var ab = _make_distinct_operands()
+    var c = ab[0] / ab[1]
+    for i in range(6):
+        assert_equal(c.item(i), ab[0].item(i) / ab[1].item(i), "cpu div distinct")
 
 
 def test_add_cpu_shape_mismatch_raises() raises:
@@ -46,35 +73,34 @@ def test_add_cpu_shape_mismatch_raises() raises:
     assert_true(raised, "shape mismatch should raise")
 
 
-def _run_gpu_add_test[device: Device]() raises:
-    var a_host = zeros[DType.float32, Device.CPU](Shape(6))
-    var b_host = zeros[DType.float32, Device.CPU](Shape(6))
-    for i in range(6):
-        a_host.itemset(i, Float32(i))
-        b_host.itemset(i, Float32(100 * i))
+def _run_gpu_binary_op_test[device: Device]() raises:
+    var ab = _make_distinct_operands()
+    var a_gpu = ab[0].to[device]()
+    var b_gpu = ab[1].to[device]()
 
-    var a_gpu = a_host.to[device]()
-    var b_gpu = b_host.to[device]()
-    var c_gpu = a_gpu + b_gpu
-    var c_host = c_gpu.to_host()
+    var add_host = (a_gpu + b_gpu).to_host()
+    var sub_host = (a_gpu - b_gpu).to_host()
+    var mul_host = (a_gpu * b_gpu).to_host()
+    var div_host = (a_gpu / b_gpu).to_host()
 
     for i in range(6):
-        assert_equal(
-            c_host.item(i),
-            Float32(i) + Float32(100 * i),
-            "gpu add matches expected (device=" + String(device) + ")",
-        )
+        var av = ab[0].item(i)
+        var bv = ab[1].item(i)
+        assert_equal(add_host.item(i), av + bv, "gpu add matches cpu")
+        assert_equal(sub_host.item(i), av - bv, "gpu sub matches cpu")
+        assert_equal(mul_host.item(i), av * bv, "gpu mul matches cpu")
+        assert_equal(div_host.item(i), av / bv, "gpu div matches cpu")
 
 
-def test_add_gpu_matches_cpu_when_available() raises:
+def test_binary_ops_gpu_match_cpu_when_available() raises:
     comptime if has_nvidia_gpu_accelerator():
-        _run_gpu_add_test[Device.CUDA]()
+        _run_gpu_binary_op_test[Device.CUDA]()
     elif has_amd_gpu_accelerator():
-        _run_gpu_add_test[Device.ROCM]()
+        _run_gpu_binary_op_test[Device.ROCM]()
     elif has_apple_gpu_accelerator():
-        _run_gpu_add_test[Device.MPS]()
+        _run_gpu_binary_op_test[Device.MPS]()
     else:
-        assert_true(True, "no gpu available; gpu add test skipped")
+        assert_true(True, "no gpu available; gpu binary op tests skipped")
 
 
 def main() raises:

--- a/tests/core/test_accelerator_operations.mojo
+++ b/tests/core/test_accelerator_operations.mojo
@@ -1,0 +1,88 @@
+"""
+Tests for `AcceleratorNDArray` elementwise operation dispatch.
+"""
+
+from numojo.core.accelerator.device import Device
+from numojo.core.accelerator_ndarray import full, zeros
+from numojo.core.layout.ndshape import NDArrayShape as Shape
+from std.testing.testing import assert_true, assert_equal
+from std.testing import TestSuite
+from std.sys.info import (
+    has_amd_gpu_accelerator,
+    has_apple_gpu_accelerator,
+    has_nvidia_gpu_accelerator,
+)
+
+
+def test_add_cpu_uniform() raises:
+    var a = full[DType.float32, Device.CPU](Shape(8), 3.0)
+    var b = full[DType.float32, Device.CPU](Shape(8), 4.0)
+    var c = a + b
+    for i in range(8):
+        assert_equal(c.item(i), 7.0, "cpu add uniform")
+
+
+def test_add_cpu_distinct_values() raises:
+    var a = zeros[DType.float32, Device.CPU](Shape(6))
+    var b = zeros[DType.float32, Device.CPU](Shape(6))
+    for i in range(6):
+        a.itemset(i, Float32(i))
+        b.itemset(i, Float32(100 * i))
+    var c = a + b
+    for i in range(6):
+        assert_equal(
+            c.item(i), Float32(i) + Float32(100 * i), "cpu add distinct"
+        )
+
+
+def test_add_cpu_shape_mismatch_raises() raises:
+    var a = full[DType.float32, Device.CPU](Shape(4), 1.0)
+    var b = full[DType.float32, Device.CPU](Shape(5), 1.0)
+    var raised = False
+    try:
+        _ = a + b
+    except:
+        raised = True
+    assert_true(raised, "shape mismatch should raise")
+
+
+def _run_gpu_add_test[device: Device]() raises:
+    var a_host = zeros[DType.float32, Device.CPU](Shape(6))
+    var b_host = zeros[DType.float32, Device.CPU](Shape(6))
+    for i in range(6):
+        a_host.itemset(i, Float32(i))
+        b_host.itemset(i, Float32(100 * i))
+
+    var a_gpu = a_host.to[device]()
+    var b_gpu = b_host.to[device]()
+    var c_gpu = a_gpu + b_gpu
+    var c_host = c_gpu.to_host()
+
+    for i in range(6):
+        assert_equal(
+            c_host.item(i),
+            Float32(i) + Float32(100 * i),
+            "gpu add matches expected (device=" + String(device) + ")",
+        )
+
+
+def test_add_gpu_matches_cpu_when_available() raises:
+    comptime if has_nvidia_gpu_accelerator():
+        _run_gpu_add_test[Device.CUDA]()
+    elif has_amd_gpu_accelerator():
+        _run_gpu_add_test[Device.ROCM]()
+    elif has_apple_gpu_accelerator():
+        _run_gpu_add_test[Device.MPS]()
+    else:
+        assert_true(True, "no gpu available; gpu add test skipped")
+
+
+def main() raises:
+    if (
+        has_nvidia_gpu_accelerator()
+        or has_amd_gpu_accelerator()
+        or has_apple_gpu_accelerator()
+    ):
+        TestSuite.discover_tests[__functions_in_module()]().run()
+    else:
+        print("No GPU available; skipping GPU tests.")

--- a/tests/core/test_operations.mojo
+++ b/tests/core/test_operations.mojo
@@ -1,7 +1,42 @@
+"""
+Backend (HostExecutor) regression tests.
+
+`HostExecutor` picks between a serial path and a chunked-parallel path
+(`parallelize`) based on array size (see `_num_tasks_for` in
+`numojo/routines/operations/backend.mojo`).
+
+Every test below is run at both
+a SMALL size (forces the serial fallback) and a LARGE size (forces the
+parallel path) so a regression in either path is caught.
+"""
+
 import numojo as nm
 from numojo.prelude import *
+from numojo.routines.math.arithmetic import fma
+from numojo.routines.logic.contents import isnan
+from std.python import Python, PythonObject
 from std.testing.testing import assert_true
 from std.testing import TestSuite
+
+comptime SMALL_N = 5
+comptime LARGE_N = 200_000
+
+
+def check_close[
+    dtype: DType
+](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
+    var np = Python.import_module("numpy")
+    assert_true(
+        np.all(np.isclose(array.to_numpy(), np_sol, atol=PythonObject(1e-6))),
+        st,
+    )
+
+
+def check_equal[
+    dtype: DType
+](array: nm.NDArray[dtype], np_sol: PythonObject, st: String) raises:
+    var np = Python.import_module("numpy")
+    assert_true(np.all(np.equal(array.to_numpy(), np_sol)), st)
 
 
 def test_ndarray_multiplication_commutes() raises:
@@ -10,6 +45,245 @@ def test_ndarray_multiplication_commutes() raises:
     var L = 2.0 * (A @ B)
     var R = (A @ B) * 2.0
     assert_true((L == R).all())
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_unary: NDArray -> NDArray  (e.g. exp, sin, sqrt)
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_unary_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    check_close(nm.exp(a), np.exp(anp), "apply_unary (serial): exp mismatch")
+
+
+def test_apply_unary_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    check_close(nm.exp(a), np.exp(anp), "apply_unary (parallel): exp mismatch")
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_binary: NDArray, NDArray -> NDArray  (e.g. add, mul)
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_binary_array_array_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var b = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(a + b, anp + bnp, "apply_binary (serial): add mismatch")
+    check_close(a * b, anp * bnp, "apply_binary (serial): mul mismatch")
+
+
+def test_apply_binary_array_array_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var b = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(a + b, anp + bnp, "apply_binary (parallel): add mismatch")
+    check_close(a * b, anp * bnp, "apply_binary (parallel): mul mismatch")
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_binary: NDArray, Scalar -> NDArray  (and Scalar, NDArray -> NDArray)
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_binary_array_scalar_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    check_close(
+        a + 5.0, anp + 5.0, "apply_binary (serial): array+scalar mismatch"
+    )
+    check_close(
+        5.0 + a, 5.0 + anp, "apply_binary (serial): scalar+array mismatch"
+    )
+
+
+def test_apply_binary_array_scalar_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    check_close(
+        a + 5.0, anp + 5.0, "apply_binary (parallel): array+scalar mismatch"
+    )
+    check_close(
+        5.0 + a, 5.0 + anp, "apply_binary (parallel): scalar+array mismatch"
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_binary_predicate: NDArray, NDArray -> NDArray[bool]
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_binary_predicate_array_array_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var b = nm.arange[nm.f64](SMALL_N, 0, -1)
+    check_equal(
+        a > b,
+        a.to_numpy() > b.to_numpy(),
+        "apply_binary_predicate (serial): array>array mismatch",
+    )
+
+
+def test_apply_binary_predicate_array_array_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var b = nm.arange[nm.f64](LARGE_N, 0, -1)
+    check_equal(
+        a > b,
+        a.to_numpy() > b.to_numpy(),
+        "apply_binary_predicate (parallel): array>array mismatch",
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_binary_predicate: NDArray, Scalar -> NDArray[bool]
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_binary_predicate_array_scalar_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    check_equal(
+        a > 2.0,
+        anp > 2.0,
+        "apply_binary_predicate (serial): array>scalar mismatch",
+    )
+
+
+def test_apply_binary_predicate_array_scalar_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    check_equal(
+        a > 2.0,
+        anp > 2.0,
+        "apply_binary_predicate (parallel): array>scalar mismatch",
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_unary_predicate: NDArray -> NDArray[bool]  (e.g. isnan)
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_unary_predicate_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    check_equal(
+        isnan(a),
+        np.isnan(anp),
+        "apply_unary_predicate (serial): isnan mismatch",
+    )
+
+
+def test_apply_unary_predicate_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    check_equal(
+        isnan(a),
+        np.isnan(anp),
+        "apply_unary_predicate (parallel): isnan mismatch",
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# apply_ternary: NDArray, NDArray, NDArray -> NDArray  (fma)
+# and NDArray, NDArray, Scalar -> NDArray
+# ===-----------------------------------------------------------------------===#
+
+
+def test_apply_ternary_array_array_array_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var b = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(
+        fma(a, b, a),
+        anp * bnp + anp,
+        "apply_ternary (serial): fma(a,b,a) mismatch",
+    )
+
+
+def test_apply_ternary_array_array_array_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var b = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(
+        fma(a, b, a),
+        anp * bnp + anp,
+        "apply_ternary (parallel): fma(a,b,a) mismatch",
+    )
+
+
+def test_apply_ternary_array_array_scalar_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, SMALL_N + 1)
+    var b = nm.arange[nm.f64](1, SMALL_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(
+        fma(a, b, 2.0),
+        anp * bnp + 2.0,
+        "apply_ternary (serial): fma(a,b,2.0) mismatch",
+    )
+
+
+def test_apply_ternary_array_array_scalar_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, LARGE_N + 1)
+    var b = nm.arange[nm.f64](1, LARGE_N + 1)
+    var anp = a.to_numpy()
+    var bnp = b.to_numpy()
+    check_close(
+        fma(a, b, 2.0),
+        anp * bnp + 2.0,
+        "apply_ternary (parallel): fma(a,b,2.0) mismatch",
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# Automatic broadcasting through the same backend (Phase 1 regression net)
+# ===-----------------------------------------------------------------------===#
+
+
+def test_broadcast_through_backend_small() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, 4).reshape(Shape(3, 1))
+    var b = nm.arange[nm.f64](1, 5).reshape(Shape(1, 4))
+    check_close(
+        a + b,
+        a.to_numpy() + b.to_numpy(),
+        "broadcast (serial): (3,1)+(1,4) mismatch",
+    )
+
+
+def test_broadcast_through_backend_large() raises:
+    var np = Python.import_module("numpy")
+    var a = nm.arange[nm.f64](1, 1001).reshape(Shape(1000, 1))
+    var b = nm.arange[nm.f64](1, 1001).reshape(Shape(1, 1000))
+    check_close(
+        a + b,
+        a.to_numpy() + b.to_numpy(),
+        "broadcast (parallel): (1000,1)+(1,1000) mismatch",
+    )
 
 
 def main() raises:


### PR DESCRIPTION
- Add the first real GPU compute path for AcceleratorNDArray: add, sub, mul, div, and neg, dispatching via comptime if conditional to a CPU loop or to a hand-written GPU kernel otherwise (These are currently very naive algorithms).

- Add AcceleratorNDArray.unsafe_device_ptr() / .device_context() - GPU-side counterparts to the existing CPU-only unsafe_ptr() (This will be remodelled in upcoming updates for memory safety).

- Binary ops share one op-code-parameterized kernel (ADD/SUB/MUL/DIV); neg gets its own dedicated kernel since it's currently the only unary op. Both require C-contiguous (and same-shape, for binary) operands for now - raise otherwise.

- Add tests/core/test_accelerator_operations.mojo. 

#273 