### PR TITLE
[Indexing][NDArray] Add fancy indexing and `where` function

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -264,6 +264,7 @@ from numojo.routines.indexing import (
     take_along_axis,
     take,
     nonzero,
+    fancy_index,
 )
 
 

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,12 +31,7 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import (
-    NDArrayShape,
-    NDArrayStrides,
-    Flags,
-    newaxis
-)
+from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
 
 from .dtype import (
     i8,

--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -31,7 +31,12 @@ from .error import (
 
 from .matrix import Matrix
 
-from .layout import NDArrayShape, NDArrayStrides, Flags, newaxis
+from .layout import (
+    NDArrayShape,
+    NDArrayStrides,
+    Flags,
+    newaxis
+)
 
 from .dtype import (
     i8,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -92,6 +92,7 @@ from numojo.routines.indexing import (
     nonzero as _nonzero,
     put as _put,
     searchsorted as _searchsorted,
+    fancy_index as _fancy_index,
 )
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
@@ -1483,6 +1484,44 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         return self[indices_array]
+
+    def __getitem__(
+        self, index_arrays: List[NDArray[DType.int]]
+    ) raises -> Self:
+        """Element-wise multi-axis fancy (advanced) indexing via a list of
+        index arrays.
+
+        Each element of `index_arrays` is an integer array indexing one axis.
+        All arrays are broadcast against each other; the output shape equals
+        that broadcast shape.  Mirrors NumPy's ``a[[row_arr, col_arr]]`` syntax
+        (note the outer ``[]`` is the list literal).
+
+        The number of index arrays must equal `self.ndim`.
+
+        Args:
+            index_arrays: A list of integer NDArrays, one per axis.
+
+        Returns:
+            Array of shape ``broadcast(index_arrays)`` whose element ``i``
+            equals ``self[index_arrays[0][i], index_arrays[1][i], ...]``.
+
+        Raises:
+            Error: If the number of index arrays does not equal `self.ndim`.
+            Error: If the index arrays are not mutually broadcast-compatible.
+            Error: If any index value is out of bounds for its axis.
+
+        Examples:
+
+        ```console
+        >>> var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+        >>> var rows = nm.array[nm.int]("[0, 1, 2]")
+        >>> var cols = nm.array[nm.int]("[2, 3, 0]")
+        >>> print(a[[rows, cols]])
+        [       2       7       8       ]
+        1-D array  Shape: [3]  DType: int32
+        ```.
+        """
+        return _fancy_index(self, index_arrays)
 
     def __getitem__(self, mask: NDArray[DType.bool]) raises -> Self:
         # TODO: Extend the mask into multiple dimensions.
@@ -5079,6 +5118,40 @@ struct NDArray[dtype: DType = DType.float64](
             ```
         """
         return _take_along_axis(self, indices, axis)
+
+    def fancy_index(self, *index_arrays: NDArray[DType.int]) raises -> Self:
+        """Element-wise multi-axis fancy (advanced) indexing.
+
+        Selects elements from the array by supplying one integer-array index
+        per axis.  All index arrays are broadcast against each other; the
+        output shape equals that broadcast shape.  Mirrors NumPy's
+        ``a[row_arr, col_arr, ...]`` syntax.
+
+        Args:
+            index_arrays: Exactly `self.ndim` integer index arrays, one per
+                axis.  Each is broadcast to the common shape before indexing.
+
+        Returns:
+            Array of shape ``broadcast(index_arrays)`` whose element ``i``
+            equals ``self[index_arrays[0][i], index_arrays[1][i], ...]``.
+
+        Raises:
+            Error: If the number of index arrays does not equal `self.ndim`.
+            Error: If the index arrays are not mutually broadcast-compatible.
+            Error: If any index value is out of bounds for its axis.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+            var rows = nm.array[nm.int]("[0, 1]")
+            var cols = nm.array[nm.int]("[2, 3]")
+            print(a.fancy_index(rows, cols))
+            # [2  7]
+            ```
+        """
+        return _fancy_index(self, *index_arrays)
 
     def put(mut self, indices: NDArray[DType.int], values: Self) raises:
         """Replaces values at flat (linear) index positions in-place.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -693,7 +693,6 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
-
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -693,6 +693,7 @@ struct NDArray[dtype: DType = DType.float64](
             self._copy_first_axis_slice(self, norm, result)
             return result^
 
+
     # perhaps move these to a utility module
     def _copy_first_axis_slice(
         self,

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -124,9 +124,9 @@ def `where`[
         ```
         .
     """
-    var cond_bc = broadcast_to(condition, condition.shape.broadcast(
-        x.shape.broadcast(y.shape)
-    ))
+    var cond_bc = broadcast_to(
+        condition, condition.shape.broadcast(x.shape.broadcast(y.shape))
+    )
     var x_bc = broadcast_to(x, cond_bc.shape)
     var y_bc = broadcast_to(y, cond_bc.shape)
 
@@ -239,10 +239,13 @@ def `where`[
 # Indexing-like operations
 # ===----------------------------------------------------------------------=== #
 
+
 def fancy_index[
     dtype: DType,
     //,
-](a: NDArray[dtype], index_arrays: List[NDArray[DType.int]]) raises -> NDArray[dtype]:
+](a: NDArray[dtype], index_arrays: List[NDArray[DType.int]]) raises -> NDArray[
+    dtype
+]:
     """Element-wise multi-axis fancy (advanced) indexing.
 
     Selects elements from `a` by supplying one integer-array index per axis
@@ -303,15 +306,14 @@ def fancy_index[
                 String(
                     "\nError in `fancy_index`: index arrays are not"
                     " broadcast-compatible: "
-                ) + String(e)
+                )
+                + String(e)
             )
 
     # Materialise each broadcast index array as a contiguous buffer.
     var bc_indices = List[NDArray[DType.int]](capacity=n_idx)
     for k in range(n_idx):
-        bc_indices.append(
-            broadcast_to(index_arrays[k], out_shape).contiguous()
-        )
+        bc_indices.append(broadcast_to(index_arrays[k], out_shape).contiguous())
 
     var result = NDArray[dtype](out_shape)
     var out_size = result.size
@@ -339,7 +341,9 @@ def fancy_index[
 def fancy_index[
     dtype: DType,
     //,
-](a: NDArray[dtype], *index_arrays: NDArray[DType.int]) raises -> NDArray[dtype]:
+](a: NDArray[dtype], *index_arrays: NDArray[DType.int]) raises -> NDArray[
+    dtype
+]:
     """Element-wise multi-axis fancy (advanced) indexing (variadic overload).
 
     Convenience overload that accepts index arrays as variadic positional
@@ -376,6 +380,7 @@ def fancy_index[
     for k in range(len(index_arrays)):
         idx_list.append(index_arrays[k].copy())  # variadic refs can't be moved
     return fancy_index(a, idx_list)
+
 
 def compress[
     dtype: DType

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -219,7 +219,7 @@ def `where`[
         import numojo as nm
 
         var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
-        var mask = nm.array[nm.bool]("[True, False, True, False]")
+        var mask = nm.array[nm.boolean]("[True, False, True, False]")
         print(nm.where(mask, Scalar[nm.f32](0.0), b))
         # [0.0  20.0  0.0  40.0]
         ```
@@ -239,6 +239,143 @@ def `where`[
 # Indexing-like operations
 # ===----------------------------------------------------------------------=== #
 
+def fancy_index[
+    dtype: DType,
+    //,
+](a: NDArray[dtype], index_arrays: List[NDArray[DType.int]]) raises -> NDArray[dtype]:
+    """Element-wise multi-axis fancy (advanced) indexing.
+
+    Selects elements from `a` by supplying one integer-array index per axis
+    as a ``List``.  All index arrays are broadcast against each other; the
+    output shape equals that broadcast shape.  This allows the ``a[[row_arr, col_arr, ...]]``
+    syntax (the outer ``[]`` is the list literal).
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Source N-D array.
+        index_arrays: List of integer NDArrays — exactly `a.ndim` entries,
+            one per axis.  Each array is broadcast to the common shape.
+
+    Returns:
+        Array of shape ``broadcast(index_arrays)`` whose element ``i`` equals
+        ``a[index_arrays[0][i], index_arrays[1][i], ...]``.
+
+    Raises:
+        Error: If the number of index arrays does not equal `a.ndim`.
+        Error: If the index arrays are not mutually broadcast-compatible.
+        Error: If any index value is out of bounds for its axis.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+        var rows = nm.array[nm.int]("[0, 1]")
+        var cols = nm.array[nm.int]("[2, 3]")
+        var idx = List[nm.NDArray[DType.int]]()
+        idx.append(rows^)
+        idx.append(cols^)
+        print(nm.fancy_index(a, idx))
+        # [2  7]
+        # or via __getitem__:
+        print(a[idx])
+        # [2  7]
+        ```
+    """
+    var n_idx = len(index_arrays)
+    if n_idx != a.ndim:
+        raise Error(
+            String(
+                "\nError in `fancy_index`: expected {} index arrays (one per"
+                " axis), got {}."
+            ).format(a.ndim, n_idx)
+        )
+
+    # Broadcast all index arrays to a common shape.
+    var out_shape = index_arrays[0].shape
+    for k in range(1, n_idx):
+        try:
+            out_shape = out_shape.broadcast(index_arrays[k].shape)
+        except e:
+            raise Error(
+                String(
+                    "\nError in `fancy_index`: index arrays are not"
+                    " broadcast-compatible: "
+                ) + String(e)
+            )
+
+    # Materialise each broadcast index array as a contiguous buffer.
+    var bc_indices = List[NDArray[DType.int]](capacity=n_idx)
+    for k in range(n_idx):
+        bc_indices.append(
+            broadcast_to(index_arrays[k], out_shape).contiguous()
+        )
+
+    var result = NDArray[dtype](out_shape)
+    var out_size = result.size
+
+    for i in range(out_size):
+        var coords = List[Int](capacity=n_idx)
+        for k in range(n_idx):
+            var raw = Int(bc_indices[k]._buf.ptr[i])
+            var ax_size = a.shape[k]
+            if raw < -ax_size or raw >= ax_size:
+                raise Error(
+                    String(
+                        "\nError in `fancy_index`: index {} is out of bounds"
+                        " for axis {} with size {}."
+                    ).format(raw, k, ax_size)
+                )
+            if raw < 0:
+                raw += ax_size
+            coords.append(raw)
+        result._buf.ptr[i] = a._getitem(coords)
+
+    return result^
+
+
+def fancy_index[
+    dtype: DType,
+    //,
+](a: NDArray[dtype], *index_arrays: NDArray[DType.int]) raises -> NDArray[dtype]:
+    """Element-wise multi-axis fancy (advanced) indexing (variadic overload).
+
+    Convenience overload that accepts index arrays as variadic positional
+    arguments instead of a ``List``.  Delegates to the ``List`` overload.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Source N-D array.
+        index_arrays: Exactly `a.ndim` integer index arrays, one per axis.
+
+    Returns:
+        Array of shape ``broadcast(index_arrays)``.
+
+    Raises:
+        Error: If the number of index arrays does not equal `a.ndim`.
+        Error: If the index arrays are not mutually broadcast-compatible.
+        Error: If any index value is out of bounds for its axis.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
+        var rows = nm.array[nm.int]("[0, 1]")
+        var cols = nm.array[nm.int]("[2, 3]")
+        print(nm.fancy_index(a, rows, cols))
+        # [2  7]
+        ```
+        .
+    """
+    var idx_list = List[NDArray[DType.int]](capacity=len(index_arrays))
+    for k in range(len(index_arrays)):
+        idx_list.append(index_arrays[k].copy())  # variadic refs can't be moved
+    return fancy_index(a, idx_list)
 
 def compress[
     dtype: DType

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -83,6 +83,158 @@ def `where`[
             x.itemset(i, y_c._buf.ptr[i])
 
 
+def `where`[
+    dtype: DType
+](
+    condition: NDArray[DType.bool],
+    x: NDArray[dtype],
+    y: NDArray[dtype],
+) raises -> NDArray[dtype]:
+    """Returns elements chosen from `x` or `y` depending on `condition`.
+
+    This is the functional (non-mutating) form: ``np.where(condition, x, y)``.
+    ``condition``, ``x``, and ``y`` are broadcast against each other following
+    NumPy broadcasting rules.  Elements where ``condition`` is True come from
+    ``x``; elements where it is False come from ``y``.
+
+    Parameters:
+        dtype: DType of `x` and `y`.
+
+    Args:
+        condition: Boolean selector array.
+        x: Values used where ``condition`` is True.
+        y: Values used where ``condition`` is False.
+
+    Returns:
+        New array of the broadcast shape filled from `x` where True and `y`
+        where False.
+
+    Raises:
+        Error: If ``condition``, ``x``, and ``y`` are not broadcast-compatible.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
+        var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
+        var mask = nm.array[nm.boolean]("[True, False, True, False]")
+        print(nm.where(mask, a, b))
+        # [1.0  20.0  3.0  40.0]
+        ```
+        .
+    """
+    var cond_bc = broadcast_to(condition, condition.shape.broadcast(
+        x.shape.broadcast(y.shape)
+    ))
+    var x_bc = broadcast_to(x, cond_bc.shape)
+    var y_bc = broadcast_to(y, cond_bc.shape)
+
+    var cond_c = cond_bc.contiguous()
+    var x_c = x_bc.contiguous()
+    var y_c = y_bc.contiguous()
+
+    var result = NDArray[dtype](cond_c.shape)
+    for i in range(result.size):
+        if cond_c._buf.ptr[i]:
+            result._buf.ptr[i] = x_c._buf.ptr[i]
+        else:
+            result._buf.ptr[i] = y_c._buf.ptr[i]
+    return result^
+
+
+def `where`[
+    dtype: DType
+](
+    condition: NDArray[DType.bool],
+    x: NDArray[dtype],
+    y: Scalar[dtype],
+) raises -> NDArray[dtype]:
+    """Returns elements from `x` or scalar `y` depending on `condition`.
+
+    Overload of ``where`` where the false-branch is a scalar broadcast.
+
+    Parameters:
+        dtype: DType of `x` and `y`.
+
+    Args:
+        condition: Boolean selector array.
+        x: Values used where ``condition`` is True.
+        y: Scalar used where ``condition`` is False.
+
+    Returns:
+        New array filled from `x` where True and `y` everywhere else.
+
+    Raises:
+        Error: If ``condition`` and `x` are not broadcast-compatible.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
+        var mask = nm.array[nm.boolean]("[True, False, True, False]")
+        print(nm.where(mask, a, Scalar[nm.f32](0.0)))
+        # [1.0  0.0  3.0  0.0]
+        ```
+        .
+    """
+    var bc_shape = condition.shape.broadcast(x.shape)
+    var cond_c = broadcast_to(condition, bc_shape).contiguous()
+    var x_c = broadcast_to(x, bc_shape).contiguous()
+
+    var result = NDArray[dtype](bc_shape)
+    for i in range(result.size):
+        result._buf.ptr[i] = x_c._buf.ptr[i] if cond_c._buf.ptr[i] else y
+    return result^
+
+
+def `where`[
+    dtype: DType
+](
+    condition: NDArray[DType.bool],
+    x: Scalar[dtype],
+    y: NDArray[dtype],
+) raises -> NDArray[dtype]:
+    """Returns scalar `x` or elements of `y` depending on `condition`.
+
+    Overload of ``where`` where the true-branch is a scalar broadcast.
+
+    Parameters:
+        dtype: DType of `x` and `y`.
+
+    Args:
+        condition: Boolean selector array.
+        x: Scalar used where ``condition`` is True.
+        y: Values used where ``condition`` is False.
+
+    Returns:
+        New array filled from `x` where True and `y` everywhere else.
+
+    Raises:
+        Error: If ``condition`` and `y` are not broadcast-compatible.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
+        var mask = nm.array[nm.bool]("[True, False, True, False]")
+        print(nm.where(mask, Scalar[nm.f32](0.0), b))
+        # [0.0  20.0  0.0  40.0]
+        ```
+        .
+    """
+    var bc_shape = condition.shape.broadcast(y.shape)
+    var cond_c = broadcast_to(condition, bc_shape).contiguous()
+    var y_c = broadcast_to(y, bc_shape).contiguous()
+
+    var result = NDArray[dtype](bc_shape)
+    for i in range(result.size):
+        result._buf.ptr[i] = x if cond_c._buf.ptr[i] else y_c._buf.ptr[i]
+    return result^
+
+
 # ===----------------------------------------------------------------------=== #
 # Indexing-like operations
 # ===----------------------------------------------------------------------=== #

--- a/tests/core/test_fancy_index.mojo
+++ b/tests/core/test_fancy_index.mojo
@@ -122,7 +122,7 @@ def test_fancy_index_out_of_bounds_raises() raises:
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var raised = False
     try:
-        var rows = nm.array[nm.int]("[5]")   # axis 0 size = 3
+        var rows = nm.array[nm.int]("[5]")  # axis 0 size = 3
         var cols = nm.array[nm.int]("[0]")
         var _r = a.fancy_index(rows, cols)
     except:

--- a/tests/core/test_fancy_index.mojo
+++ b/tests/core/test_fancy_index.mojo
@@ -1,0 +1,134 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_fancy_index_2d_pointwise() raises:
+    """Two 1-D index arrays on a 2-D array select pointwise elements."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    # a[0,2] = 2,  a[1,3] = 7,  a[2,0] = 8
+    var rows = nm.array[nm.int]("[0, 1, 2]")
+    var cols = nm.array[nm.int]("[2, 3, 0]")
+    var result = a.fancy_index(rows, cols)
+    assert_equal(result.ndim, 1)
+    assert_equal(result.shape[0], 3)
+    assert_equal(Int(result.item(0)), 2)
+    assert_equal(Int(result.item(1)), 7)
+    assert_equal(Int(result.item(2)), 8)
+
+
+def test_fancy_index_2d_free_fn() raises:
+    """Free function nm.fancy_index produces the same result as the method."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var rows = nm.array[nm.int]("[0, 1]")
+    var cols = nm.array[nm.int]("[2, 3]")
+    var r1 = a.fancy_index(rows, cols)
+    var r2 = nm.fancy_index(a, rows, cols)
+    assert_equal(Int(r1.item(0)), Int(r2.item(0)))
+    assert_equal(Int(r1.item(1)), Int(r2.item(1)))
+
+
+def test_fancy_index_getitem_list_syntax() raises:
+    """a[[rows, cols]] subscript syntax via List[NDArray[DType.int]]."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var rows = nm.array[nm.int]("[0, 1, 2]")
+    var cols = nm.array[nm.int]("[2, 3, 0]")
+    var idx = List[nm.NDArray[DType.int]]()
+    idx.append(rows^)
+    idx.append(cols^)
+    var result = a[idx]
+    assert_equal(result.ndim, 1)
+    assert_equal(result.shape[0], 3)
+    assert_equal(Int(result.item(0)), 2)
+    assert_equal(Int(result.item(1)), 7)
+    assert_equal(Int(result.item(2)), 8)
+
+
+def test_fancy_index_2d_grid() raises:
+    """2-D index arrays select a grid of elements."""
+    # a = [[0,1,2,3],[4,5,6,7]]  shape (2,4)
+    var a = nm.arange[nm.f32](0, 8).reshape(Shape(2, 4))
+    # row_idx = [[0, 1],[1, 0]], col_idx = [[1, 2],[3, 0]]
+    # selected: a[0,1]=1, a[1,2]=6, a[1,3]=7, a[0,0]=0
+    var r = nm.array[nm.int]("[[0, 1],[1, 0]]")
+    var c = nm.array[nm.int]("[[1, 2],[3, 0]]")
+    var result = a.fancy_index(r, c)
+    assert_equal(result.ndim, 2)
+    assert_equal(result.shape[0], 2)
+    assert_equal(result.shape[1], 2)
+    assert_equal(Int(result.item(0, 0)), 1)
+    assert_equal(Int(result.item(0, 1)), 6)
+    assert_equal(Int(result.item(1, 0)), 7)
+    assert_equal(Int(result.item(1, 1)), 0)
+
+
+def test_fancy_index_negative_indices() raises:
+    """Negative indices are normalised correctly."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    # a[-1, -1] = a[2, 3] = 11
+    var rows = nm.array[nm.int]("[-1]")
+    var cols = nm.array[nm.int]("[-1]")
+    var result = a.fancy_index(rows, cols)
+    assert_equal(Int(result.item(0)), 11)
+
+
+def test_fancy_index_3d() raises:
+    """Three index arrays on a 3-D source array."""
+    # shape (2, 3, 4), values 0..23
+    var a = nm.arange[nm.i32](0, 24).reshape(Shape(2, 3, 4))
+    # a[0, 1, 2] = 0*12 + 1*4 + 2 = 6
+    # a[1, 2, 3] = 1*12 + 2*4 + 3 = 23
+    var i0 = nm.array[nm.int]("[0, 1]")
+    var i1 = nm.array[nm.int]("[1, 2]")
+    var i2 = nm.array[nm.int]("[2, 3]")
+    var result = a.fancy_index(i0, i1, i2)
+    assert_equal(result.shape[0], 2)
+    assert_equal(Int(result.item(0)), 6)
+    assert_equal(Int(result.item(1)), 23)
+
+
+def test_fancy_index_broadcast() raises:
+    """Index arrays of different shapes broadcast against each other."""
+    # a shape (3, 4): use row scalar-like [1] broadcast against col [0,1,2,3]
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    # row [1] broadcasts to [1,1,1,1], col [0,1,2,3]
+    # selects a[1,0]=4, a[1,1]=5, a[1,2]=6, a[1,3]=7
+    var rows = nm.array[nm.int]("[1]")
+    var cols = nm.array[nm.int]("[0, 1, 2, 3]")
+    var result = a.fancy_index(rows, cols)
+    assert_equal(result.shape[0], 4)
+    assert_equal(Int(result.item(0)), 4)
+    assert_equal(Int(result.item(1)), 5)
+    assert_equal(Int(result.item(2)), 6)
+    assert_equal(Int(result.item(3)), 7)
+
+
+def test_fancy_index_wrong_n_arrays_raises() raises:
+    """Passing wrong number of index arrays raises an error."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var raised = False
+    try:
+        # a is 2-D, but only 1 index array → should raise
+        var _r = nm.fancy_index(a, nm.array[nm.int]("[0, 1]"))
+    except:
+        raised = True
+    assert_true(raised, "wrong number of index arrays should raise")
+
+
+def test_fancy_index_out_of_bounds_raises() raises:
+    """An out-of-bounds index raises an error."""
+    var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
+    var raised = False
+    try:
+        var rows = nm.array[nm.int]("[5]")   # axis 0 size = 3
+        var cols = nm.array[nm.int]("[0]")
+        var _r = a.fancy_index(rows, cols)
+    except:
+        raised = True
+    assert_true(raised, "out-of-bounds fancy index should raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_where.mojo
+++ b/tests/core/test_where.mojo
@@ -1,0 +1,80 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_true
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_where_array_array() raises:
+    """where(cond, x, y) with two arrays picks x where True, y where False."""
+    var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
+    var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
+    var mask = nm.array[boolean]("[1, 0, 1, 0]")
+    var result = nm.`where`(mask, a, b)
+    assert_equal(result.shape[0], 4)
+    assert_equal(Int(result.item(0)), 1)
+    assert_equal(Int(result.item(1)), 20)
+    assert_equal(Int(result.item(2)), 3)
+    assert_equal(Int(result.item(3)), 40)
+
+
+def test_where_array_scalar() raises:
+    """where(cond, x, scalar) fills scalar where False."""
+    var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
+    var mask = nm.array[boolean]("[1, 0, 1, 0]")
+    var result = nm.`where`(mask, a, Scalar[nm.f32](0.0))
+    assert_equal(Int(result.item(0)), 1)
+    assert_equal(Int(result.item(1)), 0)
+    assert_equal(Int(result.item(2)), 3)
+    assert_equal(Int(result.item(3)), 0)
+
+
+def test_where_scalar_array() raises:
+    """where(cond, scalar, y) fills scalar where True."""
+    var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
+    var mask = nm.array[boolean]("[1, 0, 1, 0]")
+    var result = nm.`where`(mask, Scalar[nm.f32](-1.0), b)
+    assert_equal(Int(result.item(0)), -1)
+    assert_equal(Int(result.item(1)), 20)
+    assert_equal(Int(result.item(2)), -1)
+    assert_equal(Int(result.item(3)), 40)
+
+
+def test_where_all_true() raises:
+    """All-True mask returns x unchanged."""
+    var a = nm.array[nm.i32]("[5, 6, 7]")
+    var b = nm.array[nm.i32]("[0, 0, 0]")
+    var mask = nm.array[boolean]("[1, 1, 1]")
+    var result = nm.`where`(mask, a, b)
+    assert_equal(Int(result.item(0)), 5)
+    assert_equal(Int(result.item(1)), 6)
+    assert_equal(Int(result.item(2)), 7)
+
+
+def test_where_all_false() raises:
+    """All-False mask returns y unchanged."""
+    var a = nm.array[nm.i32]("[5, 6, 7]")
+    var b = nm.array[nm.i32]("[1, 2, 3]")
+    var mask = nm.array[boolean]("[0, 0, 0]")
+    var result = nm.`where`(mask, a, b)
+    assert_equal(Int(result.item(0)), 1)
+    assert_equal(Int(result.item(1)), 2)
+    assert_equal(Int(result.item(2)), 3)
+
+
+def test_where_2d() raises:
+    """where works element-wise on 2-D arrays."""
+    var a = nm.arange[nm.i32](1, 5).reshape(Shape(2, 2))
+    var b = nm.zeros[nm.i32](Shape(2, 2))
+    # mask = [[True, False],[False, True]]
+    var mask = nm.array[boolean]("[[1, 0],[0, 1]]")
+    var result = nm.`where`(mask, a, b)
+    assert_equal(result.ndim, 2)
+    assert_equal(Int(result.item(0, 0)), 1)   # from a
+    assert_equal(Int(result.item(0, 1)), 0)   # from b
+    assert_equal(Int(result.item(1, 0)), 0)   # from b
+    assert_equal(Int(result.item(1, 1)), 4)   # from a
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_where.mojo
+++ b/tests/core/test_where.mojo
@@ -70,10 +70,10 @@ def test_where_2d() raises:
     var mask = nm.array[boolean]("[[1, 0],[0, 1]]")
     var result = nm.`where`(mask, a, b)
     assert_equal(result.ndim, 2)
-    assert_equal(Int(result.item(0, 0)), 1)   # from a
-    assert_equal(Int(result.item(0, 1)), 0)   # from b
-    assert_equal(Int(result.item(1, 0)), 0)   # from b
-    assert_equal(Int(result.item(1, 1)), 4)   # from a
+    assert_equal(Int(result.item(0, 0)), 1)  # from a
+    assert_equal(Int(result.item(0, 1)), 0)  # from b
+    assert_equal(Int(result.item(1, 0)), 0)  # from b
+    assert_equal(Int(result.item(1, 1)), 4)  # from a
 
 
 def main() raises:


### PR DESCRIPTION
This PR adds support for the following, 

1) Fancy indexing similar to numpy which lets us do the following,
```mojo
        import numojo as nm

        var a = nm.arange[nm.i32](12).reshape(nm.Shape(3, 4))
        var rows = nm.array[nm.int]("[0, 1]")
        var cols = nm.array[nm.int]("[2, 3]")
        var idx = List[nm.NDArray[DType.int]]()
        idx.append(rows^)
        idx.append(cols^)
        print(nm.fancy_index(a, idx))
        # [2  7]
        # or via __getitem__:
        print(a[idx])
        # [2  7]
```

2) Functional `where` which lets us do the the following, 
```mojo
        import numojo as nm

        var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
        var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
        var mask = nm.array[nm.boolean]("[True, False, True, False]")
        print(nm.where(mask, a, b))
        # [1.0  20.0  3.0  
```