### PR TITLE
[Routines] Add `put`, N-D `diagonal`, `searchsorted`

### DIFF
--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,12 +31,7 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import (
-    NDArrayShape,
-    NDArrayStrides,
-    Flags,
-    newaxis
-)
+from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
 
 from .dtype import (
     i8,

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,7 +31,12 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
+from .layout import (
+    NDArrayShape,
+    NDArrayStrides,
+    Flags,
+    newaxis
+)
 
 from .dtype import (
     i8,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -88,7 +88,10 @@ import numojo.routines.statistics as statistics
 from numojo.routines.indexing import (
     compress,
     take as _take,
+    take_along_axis as _take_along_axis,
     nonzero as _nonzero,
+    put as _put,
+    searchsorted as _searchsorted,
 )
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
@@ -4960,22 +4963,33 @@ struct NDArray[dtype: DType = DType.float64](
         """
         return numojo_math.cumsum[Self.dtype](self.copy(), axis=axis)
 
-    def diagonal(self, offset: Int = 0) raises -> Self:
+    def diagonal(
+        self, offset: Int = 0, axis1: Int = 0, axis2: Int = 1
+    ) raises -> Self:
         """Returns specific diagonals.
 
-        Currently supports only 2D arrays.
+        For 2-D arrays (the default `axis1=0, axis2=1`), returns the 1-D
+        diagonal at the given `offset`. For N-D arrays, `axis1`/`axis2`
+        select the two axes whose 2-D sub-array diagonals are extracted; the
+        result has those two axes removed and replaced by a trailing
+        diagonal axis.
 
         Args:
             offset: The offset of the diagonal from the main diagonal.
+            axis1: First axis of the 2-D sub-arrays from which the
+                diagonals should be taken. Defaults to 0.
+            axis2: Second axis of the 2-D sub-arrays from which the
+                diagonals should be taken. Defaults to 1.
 
         Returns:
-            The diagonal of the NDArray.
+            The diagonal(s) of the NDArray.
 
         Raises:
-            Error: If the array is not 2D.
+            Error: If the array has fewer than 2 dimensions.
+            Error: If `axis1` or `axis2` is out of bounds, or equal.
             Error: If the offset is beyond the shape of the array.
         """
-        return linalg.diagonal(self, offset=offset)
+        return linalg.diagonal(self, offset=offset, axis1=axis1, axis2=axis2)
 
     def take(self, indices: NDArray[DType.int], axis: Int) raises -> Self:
         """Takes elements from the array along an axis.
@@ -5035,6 +5049,153 @@ struct NDArray[dtype: DType = DType.float64](
             ```
         """
         return _take(self, indices)
+
+    def take_along_axis(
+        self, indices: NDArray[DType.int], axis: Int = 0
+    ) raises -> Self:
+        """Takes values from the array along the given axis based on indices.
+
+        Args:
+            indices: The indices array.
+            axis: The axis along which to take values. Default is 0.
+
+        Returns:
+            An array with the same shape as indices with values taken from
+            the array along the given axis.
+
+        Raises:
+            Error: If the axis is out of bounds for the array.
+            Error: If the ndim of self and indices are not the same.
+            Error: If the shape of indices does not match the shape of self
+                except along the given axis.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i8](12).reshape(nm.Shape(3, 4))
+            var ind = nm.array[nm.int]("[[0, 1, 2, 0], [1, 0, 2, 1]]")
+            print(a.take_along_axis(ind, axis=0))
+            ```
+        """
+        return _take_along_axis(self, indices, axis)
+
+    def put(mut self, indices: NDArray[DType.int], values: Self) raises:
+        """Replaces values at flat (linear) index positions in-place.
+
+        Equivalent to `self.flatten()[indices] = values`, but writes
+        directly into `self`. If `values` has fewer elements than
+        `indices`, it is repeated (broadcast) cyclically over `indices`.
+
+        Args:
+            indices: Linear (flat) indices into `self`. May be any shape.
+                Negative indices are normalised (counted from the end).
+            values: Values to write. Broadcast cyclically if shorter than
+                `indices`.
+
+        Raises:
+            Error: If any index is out of bounds for the flattened array.
+            Error: If `values` is empty while `indices` is not.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i32](6)
+            a.put(nm.array[nm.int]("[0, 2]"), nm.array[nm.i32]("[10, 20]"))
+            print(a)
+            # [10, 1, 20, 3, 4, 5]
+            ```
+        """
+        _put(self, indices, values)
+
+    def put(
+        mut self, indices: NDArray[DType.int], value: Scalar[Self.dtype]
+    ) raises:
+        """Replaces values at flat (linear) index positions in-place with a
+        single broadcast scalar.
+
+        This is a method ***OVERLOAD*** of `put` for the scalar-`value` case.
+
+        Args:
+            indices: Linear (flat) indices into `self`. May be any shape.
+                Negative indices are normalised (counted from the end).
+            value: Scalar value written to every selected position.
+
+        Raises:
+            Error: If any index is out of bounds for the flattened array.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i32](6)
+            a.put(nm.array[nm.int]("[0, 2]"), Scalar[nm.i32](99))
+            print(a)
+            # [99, 1, 99, 3, 4, 5]
+            ```
+        """
+        _put(self, indices, value)
+
+    def searchsorted(
+        self, v: Self, side: String = "left"
+    ) raises -> NDArray[DType.int]:
+        """Finds indices where elements of `v` should be inserted into
+        `self` (assumed sorted, 1-D) to keep it sorted. Uses binary search.
+
+        Args:
+            v: Array of values to find insertion indices for.
+            side: `"left"` (default) returns the leftmost valid insertion
+                index; `"right"` returns the rightmost.
+
+        Returns:
+            Array of insertion indices, same shape as `v`.
+
+        Raises:
+            Error: If `self` is not 1-D.
+            Error: If `side` is not `"left"` or `"right"`.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+            print(a.searchsorted(nm.array[nm.i32]("[2, 6]")))
+            # [1, 3]
+            ```
+        """
+        return _searchsorted(self, v, side)
+
+    def searchsorted(
+        self, v: Scalar[Self.dtype], side: String = "left"
+    ) raises -> Int:
+        """Finds the index where scalar `v` should be inserted into `self`
+        (assumed sorted, 1-D) to keep it sorted.
+
+        This is a method ***OVERLOAD*** of `searchsorted` for a scalar `v`.
+
+        Args:
+            v: Scalar value to find the insertion index for.
+            side: `"left"` (default) returns the leftmost valid insertion
+                index; `"right"` returns the rightmost.
+
+        Returns:
+            Insertion index.
+
+        Raises:
+            Error: If `self` is not 1-D.
+            Error: If `side` is not `"left"` or `"right"`.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+            print(a.searchsorted(Scalar[nm.i32](4)))
+            # 2
+            ```
+        """
+        return _searchsorted(self, v, side)
 
     def fill(mut self, val: Scalar[Self.dtype]):
         """Fills all items of the array with the given value.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -690,6 +690,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
+
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -690,7 +690,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -856,9 +856,7 @@ def searchsorted[
 def searchsorted[
     dtype: DType,
     //,
-](
-    a: NDArray[dtype], v: Scalar[dtype], side: String = "left"
-) raises -> Int:
+](a: NDArray[dtype], v: Scalar[dtype], side: String = "left") raises -> Int:
     """Finds the index where scalar `v` should be inserted into sorted 1-D
     array `a` to keep it sorted.
 

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -564,6 +564,138 @@ def take[
 
 
 # ===----------------------------------------------------------------------=== #
+# put
+# ===----------------------------------------------------------------------=== #
+
+
+def put[
+    dtype: DType,
+    //,
+](
+    mut a: NDArray[dtype],
+    indices: NDArray[DType.int],
+    values: NDArray[dtype],
+) raises:
+    """Replaces values at flat (linear) index positions of `a` in-place.
+
+    Equivalent to `a.flatten()[indices] = values`, but writes directly into
+    `a` (any array order). If `values` has fewer elements than `indices`, it
+    is repeated (broadcast) cyclically over `indices`. `values` must not be empty
+    unless `indices` is also empty.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Destination array to be modified in-place.
+        indices: Linear (flat) indices into `a`. May be any shape. Negative
+            indices are normalised (counted from the end).
+        values: Values to write. Broadcast cyclically if shorter than
+            `indices`.
+
+    Raises:
+        Error: If any index is out of bounds for the flattened array.
+        Error: If `values` is empty while `indices` is not.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](6)
+        nm.indexing.put(a, nm.array[nm.int]("[0, 2]"), nm.array[nm.i32]("[10, 20]"))
+        print(a)
+        # [10, 1, 20, 3, 4, 5]
+        ```
+        .
+    """
+    if indices.size == 0:
+        return
+
+    if values.size == 0:
+        raise Error(
+            String(
+                "\nError in `put`: values is empty but indices has {}"
+                " element(s)."
+            ).format(indices.size)
+        )
+
+    var indices_c = indices.contiguous()
+    var values_c = values.contiguous()
+
+    for i in range(indices_c.size):
+        var raw = Int(indices_c._buf.ptr[i])
+        if raw < -a.size or raw >= a.size:
+            raise Error(
+                String(
+                    "\nError in `put`: index {} is out of bounds for array"
+                    " of size {}."
+                ).format(raw, a.size)
+            )
+        var norm_idx = raw
+        if norm_idx < 0:
+            norm_idx += a.size
+
+        a.itemset(norm_idx, values_c._buf.ptr[i % values_c.size])
+
+
+def put[
+    dtype: DType,
+    //,
+](
+    mut a: NDArray[dtype],
+    indices: NDArray[DType.int],
+    value: Scalar[dtype],
+) raises:
+    """Replaces values at flat (linear) index positions of `a` in-place with
+    a single broadcast scalar.
+
+    This is a function ***OVERLOAD*** of `put` for the scalar-`value` case.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Destination array to be modified in-place.
+        indices: Linear (flat) indices into `a`. May be any shape. Negative
+            indices are normalised (counted from the end).
+        value: Scalar value written to every selected position.
+
+    Raises:
+        Error: If any index is out of bounds for the flattened array.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](6)
+        nm.indexing.put(a, nm.array[nm.int]("[0, 2]"), Scalar[nm.i32](99))
+        print(a)
+        # [99, 1, 99, 3, 4, 5]
+        ```
+        .
+    """
+    if indices.size == 0:
+        return
+
+    var indices_c = indices.contiguous()
+
+    for i in range(indices_c.size):
+        var raw = Int(indices_c._buf.ptr[i])
+        if raw < -a.size or raw >= a.size:
+            raise Error(
+                String(
+                    "\nError in `put`: index {} is out of bounds for array"
+                    " of size {}."
+                ).format(raw, a.size)
+            )
+        var norm_idx = raw
+        if norm_idx < 0:
+            norm_idx += a.size
+
+        a.itemset(norm_idx, value)
+
+
+# ===----------------------------------------------------------------------=== #
 # nonzero
 # ===----------------------------------------------------------------------=== #
 
@@ -632,3 +764,163 @@ def nonzero[
             out_idx += 1
 
     return result^
+
+
+# ===----------------------------------------------------------------------=== #
+# searchsorted
+# ===----------------------------------------------------------------------=== #
+
+
+def searchsorted[
+    dtype: DType,
+    //,
+](
+    a: NDArray[dtype], v: NDArray[dtype], side: String = "left"
+) raises -> NDArray[DType.int]:
+    """Finds indices where elements of `v` should be inserted into sorted
+    1-D array `a` to keep it sorted.
+
+    Uses binary search. `a` must be a 1-D array, assumed (not verified)
+    to be sorted in ascending order.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: 1-D sorted source array.
+        v: Array of values to find insertion indices for.
+        side: `"left"` (default) returns the leftmost valid insertion index;
+            `"right"` returns the rightmost.
+
+    Returns:
+        Array of insertion indices, same shape as `v`.
+
+    Raises:
+        Error: If `a` is not 1-D.
+        Error: If `side` is not `"left"` or `"right"`.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+        print(nm.indexing.searchsorted(a, nm.array[nm.i32]("[2, 6]")))
+        # [1, 3]
+        ```
+        .
+    """
+    if a.ndim != 1:
+        raise Error(
+            String(
+                "\nError in `searchsorted`: `a` must be a 1-D array, got {}"
+                " dimensions."
+            ).format(a.ndim)
+        )
+    if side != "left" and side != "right":
+        raise Error(
+            String(
+                "\nError in `searchsorted`: `side` must be 'left' or"
+                " 'right', got '{}'."
+            ).format(side)
+        )
+
+    var a_c = a.contiguous()
+    var v_c = v.contiguous()
+    var n = a_c.size
+
+    var result = NDArray[DType.int](Shape(v_c.shape))
+
+    for i in range(v_c.size):
+        var target = v_c._buf.ptr[i]
+        var lo = 0
+        var hi = n
+        if side == "left":
+            while lo < hi:
+                var mid = (lo + hi) // 2
+                if a_c._buf.ptr[mid] < target:
+                    lo = mid + 1
+                else:
+                    hi = mid
+        else:
+            while lo < hi:
+                var mid = (lo + hi) // 2
+                if a_c._buf.ptr[mid] <= target:
+                    lo = mid + 1
+                else:
+                    hi = mid
+        result._buf.ptr[i] = Scalar[DType.int](lo)
+
+    return result^
+
+
+def searchsorted[
+    dtype: DType,
+    //,
+](
+    a: NDArray[dtype], v: Scalar[dtype], side: String = "left"
+) raises -> Int:
+    """Finds the index where scalar `v` should be inserted into sorted 1-D
+    array `a` to keep it sorted.
+
+    This is a function ***OVERLOAD*** of `searchsorted` for a scalar `v`.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: 1-D sorted source array.
+        v: Scalar value to find the insertion index for.
+        side: `"left"` (default) returns the leftmost valid insertion index;
+            `"right"` returns the rightmost.
+
+    Returns:
+        Insertion index.
+
+    Raises:
+        Error: If `a` is not 1-D.
+        Error: If `side` is not `"left"` or `"right"`.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+        print(nm.indexing.searchsorted(a, Scalar[nm.i32](4)))
+        # 2
+        ```
+        .
+    """
+    if a.ndim != 1:
+        raise Error(
+            String(
+                "\nError in `searchsorted`: `a` must be a 1-D array, got {}"
+                " dimensions."
+            ).format(a.ndim)
+        )
+    if side != "left" and side != "right":
+        raise Error(
+            String(
+                "\nError in `searchsorted`: `side` must be 'left' or"
+                " 'right', got '{}'."
+            ).format(side)
+        )
+
+    var a_c = a.contiguous()
+    var n = a_c.size
+    var lo = 0
+    var hi = n
+    if side == "left":
+        while lo < hi:
+            var mid = (lo + hi) // 2
+            if a_c._buf.ptr[mid] < v:
+                lo = mid + 1
+            else:
+                hi = mid
+    else:
+        while lo < hi:
+            var mid = (lo + hi) // 2
+            if a_c._buf.ptr[mid] <= v:
+                lo = mid + 1
+            else:
+                hi = mid
+    return lo

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -66,8 +66,7 @@ def diagonal[
     """
     if a.ndim < 2:
         raise Error(
-            "\nError in `diagonal`: Array must have at least 2 dimensions,"
-            " got "
+            "\nError in `diagonal`: Array must have at least 2 dimensions, got "
             + String(a.ndim)
         )
 
@@ -91,9 +90,7 @@ def diagonal[
             ).format(axis1, axis2, a.ndim)
         )
     if norm_axis1 == norm_axis2:
-        raise Error(
-            "\nError in `diagonal`: axis1 and axis2 must be different."
-        )
+        raise Error("\nError in `diagonal`: axis1 and axis2 must be different.")
 
     if not a.is_c_contiguous():
         return diagonal(a.contiguous(), offset, axis1, axis2)

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -15,17 +15,29 @@ from std.algorithm import parallelize, vectorize
 
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
+from numojo.core.layout import NDArrayShape
+from numojo.core.type_aliases import Shape
 
 
 def diagonal[
     dtype: DType
-](a: NDArray[dtype], offset: Int = 0) raises -> NDArray[dtype]:
+](
+    a: NDArray[dtype], offset: Int = 0, axis1: Int = 0, axis2: Int = 1
+) raises -> NDArray[dtype]:
     """
     Returns specific diagonals.
-    Currently supports only 2D arrays.
+
+    For 2-D arrays (the default `axis1=0, axis2=1` case), returns the 1-D
+    diagonal at the given `offset`. For N-D arrays, `axis1` and `axis2` are
+    treated as the two axes that define the 2-D sub-arrays whose diagonals
+    are extracted; the result has the two diagonalized axes removed and
+    replaced by a new last axis holding the diagonal values. The result shape is
+    `a.shape[axes not in {axis1, axis2}] + (diagonal_length,)`, where the
+    surviving axes keep their original relative order.
 
     Raises:
-        Error: If the array is not 2D.
+        Error: If the array has fewer than 2 dimensions.
+        Error: If `axis1` or `axis2` is out of bounds, or `axis1 == axis2`.
         Error: If the offset is beyond the shape of the array.
 
     Parameters:
@@ -34,44 +46,138 @@ def diagonal[
     Args:
         a: An NDArray.
         offset: Offset of the diagonal from the main diagonal.
+        axis1: First axis of the 2-D sub-arrays from which the diagonals
+            should be taken. Defaults to 0.
+        axis2: Second axis of the 2-D sub-arrays from which the diagonals
+            should be taken. Defaults to 1.
 
     Returns:
-        The diagonal of the NDArray.
-    """
+        The diagonal(s) of the NDArray.
 
-    if a.ndim != 2:
-        raise Error("\nError in `diagonal`: Only supports 2D arrays")
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](60).reshape(nm.Shape(3, 4, 5))
+        # axis1=0, axis2=1 (default): result shape (5, 3) -- min(3,4)=3
+        print(nm.linalg.diagonal(a, axis1=0, axis2=1))
+        ```
+        .
+    """
+    if a.ndim < 2:
+        raise Error(
+            "\nError in `diagonal`: Array must have at least 2 dimensions,"
+            " got "
+            + String(a.ndim)
+        )
+
+    var norm_axis1 = axis1
+    if norm_axis1 < 0:
+        norm_axis1 = a.ndim + norm_axis1
+    var norm_axis2 = axis2
+    if norm_axis2 < 0:
+        norm_axis2 = a.ndim + norm_axis2
+
+    if (
+        norm_axis1 < 0
+        or norm_axis1 >= a.ndim
+        or norm_axis2 < 0
+        or norm_axis2 >= a.ndim
+    ):
+        raise Error(
+            String(
+                "\nError in `diagonal`: axis1 {} and axis2 {} must be valid"
+                " axes for an array with {} dimensions."
+            ).format(axis1, axis2, a.ndim)
+        )
+    if norm_axis1 == norm_axis2:
+        raise Error(
+            "\nError in `diagonal`: axis1 and axis2 must be different."
+        )
 
     if not a.is_c_contiguous():
-        return diagonal(a.contiguous(), offset)
+        return diagonal(a.contiguous(), offset, axis1, axis2)
 
-    var m: Int = a.shape[0]
-    var n: Int = a.shape[1]
+    var m: Int = a.shape[norm_axis1]
+    var n: Int = a.shape[norm_axis2]
 
     if offset > n - 1 or offset < -(m - 1):
         raise Error(
             "\nError in `diagonal`: Offset "
             + String(offset)
-            + " is outside the valid range for array with shape ("
+            + " is outside the valid range for axes with shape ("
             + String(m)
             + ", "
             + String(n)
             + ")"
         )
 
-    var result: NDArray[dtype]
-
+    var diag_len: Int
+    var start_row: Int
+    var start_col: Int
     if offset >= 0:
-        var size_of_result: Int = min(m, n - offset)
-        result = NDArray[dtype](Shape(size_of_result))
-        for i in range(size_of_result):
-            result._buf.ptr[i] = a._buf.ptr[i * n + (i + offset)]
+        diag_len = min(m, n - offset)
+        start_row = 0
+        start_col = offset
     else:
-        var k: Int = -offset
-        var size_of_result: Int = min(m - k, n)
-        result = NDArray[dtype](Shape(size_of_result))
-        for i in range(size_of_result):
-            result._buf.ptr[i] = a._buf.ptr[(i + k) * n + i]
+        diag_len = min(m + offset, n)
+        start_row = -offset
+        start_col = 0
+
+    # Fast path: simple 2-D case with default axes.
+    if a.ndim == 2 and norm_axis1 == 0 and norm_axis2 == 1:
+        var result2d = NDArray[dtype](Shape(diag_len))
+        for i in range(diag_len):
+            result2d._buf.ptr[i] = a._buf.ptr[
+                (i + start_row) * n + (i + start_col)
+            ]
+        return result2d^
+
+    # General N-D case: surviving axes (in original order) come first,
+    # the diagonal axis (length `diag_len`) is appended last.
+    var surviving_axes = List[Int]()
+    for d in range(a.ndim):
+        if d != norm_axis1 and d != norm_axis2:
+            surviving_axes.append(d)
+
+    var out_shape_list = List[Int]()
+    for d in surviving_axes:
+        out_shape_list.append(a.shape[d])
+    out_shape_list.append(diag_len)
+
+    var result = NDArray[dtype](NDArrayShape(out_shape_list))
+
+    var surviving_size = 1
+    for d in surviving_axes:
+        surviving_size *= a.shape[d]
+
+    # strides of `a` (C-contiguous, since we ensured this above)
+    var a_strides = List[Int]()
+    for _ in range(a.ndim):
+        a_strides.append(0)
+    var stride_acc = 1
+    for d in range(a.ndim - 1, -1, -1):
+        a_strides[d] = stride_acc
+        stride_acc *= a.shape[d]
+
+    for outer in range(surviving_size):
+        # Decode `outer` into coordinates along `surviving_axes`.
+        var rem = outer
+        var base_offset = 0
+        for k in range(len(surviving_axes) - 1, -1, -1):
+            var axis_d = surviving_axes[k]
+            var dim_size = a.shape[axis_d]
+            var coord = rem % dim_size
+            rem //= dim_size
+            base_offset += coord * a_strides[axis_d]
+
+        for i in range(diag_len):
+            var src_offset = (
+                base_offset
+                + (i + start_row) * a_strides[norm_axis1]
+                + (i + start_col) * a_strides[norm_axis2]
+            )
+            result._buf.ptr[outer * diag_len + i] = a._buf.ptr[src_offset]
 
     return result^
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,1186 +1,1186 @@
 version: 7
 platforms:
-- name: linux-64
-- name: osx-arm64
+  - name: linux-64
+  - name: osx-arm64
 environments:
   default:
     channels:
-    - url: https://conda.modular.com/max/
-    - url: https://conda.anaconda.org/conda-forge/
-    - url: https://conda.modular.com/max-nightly/
-    - url: https://repo.prefix.dev/modular-community/
+      - url: https://conda.modular.com/max/
+      - url: https://conda.anaconda.org/conda-forge/
+      - url: https://conda.modular.com/max-nightly/
+      - url: https://repo.prefix.dev/modular-community/
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+        - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+        - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
+        - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
+        - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+        - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+        - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+        - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
+        - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
+        - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
 packages:
-- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  build_number: 20
-  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  md5: a9f577daf3de00bca7c3c76c0ecbd1de
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgomp >=7.5.0
-  constrains:
-  - openmp_impl <0.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 28948
-  timestamp: 1770939786096
-- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-  md5: d2ffd7602c02f2b316fd921d39876885
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 260182
-  timestamp: 1771350215188
-- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
-  md5: b38117a3c920364aff79f870c984b4a3
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  license: LGPL-2.1-or-later
-  size: 134088
-  timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
-  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - keyutils >=1.6.3,<2.0a0
-  - libedit >=3.1.20250104,<3.2.0a0
-  - libedit >=3.1.20250104,<4.0a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - openssl >=3.5.7,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1388990
-  timestamp: 1781859420533
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
-  md5: 18335a698559cdbcd86150a48bf54ba6
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
-  constrains:
-  - binutils_impl_linux-64 2.45.1
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 728002
-  timestamp: 1774197446916
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
-  build_number: 8
-  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
-  md5: 00fc660ab1b2f5ca07e92b4900d10c79
-  depends:
-  - libopenblas >=0.3.33,<0.3.34.0a0
-  - libopenblas >=0.3.33,<1.0a0
-  constrains:
-  - blas 2.308   openblas
-  - mkl <2027
-  - libcblas   3.11.0   8*_openblas
-  - liblapack  3.11.0   8*_openblas
-  - liblapacke 3.11.0   8*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18804
-  timestamp: 1779859100675
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
-  build_number: 8
-  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
-  md5: 33a413f1095f8325e5c30fde3b0d2445
-  depends:
-  - libblas 3.11.0 8_h4a7cf45_openblas
-  constrains:
-  - blas 2.308   openblas
-  - liblapacke 3.11.0   8*_openblas
-  - liblapack  3.11.0   8*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18778
-  timestamp: 1779859107964
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
-  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
-  depends:
-  - ncurses
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - ncurses >=6.5,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 134676
-  timestamp: 1738479519902
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  md5: b24d3c612f71e7aa74158d92106318b2
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - expat 2.8.1.*
-  license: MIT
-  license_family: MIT
-  size: 77856
-  timestamp: 1781203599810
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
-  md5: a360c33a5abe61c07959e449fa1453eb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: MIT
-  license_family: MIT
-  size: 58592
-  timestamp: 1769456073053
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
-  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - _openmp_mutex >=4.5
-  constrains:
-  - libgcc-ng ==15.2.0=*_19
-  - libgomp 15.2.0 he0feb66_19
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 1041084
-  timestamp: 1778269013026
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
-  sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
-  md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
-  depends:
-  - libgfortran5 15.2.0 h68bc16d_19
-  constrains:
-  - libgfortran-ng ==15.2.0=*_19
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27655
-  timestamp: 1778269042954
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
-  sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
-  md5: 85072b0ad177c966294f129b7c04a2d5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=15.2.0
-  constrains:
-  - libgfortran 15.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 2483673
-  timestamp: 1778269025089
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
-  md5: faac990cb7aedc7f3a2224f2c9b0c26c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 603817
-  timestamp: 1778268942614
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
-  build_number: 8
-  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
-  md5: 809be8ba8712c77bc7d44c2d99390dc4
-  depends:
-  - libblas 3.11.0 8_h4a7cf45_openblas
-  constrains:
-  - blas 2.308   openblas
-  - libcblas   3.11.0   8*_openblas
-  - liblapacke 3.11.0   8*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18790
-  timestamp: 1779859115086
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
-  md5: b88d90cad08e6bc8ad540cb310a761fb
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  constrains:
-  - xz 5.8.3.*
-  license: 0BSD
-  size: 113478
-  timestamp: 1775825492909
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
-  md5: 2c21e66f50753a083cbe6b80f38268fa
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 92400
-  timestamp: 1769482286018
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-  sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
-  md5: 2d3278b721e40468295ca755c3b84070
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  constrains:
-  - openblas >=0.3.33,<0.3.34.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5931919
-  timestamp: 1776993658641
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-  sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
-  md5: 965e4d531b588b2e42f66fd8e48b056c
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: ISC
-  size: 269272
-  timestamp: 1779163468406
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-  sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
-  md5: 062b0ac602fb0adf250e3dfa86f221c4
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.2,<2.0a0
-  license: blessing
-  size: 957849
-  timestamp: 1780574429573
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
-  md5: 5794b3bdc38177caf969dabd3af08549
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc 15.2.0 he0feb66_19
-  constrains:
-  - libstdcxx-ng ==15.2.0=*_19
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 5852044
-  timestamp: 1778269036376
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
-  md5: 01bb81d12c957de066ea7362007df642
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 40017
-  timestamp: 1781625522462
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-  md5: d87ff7921124eccd67248aa483c23fec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - zlib 1.3.2 *_2
-  license: Zlib
-  license_family: Other
-  size: 63629
-  timestamp: 1774072609062
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
-  md5: fc21868a1a5aacc937e7a18747acb8a5
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  license: X11 AND BSD-3-Clause
-  size: 918956
-  timestamp: 1777422145199
-- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
-  sha256: 7caba80d1515ef3a697a96fa23a1f14fceffd76f3261f0daea510d5a2209b064
-  md5: 508c839b99562e2354917a6c83ab195b
-  depends:
-  - python
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - python_abi 3.13.* *_cp313
-  - libblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 9005587
-  timestamp: 1782112542305
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-  sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
-  md5: 79dd2074b5cd5c5c6b2930514a11e22d
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - ca-certificates
-  - libgcc >=14
-  license: Apache-2.0
-  license_family: Apache
-  size: 3159683
-  timestamp: 1781069855778
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
-  build_number: 100
-  sha256: f2146aff59ce4b571a8f1d1acf94f9bed6cc18ab5632d7dcc940fb48ecdeef99
-  md5: 93762cd272814a142cf21d794f8fb0c1
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.8.1,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - liblzma >=5.8.3,<6.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libuuid >=2.42.1,<3.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.7,<4.0a0
-  - python_abi 3.13.* *_cp313
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  license: Python-2.0
-  size: 37398694
-  timestamp: 1781258934574
-  python_site_packages_path: lib/python3.13/site-packages
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
-  noarch: python
-  sha256: 970b2a1d12983d8d1cc05d914ad88a0b6ef1fa14038c9649aa834dd6ebee65d7
-  md5: acd216255e1370e9aeab5351b831f07c
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - _python_abi3_support 1.*
-  - cpython >=3.12
-  - zeromq >=4.3.5,<4.4.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 210896
-  timestamp: 1779483879367
-- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
-  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 345073
-  timestamp: 1765813471974
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
-  sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
-  md5: a32f88181ff9a3451c71be1f17a7c799
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx >=14
-  - numpy <2.7
-  - numpy >=1.23,<3
-  - numpy >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 17171066
-  timestamp: 1781912954186
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
-  md5: cffd3bdd58090148f4cfcd831f4b26ab
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
-  constrains:
-  - xorg-libx11 >=1.8.12,<2.0a0
-  license: TCL
-  license_family: BSD
-  size: 3301196
-  timestamp: 1769460227866
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
-  sha256: ed2f17b2bc92389187b47e7444aa7d6ab6c70c3f3ba6bf2ced508027e60e82cb
-  md5: 9665531f18d2bcbc946e3ba0cf53ea91
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 885824
-  timestamp: 1781006802459
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
-  sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
-  md5: 96b08867e21d4694fa5c2c226e6581b0
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - krb5 >=1.22.2,<1.23.0a0
-  - libsodium >=1.0.22,<1.0.23.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 311184
-  timestamp: 1779123989774
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
-  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 601375
-  timestamp: 1764777111296
-- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
-  md5: aaa2a381ccc56eac91d63b6c1240312f
-  depends:
-  - cpython
-  - python-gil
-  license: MIT
-  license_family: MIT
-  size: 8191
-  timestamp: 1744137672556
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-  md5: a9965dd99f683c5f444428f896635716
-  depends:
-  - __unix
-  license: ISC
-  size: 128866
-  timestamp: 1781708962055
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-  sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
-  md5: 554304a07e581a85891b15e39ea9f268
-  depends:
-  - __unix
-  - python
-  - python >=3.10
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 104999
-  timestamp: 1779900548735
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-  noarch: generic
-  sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
-  md5: 22ff6a23190a29024b0df04b4caa0c66
-  depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi * *_cp313
-  license: Python-2.0
-  size: 48337
-  timestamp: 1781257766256
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-  md5: ffc17e785d64e12fc311af9184221839
-  depends:
-  - python >=3.10
-  - zipp >=3.20
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 34766
-  timestamp: 1779714582554
-- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-  sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
-  md5: 4ebae00eae9705b0c3d6d1018a81d047
-  depends:
-  - importlib-metadata >=4.8.3
-  - jupyter_core >=4.12,!=5.0.*
-  - python >=3.9
-  - python-dateutil >=2.8.2
-  - pyzmq >=23.0
-  - tornado >=6.2
-  - traitlets >=5.3
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 106342
-  timestamp: 1733441040958
-- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-  sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
-  md5: b38fe4e78ee75def7e599843ef4c1ab0
-  depends:
-  - __unix
-  - python
-  - platformdirs >=2.5
-  - python >=3.10
-  - traitlets >=5.3
-  - python
-  constrains:
-  - pywin32 >=300
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 65503
-  timestamp: 1760643864586
-- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-  sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
-  md5: e9c622e0d00fa24a6292279af3ab6d06
-  depends:
-  - python >=3.9
-  license: MIT
-  license_family: MIT
-  size: 11766
-  timestamp: 1745776666688
-- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
-  md5: 4c06a92e74452cfa53623a81592e8934
-  depends:
-  - python >=3.8
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 91574
-  timestamp: 1777103621679
-- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-  sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
-  md5: 11adc78451c998c0fd162584abfa3559
-  depends:
-  - python >=3.10
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 56559
-  timestamp: 1777271601895
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-  sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
-  md5: 2c5ef45db85d34799771629bd5860fd7
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 26308
-  timestamp: 1779972894916
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
-  md5: 5b8d21249ff20967101ffa321cab24e8
-  depends:
-  - python >=3.9
-  - six >=1.5
-  - python
-  license: Apache-2.0
-  license_family: APACHE
-  size: 233310
-  timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-  sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
-  md5: 200323d73f85b9c5c411db8c8c4942db
-  depends:
-  - cpython 3.13.14.*
-  - python_abi * *_cp313
-  license: Python-2.0
-  size: 48307
-  timestamp: 1781257788601
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-  build_number: 8
-  sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
-  md5: 94305520c52a4aa3f6c2b1ff6008d9f8
-  constrains:
-  - python 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7002
-  timestamp: 1752805902938
-- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
-  md5: 3339e3b65d58accf4ca4fb8748ab16b3
-  depends:
-  - python >=3.9
-  - python
-  license: MIT
-  license_family: MIT
-  size: 18455
-  timestamp: 1753199211006
-- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
-  md5: b5325cf06a000c5b14970462ff5e4d58
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 21561
-  timestamp: 1774492402955
-- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-  sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
-  md5: 37e3be7b6e2977d37b8fa5da229f5dc0
-  depends:
-  - python >=3.10
-  - python
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 115158
-  timestamp: 1780507822178
-- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
-  md5: ad659d0a2b3e47e38d829aa8cad2d610
-  license: LicenseRef-Public-Domain
-  size: 119135
-  timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-  sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
-  md5: ba3dcdc8584155c97c648ae9c044b7a3
-  depends:
-  - python >=3.10
-  - python
-  license: MIT
-  license_family: MIT
-  size: 24190
-  timestamp: 1779159948016
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-  build_number: 7
-  sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
-  md5: a44032f282e7d2acdeb1c240308052dd
-  depends:
-  - llvm-openmp >=9.0.1
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8325
-  timestamp: 1764092507920
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
-  md5: 620b85a3f45526a8bc4d23fd78fc22f0
-  depends:
-  - __osx >=11.0
-  license: bzip2-1.0.6
-  license_family: BSD
-  size: 124834
-  timestamp: 1771350416561
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
-  md5: f1182c91c0de31a7abd40cedf6a5ebef
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 12361647
-  timestamp: 1773822915649
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
-  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
-  md5: 8780f41b013d19219faef9c82260744b
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libedit >=3.1.20250104,<3.2.0a0
-  - libedit >=3.1.20250104,<4.0a0
-  - openssl >=3.5.7,<4.0a0
-  license: MIT
-  license_family: MIT
-  size: 1159780
-  timestamp: 1781859501654
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
-  build_number: 8
-  sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
-  md5: dbfe729181a32741ae63ecb41eefbac6
-  depends:
-  - libopenblas >=0.3.33,<0.3.34.0a0
-  - libopenblas >=0.3.33,<1.0a0
-  constrains:
-  - blas 2.308   openblas
-  - liblapack  3.11.0   8*_openblas
-  - liblapacke 3.11.0   8*_openblas
-  - libcblas   3.11.0   8*_openblas
-  - mkl <2027
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18949
-  timestamp: 1779859141315
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
-  build_number: 8
-  sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
-  md5: 03a2ef3491da9e5b4d18c03e9f4b3109
-  depends:
-  - libblas 3.11.0 8_h51639a9_openblas
-  constrains:
-  - blas 2.308   openblas
-  - liblapack  3.11.0   8*_openblas
-  - liblapacke 3.11.0   8*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18911
-  timestamp: 1779859147634
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
-  md5: 89f76a2a21a3ec3ec983b5eb237c4113
-  depends:
-  - __osx >=11.0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  size: 569349
-  timestamp: 1781670209146
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
-  md5: 44083d2d2c2025afca315c7a172eab2b
-  depends:
-  - ncurses
-  - __osx >=11.0
-  - ncurses >=6.5,<7.0a0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 107691
-  timestamp: 1738479560845
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  md5: a915151d5d3c5bf039f5ccc8402a436f
-  depends:
-  - __osx >=11.0
-  constrains:
-  - expat 2.8.1.*
-  license: MIT
-  license_family: MIT
-  size: 69362
-  timestamp: 1781203631990
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
-  md5: 43c04d9cb46ef176bb2a4c77e324d599
-  depends:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 40979
-  timestamp: 1769456747661
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-  sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
-  md5: 644058123986582db33aebd4ae2ca184
-  depends:
-  - _openmp_mutex
-  constrains:
-  - libgcc-ng ==15.2.0=*_19
-  - libgomp 15.2.0 19
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 404080
-  timestamp: 1778273064154
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-  sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
-  md5: 1ea03f87cdb1078fbc0e2b2deb63752c
-  depends:
-  - libgfortran5 15.2.0 hdae7583_19
-  constrains:
-  - libgfortran-ng ==15.2.0=*_19
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 139675
-  timestamp: 1778273280875
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-  sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
-  md5: ba36d8c606a6a53fe0b8c12d47267b3d
-  depends:
-  - libgcc >=15.2.0
-  constrains:
-  - libgfortran 15.2.0
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 599691
-  timestamp: 1778273075448
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
-  build_number: 8
-  sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
-  md5: 85adeb3d469d082dbd9c8c39e36dec57
-  depends:
-  - libblas 3.11.0 8_h51639a9_openblas
-  constrains:
-  - libcblas   3.11.0   8*_openblas
-  - blas 2.308   openblas
-  - liblapacke 3.11.0   8*_openblas
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 18925
-  timestamp: 1779859153970
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
-  md5: b1fd823b5ae54fbec272cea0811bd8a9
-  depends:
-  - __osx >=11.0
-  constrains:
-  - xz 5.8.3.*
-  license: 0BSD
-  size: 92472
-  timestamp: 1775825802659
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-  sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
-  md5: 57c4be259f5e0b99a5983799a228ae55
-  depends:
-  - __osx >=11.0
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 73690
-  timestamp: 1769482560514
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
-  sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
-  md5: 909e41855c29f0d52ae630198cd57135
-  depends:
-  - __osx >=11.0
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - llvm-openmp >=19.1.7
-  constrains:
-  - openblas >=0.3.33,<0.3.34.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 4304965
-  timestamp: 1776995497368
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-  sha256: 202be45db5726757a8ea1f374f85aacc18c504f5ff15b2558496dff4c8779c48
-  md5: 9ed5ab909c449bdcae72322e44875a18
-  depends:
-  - __osx >=11.0
-  license: ISC
-  size: 247352
-  timestamp: 1779164136206
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-  sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
-  md5: 1ebde5c677f00765233a17e278571177
-  depends:
-  - __osx >=11.0
-  - icu >=78.3,<79.0a0
-  - libzlib >=1.3.2,<2.0a0
-  license: blessing
-  size: 927724
-  timestamp: 1780575223548
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
-  md5: bc5a5721b6439f2f62a84f2548136082
-  depends:
-  - __osx >=11.0
-  constrains:
-  - zlib 1.3.2 *_2
-  license: Zlib
-  license_family: Other
-  size: 47759
-  timestamp: 1774072956767
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-  sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
-  md5: a9c118f6343fb6301b6f3b4e94c4c562
-  depends:
-  - __osx >=11.0
-  constrains:
-  - intel-openmp <0.0a0
-  - openmp 22.1.8|22.1.8.*
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: APACHE
-  size: 286313
-  timestamp: 1781736516782
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
-  md5: 343d10ed5b44030a2f67193905aea159
-  depends:
-  - __osx >=11.0
-  license: X11 AND BSD-3-Clause
-  size: 805509
-  timestamp: 1777423252320
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
-  sha256: 9192f87dfc1d57249ed8d7367353de6ab6caa8525d6fd6efa03d83758f46adad
-  md5: cb5c510ee24c7966001e122abe8d85b8
-  depends:
-  - python
-  - libcxx >=19
-  - __osx >=11.0
-  - python_abi 3.13.* *_cp313
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - libblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7055163
-  timestamp: 1782112549179
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
-  md5: 8187a86242741725bfa74785fe812979
-  depends:
-  - __osx >=11.0
-  - ca-certificates
-  license: Apache-2.0
-  license_family: Apache
-  size: 3102584
-  timestamp: 1781069820667
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
-  build_number: 100
-  sha256: c89eedab6b293fae654d75483d8f3e5eb3ff9ce2478134d902676c1dd20c7dfd
-  md5: e556c07deaa168043f8430bb046092e2
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.7,<4.0a0
-  - python_abi 3.13.* *_cp313
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  license: Python-2.0
-  size: 17017633
-  timestamp: 1781257915644
-  python_site_packages_path: lib/python3.13/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
-  noarch: python
-  sha256: 086cc67ec57afb7c9c09b5e09e7356b536b5b1af6c2e97117dc022cd22f0d472
-  md5: 73f22bde4991f30ae2bfac3811577c15
-  depends:
-  - python
-  - libcxx >=19
-  - __osx >=11.0
-  - zeromq >=4.3.5,<4.4.0a0
-  - _python_abi3_support 1.*
-  - cpython >=3.12
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 191432
-  timestamp: 1779484184540
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
-  md5: f8381319127120ce51e081dce4865cf4
-  depends:
-  - __osx >=11.0
-  - ncurses >=6.5,<7.0a0
-  license: GPL-3.0-only
-  license_family: GPL
-  size: 313930
-  timestamp: 1765813902568
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
-  sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
-  md5: 110ff05ffef908af95192bb17c4006a0
-  depends:
-  - __osx >=11.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=19
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - numpy <2.7
-  - numpy >=1.23,<3
-  - numpy >=2.0.0
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 14094513
-  timestamp: 1781912946907
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
-  md5: a9d86bc62f39b94c4661716624eb21b0
-  depends:
-  - __osx >=11.0
-  - libzlib >=1.3.1,<2.0a0
-  license: TCL
-  license_family: BSD
-  size: 3127137
-  timestamp: 1769460817696
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
-  sha256: 02c7b05be4d74da0d7329f92445646e3489634f0c3e59b26efefd846662ac20a
-  md5: dbc95e65c936251c3d32111c867d84e1
-  depends:
-  - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
-  license: Apache-2.0
-  license_family: Apache
-  size: 889689
-  timestamp: 1781007967544
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
-  sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
-  md5: d31c0e54c4f9c51100ec8c812ee925d1
-  depends:
-  - libcxx >=19
-  - __osx >=11.0
-  - krb5 >=1.22.2,<1.23.0a0
-  - libsodium >=1.0.22,<1.0.23.0a0
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 245404
-  timestamp: 1779124076307
-- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
-  sha256: 7553366c138bae2fcf8617582f1bb6d6b6742087bd6a83ea83aa41c023499382
-  md5: 8d4390edde2dcf29880c57b3088f15aa
-  depends:
-  - python >=3.10
-  - mojo-compiler ==1.0.0b2
-  - mblack ==26.4.0
-  - jupyter_client >=8.6.2,<8.7
-  license: LicenseRef-Modular-Proprietary
-  size: 96475709
-  timestamp: 1781237127405
-- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
-  sha256: 87f8e9ef573f37072423aeb56a7c468bdb5f5889476bce4aa7c3396665c651fe
-  md5: 6be85d17872f5c2370015ca4ec07dd0d
-  depends:
-  - mojo-python ==1.0.0b2
-  license: LicenseRef-Modular-Proprietary
-  size: 85342385
-  timestamp: 1781237127405
-- conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-  noarch: python
-  sha256: e2497cbefbf5d962cd0db8c1b893e7e48d8f3603cab84a9d8bad0030b5bb26b1
-  md5: ec6bf2b9588f5ba4bd3472c0773c4892
-  depends:
-  - python >=3.10
-  - click >=8.0.0
-  - mypy_extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0
-  license: LicenseRef-Modular-Proprietary
-  size: 135301
-  timestamp: 1781220755102
-- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
-  noarch: python
-  sha256: 37bf44a74edcd2ebaec7fe8299ef183e006ad051bfcf21caa06becc0e0eeffd5
-  md5: 8781bd673909835fa59ce818e3835839
-  depends:
-  - python >=3.10
-  license: LicenseRef-Modular-Proprietary
-  size: 24682
-  timestamp: 1781220753246
-- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
-  sha256: 39bb59a309af5e4c78c077263e5824e33bba8159a1e0fc39ff2786a1f9d5762b
-  md5: 1a6b6dd12763032e46b956407b39ab48
-  depends:
-  - python >=3.10
-  - mojo-compiler ==1.0.0b2
-  - mblack ==26.4.0
-  - jupyter_client >=8.6.2,<8.7
-  license: LicenseRef-Modular-Proprietary
-  size: 84573003
-  timestamp: 1781237324882
-- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
-  sha256: 91c4d590a152ec2e26846955fcd7ec02796dfaffefa006a1c0c5790575be2051
-  md5: cd8d3f4a22e5f14dd909d0d5570c4940
-  depends:
-  - mojo-python ==1.0.0b2
-  license: LicenseRef-Modular-Proprietary
-  size: 62655166
-  timestamp: 1781237320083
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    build_number: 20
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgomp >=7.5.0
+    constrains:
+      - openmp_impl <0.0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 28948
+    timestamp: 1770939786096
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+    sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+    md5: d2ffd7602c02f2b316fd921d39876885
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 260182
+    timestamp: 1771350215188
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+    sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+    md5: b38117a3c920364aff79f870c984b4a3
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=13
+    license: LGPL-2.1-or-later
+    size: 134088
+    timestamp: 1754905959823
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - keyutils >=1.6.3,<2.0a0
+      - libedit >=3.1.20250104,<3.2.0a0
+      - libedit >=3.1.20250104,<4.0a0
+      - libgcc >=14
+      - libstdcxx >=14
+      - openssl >=3.5.7,<4.0a0
+    license: MIT
+    license_family: MIT
+    size: 1388990
+    timestamp: 1781859420533
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+    sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+    md5: 18335a698559cdbcd86150a48bf54ba6
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - zstd >=1.5.7,<1.6.0a0
+    constrains:
+      - binutils_impl_linux-64 2.45.1
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 728002
+    timestamp: 1774197446916
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+    build_number: 8
+    sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+    md5: 00fc660ab1b2f5ca07e92b4900d10c79
+    depends:
+      - libopenblas >=0.3.33,<0.3.34.0a0
+      - libopenblas >=0.3.33,<1.0a0
+    constrains:
+      - blas 2.308   openblas
+      - mkl <2027
+      - libcblas   3.11.0   8*_openblas
+      - liblapack  3.11.0   8*_openblas
+      - liblapacke 3.11.0   8*_openblas
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18804
+    timestamp: 1779859100675
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+    build_number: 8
+    sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+    md5: 33a413f1095f8325e5c30fde3b0d2445
+    depends:
+      - libblas 3.11.0 8_h4a7cf45_openblas
+    constrains:
+      - blas 2.308   openblas
+      - liblapacke 3.11.0   8*_openblas
+      - liblapack  3.11.0   8*_openblas
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18778
+    timestamp: 1779859107964
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+    sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+    md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+    depends:
+      - ncurses
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=13
+      - ncurses >=6.5,<7.0a0
+    license: BSD-2-Clause
+    license_family: BSD
+    size: 134676
+    timestamp: 1738479519902
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    md5: b24d3c612f71e7aa74158d92106318b2
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    constrains:
+      - expat 2.8.1.*
+    license: MIT
+    license_family: MIT
+    size: 77856
+    timestamp: 1781203599810
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+    sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+    md5: a360c33a5abe61c07959e449fa1453eb
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    license: MIT
+    license_family: MIT
+    size: 58592
+    timestamp: 1769456073053
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+    sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+    md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - _openmp_mutex >=4.5
+    constrains:
+      - libgcc-ng ==15.2.0=*_19
+      - libgomp 15.2.0 he0feb66_19
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 1041084
+    timestamp: 1778269013026
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+    sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+    md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+    depends:
+      - libgfortran5 15.2.0 h68bc16d_19
+    constrains:
+      - libgfortran-ng ==15.2.0=*_19
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 27655
+    timestamp: 1778269042954
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+    sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+    md5: 85072b0ad177c966294f129b7c04a2d5
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=15.2.0
+    constrains:
+      - libgfortran 15.2.0
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 2483673
+    timestamp: 1778269025089
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+    sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+    md5: faac990cb7aedc7f3a2224f2c9b0c26c
+    depends:
+      - __glibc >=2.17,<3.0.a0
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 603817
+    timestamp: 1778268942614
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+    build_number: 8
+    sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+    md5: 809be8ba8712c77bc7d44c2d99390dc4
+    depends:
+      - libblas 3.11.0 8_h4a7cf45_openblas
+    constrains:
+      - blas 2.308   openblas
+      - libcblas   3.11.0   8*_openblas
+      - liblapacke 3.11.0   8*_openblas
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18790
+    timestamp: 1779859115086
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+    sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+    md5: b88d90cad08e6bc8ad540cb310a761fb
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    constrains:
+      - xz 5.8.3.*
+    license: 0BSD
+    size: 113478
+    timestamp: 1775825492909
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+    sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+    md5: 2c21e66f50753a083cbe6b80f38268fa
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    license: BSD-2-Clause
+    license_family: BSD
+    size: 92400
+    timestamp: 1769482286018
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+    sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+    md5: 2d3278b721e40468295ca755c3b84070
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+      - libgfortran
+      - libgfortran5 >=14.3.0
+    constrains:
+      - openblas >=0.3.33,<0.3.34.0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 5931919
+    timestamp: 1776993658641
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+    sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
+    md5: 965e4d531b588b2e42f66fd8e48b056c
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    license: ISC
+    size: 269272
+    timestamp: 1779163468406
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+    md5: 062b0ac602fb0adf250e3dfa86f221c4
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+      - libzlib >=1.3.2,<2.0a0
+    license: blessing
+    size: 957849
+    timestamp: 1780574429573
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+    sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+    md5: 5794b3bdc38177caf969dabd3af08549
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc 15.2.0 he0feb66_19
+    constrains:
+      - libstdcxx-ng ==15.2.0=*_19
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 5852044
+    timestamp: 1778269036376
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+    md5: 01bb81d12c957de066ea7362007df642
+    depends:
+      - libgcc >=14
+      - __glibc >=2.17,<3.0.a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 40017
+    timestamp: 1781625522462
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+    sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+    md5: d87ff7921124eccd67248aa483c23fec
+    depends:
+      - __glibc >=2.17,<3.0.a0
+    constrains:
+      - zlib 1.3.2 *_2
+    license: Zlib
+    license_family: Other
+    size: 63629
+    timestamp: 1774072609062
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+    sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+    md5: fc21868a1a5aacc937e7a18747acb8a5
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+    license: X11 AND BSD-3-Clause
+    size: 918956
+    timestamp: 1777422145199
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
+    sha256: 7caba80d1515ef3a697a96fa23a1f14fceffd76f3261f0daea510d5a2209b064
+    md5: 508c839b99562e2354917a6c83ab195b
+    depends:
+      - python
+      - libgcc >=14
+      - __glibc >=2.17,<3.0.a0
+      - libstdcxx >=14
+      - python_abi 3.13.* *_cp313
+      - libblas >=3.9.0,<4.0a0
+      - liblapack >=3.9.0,<4.0a0
+      - libcblas >=3.9.0,<4.0a0
+    constrains:
+      - numpy-base <0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 9005587
+    timestamp: 1782112542305
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+    sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+    md5: 79dd2074b5cd5c5c6b2930514a11e22d
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - ca-certificates
+      - libgcc >=14
+    license: Apache-2.0
+    license_family: Apache
+    size: 3159683
+    timestamp: 1781069855778
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
+    build_number: 100
+    sha256: f2146aff59ce4b571a8f1d1acf94f9bed6cc18ab5632d7dcc940fb48ecdeef99
+    md5: 93762cd272814a142cf21d794f8fb0c1
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - bzip2 >=1.0.8,<2.0a0
+      - ld_impl_linux-64 >=2.36.1
+      - libexpat >=2.8.1,<3.0a0
+      - libffi >=3.5.2,<3.6.0a0
+      - libgcc >=14
+      - liblzma >=5.8.3,<6.0a0
+      - libmpdec >=4.0.0,<5.0a0
+      - libsqlite >=3.53.2,<4.0a0
+      - libuuid >=2.42.1,<3.0a0
+      - libzlib >=1.3.2,<2.0a0
+      - ncurses >=6.6,<7.0a0
+      - openssl >=3.5.7,<4.0a0
+      - python_abi 3.13.* *_cp313
+      - readline >=8.3,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+    license: Python-2.0
+    size: 37398694
+    timestamp: 1781258934574
+    python_site_packages_path: lib/python3.13/site-packages
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+    noarch: python
+    sha256: 970b2a1d12983d8d1cc05d914ad88a0b6ef1fa14038c9649aa834dd6ebee65d7
+    md5: acd216255e1370e9aeab5351b831f07c
+    depends:
+      - python
+      - libgcc >=14
+      - libstdcxx >=14
+      - __glibc >=2.17,<3.0.a0
+      - _python_abi3_support 1.*
+      - cpython >=3.12
+      - zeromq >=4.3.5,<4.4.0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 210896
+    timestamp: 1779483879367
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+    sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+    md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+      - ncurses >=6.5,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 345073
+    timestamp: 1765813471974
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+    sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
+    md5: a32f88181ff9a3451c71be1f17a7c799
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libblas >=3.9.0,<4.0a0
+      - libcblas >=3.9.0,<4.0a0
+      - libgcc >=14
+      - libgfortran
+      - libgfortran5 >=14.3.0
+      - liblapack >=3.9.0,<4.0a0
+      - libstdcxx >=14
+      - numpy <2.7
+      - numpy >=1.23,<3
+      - numpy >=2.0.0
+      - python >=3.13,<3.14.0a0
+      - python_abi 3.13.* *_cp313
+    license: BSD-3-Clause
+    license_family: BSD
+    run_exports: {}
+    size: 17171066
+    timestamp: 1781912954186
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+    sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+    md5: cffd3bdd58090148f4cfcd831f4b26ab
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+      - libzlib >=1.3.1,<2.0a0
+    constrains:
+      - xorg-libx11 >=1.8.12,<2.0a0
+    license: TCL
+    license_family: BSD
+    size: 3301196
+    timestamp: 1769460227866
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+    sha256: ed2f17b2bc92389187b47e7444aa7d6ab6c70c3f3ba6bf2ced508027e60e82cb
+    md5: 9665531f18d2bcbc946e3ba0cf53ea91
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libgcc >=14
+      - python >=3.13,<3.14.0a0
+      - python_abi 3.13.* *_cp313
+    license: Apache-2.0
+    license_family: Apache
+    size: 885824
+    timestamp: 1781006802459
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+    sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
+    md5: 96b08867e21d4694fa5c2c226e6581b0
+    depends:
+      - libgcc >=14
+      - __glibc >=2.17,<3.0.a0
+      - libstdcxx >=14
+      - krb5 >=1.22.2,<1.23.0a0
+      - libsodium >=1.0.22,<1.0.23.0a0
+    license: MPL-2.0
+    license_family: MOZILLA
+    size: 311184
+    timestamp: 1779123989774
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+    sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+    md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+    depends:
+      - __glibc >=2.17,<3.0.a0
+      - libzlib >=1.3.1,<2.0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 601375
+    timestamp: 1764777111296
+  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+    sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
+    md5: aaa2a381ccc56eac91d63b6c1240312f
+    depends:
+      - cpython
+      - python-gil
+    license: MIT
+    license_family: MIT
+    size: 8191
+    timestamp: 1744137672556
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+    md5: a9965dd99f683c5f444428f896635716
+    depends:
+      - __unix
+    license: ISC
+    size: 128866
+    timestamp: 1781708962055
+  - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+    sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
+    md5: 554304a07e581a85891b15e39ea9f268
+    depends:
+      - __unix
+      - python
+      - python >=3.10
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 104999
+    timestamp: 1779900548735
+  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+    noarch: generic
+    sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
+    md5: 22ff6a23190a29024b0df04b4caa0c66
+    depends:
+      - python >=3.13,<3.14.0a0
+      - python_abi * *_cp313
+    license: Python-2.0
+    size: 48337
+    timestamp: 1781257766256
+  - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+    md5: ffc17e785d64e12fc311af9184221839
+    depends:
+      - python >=3.10
+      - zipp >=3.20
+      - python
+    license: Apache-2.0
+    license_family: APACHE
+    size: 34766
+    timestamp: 1779714582554
+  - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+    md5: 4ebae00eae9705b0c3d6d1018a81d047
+    depends:
+      - importlib-metadata >=4.8.3
+      - jupyter_core >=4.12,!=5.0.*
+      - python >=3.9
+      - python-dateutil >=2.8.2
+      - pyzmq >=23.0
+      - tornado >=6.2
+      - traitlets >=5.3
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 106342
+    timestamp: 1733441040958
+  - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+    sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
+    md5: b38fe4e78ee75def7e599843ef4c1ab0
+    depends:
+      - __unix
+      - python
+      - platformdirs >=2.5
+      - python >=3.10
+      - traitlets >=5.3
+      - python
+    constrains:
+      - pywin32 >=300
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 65503
+    timestamp: 1760643864586
+  - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+    sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
+    md5: e9c622e0d00fa24a6292279af3ab6d06
+    depends:
+      - python >=3.9
+    license: MIT
+    license_family: MIT
+    size: 11766
+    timestamp: 1745776666688
+  - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+    md5: 4c06a92e74452cfa53623a81592e8934
+    depends:
+      - python >=3.8
+      - python
+    license: Apache-2.0
+    license_family: APACHE
+    size: 91574
+    timestamp: 1777103621679
+  - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+    sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
+    md5: 11adc78451c998c0fd162584abfa3559
+    depends:
+      - python >=3.10
+    license: MPL-2.0
+    license_family: MOZILLA
+    size: 56559
+    timestamp: 1777271601895
+  - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+    sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
+    md5: 2c5ef45db85d34799771629bd5860fd7
+    depends:
+      - python >=3.10
+      - python
+    license: MIT
+    license_family: MIT
+    size: 26308
+    timestamp: 1779972894916
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+    md5: 5b8d21249ff20967101ffa321cab24e8
+    depends:
+      - python >=3.9
+      - six >=1.5
+      - python
+    license: Apache-2.0
+    license_family: APACHE
+    size: 233310
+    timestamp: 1751104122689
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+    sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
+    md5: 200323d73f85b9c5c411db8c8c4942db
+    depends:
+      - cpython 3.13.14.*
+      - python_abi * *_cp313
+    license: Python-2.0
+    size: 48307
+    timestamp: 1781257788601
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+    build_number: 8
+    sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
+    md5: 94305520c52a4aa3f6c2b1ff6008d9f8
+    constrains:
+      - python 3.13.* *_cp313
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 7002
+    timestamp: 1752805902938
+  - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+    sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+    md5: 3339e3b65d58accf4ca4fb8748ab16b3
+    depends:
+      - python >=3.9
+      - python
+    license: MIT
+    license_family: MIT
+    size: 18455
+    timestamp: 1753199211006
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+    sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+    md5: b5325cf06a000c5b14970462ff5e4d58
+    depends:
+      - python >=3.10
+      - python
+    license: MIT
+    license_family: MIT
+    size: 21561
+    timestamp: 1774492402955
+  - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
+    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+    depends:
+      - python >=3.10
+      - python
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 115158
+    timestamp: 1780507822178
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+    sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+    md5: ad659d0a2b3e47e38d829aa8cad2d610
+    license: LicenseRef-Public-Domain
+    size: 119135
+    timestamp: 1767016325805
+  - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+    sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+    md5: ba3dcdc8584155c97c648ae9c044b7a3
+    depends:
+      - python >=3.10
+      - python
+    license: MIT
+    license_family: MIT
+    size: 24190
+    timestamp: 1779159948016
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+    build_number: 7
+    sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+    md5: a44032f282e7d2acdeb1c240308052dd
+    depends:
+      - llvm-openmp >=9.0.1
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 8325
+    timestamp: 1764092507920
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+    sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+    md5: 620b85a3f45526a8bc4d23fd78fc22f0
+    depends:
+      - __osx >=11.0
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 124834
+    timestamp: 1771350416561
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+    sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+    md5: f1182c91c0de31a7abd40cedf6a5ebef
+    depends:
+      - __osx >=11.0
+    license: MIT
+    license_family: MIT
+    size: 12361647
+    timestamp: 1773822915649
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+    md5: 8780f41b013d19219faef9c82260744b
+    depends:
+      - __osx >=11.0
+      - libcxx >=19
+      - libedit >=3.1.20250104,<3.2.0a0
+      - libedit >=3.1.20250104,<4.0a0
+      - openssl >=3.5.7,<4.0a0
+    license: MIT
+    license_family: MIT
+    size: 1159780
+    timestamp: 1781859501654
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+    build_number: 8
+    sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
+    md5: dbfe729181a32741ae63ecb41eefbac6
+    depends:
+      - libopenblas >=0.3.33,<0.3.34.0a0
+      - libopenblas >=0.3.33,<1.0a0
+    constrains:
+      - blas 2.308   openblas
+      - liblapack  3.11.0   8*_openblas
+      - liblapacke 3.11.0   8*_openblas
+      - libcblas   3.11.0   8*_openblas
+      - mkl <2027
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18949
+    timestamp: 1779859141315
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+    build_number: 8
+    sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
+    md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+    depends:
+      - libblas 3.11.0 8_h51639a9_openblas
+    constrains:
+      - blas 2.308   openblas
+      - liblapack  3.11.0   8*_openblas
+      - liblapacke 3.11.0   8*_openblas
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18911
+    timestamp: 1779859147634
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+    md5: 89f76a2a21a3ec3ec983b5eb237c4113
+    depends:
+      - __osx >=11.0
+    license: Apache-2.0 WITH LLVM-exception
+    license_family: Apache
+    size: 569349
+    timestamp: 1781670209146
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+    sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+    md5: 44083d2d2c2025afca315c7a172eab2b
+    depends:
+      - ncurses
+      - __osx >=11.0
+      - ncurses >=6.5,<7.0a0
+    license: BSD-2-Clause
+    license_family: BSD
+    size: 107691
+    timestamp: 1738479560845
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    depends:
+      - __osx >=11.0
+    constrains:
+      - expat 2.8.1.*
+    license: MIT
+    license_family: MIT
+    size: 69362
+    timestamp: 1781203631990
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+    sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+    md5: 43c04d9cb46ef176bb2a4c77e324d599
+    depends:
+      - __osx >=11.0
+    license: MIT
+    license_family: MIT
+    size: 40979
+    timestamp: 1769456747661
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+    sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
+    md5: 644058123986582db33aebd4ae2ca184
+    depends:
+      - _openmp_mutex
+    constrains:
+      - libgcc-ng ==15.2.0=*_19
+      - libgomp 15.2.0 19
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 404080
+    timestamp: 1778273064154
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+    sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
+    md5: 1ea03f87cdb1078fbc0e2b2deb63752c
+    depends:
+      - libgfortran5 15.2.0 hdae7583_19
+    constrains:
+      - libgfortran-ng ==15.2.0=*_19
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 139675
+    timestamp: 1778273280875
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+    sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
+    md5: ba36d8c606a6a53fe0b8c12d47267b3d
+    depends:
+      - libgcc >=15.2.0
+    constrains:
+      - libgfortran 15.2.0
+    license: GPL-3.0-only WITH GCC-exception-3.1
+    license_family: GPL
+    size: 599691
+    timestamp: 1778273075448
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+    build_number: 8
+    sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
+    md5: 85adeb3d469d082dbd9c8c39e36dec57
+    depends:
+      - libblas 3.11.0 8_h51639a9_openblas
+    constrains:
+      - libcblas   3.11.0   8*_openblas
+      - blas 2.308   openblas
+      - liblapacke 3.11.0   8*_openblas
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 18925
+    timestamp: 1779859153970
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+    sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+    md5: b1fd823b5ae54fbec272cea0811bd8a9
+    depends:
+      - __osx >=11.0
+    constrains:
+      - xz 5.8.3.*
+    license: 0BSD
+    size: 92472
+    timestamp: 1775825802659
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+    sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
+    md5: 57c4be259f5e0b99a5983799a228ae55
+    depends:
+      - __osx >=11.0
+    license: BSD-2-Clause
+    license_family: BSD
+    size: 73690
+    timestamp: 1769482560514
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+    sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
+    md5: 909e41855c29f0d52ae630198cd57135
+    depends:
+      - __osx >=11.0
+      - libgfortran
+      - libgfortran5 >=14.3.0
+      - llvm-openmp >=19.1.7
+    constrains:
+      - openblas >=0.3.33,<0.3.34.0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 4304965
+    timestamp: 1776995497368
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
+    sha256: 202be45db5726757a8ea1f374f85aacc18c504f5ff15b2558496dff4c8779c48
+    md5: 9ed5ab909c449bdcae72322e44875a18
+    depends:
+      - __osx >=11.0
+    license: ISC
+    size: 247352
+    timestamp: 1779164136206
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+    md5: 1ebde5c677f00765233a17e278571177
+    depends:
+      - __osx >=11.0
+      - icu >=78.3,<79.0a0
+      - libzlib >=1.3.2,<2.0a0
+    license: blessing
+    size: 927724
+    timestamp: 1780575223548
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+    sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+    md5: bc5a5721b6439f2f62a84f2548136082
+    depends:
+      - __osx >=11.0
+    constrains:
+      - zlib 1.3.2 *_2
+    license: Zlib
+    license_family: Other
+    size: 47759
+    timestamp: 1774072956767
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
+    md5: a9c118f6343fb6301b6f3b4e94c4c562
+    depends:
+      - __osx >=11.0
+    constrains:
+      - intel-openmp <0.0a0
+      - openmp 22.1.8|22.1.8.*
+    license: Apache-2.0 WITH LLVM-exception
+    license_family: APACHE
+    size: 286313
+    timestamp: 1781736516782
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+    sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+    md5: 343d10ed5b44030a2f67193905aea159
+    depends:
+      - __osx >=11.0
+    license: X11 AND BSD-3-Clause
+    size: 805509
+    timestamp: 1777423252320
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
+    sha256: 9192f87dfc1d57249ed8d7367353de6ab6caa8525d6fd6efa03d83758f46adad
+    md5: cb5c510ee24c7966001e122abe8d85b8
+    depends:
+      - python
+      - libcxx >=19
+      - __osx >=11.0
+      - python_abi 3.13.* *_cp313
+      - libcblas >=3.9.0,<4.0a0
+      - liblapack >=3.9.0,<4.0a0
+      - libblas >=3.9.0,<4.0a0
+    constrains:
+      - numpy-base <0a0
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 7055163
+    timestamp: 1782112549179
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+    sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
+    md5: 8187a86242741725bfa74785fe812979
+    depends:
+      - __osx >=11.0
+      - ca-certificates
+    license: Apache-2.0
+    license_family: Apache
+    size: 3102584
+    timestamp: 1781069820667
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
+    build_number: 100
+    sha256: c89eedab6b293fae654d75483d8f3e5eb3ff9ce2478134d902676c1dd20c7dfd
+    md5: e556c07deaa168043f8430bb046092e2
+    depends:
+      - __osx >=11.0
+      - bzip2 >=1.0.8,<2.0a0
+      - libexpat >=2.8.1,<3.0a0
+      - libffi >=3.5.2,<3.6.0a0
+      - liblzma >=5.8.3,<6.0a0
+      - libmpdec >=4.0.0,<5.0a0
+      - libsqlite >=3.53.2,<4.0a0
+      - libzlib >=1.3.2,<2.0a0
+      - ncurses >=6.6,<7.0a0
+      - openssl >=3.5.7,<4.0a0
+      - python_abi 3.13.* *_cp313
+      - readline >=8.3,<9.0a0
+      - tk >=8.6.13,<8.7.0a0
+      - tzdata
+    license: Python-2.0
+    size: 17017633
+    timestamp: 1781257915644
+    python_site_packages_path: lib/python3.13/site-packages
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
+    noarch: python
+    sha256: 086cc67ec57afb7c9c09b5e09e7356b536b5b1af6c2e97117dc022cd22f0d472
+    md5: 73f22bde4991f30ae2bfac3811577c15
+    depends:
+      - python
+      - libcxx >=19
+      - __osx >=11.0
+      - zeromq >=4.3.5,<4.4.0a0
+      - _python_abi3_support 1.*
+      - cpython >=3.12
+    license: BSD-3-Clause
+    license_family: BSD
+    size: 191432
+    timestamp: 1779484184540
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+    sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+    md5: f8381319127120ce51e081dce4865cf4
+    depends:
+      - __osx >=11.0
+      - ncurses >=6.5,<7.0a0
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 313930
+    timestamp: 1765813902568
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
+    sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
+    md5: 110ff05ffef908af95192bb17c4006a0
+    depends:
+      - __osx >=11.0
+      - libblas >=3.9.0,<4.0a0
+      - libcblas >=3.9.0,<4.0a0
+      - libcxx >=19
+      - libgfortran
+      - libgfortran5 >=14.3.0
+      - liblapack >=3.9.0,<4.0a0
+      - numpy <2.7
+      - numpy >=1.23,<3
+      - numpy >=2.0.0
+      - python >=3.13,<3.14.0a0
+      - python_abi 3.13.* *_cp313
+    license: BSD-3-Clause
+    license_family: BSD
+    run_exports: {}
+    size: 14094513
+    timestamp: 1781912946907
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+    sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
+    md5: a9d86bc62f39b94c4661716624eb21b0
+    depends:
+      - __osx >=11.0
+      - libzlib >=1.3.1,<2.0a0
+    license: TCL
+    license_family: BSD
+    size: 3127137
+    timestamp: 1769460817696
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+    sha256: 02c7b05be4d74da0d7329f92445646e3489634f0c3e59b26efefd846662ac20a
+    md5: dbc95e65c936251c3d32111c867d84e1
+    depends:
+      - __osx >=11.0
+      - python >=3.13,<3.14.0a0
+      - python >=3.13,<3.14.0a0 *_cp313
+      - python_abi 3.13.* *_cp313
+    license: Apache-2.0
+    license_family: Apache
+    size: 889689
+    timestamp: 1781007967544
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+    sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
+    md5: d31c0e54c4f9c51100ec8c812ee925d1
+    depends:
+      - libcxx >=19
+      - __osx >=11.0
+      - krb5 >=1.22.2,<1.23.0a0
+      - libsodium >=1.0.22,<1.0.23.0a0
+    license: MPL-2.0
+    license_family: MOZILLA
+    size: 245404
+    timestamp: 1779124076307
+  - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
+    sha256: 7553366c138bae2fcf8617582f1bb6d6b6742087bd6a83ea83aa41c023499382
+    md5: 8d4390edde2dcf29880c57b3088f15aa
+    depends:
+      - python >=3.10
+      - mojo-compiler ==1.0.0b2
+      - mblack ==26.4.0
+      - jupyter_client >=8.6.2,<8.7
+    license: LicenseRef-Modular-Proprietary
+    size: 96475709
+    timestamp: 1781237127405
+  - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
+    sha256: 87f8e9ef573f37072423aeb56a7c468bdb5f5889476bce4aa7c3396665c651fe
+    md5: 6be85d17872f5c2370015ca4ec07dd0d
+    depends:
+      - mojo-python ==1.0.0b2
+    license: LicenseRef-Modular-Proprietary
+    size: 85342385
+    timestamp: 1781237127405
+  - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
+    noarch: python
+    sha256: e2497cbefbf5d962cd0db8c1b893e7e48d8f3603cab84a9d8bad0030b5bb26b1
+    md5: ec6bf2b9588f5ba4bd3472c0773c4892
+    depends:
+      - python >=3.10
+      - click >=8.0.0
+      - mypy_extensions >=0.4.3
+      - packaging >=22.0
+      - pathspec >=0.9.0
+      - platformdirs >=2
+      - tomli >=1.1.0
+    license: LicenseRef-Modular-Proprietary
+    size: 135301
+    timestamp: 1781220755102
+  - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
+    noarch: python
+    sha256: 37bf44a74edcd2ebaec7fe8299ef183e006ad051bfcf21caa06becc0e0eeffd5
+    md5: 8781bd673909835fa59ce818e3835839
+    depends:
+      - python >=3.10
+    license: LicenseRef-Modular-Proprietary
+    size: 24682
+    timestamp: 1781220753246
+  - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
+    sha256: 39bb59a309af5e4c78c077263e5824e33bba8159a1e0fc39ff2786a1f9d5762b
+    md5: 1a6b6dd12763032e46b956407b39ab48
+    depends:
+      - python >=3.10
+      - mojo-compiler ==1.0.0b2
+      - mblack ==26.4.0
+      - jupyter_client >=8.6.2,<8.7
+    license: LicenseRef-Modular-Proprietary
+    size: 84573003
+    timestamp: 1781237324882
+  - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
+    sha256: 91c4d590a152ec2e26846955fcd7ec02796dfaffefa006a1c0c5790575be2051
+    md5: cd8d3f4a22e5f14dd909d0d5570c4940
+    depends:
+      - mojo-python ==1.0.0b2
+    license: LicenseRef-Modular-Proprietary
+    size: 62655166
+    timestamp: 1781237320083

--- a/tests/core/test_diagonal.mojo
+++ b/tests/core/test_diagonal.mojo
@@ -1,0 +1,92 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_diagonal_2d_main() raises:
+    """2-D diagonal, default offset=0, matches the legacy 2-D behavior."""
+    var a = nm.arange[nm.i32](0, 9).reshape(Shape(3, 3))
+    var d = a.diagonal()
+    assert_equal(d.ndim, 1)
+    assert_equal(d.size, 3)
+    assert_equal(Int(d.item(0)), 0)
+    assert_equal(Int(d.item(1)), 4)
+    assert_equal(Int(d.item(2)), 8)
+
+
+def test_diagonal_2d_offset() raises:
+    """2-D diagonal with positive and negative offsets."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var d_pos = a.diagonal(offset=1)
+    assert_equal(d_pos.size, 3)
+    assert_equal(Int(d_pos.item(0)), 1)
+    assert_equal(Int(d_pos.item(1)), 6)
+    assert_equal(Int(d_pos.item(2)), 11)
+
+    var d_neg = a.diagonal(offset=-1)
+    assert_equal(d_neg.size, 2)
+    assert_equal(Int(d_neg.item(0)), 4)
+    assert_equal(Int(d_neg.item(1)), 9)
+
+
+def test_diagonal_3d_default_axes() raises:
+    """3-D diagonal with axis1=0, axis2=1: result shape (5, min(3,4))=(5,3)."""
+    # a[i,j,k] = i*20 + j*5 + k, shape (3, 4, 5)
+    var a = nm.arange[nm.i32](0, 60).reshape(Shape(3, 4, 5))
+    var d = a.diagonal(axis1=0, axis2=1)
+    assert_equal(d.ndim, 2)
+    assert_equal(d.shape[0], 5)
+    assert_equal(d.shape[1], 3)
+    # d[k, i] = a[i, i, k] = i*20 + i*5 + k = 25*i + k
+    for k in range(5):
+        for i in range(3):
+            assert_equal(Int(d.item(k, i)), 25 * i + k)
+
+
+def test_diagonal_3d_axis1_axis2() raises:
+    """3-D diagonal with axis1=1, axis2=2: result shape (3, min(4,5))=(3,4)."""
+    # a[i,j,k] = i*20 + j*5 + k, shape (3, 4, 5)
+    var a = nm.arange[nm.i32](0, 60).reshape(Shape(3, 4, 5))
+    var d = a.diagonal(axis1=1, axis2=2)
+    assert_equal(d.ndim, 2)
+    assert_equal(d.shape[0], 3)
+    assert_equal(d.shape[1], 4)
+    # d[i, j] = a[i, j, j] = i*20 + j*5 + j = i*20 + 6*j
+    for i in range(3):
+        for j in range(4):
+            assert_equal(Int(d.item(i, j)), i * 20 + 6 * j)
+
+
+def test_diagonal_not_2d_no_longer_errors_for_3d() raises:
+    """A 3-D array no longer raises (previous 2-D-only restriction lifted)."""
+    var a = nm.arange[nm.i32](0, 60).reshape(Shape(3, 4, 5))
+    var d = a.diagonal()
+    assert_equal(d.ndim, 2)
+
+
+def test_diagonal_1d_raises() raises:
+    """diagonal on a 1-D array raises (fewer than 2 dims)."""
+    var a = nm.arange[nm.i32](0, 5)
+    var raised = False
+    try:
+        var _d = a.diagonal()
+    except:
+        raised = True
+    assert_true(raised, "1-D diagonal should raise")
+
+
+def test_diagonal_same_axis_raises() raises:
+    """diagonal with axis1 == axis2 raises."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var raised = False
+    try:
+        var _d = a.diagonal(axis1=0, axis2=0)
+    except:
+        raised = True
+    assert_true(raised, "axis1 == axis2 should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_nonzero.mojo
+++ b/tests/core/test_nonzero.mojo
@@ -1,0 +1,42 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_nonzero_1d() raises:
+    """nonzero on a 1-D array returns flat positions of non-zero entries."""
+    var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+    var idx = a.nonzero()
+    assert_equal(len(idx), 1)
+    assert_equal(idx[0].size, 3)
+    assert_equal(Int(idx[0].item(0)), 0)
+    assert_equal(Int(idx[0].item(1)), 2)
+    assert_equal(Int(idx[0].item(2)), 4)
+
+
+def test_nonzero_2d() raises:
+    """nonzero on a 2-D array returns one coordinate array per dimension."""
+    var b = nm.array[nm.i32]("[[1, 0], [0, 4]]")
+    var idx2 = b.nonzero()
+    assert_equal(len(idx2), 2)
+    assert_equal(Int(idx2[0].item(0)), 0)
+    assert_equal(Int(idx2[1].item(0)), 0)
+    assert_equal(Int(idx2[0].item(1)), 1)
+    assert_equal(Int(idx2[1].item(1)), 1)
+
+
+def test_nonzero_all_zero_raises() raises:
+    """nonzero raises when the array has no non-zero elements."""
+    var a = nm.zeros[nm.i32](Shape(3))
+    var raised = False
+    try:
+        var _idx = a.nonzero()
+    except:
+        raised = True
+    assert_true(raised, "all-zero array nonzero() should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_put.mojo
+++ b/tests/core/test_put.mojo
@@ -44,7 +44,8 @@ def test_put_values_broadcast_cyclically() raises:
 
 
 def test_put_on_2d_array_flat_indexing() raises:
-    """put indexes into the flattened (ravel-order) positions of an N-D array."""
+    """put indexes into the flattened (ravel-order) positions of an N-D array.
+    """
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     a.put(nm.array[nm.int]("[0, 5, 11]"), nm.array[nm.i32]("[-1, -2, -3]"))
     assert_equal(Int(a.item(0, 0)), -1)

--- a/tests/core/test_put.mojo
+++ b/tests/core/test_put.mojo
@@ -1,0 +1,67 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_put_array_values_happy_path() raises:
+    """put with an array of values writes into flat positions."""
+    var a = nm.arange[nm.i32](0, 6)
+    a.put(nm.array[nm.int]("[0, 2]"), nm.array[nm.i32]("[10, 20]"))
+    assert_equal(Int(a.item(0)), 10)
+    assert_equal(Int(a.item(1)), 1)
+    assert_equal(Int(a.item(2)), 20)
+    assert_equal(Int(a.item(3)), 3)
+
+
+def test_put_scalar_broadcast() raises:
+    """put with a scalar value broadcasts to all indices."""
+    var a = nm.arange[nm.i32](0, 6)
+    a.put(nm.array[nm.int]("[0, 2]"), Scalar[nm.i32](99))
+    assert_equal(Int(a.item(0)), 99)
+    assert_equal(Int(a.item(1)), 1)
+    assert_equal(Int(a.item(2)), 99)
+    assert_equal(Int(a.item(3)), 3)
+
+
+def test_put_negative_indices() raises:
+    """put accepts negative (from-the-end) flat indices."""
+    var a = nm.arange[nm.i32](0, 6)
+    a.put(nm.array[nm.int]("[-1, -2]"), nm.array[nm.i32]("[100, 200]"))
+    assert_equal(Int(a.item(5)), 100)
+    assert_equal(Int(a.item(4)), 200)
+
+
+def test_put_values_broadcast_cyclically() raises:
+    """When values is shorter than indices, it cycles."""
+    var a = nm.arange[nm.i32](0, 6)
+    a.put(nm.array[nm.int]("[0, 1, 2, 3]"), nm.array[nm.i32]("[7, 8]"))
+    assert_equal(Int(a.item(0)), 7)
+    assert_equal(Int(a.item(1)), 8)
+    assert_equal(Int(a.item(2)), 7)
+    assert_equal(Int(a.item(3)), 8)
+
+
+def test_put_on_2d_array_flat_indexing() raises:
+    """put indexes into the flattened (ravel-order) positions of an N-D array."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    a.put(nm.array[nm.int]("[0, 5, 11]"), nm.array[nm.i32]("[-1, -2, -3]"))
+    assert_equal(Int(a.item(0, 0)), -1)
+    assert_equal(Int(a.item(1, 1)), -2)
+    assert_equal(Int(a.item(2, 3)), -3)
+
+
+def test_put_out_of_bounds_raises() raises:
+    """put raises when an index is out of bounds for the flattened array."""
+    var a = nm.arange[nm.i32](0, 6)
+    var raised = False
+    try:
+        a.put(nm.array[nm.int]("[0, 10]"), nm.array[nm.i32]("[1, 2]"))
+    except:
+        raised = True
+    assert_true(raised, "out-of-bounds put index should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_searchsorted.mojo
+++ b/tests/core/test_searchsorted.mojo
@@ -1,0 +1,63 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_searchsorted_scalar_left() raises:
+    """searchsorted with a scalar value, default side='left'."""
+    var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+    assert_equal(a.searchsorted(Scalar[nm.i32](4)), 2)
+    assert_equal(a.searchsorted(Scalar[nm.i32](1)), 0)
+    assert_equal(a.searchsorted(Scalar[nm.i32](8)), 4)
+    assert_equal(a.searchsorted(Scalar[nm.i32](0)), 0)
+
+
+def test_searchsorted_scalar_right() raises:
+    """searchsorted with side='right' returns the rightmost insertion point."""
+    var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+    assert_equal(a.searchsorted(Scalar[nm.i32](3), side="right"), 2)
+    assert_equal(a.searchsorted(Scalar[nm.i32](3), side="left"), 1)
+
+
+def test_searchsorted_array_values() raises:
+    """searchsorted with an array of values returns one index per value."""
+    var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+    var result = a.searchsorted(nm.array[nm.i32]("[2, 6]"))
+    assert_equal(result.size, 2)
+    assert_equal(Int(result.item(0)), 1)
+    assert_equal(Int(result.item(1)), 3)
+
+
+def test_searchsorted_duplicates_left_right() raises:
+    """searchsorted handles duplicate values correctly for both sides."""
+    var a = nm.array[nm.i32]("[1, 2, 2, 2, 5]")
+    assert_equal(a.searchsorted(Scalar[nm.i32](2), side="left"), 1)
+    assert_equal(a.searchsorted(Scalar[nm.i32](2), side="right"), 4)
+
+
+def test_searchsorted_non_1d_raises() raises:
+    """searchsorted raises when `self` is not 1-D."""
+    var a = nm.arange[nm.i32](0, 6).reshape(Shape(2, 3))
+    var raised = False
+    try:
+        var _r = a.searchsorted(Scalar[nm.i32](2))
+    except:
+        raised = True
+    assert_true(raised, "searchsorted on non-1D array should raise")
+
+
+def test_searchsorted_invalid_side_raises() raises:
+    """searchsorted raises for an invalid `side` argument."""
+    var a = nm.array[nm.i32]("[1, 3, 5, 7]")
+    var raised = False
+    try:
+        var _r = a.searchsorted(Scalar[nm.i32](2), side="middle")
+    except:
+        raised = True
+    assert_true(raised, "invalid side value should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_take.mojo
+++ b/tests/core/test_take.mojo
@@ -1,0 +1,58 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_take_axis0() raises:
+    """take along axis 0 selects rows."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var result = a.take(nm.array[nm.int]("[2, 0, 1]"), axis=0)
+    assert_equal(result.shape[0], 3)
+    assert_equal(result.shape[1], 4)
+    assert_equal(Int(result.item(0, 0)), 8)
+    assert_equal(Int(result.item(1, 0)), 0)
+    assert_equal(Int(result.item(2, 0)), 4)
+
+
+def test_take_axis1() raises:
+    """take along axis 1 selects columns."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var result = a.take(nm.array[nm.int]("[1, 3]"), axis=1)
+    assert_equal(result.shape[0], 3)
+    assert_equal(result.shape[1], 2)
+    assert_equal(Int(result.item(0, 0)), 1)
+    assert_equal(Int(result.item(0, 1)), 3)
+
+
+def test_take_flat_no_axis() raises:
+    """take without axis flattens first."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var result = a.take(nm.array[nm.int]("[0, 5, 11]"))
+    assert_equal(result.ndim, 1)
+    assert_equal(Int(result.item(0)), 0)
+    assert_equal(Int(result.item(1)), 5)
+    assert_equal(Int(result.item(2)), 11)
+
+
+def test_take_negative_indices() raises:
+    """take normalises negative indices along the axis."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var result = a.take(nm.array[nm.int]("[-1]"), axis=0)
+    assert_equal(Int(result.item(0, 0)), 8)
+
+
+def test_take_out_of_bounds_raises() raises:
+    """take raises for an out-of-bounds index along the axis."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var raised = False
+    try:
+        var _r = a.take(nm.array[nm.int]("[5]"), axis=0)
+    except:
+        raised = True
+    assert_true(raised, "out-of-bounds take index should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_take_along_axis.mojo
+++ b/tests/core/test_take_along_axis.mojo
@@ -8,9 +8,9 @@ from numojo.prelude import *
 def test_take_along_axis_method_axis0() raises:
     """a.take_along_axis(indices, axis) delegates to the routine correctly."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
-    var ind = nm.array[nm.int](
-        "[[0, 1, 2, 0], [1, 0, 2, 1]]"
-    ).reshape(Shape(2, 4))
+    var ind = nm.array[nm.int]("[[0, 1, 2, 0], [1, 0, 2, 1]]").reshape(
+        Shape(2, 4)
+    )
     var result = a.take_along_axis(ind, axis=0)
     assert_equal(result.shape[0], 2)
     assert_equal(result.shape[1], 4)

--- a/tests/core/test_take_along_axis.mojo
+++ b/tests/core/test_take_along_axis.mojo
@@ -1,0 +1,35 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_take_along_axis_method_axis0() raises:
+    """a.take_along_axis(indices, axis) delegates to the routine correctly."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var ind = nm.array[nm.int](
+        "[[0, 1, 2, 0], [1, 0, 2, 1]]"
+    ).reshape(Shape(2, 4))
+    var result = a.take_along_axis(ind, axis=0)
+    assert_equal(result.shape[0], 2)
+    assert_equal(result.shape[1], 4)
+    # column 0: take rows [0,1] -> a[0,0]=0, a[1,0]=4
+    assert_equal(Int(result.item(0, 0)), 0)
+    assert_equal(Int(result.item(1, 0)), 4)
+
+
+def test_take_along_axis_method_default_axis() raises:
+    """Default axis is 0."""
+    var a = nm.arange[nm.i32](0, 6).reshape(Shape(3, 2))
+    var ind = nm.array[nm.int]("[[0, 0], [1, 1], [2, 2]]")
+    var result = a.take_along_axis(ind)
+    assert_equal(result.shape[0], 3)
+    assert_equal(result.shape[1], 2)
+    assert_equal(Int(result.item(0, 0)), 0)
+    assert_equal(Int(result.item(1, 0)), 2)
+    assert_equal(Int(result.item(2, 1)), 5)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- Add `NDArray.put(indices, values)`:  writes into flat (ravel-order) index positions, in-place. Accepts an array of values (cyclically broadcast if shorter than indices, matching NumPy) or a single scalar. Raises on out-of-bounds indices.

- Generalize `diagonal()` from 2-D-only to N-D: diagonal(offset=0, axis1=0, axis2=1) now works on arrays of any rank, diagonalizing the given axis pair and moving the diagonal to the last axis (NumPy-matching axis ordering). The original 2-D path is preserved as an explicit fast case, so existing behavior/callers are unaffected.

- Add `searchsorted(v, side="left")`: binary search (not a linear scan) returning insertion index/indices to keep a sorted 1-D array sorted; supports both scalar and array v, and "left"/"right" sides.

- Add `NDArray.take_along_axis(indices, axis=0)`: thin method wrapper around the existing take_along_axis routine, for parity with the other getter methods already on NDArray.