### PR TITLE
[mojo][core] Update the codebase to mojo v1.0.0

### DIFF
--- a/numojo/core/__init__.mojo
+++ b/numojo/core/__init__.mojo
@@ -91,10 +91,10 @@ from .accelerator import Device, cpu, cuda, mps, rocm
 
 from .indexing import Item, IndexMethods, TraverseMethods, Validator
 
-import .dtype
-import .layout
-import .memory
-import .matrix
-import .complex
-import .traits
-import .accelerator
+from . import dtype
+from . import layout
+from . import memory
+from . import matrix
+from . import complex
+from . import traits
+from . import accelerator

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -160,8 +160,8 @@ struct DeviceHandle[device: Device](Copyable, Movable, Writable):
     def __init__(out self, *, copy: Self):
         self.context = copy.context.copy()
 
-    def __init__(out self, *, deinit take: Self):
-        self.context = take.context^
+    def __init__(out self, *, deinit move: Self):
+        self.context = move.context^
 
     def __str__(self) -> String:
         return "DeviceHandle(" + Self.device.device_name() + ", context=True)"

--- a/numojo/core/accelerator/device.mojo
+++ b/numojo/core/accelerator/device.mojo
@@ -15,7 +15,7 @@ from std.sys.info import (
     has_amd_gpu_accelerator,
     has_apple_gpu_accelerator,
 )
-from std.gpu.host import DeviceContext
+from max.gpu.host import DeviceContext
 
 from numojo.core.error import NumojoError
 

--- a/numojo/core/accelerator/kernels/binary_ops.mojo
+++ b/numojo/core/accelerator/kernels/binary_ops.mojo
@@ -12,7 +12,7 @@ on contiguous `AcceleratorNDArray` buffers.
 """
 
 from std.gpu import thread_idx, block_idx, block_dim
-from std.gpu.host import DeviceContext
+from max.gpu.host import DeviceContext
 
 comptime ADD = 0
 comptime SUB = 1

--- a/numojo/core/accelerator/kernels/binary_ops.mojo
+++ b/numojo/core/accelerator/kernels/binary_ops.mojo
@@ -45,7 +45,9 @@ def binary_op_kernel[
     """GPU kernel: `result[i] = op(a[i], b[i])` for contiguous buffers."""
     var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
     if i < size:
-        result[unsafe_offset=i] = _binary_op[dtype, op_code](a[unsafe_offset=i], b[unsafe_offset=i])
+        result[unsafe_offset=i] = _binary_op[dtype, op_code](
+            a[unsafe_offset=i], b[unsafe_offset=i]
+        )
 
 
 def launch_config(size: Int) -> Tuple[Int, Int]:

--- a/numojo/core/accelerator/kernels/binary_ops.mojo
+++ b/numojo/core/accelerator/kernels/binary_ops.mojo
@@ -37,15 +37,15 @@ def _binary_op[
 def binary_op_kernel[
     dtype: DType, op_code: Int
 ](
-    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    result: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
+    b: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     """GPU kernel: `result[i] = op(a[i], b[i])` for contiguous buffers."""
     var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
     if i < size:
-        result[i] = _binary_op[dtype, op_code](a[i], b[i])
+        result[unsafe_offset=i] = _binary_op[dtype, op_code](a[unsafe_offset=i], b[unsafe_offset=i])
 
 
 def launch_config(size: Int) -> Tuple[Int, Int]:
@@ -63,9 +63,9 @@ def launch_binary_op[
     dtype: DType, op_code: Int
 ](
     context: DeviceContext,
-    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    b: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    result: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
+    b: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
     sync: Bool = True,
 ) raises:

--- a/numojo/core/accelerator/kernels/reduction_ops.mojo
+++ b/numojo/core/accelerator/kernels/reduction_ops.mojo
@@ -10,8 +10,9 @@
 GPU kernel functions and launch helpers for full-array reduction ops.
 """
 
-from std.gpu import thread_idx, block_idx, block_dim, barrier
-from std.gpu.host import DeviceContext
+from std.gpu import thread_idx, block_idx, block_dim
+from max.gpu.sync import barrier
+from max.gpu.host import DeviceContext
 from std.memory import AddressSpace, stack_allocation, alloc
 
 from .binary_ops import launch_config

--- a/numojo/core/accelerator/kernels/reduction_ops.mojo
+++ b/numojo/core/accelerator/kernels/reduction_ops.mojo
@@ -21,8 +21,8 @@ from .binary_ops import launch_config
 def sum_reduce_kernel[
     dtype: DType, block_size: Int
 ](
-    partial_sums: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    partial_sums: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     """GPU kernel: each block reduces its chunk of `a` to one partial sum.
@@ -39,27 +39,27 @@ def sum_reduce_kernel[
     var idx = bid * block_size + tid
 
     if idx < size:
-        smem[tid] = a[idx]
+        smem[unsafe_offset=tid] = a[unsafe_offset=idx]
     else:
-        smem[tid] = Scalar[dtype](0)
+        smem[unsafe_offset=tid] = Scalar[dtype](0)
     barrier()
 
     var stride = block_size >> 1
     while stride > 0:
         if tid < stride:
-            smem[tid] += smem[tid + stride]
+            smem[unsafe_offset=tid] += smem[unsafe_offset=tid + stride]
         barrier()
         stride >>= 1
 
     if tid == 0:
-        partial_sums[bid] = smem[0]
+        partial_sums[unsafe_offset=bid] = smem[unsafe_offset=0]
 
 
 def launch_sum_reduce[
     dtype: DType
 ](
     context: DeviceContext,
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ) raises -> Scalar[dtype]:
     """Launch the GPU sum-reduction kernel and combine partial sums.
@@ -92,7 +92,7 @@ def launch_sum_reduce[
 
     var result = Scalar[dtype](0)
     for i in range(num_blocks):
-        result += host_partial[i]
+        result += host_partial[unsafe_offset=i]
 
-    host_partial.free()
+    host_partial.unsafe_free()
     return result

--- a/numojo/core/accelerator/kernels/reduction_ops.mojo
+++ b/numojo/core/accelerator/kernels/reduction_ops.mojo
@@ -13,7 +13,8 @@ GPU kernel functions and launch helpers for full-array reduction ops.
 from std.gpu import thread_idx, block_idx, block_dim
 from max.gpu.sync import barrier
 from max.gpu.host import DeviceContext
-from std.memory import AddressSpace, stack_allocation, alloc
+from std.memory import AddressSpace, stack_allocation
+from std.memory.alloc import unsafe_alloc
 
 from .binary_ops import launch_config
 
@@ -86,7 +87,7 @@ def launch_sum_reduce[
         block_dim=block_dim_size,
     )
 
-    var host_partial = alloc[Scalar[dtype]](num_blocks)
+    var host_partial = unsafe_alloc[Scalar[dtype]](num_blocks)
     partial_sums.enqueue_copy_to(host_partial)
     context.synchronize()
 

--- a/numojo/core/accelerator/kernels/unary_ops.mojo
+++ b/numojo/core/accelerator/kernels/unary_ops.mojo
@@ -20,22 +20,22 @@ from .binary_ops import launch_config
 def neg_kernel[
     dtype: DType
 ](
-    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    result: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
 ):
     """GPU kernel: `result[i] = -a[i]` for contiguous buffers."""
     var i = Int(thread_idx.x) + Int(block_idx.x) * Int(block_dim.x)
     if i < size:
-        result[i] = -a[i]
+        result[unsafe_offset=i] = -a[unsafe_offset=i]
 
 
 def launch_neg[
     dtype: DType
 ](
     context: DeviceContext,
-    result: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    result: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], MutAnyOrigin],
     size: Int,
     sync: Bool = True,
 ) raises:

--- a/numojo/core/accelerator/kernels/unary_ops.mojo
+++ b/numojo/core/accelerator/kernels/unary_ops.mojo
@@ -12,7 +12,7 @@ on contiguous `AcceleratorNDArray` buffers.
 """
 
 from std.gpu import thread_idx, block_idx, block_dim
-from std.gpu.host import DeviceContext
+from max.gpu.host import DeviceContext
 
 from .binary_ops import launch_config
 

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -247,7 +247,7 @@ struct AcceleratorNDArray[
 
     def unsafe_ptr(
         ref self,
-    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+    ) -> Pointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device.type == "cpu"
     ):
         return (
@@ -258,7 +258,7 @@ struct AcceleratorNDArray[
 
     def unsafe_device_ptr(
         ref self,
-    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+    ) -> Pointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device.type == "gpu"
     ):
         """Return the raw device pointer to the buffer's data.
@@ -663,7 +663,7 @@ struct AcceleratorNDArray[
             var src_ptr = self._buf.host_storage.unsafe_value().ptr
             var dst_ptr = out._buf.host_storage.unsafe_value().ptr
             for i in range(self.size):
-                dst_ptr[i] = src_ptr[i]
+                dst_ptr[unsafe_offset=i] = src_ptr[unsafe_offset=i]
         else:
             self._buf.device_storage.unsafe_value().get_buffer().enqueue_copy_to(
                 out._buf.device_storage.unsafe_value().get_buffer()
@@ -681,7 +681,7 @@ struct AcceleratorNDArray[
             var src_ptr = self._buf.host_storage.unsafe_value().ptr
             var dst_ptr = out._buf.host_storage.unsafe_value().ptr
             for i in range(self.size):
-                dst_ptr[i] = src_ptr[i]
+                dst_ptr[unsafe_offset=i] = src_ptr[unsafe_offset=i]
         else:
             self._buf.device_storage.unsafe_value().get_buffer().enqueue_copy_to(
                 out._buf.host_storage.unsafe_value().ptr
@@ -702,7 +702,7 @@ struct AcceleratorNDArray[
             var src_ptr = host._buf.host_storage.unsafe_value().ptr
             var dst_ptr = out._buf.host_storage.unsafe_value().ptr
             for i in range(host.size):
-                dst_ptr[i] = src_ptr[i]
+                dst_ptr[unsafe_offset=i] = src_ptr[unsafe_offset=i]
             return out^
         else:
             var host = self.to_host()
@@ -773,16 +773,16 @@ struct AcceleratorNDArray[
             var src2 = other.unsafe_ptr()
             comptime if op_code == kernels.ADD:
                 for i in range(self.size):
-                    dst[i] = src1[i] + src2[i]
+                    dst[unsafe_offset=i] = src1[unsafe_offset=i] + src2[unsafe_offset=i]
             elif op_code == kernels.SUB:
                 for i in range(self.size):
-                    dst[i] = src1[i] - src2[i]
+                    dst[unsafe_offset=i] = src1[unsafe_offset=i] - src2[unsafe_offset=i]
             elif op_code == kernels.MUL:
                 for i in range(self.size):
-                    dst[i] = src1[i] * src2[i]
+                    dst[unsafe_offset=i] = src1[unsafe_offset=i] * src2[unsafe_offset=i]
             else:
                 for i in range(self.size):
-                    dst[i] = src1[i] / src2[i]
+                    dst[unsafe_offset=i] = src1[unsafe_offset=i] / src2[unsafe_offset=i]
         else:
             comptime assert Self.device.type == "gpu"
             var context = self.device_context()
@@ -836,7 +836,7 @@ struct AcceleratorNDArray[
             var src = self.unsafe_ptr()
             var result = Scalar[Self.dtype](0)
             for i in range(self.size):
-                result += src[i]
+                result += src[unsafe_offset=i]
             return result
         else:
             comptime assert Self.device.type == "gpu"
@@ -871,7 +871,7 @@ struct AcceleratorNDArray[
             var dst = out.unsafe_ptr()
             var src = self.unsafe_ptr()
             for i in range(self.size):
-                dst[i] = -src[i]
+                dst[unsafe_offset=i] = -src[unsafe_offset=i]
         else:
             comptime assert Self.device.type == "gpu"
             var context = self.device_context()

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -23,6 +23,7 @@ from numojo.core.accelerator.device import Device
 import numojo.core.accelerator.kernels as kernels
 from numojo.core.ndarray import NDArray
 from numojo.core.dtype.default_dtype import _concise_dtype_str
+from numojo.core.type_aliases import Shape
 
 
 struct AcceleratorNDArray[
@@ -134,14 +135,14 @@ struct AcceleratorNDArray[
         self._buf = copy._buf.copy()
 
     @always_inline("nodebug")
-    def __init__(out self, *, deinit take: Self):
-        self.ndim = take.ndim
-        self.shape = take.shape
-        self.size = take.size
-        self.strides = take.strides
-        self.offset = take.offset
-        self.flags = take.flags
-        self._buf = take._buf^
+    def __init__(out self, *, deinit move: Self):
+        self.ndim = move.ndim
+        self.shape = move.shape
+        self.size = move.size
+        self.strides = move.strides
+        self.offset = move.offset
+        self.flags = move.flags
+        self._buf = move._buf^
 
     @always_inline("nodebug")
     def view(self) raises -> Self:

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -11,7 +11,7 @@ Device-aware NDArray that stores data in `AcceleratorDataContainer`.
 """
 
 from std.memory import UnsafePointer
-from std.gpu.host import DeviceContext
+from max.gpu.host import DeviceContext
 from numojo.core.error import NumojoError
 from numojo.core.layout.flags import Flags
 from numojo.core.layout.ndshape import NDArrayShape
@@ -250,7 +250,11 @@ struct AcceleratorNDArray[
     ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device.type == "cpu"
     ):
-        return self._buf.host_storage.unsafe_value().ptr + self.offset
+        return (
+            self._buf.host_storage.unsafe_value()
+            .ptr.unsafe_offset(self.offset)
+            .as_unsafe_any_origin()
+        )
 
     def unsafe_device_ptr(
         ref self,

--- a/numojo/core/accelerator_ndarray.mojo
+++ b/numojo/core/accelerator_ndarray.mojo
@@ -774,16 +774,24 @@ struct AcceleratorNDArray[
             var src2 = other.unsafe_ptr()
             comptime if op_code == kernels.ADD:
                 for i in range(self.size):
-                    dst[unsafe_offset=i] = src1[unsafe_offset=i] + src2[unsafe_offset=i]
+                    dst[unsafe_offset=i] = (
+                        src1[unsafe_offset=i] + src2[unsafe_offset=i]
+                    )
             elif op_code == kernels.SUB:
                 for i in range(self.size):
-                    dst[unsafe_offset=i] = src1[unsafe_offset=i] - src2[unsafe_offset=i]
+                    dst[unsafe_offset=i] = (
+                        src1[unsafe_offset=i] - src2[unsafe_offset=i]
+                    )
             elif op_code == kernels.MUL:
                 for i in range(self.size):
-                    dst[unsafe_offset=i] = src1[unsafe_offset=i] * src2[unsafe_offset=i]
+                    dst[unsafe_offset=i] = (
+                        src1[unsafe_offset=i] * src2[unsafe_offset=i]
+                    )
             else:
                 for i in range(self.size):
-                    dst[unsafe_offset=i] = src1[unsafe_offset=i] / src2[unsafe_offset=i]
+                    dst[unsafe_offset=i] = (
+                        src1[unsafe_offset=i] / src2[unsafe_offset=i]
+                    )
         else:
             comptime assert Self.device.type == "gpu"
             var context = self.device_context()

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -842,12 +842,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             var block: Int = self.size // self.shape[0]
             unsafe_memcpy(
                 dest=result._re._buf.ptr,
-                src=self._re._buf.ptr + norm * block,
+                src=self._re._buf.ptr.unsafe_offset(norm * block),
                 count=block,
             )
             unsafe_memcpy(
                 dest=result._im._buf.ptr,
-                src=self._im._buf.ptr + norm * block,
+                src=self._im._buf.ptr.unsafe_offset(norm * block),
                 count=block,
             )
             return result^
@@ -1176,15 +1176,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     )
                 )
             unsafe_memcpy(
-                dest=result._re._buf.ptr + i * size_per_item,
-                src=self._re._buf.ptr
-                + indices.item(i) * Scalar[DType.int](size_per_item),
+                dest=result._re._buf.ptr.unsafe_offset(i * size_per_item),
+                src=self._re._buf.ptr.unsafe_offset(indices.item(i) * Scalar[DType.int](size_per_item)),
                 count=size_per_item,
             )
             unsafe_memcpy(
-                dest=result._im._buf.ptr + i * size_per_item,
-                src=self._im._buf.ptr
-                + indices.item(i) * Scalar[DType.int](size_per_item),
+                dest=result._im._buf.ptr.unsafe_offset(i * size_per_item),
+                src=self._im._buf.ptr.unsafe_offset(indices.item(i) * Scalar[DType.int](size_per_item)),
                 count=size_per_item,
             )
 
@@ -1209,7 +1207,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var indices_array = NDArray[DType.int](shape=Shape(len(indices)))
         for i in range(len(indices)):
-            (indices_array._buf.ptr + i).unsafe_write(
+            (indices_array._buf.ptr.unsafe_offset(i)).unsafe_write(
                 Scalar[DType.int](indices[i])
             )
 
@@ -1253,10 +1251,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             var offset = 0
             for i in range(mask.size):
                 if mask.item(i):
-                    (result._re._buf.ptr + offset).unsafe_write(
+                    (result._re._buf.ptr.unsafe_offset(offset)).unsafe_write(
                         self._re._buf.ptr[unsafe_offset=i]
                     )
-                    (result._im._buf.ptr + offset).unsafe_write(
+                    (result._im._buf.ptr.unsafe_offset(offset)).unsafe_write(
                         self._im._buf.ptr[unsafe_offset=i]
                     )
                     offset += 1
@@ -1312,13 +1310,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         for i in range(mask.size):
             if mask.item(i):
                 unsafe_memcpy(
-                    dest=result._re._buf.ptr + offset * size_per_item,
-                    src=self._re._buf.ptr + i * size_per_item,
+                    dest=result._re._buf.ptr.unsafe_offset(offset * size_per_item),
+                    src=self._re._buf.ptr.unsafe_offset(i * size_per_item),
                     count=size_per_item,
                 )
                 unsafe_memcpy(
-                    dest=result._im._buf.ptr + offset * size_per_item,
-                    src=self._im._buf.ptr + i * size_per_item,
+                    dest=result._im._buf.ptr.unsafe_offset(offset * size_per_item),
+                    src=self._im._buf.ptr.unsafe_offset(i * size_per_item),
                     count=size_per_item,
                 )
                 offset += 1
@@ -1341,7 +1339,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var mask_array = NDArray[DType.bool](shape=Shape(len(mask)))
         for i in range(len(mask)):
-            (mask_array._buf.ptr + i).unsafe_write(mask[i])
+            (mask_array._buf.ptr.unsafe_offset(i)).unsafe_write(mask[i])
 
         return self[mask_array]
 
@@ -1404,19 +1402,17 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.flags.F_CONTIGUOUS:
             return ComplexSIMD[Self.cdtype](
                 re=(
-                    self._re._buf.ptr
-                    + IndexMethods.transfer_offset(index, self.strides)
+                    self._re._buf.ptr.unsafe_offset(IndexMethods.transfer_offset(index, self.strides))
                 )[],
                 im=(
-                    self._im._buf.ptr
-                    + IndexMethods.transfer_offset(index, self.strides)
+                    self._im._buf.ptr.unsafe_offset(IndexMethods.transfer_offset(index, self.strides))
                 )[],
             )
 
         else:
             return ComplexSIMD[Self.cdtype](
-                re=(self._re._buf.ptr + index)[],
-                im=(self._im._buf.ptr + index)[],
+                re=(self._re._buf.ptr.unsafe_offset(index))[],
+                im=(self._im._buf.ptr.unsafe_offset(index))[],
             )
 
     def item(self, *index: Int) raises -> ComplexSIMD[Self.cdtype]:
@@ -1487,12 +1483,10 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
         return ComplexSIMD[Self.cdtype](
             re=(
-                self._re._buf.ptr
-                + IndexMethods.get_1d_index(index, self.strides)
+                self._re._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
             )[],
             im=(
-                self._im._buf.ptr
-                + IndexMethods.get_1d_index(index, self.strides)
+                self._im._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
             )[],
         )
 
@@ -1837,12 +1831,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.flags.C_CONTIGUOUS & val.flags.C_CONTIGUOUS:
             var block = self.size // self.shape[0]
             unsafe_memcpy(
-                dest=self._re._buf.ptr + norm * block,
+                dest=self._re._buf.ptr.unsafe_offset(norm * block),
                 src=val._re._buf.ptr,
                 count=block,
             )
             unsafe_memcpy(
-                dest=self._im._buf.ptr + norm * block,
+                dest=self._im._buf.ptr.unsafe_offset(norm * block),
                 src=val._im._buf.ptr,
                 count=block,
             )

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -33,7 +33,7 @@ import std.builtin.bool as builtin_bool
 import std.math as builtin_math
 from std.collections.optional import Optional
 from std.math import log10, sqrt
-from std.memory import memset_zero, memcpy, UnsafePointer
+from std.memory import unsafe_memset_zero, unsafe_memcpy, UnsafePointer
 from std.python import Python, PythonObject
 from std.sys import simd_width_of
 from std.utils import Variant
@@ -501,15 +501,15 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """Stride-safe logical flat load."""
         var off = self._flat_offset(flat_index)
         return ComplexSIMD[Self.cdtype](
-            self._re._buf.ptr[off], self._im._buf.ptr[off]
+            self._re._buf.ptr[unsafe_offset=off], self._im._buf.ptr[unsafe_offset=off]
         )
 
     @always_inline("nodebug")
     def _flat_store(mut self, flat_index: Int, value: ComplexSIMD[Self.cdtype]):
         """Stride-safe logical flat store."""
         var off = self._flat_offset(flat_index)
-        self._re._buf.ptr[off] = value.re
-        self._im._buf.ptr[off] = value.im
+        self._re._buf.ptr[unsafe_offset=off] = value.re
+        self._im._buf.ptr[unsafe_offset=off] = value.im
 
     @always_inline("nodebug")
     def _lex_less(
@@ -632,8 +632,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
         return ComplexSIMD[Self.cdtype](
-            re=self._re._buf.ptr[index_of_buffer],
-            im=self._im._buf.ptr[index_of_buffer],
+            re=self._re._buf.ptr[unsafe_offset=index_of_buffer],
+            im=self._im._buf.ptr[unsafe_offset=index_of_buffer],
         )
 
     def _getitem(self, indices: List[Int]) -> ComplexScalar[Self.cdtype]:
@@ -662,8 +662,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
         return ComplexSIMD[Self.cdtype](
-            re=self._re._buf.ptr[index_of_buffer],
-            im=self._im._buf.ptr[index_of_buffer],
+            re=self._re._buf.ptr[unsafe_offset=index_of_buffer],
+            im=self._im._buf.ptr[unsafe_offset=index_of_buffer],
         )
 
     def __getitem__(self) raises -> ComplexSIMD[Self.cdtype, 1]:
@@ -751,8 +751,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var idx: Int = IndexMethods.get_1d_index(index, self.strides)
         return ComplexSIMD[Self.cdtype](
-            re=self._re._buf.ptr.load[width=1](idx),
-            im=self._im._buf.ptr.load[width=1](idx),
+            re=self._re._buf.ptr.unsafe_load[width=1](idx),
+            im=self._im._buf.ptr.unsafe_load[width=1](idx),
         )
 
     def __getitem__(self, idx: Int) raises -> Self:
@@ -824,8 +824,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.ndim == 1:
             return creation._0darray[Self.cdtype](
                 ComplexSIMD[Self.cdtype](
-                    re=self._re._buf.ptr[norm],
-                    im=self._im._buf.ptr[norm],
+                    re=self._re._buf.ptr[unsafe_offset=norm],
+                    im=self._im._buf.ptr[unsafe_offset=norm],
                 )
             )
 
@@ -840,12 +840,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         # Fast path for C-contiguous
         if self.flags.C_CONTIGUOUS:
             var block: Int = self.size // self.shape[0]
-            memcpy(
+            unsafe_memcpy(
                 dest=result._re._buf.ptr,
                 src=self._re._buf.ptr + norm * block,
                 count=block,
             )
-            memcpy(
+            unsafe_memcpy(
                 dest=result._im._buf.ptr,
                 src=self._im._buf.ptr + norm * block,
                 count=block,
@@ -1175,13 +1175,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                         ),
                     )
                 )
-            memcpy(
+            unsafe_memcpy(
                 dest=result._re._buf.ptr + i * size_per_item,
                 src=self._re._buf.ptr
                 + indices.item(i) * Scalar[DType.int](size_per_item),
                 count=size_per_item,
             )
-            memcpy(
+            unsafe_memcpy(
                 dest=result._im._buf.ptr + i * size_per_item,
                 src=self._im._buf.ptr
                 + indices.item(i) * Scalar[DType.int](size_per_item),
@@ -1209,7 +1209,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var indices_array = NDArray[DType.int](shape=Shape(len(indices)))
         for i in range(len(indices)):
-            (indices_array._buf.ptr + i).init_pointee_copy(
+            (indices_array._buf.ptr + i).unsafe_write(
                 Scalar[DType.int](indices[i])
             )
 
@@ -1253,11 +1253,11 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             var offset = 0
             for i in range(mask.size):
                 if mask.item(i):
-                    (result._re._buf.ptr + offset).init_pointee_copy(
-                        self._re._buf.ptr[i]
+                    (result._re._buf.ptr + offset).unsafe_write(
+                        self._re._buf.ptr[unsafe_offset=i]
                     )
-                    (result._im._buf.ptr + offset).init_pointee_copy(
-                        self._im._buf.ptr[i]
+                    (result._im._buf.ptr + offset).unsafe_write(
+                        self._im._buf.ptr[unsafe_offset=i]
                     )
                     offset += 1
 
@@ -1311,12 +1311,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var offset = 0
         for i in range(mask.size):
             if mask.item(i):
-                memcpy(
+                unsafe_memcpy(
                     dest=result._re._buf.ptr + offset * size_per_item,
                     src=self._re._buf.ptr + i * size_per_item,
                     count=size_per_item,
                 )
-                memcpy(
+                unsafe_memcpy(
                     dest=result._im._buf.ptr + offset * size_per_item,
                     src=self._im._buf.ptr + i * size_per_item,
                     count=size_per_item,
@@ -1341,7 +1341,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var mask_array = NDArray[DType.bool](shape=Shape(len(mask)))
         for i in range(len(mask)):
-            (mask_array._buf.ptr + i).init_pointee_copy(mask[i])
+            (mask_array._buf.ptr + i).unsafe_write(mask[i])
 
         return self[mask_array]
 
@@ -1536,8 +1536,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
 
         return ComplexSIMD[Self.cdtype](
-            re=self._re._buf.ptr[index],
-            im=self._im._buf.ptr[index],
+            re=self._re._buf.ptr[unsafe_offset=index],
+            im=self._im._buf.ptr[unsafe_offset=index],
         )
 
     def load[
@@ -1572,8 +1572,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             )
 
         return ComplexSIMD[Self.cdtype, width](
-            re=self._re._buf.ptr.load[width=1](index),
-            im=self._im._buf.ptr.load[width=1](index),
+            re=self._re._buf.ptr.unsafe_load[width=1](index),
+            im=self._im._buf.ptr.unsafe_load[width=1](index),
         )
 
     def load[
@@ -1638,8 +1638,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var idx: Int = IndexMethods.get_1d_index(indices_list, self.strides)
         return ComplexSIMD[Self.cdtype, width=width](
-            re=self._re._buf.ptr.load[width=width](idx),
-            im=self._im._buf.ptr.load[width=width](idx),
+            re=self._re._buf.ptr.unsafe_load[width=width](idx),
+            im=self._im._buf.ptr.unsafe_load[width=width](idx),
         )
 
     def _adjust_slice(self, slice_list: List[Slice]) raises -> List[Slice]:
@@ -1755,8 +1755,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var index_of_buffer: Int = 0
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
-        self._re._buf.ptr[index_of_buffer] = val.re
-        self._im._buf.ptr[index_of_buffer] = val.im
+        self._re._buf.ptr[unsafe_offset=index_of_buffer] = val.re
+        self._im._buf.ptr[unsafe_offset=index_of_buffer] = val.im
 
     def __setitem__(mut self, idx: Int, val: Self) raises:
         """Assign a single first-axis slice.
@@ -1817,8 +1817,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                         ),
                     )
                 )
-            self._re._buf.ptr.store(norm, val._re._buf.ptr.load[width=1](0))
-            self._im._buf.ptr.store(norm, val._im._buf.ptr.load[width=1](0))
+            self._re._buf.ptr.unsafe_store(norm, val._re._buf.ptr.unsafe_load[width=1](0))
+            self._im._buf.ptr.unsafe_store(norm, val._im._buf.ptr.unsafe_load[width=1](0))
             return
 
         if val.shape != self.shape[1:]:
@@ -1836,12 +1836,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         if self.flags.C_CONTIGUOUS & val.flags.C_CONTIGUOUS:
             var block = self.size // self.shape[0]
-            memcpy(
+            unsafe_memcpy(
                 dest=self._re._buf.ptr + norm * block,
                 src=val._re._buf.ptr,
                 count=block,
             )
-            memcpy(
+            unsafe_memcpy(
                 dest=self._im._buf.ptr + norm * block,
                 src=val._im._buf.ptr,
                 count=block,
@@ -1908,8 +1908,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             index[i] = self.normalize(index[i], self.shape[i])
 
         var idx: Int = IndexMethods.get_1d_index(index, self.strides)
-        self._re._buf.ptr.store(idx, val.re)
-        self._im._buf.ptr.store(idx, val.im)
+        self._re._buf.ptr.unsafe_store(idx, val.re)
+        self._im._buf.ptr.unsafe_store(idx, val.im)
 
     def __setitem__(
         mut self, mask: NDArray[DType.bool], value: ComplexSIMD[Self.cdtype]
@@ -1933,7 +1933,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var mask_c = mask.contiguous()
         for i in range(mask_c.size):
-            if mask_c._buf.ptr.load[width=1](i):
+            if mask_c._buf.ptr.unsafe_load[width=1](i):
                 self.itemset(i, value)
 
     def __setitem__(
@@ -2134,7 +2134,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
 
         var mask_c = mask.contiguous()
         for i in range(mask_c.size):
-            if mask_c._buf.ptr.load[width=1](i):
+            if mask_c._buf.ptr.unsafe_load[width=1](i):
                 self.itemset(i, val.item(i))
 
     def __pos__(self) raises -> Self:
@@ -3241,8 +3241,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             )
 
-        self._re._buf.ptr.store(index, val.re)
-        self._im._buf.ptr.store(index, val.im)
+        self._re._buf.ptr.unsafe_store(index, val.re)
+        self._im._buf.ptr.unsafe_store(index, val.im)
 
     def store[
         width: Int = 1
@@ -3285,8 +3285,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
 
         var idx: Int = IndexMethods.get_1d_index(indices, self.strides)
-        self._re._buf.ptr.store(idx, val.re)
-        self._im._buf.ptr.store(idx, val.im)
+        self._re._buf.ptr.unsafe_store(idx, val.re)
+        self._im._buf.ptr.unsafe_store(idx, val.im)
 
     def reshape(self, shape: NDArrayShape, order: String = "C") raises -> Self:
         """
@@ -3382,19 +3382,19 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     var coordinate = norm_idx // c_stride[i]
                     norm_idx = norm_idx - c_stride[i] * coordinate
                     c_coordinates.append(coordinate)
-                self._re._buf.ptr.store(
+                self._re._buf.ptr.unsafe_store(
                     self._re.offset
                     + IndexMethods.get_1d_index(c_coordinates, self.strides),
                     item.re,
                 )
-                self._im._buf.ptr.store(
+                self._im._buf.ptr.unsafe_store(
                     self._im.offset
                     + IndexMethods.get_1d_index(c_coordinates, self.strides),
                     item.im,
                 )
             else:
-                self._re._buf.ptr.store(self._re.offset + norm_idx, item.re)
-                self._im._buf.ptr.store(self._im.offset + norm_idx, item.im)
+                self._re._buf.ptr.unsafe_store(self._re.offset + norm_idx, item.re)
+                self._im._buf.ptr.unsafe_store(self._im.offset + norm_idx, item.im)
         else:
             raise Error(
                 NumojoError(
@@ -3479,11 +3479,11 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     )
                 )
             indices[i] = norm_idx
-        self._re._buf.ptr.store(
+        self._re._buf.ptr.unsafe_store(
             self._re.offset + IndexMethods.get_1d_index(indices, self.strides),
             item.re,
         )
-        self._im._buf.ptr.store(
+        self._im._buf.ptr.unsafe_store(
             self._im.offset + IndexMethods.get_1d_index(indices, self.strides),
             item.im,
         )
@@ -3501,13 +3501,13 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             var result: NDArray[dtype=Self.dtype] = NDArray[dtype=Self.dtype](
                 self.shape
             )
-            memcpy(dest=result._buf.ptr, src=self._re._buf.ptr, count=self.size)
+            unsafe_memcpy(dest=result._buf.ptr, src=self._re._buf.ptr, count=self.size)
             return result^
         elif type == "im":
             var result: NDArray[dtype=Self.dtype] = NDArray[dtype=Self.dtype](
                 self.shape
             )
-            memcpy(dest=result._buf.ptr, src=self._im._buf.ptr, count=self.size)
+            unsafe_memcpy(dest=result._buf.ptr, src=self._im._buf.ptr, count=self.size)
             return result^
         else:
             raise Error(
@@ -3857,7 +3857,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 if self._lex_greater(z, best):
                     best = z
                     best_rel = k
-            result._buf.ptr[o] = Scalar[DType.int](best_rel)
+            result._buf.ptr[unsafe_offset=o] = Scalar[DType.int](best_rel)
             # result.itemset(o, Scalar[DType.int](best_rel))
         return result^
 
@@ -3906,7 +3906,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 if self._lex_less(z, best):
                     best = z
                     best_rel = k
-            result._buf.ptr[o] = Scalar[DType.int](best_rel)
+            result._buf.ptr[unsafe_offset=o] = Scalar[DType.int](best_rel)
             # result.itemset(o, Scalar[DType.int](best_rel))
         return result^
 
@@ -4122,26 +4122,26 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         var result = Self(self.shape)
 
         for i in range(self.size):
-            var re = self._re._buf.ptr.load(i)
-            var im = self._im._buf.ptr.load(i)
+            var re = self._re._buf.ptr.unsafe_load(i)
+            var im = self._im._buf.ptr.unsafe_load(i)
             var mag_sq = re * re + im * im
             var mag_val = sqrt(mag_sq)
 
             if mag_val < a_min:
                 if mag_val > 0:
                     var scale = a_min / mag_val
-                    result._re._buf.ptr.store(i, re * scale)
-                    result._im._buf.ptr.store(i, im * scale)
+                    result._re._buf.ptr.unsafe_store(i, re * scale)
+                    result._im._buf.ptr.unsafe_store(i, im * scale)
                 else:
-                    result._re._buf.ptr.store(i, a_min)
-                    result._im._buf.ptr.store(i, 0.0)
+                    result._re._buf.ptr.unsafe_store(i, a_min)
+                    result._im._buf.ptr.unsafe_store(i, 0.0)
             elif mag_val > a_max:
                 var scale = a_max / mag_val
-                result._re._buf.ptr.store(i, re * scale)
-                result._im._buf.ptr.store(i, im * scale)
+                result._re._buf.ptr.unsafe_store(i, re * scale)
+                result._im._buf.ptr.unsafe_store(i, im * scale)
             else:
-                result._re._buf.ptr.store(i, re)
-                result._im._buf.ptr.store(i, im)
+                result._re._buf.ptr.unsafe_store(i, re)
+                result._im._buf.ptr.unsafe_store(i, im)
 
         return result^
 

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -457,7 +457,7 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.print_options = take.print_options
 
     @always_inline("nodebug")
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """Destroys array buffers."""
         _ = self._re^
         _ = self._im^

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -501,7 +501,8 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         """Stride-safe logical flat load."""
         var off = self._flat_offset(flat_index)
         return ComplexSIMD[Self.cdtype](
-            self._re._buf.ptr[unsafe_offset=off], self._im._buf.ptr[unsafe_offset=off]
+            self._re._buf.ptr[unsafe_offset=off],
+            self._im._buf.ptr[unsafe_offset=off],
         )
 
     @always_inline("nodebug")
@@ -1177,12 +1178,16 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
             unsafe_memcpy(
                 dest=result._re._buf.ptr.unsafe_offset(i * size_per_item),
-                src=self._re._buf.ptr.unsafe_offset(indices.item(i) * Scalar[DType.int](size_per_item)),
+                src=self._re._buf.ptr.unsafe_offset(
+                    indices.item(i) * Scalar[DType.int](size_per_item)
+                ),
                 count=size_per_item,
             )
             unsafe_memcpy(
                 dest=result._im._buf.ptr.unsafe_offset(i * size_per_item),
-                src=self._im._buf.ptr.unsafe_offset(indices.item(i) * Scalar[DType.int](size_per_item)),
+                src=self._im._buf.ptr.unsafe_offset(
+                    indices.item(i) * Scalar[DType.int](size_per_item)
+                ),
                 count=size_per_item,
             )
 
@@ -1310,12 +1315,16 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         for i in range(mask.size):
             if mask.item(i):
                 unsafe_memcpy(
-                    dest=result._re._buf.ptr.unsafe_offset(offset * size_per_item),
+                    dest=result._re._buf.ptr.unsafe_offset(
+                        offset * size_per_item
+                    ),
                     src=self._re._buf.ptr.unsafe_offset(i * size_per_item),
                     count=size_per_item,
                 )
                 unsafe_memcpy(
-                    dest=result._im._buf.ptr.unsafe_offset(offset * size_per_item),
+                    dest=result._im._buf.ptr.unsafe_offset(
+                        offset * size_per_item
+                    ),
                     src=self._im._buf.ptr.unsafe_offset(i * size_per_item),
                     count=size_per_item,
                 )
@@ -1402,10 +1411,14 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         if self.flags.F_CONTIGUOUS:
             return ComplexSIMD[Self.cdtype](
                 re=(
-                    self._re._buf.ptr.unsafe_offset(IndexMethods.transfer_offset(index, self.strides))
+                    self._re._buf.ptr.unsafe_offset(
+                        IndexMethods.transfer_offset(index, self.strides)
+                    )
                 )[],
                 im=(
-                    self._im._buf.ptr.unsafe_offset(IndexMethods.transfer_offset(index, self.strides))
+                    self._im._buf.ptr.unsafe_offset(
+                        IndexMethods.transfer_offset(index, self.strides)
+                    )
                 )[],
             )
 
@@ -1483,10 +1496,14 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                 )
         return ComplexSIMD[Self.cdtype](
             re=(
-                self._re._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
+                self._re._buf.ptr.unsafe_offset(
+                    IndexMethods.get_1d_index(index, self.strides)
+                )
             )[],
             im=(
-                self._im._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
+                self._im._buf.ptr.unsafe_offset(
+                    IndexMethods.get_1d_index(index, self.strides)
+                )
             )[],
         )
 
@@ -1811,8 +1828,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                         ),
                     )
                 )
-            self._re._buf.ptr.unsafe_store(norm, val._re._buf.ptr.unsafe_load[width=1](0))
-            self._im._buf.ptr.unsafe_store(norm, val._im._buf.ptr.unsafe_load[width=1](0))
+            self._re._buf.ptr.unsafe_store(
+                norm, val._re._buf.ptr.unsafe_load[width=1](0)
+            )
+            self._im._buf.ptr.unsafe_store(
+                norm, val._im._buf.ptr.unsafe_load[width=1](0)
+            )
             return
 
         if val.shape != self.shape[1:]:
@@ -3387,8 +3408,12 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
                     item.im,
                 )
             else:
-                self._re._buf.ptr.unsafe_store(self._re.offset + norm_idx, item.re)
-                self._im._buf.ptr.unsafe_store(self._im.offset + norm_idx, item.im)
+                self._re._buf.ptr.unsafe_store(
+                    self._re.offset + norm_idx, item.re
+                )
+                self._im._buf.ptr.unsafe_store(
+                    self._im.offset + norm_idx, item.im
+                )
         else:
             raise Error(
                 NumojoError(
@@ -3495,13 +3520,17 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
             var result: NDArray[dtype=Self.dtype] = NDArray[dtype=Self.dtype](
                 self.shape
             )
-            unsafe_memcpy(dest=result._buf.ptr, src=self._re._buf.ptr, count=self.size)
+            unsafe_memcpy(
+                dest=result._buf.ptr, src=self._re._buf.ptr, count=self.size
+            )
             return result^
         elif type == "im":
             var result: NDArray[dtype=Self.dtype] = NDArray[dtype=Self.dtype](
                 self.shape
             )
-            unsafe_memcpy(dest=result._buf.ptr, src=self._im._buf.ptr, count=self.size)
+            unsafe_memcpy(
+                dest=result._buf.ptr, src=self._im._buf.ptr, count=self.size
+            )
             return result^
         else:
             raise Error(

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -443,18 +443,18 @@ struct ComplexNDArray[cdtype: ComplexDType = ComplexDType.float64](
         self.print_options = copy.print_options
 
     @always_inline("nodebug")
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """
         Move other into self.
         """
-        self._re = take._re^
-        self._im = take._im^
-        self.ndim = take.ndim
-        self.shape = take.shape
-        self.size = take.size
-        self.strides = take.strides
-        self.flags = take.flags
-        self.print_options = take.print_options
+        self._re = move._re^
+        self._im = move._im^
+        self.ndim = move.ndim
+        self.shape = move.shape
+        self.size = move.size
+        self.strides = move.strides
+        self.flags = move.flags
+        self.print_options = move.print_options
 
     @always_inline("nodebug")
     def __deinit__(deinit self):

--- a/numojo/core/complex/complex_ndarray.mojo
+++ b/numojo/core/complex/complex_ndarray.mojo
@@ -27,7 +27,8 @@ overloads, IO, trait, and iterator methods, as well as other utility functions.
 # ===----------------------------------------------------------------------===#
 # === Stdlib ===
 # ===----------------------------------------------------------------------===#
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 import std.builtin.bool as builtin_bool
 import std.math as builtin_math
 from std.collections.optional import Optional
@@ -83,6 +84,10 @@ import numojo.routines.math.exponents as exponents
 import numojo.routines.math.misc as misc
 import numojo.routines.searching as searching
 from numojo.routines.manipulation import reshape
+from numojo.core.ndarray import NDArray
+from numojo.routines import math
+from numojo.routines import linalg
+from numojo.core.type_aliases import Shape
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -18,6 +18,8 @@ complex number operations like conjugation and absolute value.
 from std.math import sqrt, sin, cos
 
 from numojo.core.dtype import ComplexDType
+from numojo.core.type_aliases import ComplexScalar
+from numojo.core.dtype.complex_dtype import cf64
 
 
 # TODO: add overloads for arithmetic functions to accept Scalar[dtype].
@@ -107,29 +109,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re = val
         self.im = val
 
-    @always_inline
-    def __init__(out self, re: Int, im: Int):
-        """
-        Constructs a ComplexSIMD from scalar integer real and imaginary values, broadcasted to SIMD lanes.
 
-        Args:
-            re: Integer value for the real component.
-            im: Integer value for the imaginary component.
-        """
-        self.re = Self._broadcast(Scalar[Self.dtype](re))
-        self.im = Self._broadcast(Scalar[Self.dtype](im))
-
-    @always_inline
-    def __init__(out self, val: Int):
-        """
-        Constructs a ComplexSIMD where both real and imaginary parts are set to the same integer value broadcasted to SIMD lanes.
-
-        Args:
-            val: Integer value to broadcast to both real and imaginary components.
-        """
-        var simd_val = Self._broadcast(Scalar[Self.dtype](val))
-        self.re = simd_val
-        self.im = simd_val
 
     # Factory constructors.
     @staticmethod
@@ -248,8 +228,8 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re + Self._broadcast(other), self.im)
 
-    # FIXME: currently mojo doesn't allow overloading with both SIMD[Self.dtype, Self.width] and SIMD[..., size=Self.width]. So keep SIMD[..., size=Self.width] only for now. We need this method to create complex numbers with syntax like (1 + 2 * `1j`).
-    def __add__(self, other: SIMD[..., size=Self.width]) -> Self:
+    # FIXME: currently mojo doesn't allow overloading with both SIMD[Self.dtype, Self.width] and SIMD[..., length=Self.width]. So keep SIMD[..., length=Self.width] only for now. We need this method to create complex numbers with syntax like (1 + 2 * `1j`).
+    def __add__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the sum of this ComplexSIMD instance and a SIMD vector added to the real part.
 
@@ -302,7 +282,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re += Self._broadcast(other)
 
-    def __iadd__(mut self, other: SIMD[..., size=Self.width]):
+    def __iadd__(mut self, other: SIMD[..., length=Self.width]):
         """
         In-place addition of a SIMD vector to the real part of this ComplexSIMD instance.
 
@@ -341,7 +321,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(Self._broadcast(other) + self.re, self.im)
 
-    def __radd__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __radd__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the sum of a SIMD vector and this ComplexSIMD instance, adding to the real part.
 
@@ -399,7 +379,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(self.re - Self._broadcast(other), self.im)
 
-    def __sub__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __sub__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the difference of this ComplexSIMD instance and a SIMD vector subtracted from the real part.
 
@@ -452,7 +432,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         self.re -= Self._broadcast(other)
 
-    def __isub__(mut self, other: SIMD[..., size=Self.width]):
+    def __isub__(mut self, other: SIMD[..., length=Self.width]):
         """
         In-place subtraction of a SIMD vector from the real part of this ComplexSIMD instance.
 
@@ -491,7 +471,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         """
         return Self(Self._broadcast(other) - self.re, -self.im)
 
-    def __rsub__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rsub__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the difference of a SIMD vector and this ComplexSIMD instance, subtracting from the real part.
 
@@ -554,7 +534,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(self.re * scalar_simd, self.im * scalar_simd)
 
-    def __mul__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __mul__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the product of this ComplexSIMD instance and a SIMD vector.
 
@@ -611,7 +591,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re *= scalar_simd
         self.im *= scalar_simd
 
-    def __imul__(mut self, other: SIMD[..., size=Self.width]):
+    def __imul__(mut self, other: SIMD[..., length=Self.width]):
         """
         In-place multiplication of this ComplexSIMD instance by a SIMD vector.
 
@@ -655,7 +635,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(scalar_simd * self.re, scalar_simd * self.im)
 
-    def __rmul__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rmul__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Returns the product of a SIMD vector and this ComplexSIMD instance.
 
@@ -721,7 +701,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         var scalar_simd = Self._broadcast(other)
         return Self(self.re / scalar_simd, self.im / scalar_simd)
 
-    def __truediv__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __truediv__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Performs element-wise division of this ComplexSIMD instance by a SIMD vector.
 
@@ -779,7 +759,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re /= scalar_simd
         self.im /= scalar_simd
 
-    def __itruediv__(mut self, other: SIMD[..., size=Self.width]):
+    def __itruediv__(mut self, other: SIMD[..., length=Self.width]):
         """
         Performs in-place element-wise division of this ComplexSIMD instance by a SIMD vector.
 
@@ -829,7 +809,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
             (-scalar_simd * self.im) / denom,
         )
 
-    def __rtruediv__(self, other: SIMD[..., size=Self.width]) -> Self:
+    def __rtruediv__(self, other: SIMD[..., length=Self.width]) -> Self:
         """
         Performs element-wise division of a SIMD vector by this ComplexSIMD instance.
 
@@ -1126,7 +1106,7 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
 
     # --- Representations ---
     def __str__(self) -> String:
-        return String.write(self)
+        return String(self)
 
     def write_to[W: Writer](self, mut writer: W):
         """

--- a/numojo/core/complex/complex_simd.mojo
+++ b/numojo/core/complex/complex_simd.mojo
@@ -109,8 +109,6 @@ struct ComplexSIMD[cdtype: ComplexDType = ComplexDType.float64, width: Int = 1](
         self.re = val
         self.im = val
 
-
-
     # Factory constructors.
     @staticmethod
     def zero() -> Self:

--- a/numojo/core/dtype/complex_dtype.mojo
+++ b/numojo/core/dtype/complex_dtype.mojo
@@ -17,7 +17,6 @@ from std.hashlib.hasher import Hasher
 from std.os import abort
 from std.sys import CompilationTarget
 from std.sys.info import bit_width_of, size_of
-from std.sys.intrinsics import _type_is_eq
 
 comptime _mIsSigned = UInt8(1)
 comptime _mIsInteger = UInt8(1 << 7)
@@ -268,7 +267,7 @@ struct ComplexDType(
             The name of the ComplexDType.
         """
 
-        return String.write(self)
+        return String(self)
 
     @no_inline
     def write_to[W: Writer](self, mut writer: W):
@@ -335,7 +334,7 @@ struct ComplexDType(
         Returns:
             The representation of the ComplexDType.
         """
-        return String.write("ComplexDType.", self)
+        return String("ComplexDType.", self)
 
     def write_repr_to[W: Writer](self, mut writer: W):
         """Write the string representation to a writer.
@@ -591,7 +590,7 @@ struct ComplexDType(
         elif self is ComplexDType.float64:
             return size_of[DType.float64]()
 
-        return size_of[DType.invalid]()
+        return 0
 
     @always_inline
     def bitwidth(self) -> Int:

--- a/numojo/core/error.mojo
+++ b/numojo/core/error.mojo
@@ -62,7 +62,7 @@ struct NumojoError(Writable):
         message: StringLiteral,
         location: StringLiteral,
     ):
-        err_dict = materialize[Self.ErrorDict]()
+        var err_dict = materialize[Self.ErrorDict]()
         try:
             self.category = err_dict[category]
         except:
@@ -76,7 +76,7 @@ struct NumojoError(Writable):
         message: String,
         location: Optional[String] = None,
     ):
-        err_dict = materialize[Self.ErrorDict]()
+        var err_dict = materialize[Self.ErrorDict]()
         try:
             self.category = err_dict[category]
         except:
@@ -90,7 +90,7 @@ struct NumojoError(Writable):
         message: TString,
         location: StringLiteral,
     ):
-        err_dict = materialize[Self.ErrorDict]()
+        var err_dict = materialize[Self.ErrorDict]()
         try:
             self.category = err_dict[category]
         except:

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -163,7 +163,7 @@ struct IndexBuffer(
         self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
         unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
 
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """
         Deinitialize the IndexBuffer and free resources.
         """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -13,7 +13,7 @@ This type owns a contiguous heap buffer of Ints and provides
 small helpers for pointer access and SIMD load/store.
 """
 
-from std.memory import UnsafePointer, memcpy, memset_zero
+from std.memory import UnsafePointer, unsafe_memcpy, unsafe_memset_zero
 from std.sys import simd_width_of
 from std.algorithm.functional import vectorize
 from std.os import abort
@@ -42,7 +42,7 @@ struct IndexBuffer(
     comptime _origin = MutUntrackedOrigin
     """Mutability origin of the buffer."""
 
-    var ptr: UnsafePointer[Scalar[Self.element_type], Self._origin]
+    var ptr: Pointer[Scalar[Self.element_type], Self._origin]
     """Pointer to the buffer."""
     var ndim: Int
     """Number of elements in the buffer."""
@@ -61,16 +61,16 @@ struct IndexBuffer(
 
         self.ndim = size
         if size == 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.element_type]](size)
-            memset_zero(self.ptr, size)
+            unsafe_memset_zero(self.ptr, size)
 
     def __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.element_type], Self._origin],
+        ptr: Pointer[Scalar[Self.element_type], Self._origin],
         size: Int,
     ):
         """
@@ -88,7 +88,7 @@ struct IndexBuffer(
         Initialize an empty IndexBuffer.
         """
         self.ndim = 0
-        self.ptr = UnsafePointer[
+        self.ptr = Pointer[
             Scalar[Self.element_type], Self._origin
         ].unsafe_dangling()
 
@@ -103,13 +103,13 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(values[i])
+            (self.ptr + i).unsafe_write(values[i])
 
     def __init__(out self, values: List[Scalar[Self.element_type]]):
         """
@@ -120,13 +120,13 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(values[i])
+            (self.ptr + i).unsafe_write(values[i])
 
 
     def __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
@@ -138,13 +138,13 @@ struct IndexBuffer(
         """
         self.ndim = len(values)
         if self.ndim <= 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(values[i])
+            (self.ptr + i).unsafe_write(values[i])
 
 
     def __init__(out self, *, copy: Self):
@@ -156,26 +156,26 @@ struct IndexBuffer(
         """
         self.ndim = copy.ndim
         if copy.ndim <= 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
         self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
-        memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
+        unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
 
     def __del__(deinit self):
         """
         Deinitialize the IndexBuffer and free resources.
         """
         if self.ndim > 0:
-            self.ptr.free()
+            self.ptr.unsafe_free()
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
     def get_ptr(
         ref self,
-    ) -> ref[self.ptr] UnsafePointer[Scalar[Self.element_type], Self._origin]:
+    ) -> ref[self.ptr] Pointer[Scalar[Self.element_type], Self._origin]:
         """
         Get the underlying pointer of the buffer.
 
@@ -189,7 +189,7 @@ struct IndexBuffer(
 
     def offset(
         ref self, offset: Int
-    ) -> UnsafePointer[Scalar[Self.element_type], Self._origin]:
+    ) -> Pointer[Scalar[Self.element_type], Self._origin]:
         """
         Get a pointer offset by the given amount.
 
@@ -223,7 +223,7 @@ struct IndexBuffer(
                     location="IndexBuffer.__getitem__(idx: Int)",
                 )
             )
-        return self.ptr[index]
+        return self.ptr[unsafe_offset=index]
 
     def __getitem__(self, slice: Slice) raises -> Self:
         """
@@ -251,7 +251,7 @@ struct IndexBuffer(
         var new_buffer = Self(size=length)
         var idx = 0
         for i in range(start, end, step_value):
-            new_buffer.ptr[idx] = self.ptr[i]
+            new_buffer.ptr[unsafe_offset=idx] = self.ptr[unsafe_offset=i]
             idx += 1
 
         return new_buffer^
@@ -278,7 +278,7 @@ struct IndexBuffer(
                     location="IndexBuffer.__setitem__(idx: Int)",
                 )
             )
-        self.ptr[index] = value
+        self.ptr[unsafe_offset=index] = value
 
     def __setitem__(mut self, slice: Slice, value: Self) raises:
         """
@@ -315,7 +315,7 @@ struct IndexBuffer(
 
         var idx = 0
         for i in range(start, end, step_value):
-            self.ptr[i] = value.ptr[idx]
+            self.ptr[unsafe_offset=i] = value.ptr[unsafe_offset=idx]
             idx += 1
 
 
@@ -335,7 +335,7 @@ struct IndexBuffer(
         Returns:
             SIMD vector loaded from the buffer.
         """
-        return self.ptr.load[width=width](idx)
+        return self.ptr.unsafe_load[width=width](idx)
 
     def unsafe_store[
         width: Int = 1
@@ -354,7 +354,7 @@ struct IndexBuffer(
             idx: Index to store to.
             value: SIMD vector to store.
         """
-        self.ptr.store[width=width](idx, value)
+        self.ptr.unsafe_store[width=width](idx, value)
 
     # ===----------------------------------------------------------------------=== #
     # Transformation Methods
@@ -373,9 +373,9 @@ struct IndexBuffer(
         var total_dims = self.ndim + len(values)
         var new_buf = Self(size=total_dims)
         for i in range(self.ndim):
-            new_buf.ptr[i] = self.ptr[i]
+            new_buf.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=i]
         for j in range(len(values)):
-            new_buf.ptr[self.ndim + j] = Scalar[Self.element_type](values[j])
+            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[Self.element_type](values[j])
         return new_buf^
 
     def extend(self, values: List[Int]) -> Self:
@@ -391,9 +391,9 @@ struct IndexBuffer(
         var total_dims = self.ndim + len(values)
         var new_buf = Self(size=total_dims)
         for i in range(self.ndim):
-            new_buf.ptr[i] = self.ptr[i]
+            new_buf.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=i]
         for j in range(len(values)):
-            new_buf.ptr[self.ndim + j] = Scalar[Self.element_type](values[j])
+            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[Self.element_type](values[j])
         return new_buf^
 
     def flip(mut self):
@@ -401,9 +401,9 @@ struct IndexBuffer(
         Flip the items in-place.
         """
         for i in range(self.ndim // 2):
-            var temp = self.ptr[i]
-            self.ptr[i] = self.ptr[self.ndim - 1 - i]
-            self.ptr[self.ndim - 1 - i] = temp
+            var temp = self.ptr[unsafe_offset=i]
+            self.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=self.ndim - 1 - i]
+            self.ptr[unsafe_offset=self.ndim - 1 - i] = temp
 
     def flipped(self) -> Self:
         """
@@ -414,7 +414,7 @@ struct IndexBuffer(
         """
         var res = Self(size=self.ndim)
         for i in range(self.ndim):
-            res.ptr[i] = self.ptr[self.ndim - 1 - i]
+            res.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=self.ndim - 1 - i]
         return res^
 
     def move_axis_to_end(self, axis: Int) -> Self:
@@ -434,9 +434,9 @@ struct IndexBuffer(
         var idx = 0
         for i in range(self.ndim):
             if i != ax:
-                res.ptr[idx] = self.ptr[i]
+                res.ptr[unsafe_offset=idx] = self.ptr[unsafe_offset=i]
                 idx += 1
-        res.ptr[self.ndim - 1] = self.ptr[ax]
+        res.ptr[unsafe_offset=self.ndim - 1] = self.ptr[unsafe_offset=ax]
         return res^
 
     def pop(self, axis: Int) raises -> Self:
@@ -473,7 +473,7 @@ struct IndexBuffer(
         for i in range(self.ndim):
             if i == ax:
                 continue
-            res.ptr[idx] = self.ptr[i]
+            res.ptr[unsafe_offset=idx] = self.ptr[unsafe_offset=i]
             idx += 1
         return res^
 
@@ -498,10 +498,10 @@ struct IndexBuffer(
             )
         var res = Self(size=self.ndim + 1)
         for i in range(axis):
-            res.ptr[i] = self.ptr[i]
-        res.ptr[axis] = Scalar[Self.element_type](value)
+            res.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=i]
+        res.ptr[unsafe_offset=axis] = Scalar[Self.element_type](value)
         for i in range(axis, self.ndim):
-            res.ptr[i + 1] = self.ptr[i]
+            res.ptr[unsafe_offset=i + 1] = self.ptr[unsafe_offset=i]
         return res^
 
     def join(self, *others: Self) -> Self:
@@ -520,10 +520,10 @@ struct IndexBuffer(
 
         var res = Self(size=total_dims)
         var offset = 0
-        memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
+        unsafe_memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
         offset += self.ndim
         for i in range(len(others)):
-            memcpy(
+            unsafe_memcpy(
                 dest=res.ptr + offset, src=others[i].ptr, count=others[i].ndim
             )
             offset += others[i].ndim
@@ -545,10 +545,10 @@ struct IndexBuffer(
 
         var res = Self(size=total_dims)
         var offset = 0
-        memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
+        unsafe_memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
         offset += self.ndim
         for i in range(len(others)):
-            memcpy(
+            unsafe_memcpy(
                 dest=res.ptr + offset, src=others[i].ptr, count=others[i].ndim
             )
             offset += others[i].ndim
@@ -563,12 +563,12 @@ struct IndexBuffer(
         """
         for i in range(self.ndim):
             for j in range(0, self.ndim - i - 1):
-                if (order and self.ptr[j] > self.ptr[j + 1]) or (
-                    not order and self.ptr[j] < self.ptr[j + 1]
+                if (order and self.ptr[unsafe_offset=j] > self.ptr[unsafe_offset=j + 1]) or (
+                    not order and self.ptr[unsafe_offset=j] < self.ptr[unsafe_offset=j + 1]
                 ):
-                    var temp = self.ptr[j]
-                    self.ptr[j] = self.ptr[j + 1]
-                    self.ptr[j + 1] = temp
+                    var temp = self.ptr[unsafe_offset=j]
+                    self.ptr[unsafe_offset=j] = self.ptr[unsafe_offset=j + 1]
+                    self.ptr[unsafe_offset=j + 1] = temp
 
     def sorted(self, order: Bool) -> Self:
         """
@@ -581,7 +581,7 @@ struct IndexBuffer(
             A new IndexBuffer that is sorted.
         """
         var res = Self(size=self.ndim)
-        memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
+        unsafe_memcpy(dest=res.ptr, src=self.ptr, count=self.ndim)
         res.sort(order)
         return res^
 
@@ -619,7 +619,7 @@ struct IndexBuffer(
         var result = Self(size=size)
         var val = start
         for i in range(size):
-            result.ptr[i] = Scalar[Self.element_type](val)
+            result.ptr[unsafe_offset=i] = Scalar[Self.element_type](val)
             val += step
 
         return result^
@@ -638,7 +638,7 @@ struct IndexBuffer(
         """
         var res = Self(size=size)
         for i in range(size):
-            res.ptr[i] = Scalar[Self.element_type](value)
+            res.ptr[unsafe_offset=i] = Scalar[Self.element_type](value)
         return res^
 
     @staticmethod
@@ -653,7 +653,7 @@ struct IndexBuffer(
             IndexBuffer filled with zeros.
         """
         var res = Self(size=size)
-        memset_zero(res.ptr, size)
+        unsafe_memset_zero(res.ptr, size)
         return res^
 
     @staticmethod
@@ -669,7 +669,7 @@ struct IndexBuffer(
         """
         var res = Self(size=size)
         for i in range(size):
-            res.ptr[i] = 1
+            res.ptr[unsafe_offset=i] = 1
         return res^
 
     @staticmethod
@@ -696,12 +696,12 @@ struct IndexBuffer(
 
         var res = Self(size=num)
         if num == 1:
-            res.ptr[0] = Scalar[Self.element_type](start)
+            res.ptr[unsafe_offset=0] = Scalar[Self.element_type](start)
             return res^
 
         var step = (end - start) / (num - 1)
         for i in range(num):
-            res.ptr[i] = Scalar[Self.element_type](start + i * step)
+            res.ptr[unsafe_offset=i] = Scalar[Self.element_type](start + i * step)
 
         return res^
 
@@ -719,7 +719,7 @@ struct IndexBuffer(
         var n = len(perm)
         var inverted = Self(size=n)
         for i in range(n):
-            inverted.ptr[perm.ptr[i]] = Scalar[DType.int](i)
+            inverted.ptr[unsafe_offset=perm.ptr[unsafe_offset=i]] = Scalar[DType.int](i)
         return inverted^
 
     # ===----------------------------------------------------------------------=== #
@@ -755,7 +755,7 @@ struct IndexBuffer(
         #     total += self.load[width](i).reduce_add()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):
-            total += self.ptr[i]
+            total += self.ptr[unsafe_offset=i]
         return total
 
     def product(self) -> Scalar[Self.element_type]:
@@ -770,7 +770,7 @@ struct IndexBuffer(
         #     total += self.load[width](i).reduce_mul()
         # vectorize[Self.simd_width](self.ndim, closure)
         for i in range(self.ndim):
-            total *= self.ptr[i]
+            total *= self.ptr[unsafe_offset=i]
         return total
 
     # ===----------------------------------------------------------------------=== #
@@ -803,7 +803,7 @@ struct IndexBuffer(
         """
         var res = String("IndexBuffer([")
         for i in range(self.ndim):
-            res += String(self.ptr[i])
+            res += String(self.ptr[unsafe_offset=i])
             if i < self.ndim - 1:
                 res += String(", ")
         res += String("])")
@@ -815,7 +815,7 @@ struct IndexBuffer(
         """
         writer.write("IndexBuffer([")
         for i in range(self.ndim):
-            writer.write(String(self.ptr[i]))
+            writer.write(String(self.ptr[unsafe_offset=i]))
             if i < self.ndim - 1:
                 writer.write(", ")
         writer.write("])")
@@ -831,7 +831,7 @@ struct IndexBuffer(
             True if the value is in the IndexBuffer, False otherwise.
         """
         for i in range(self.ndim):
-            if self.ptr[i] == value:
+            if self.ptr[unsafe_offset=i] == value:
                 return True
         return False
 
@@ -849,7 +849,7 @@ struct IndexBuffer(
         if self.ndim != other.ndim:
             return False
         for i in range(self.ndim):
-            if self.ptr[i] != other.ptr[i]:
+            if self.ptr[unsafe_offset=i] != other.ptr[unsafe_offset=i]:
                 return False
         return True
 
@@ -878,7 +878,7 @@ struct IndexBuffer(
             value: Value to set.
         """
         # self.ptr[idx] = value
-        (self.ptr + idx).init_pointee_copy(value)
+        (self.ptr + idx).unsafe_write(value)
 
     def tolist(self) -> List[Scalar[Self.element_type]]:
         """
@@ -888,7 +888,7 @@ struct IndexBuffer(
             Scalar[Self.element_type]
         ]()
         for i in range(self.ndim):
-            result.append(self.ptr[i])
+            result.append(self.ptr[unsafe_offset=i])
         return result^
 
     # ===----------------------------------------------------------------------=== #
@@ -926,7 +926,7 @@ struct IndexBuffer(
 # ===----------------------------------------------------------------------=== #
 struct _IndexBufferIter[
     dtype: DType,
-    origin: ImmutOrigin = ImmutUntrackedOrigin,
+    origin: ImmOrigin = ImmUntrackedOrigin,
     forward: Bool = True,
 ](ImplicitlyCopyable, Movable):
     """Iterator for Item.

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -93,7 +93,6 @@ struct IndexBuffer(
             Scalar[Self.element_type], Self._origin
         ].unsafe_dangling()
 
-
     # NOTE: In future this will be equivalent to Int.
     def __init__(out self, *values: Scalar[Self.element_type]):
         """
@@ -129,7 +128,6 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
-
     def __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
         """
         Initialize an IndexBuffer with a range of values.
@@ -146,7 +144,6 @@ struct IndexBuffer(
         self.ptr = unsafe_alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
             (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
-
 
     def __init__(out self, *, copy: Self):
         """
@@ -202,7 +199,6 @@ struct IndexBuffer(
         """
         return self.ptr.unsafe_offset(offset)
 
-
     def __getitem__(
         self, idx: Scalar[Self.element_type]
     ) raises -> Scalar[Self.element_type]:
@@ -256,7 +252,6 @@ struct IndexBuffer(
             idx += 1
 
         return new_buffer^
-
 
     def __setitem__(
         mut self,
@@ -319,8 +314,6 @@ struct IndexBuffer(
             self.ptr[unsafe_offset=i] = value.ptr[unsafe_offset=idx]
             idx += 1
 
-
-
     def unsafe_load[
         width: Int = 1
     ](self, idx: Scalar[Self.element_type]) -> SIMD[Self.element_type, width]:
@@ -376,7 +369,9 @@ struct IndexBuffer(
         for i in range(self.ndim):
             new_buf.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=i]
         for j in range(len(values)):
-            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[Self.element_type](values[j])
+            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[
+                Self.element_type
+            ](values[j])
         return new_buf^
 
     def extend(self, values: List[Int]) -> Self:
@@ -394,7 +389,9 @@ struct IndexBuffer(
         for i in range(self.ndim):
             new_buf.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=i]
         for j in range(len(values)):
-            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[Self.element_type](values[j])
+            new_buf.ptr[unsafe_offset=self.ndim + j] = Scalar[
+                Self.element_type
+            ](values[j])
         return new_buf^
 
     def flip(mut self):
@@ -403,7 +400,9 @@ struct IndexBuffer(
         """
         for i in range(self.ndim // 2):
             var temp = self.ptr[unsafe_offset=i]
-            self.ptr[unsafe_offset=i] = self.ptr[unsafe_offset=self.ndim - 1 - i]
+            self.ptr[unsafe_offset=i] = self.ptr[
+                unsafe_offset=self.ndim - 1 - i
+            ]
             self.ptr[unsafe_offset=self.ndim - 1 - i] = temp
 
     def flipped(self) -> Self:
@@ -525,7 +524,9 @@ struct IndexBuffer(
         offset += self.ndim
         for i in range(len(others)):
             unsafe_memcpy(
-                dest=res.ptr.unsafe_offset(offset), src=others[i].ptr, count=others[i].ndim
+                dest=res.ptr.unsafe_offset(offset),
+                src=others[i].ptr,
+                count=others[i].ndim,
             )
             offset += others[i].ndim
         return res^
@@ -550,7 +551,9 @@ struct IndexBuffer(
         offset += self.ndim
         for i in range(len(others)):
             unsafe_memcpy(
-                dest=res.ptr.unsafe_offset(offset), src=others[i].ptr, count=others[i].ndim
+                dest=res.ptr.unsafe_offset(offset),
+                src=others[i].ptr,
+                count=others[i].ndim,
             )
             offset += others[i].ndim
         return res^
@@ -564,8 +567,14 @@ struct IndexBuffer(
         """
         for i in range(self.ndim):
             for j in range(0, self.ndim - i - 1):
-                if (order and self.ptr[unsafe_offset=j] > self.ptr[unsafe_offset=j + 1]) or (
-                    not order and self.ptr[unsafe_offset=j] < self.ptr[unsafe_offset=j + 1]
+                if (
+                    order
+                    and self.ptr[unsafe_offset=j]
+                    > self.ptr[unsafe_offset=j + 1]
+                ) or (
+                    not order
+                    and self.ptr[unsafe_offset=j]
+                    < self.ptr[unsafe_offset=j + 1]
                 ):
                     var temp = self.ptr[unsafe_offset=j]
                     self.ptr[unsafe_offset=j] = self.ptr[unsafe_offset=j + 1]
@@ -702,7 +711,9 @@ struct IndexBuffer(
 
         var step = (end - start) / (num - 1)
         for i in range(num):
-            res.ptr[unsafe_offset=i] = Scalar[Self.element_type](start + i * step)
+            res.ptr[unsafe_offset=i] = Scalar[Self.element_type](
+                start + i * step
+            )
 
         return res^
 
@@ -720,7 +731,9 @@ struct IndexBuffer(
         var n = len(perm)
         var inverted = Self(size=n)
         for i in range(n):
-            inverted.ptr[unsafe_offset=perm.ptr[unsafe_offset=i]] = Scalar[DType.int](i)
+            inverted.ptr[unsafe_offset=perm.ptr[unsafe_offset=i]] = Scalar[
+                DType.int
+            ](i)
         return inverted^
 
     # ===----------------------------------------------------------------------=== #
@@ -835,7 +848,6 @@ struct IndexBuffer(
             if self.ptr[unsafe_offset=i] == value:
                 return True
         return False
-
 
     def __eq__(self, other: IndexBuffer) -> Bool:
         """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -92,24 +92,6 @@ struct IndexBuffer(
             Scalar[Self.element_type], Self._origin
         ].unsafe_dangling()
 
-    def __init__(out self, *values: Int):
-        """
-        Initialize an IndexBuffer with given Int values.
-
-        Args:
-            values: Variadic list of integer values.
-        """
-        self.ndim = len(values)
-        if self.ndim <= 0:
-            self.ptr = UnsafePointer[
-                Scalar[Self.element_type], Self._origin
-            ].unsafe_dangling()
-            return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
-        for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(
-                Scalar[Self.element_type](values[i])
-            )
 
     # NOTE: In future this will be equivalent to Int.
     def __init__(out self, *values: Scalar[Self.element_type]):
@@ -146,24 +128,6 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr + i).init_pointee_copy(values[i])
 
-    def __init__(out self, values: List[Int]):
-        """
-        Initialize an IndexBuffer with a list of Int values.
-
-        Args:
-            values: List of integer values.
-        """
-        self.ndim = len(values)
-        if self.ndim <= 0:
-            self.ptr = UnsafePointer[
-                Scalar[Self.element_type], Self._origin
-            ].unsafe_dangling()
-            return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
-        for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(
-                Scalar[Self.element_type](values[i])
-            )
 
     def __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
         """
@@ -182,24 +146,6 @@ struct IndexBuffer(
         for i in range(self.ndim):
             (self.ptr + i).init_pointee_copy(values[i])
 
-    def __init__(out self, values: VariadicList[Int, _]):
-        """
-        Initialize an IndexBuffer with a range of values.
-
-        Args:
-            values: Range of integer values.
-        """
-        self.ndim = len(values)
-        if self.ndim <= 0:
-            self.ptr = UnsafePointer[
-                Scalar[Self.element_type], Self._origin
-            ].unsafe_dangling()
-            return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
-        for i in range(self.ndim):
-            (self.ptr + i).init_pointee_copy(
-                Scalar[Self.element_type](values[i])
-            )
 
     def __init__(out self, *, copy: Self):
         """
@@ -255,26 +201,6 @@ struct IndexBuffer(
         """
         return self.ptr + offset
 
-    def __getitem__(self, idx: Int) raises -> Int:
-        """
-        Get the element at the given index.
-
-        Args:
-            idx: Index of the element.
-
-        Returns:
-            Element at the given index.
-        """
-        var index = idx if idx >= 0 else self.ndim + idx
-        if index < 0 or index >= self.ndim:
-            raise Error(
-                NumojoError(
-                    category="index",
-                    message="Index out of bounds",
-                    location="IndexBuffer.__getitem__(idx: Int)",
-                )
-            )
-        return Int(self.ptr[index])
 
     def __getitem__(
         self, idx: Scalar[Self.element_type]
@@ -330,24 +256,6 @@ struct IndexBuffer(
 
         return new_buffer^
 
-    def __setitem__(mut self, idx: Int, value: Int) raises:
-        """
-        Set the element at the given index.
-
-        Args:
-            idx: Index of the element.
-            value: Value to set.
-        """
-        var index = idx if idx >= 0 else self.ndim + idx
-        if index < 0 or index >= self.ndim:
-            raise Error(
-                NumojoError(
-                    category="index",
-                    message="index out of bounds",
-                    location="IndexBuffer.__setitem__(idx: Int)",
-                )
-            )
-        self.ptr[index] = Scalar[Self.element_type](value)
 
     def __setitem__(
         mut self,
@@ -410,37 +318,7 @@ struct IndexBuffer(
             self.ptr[i] = value.ptr[idx]
             idx += 1
 
-    def unsafe_load[
-        width: Int = 1
-    ](self, idx: Int) -> SIMD[Self.element_type, width]:
-        """
-        Unsafely load a SIMD vector from the buffer at the given index.
 
-        Parameters:
-            width: Width of the SIMD vector.
-
-        Args:
-            idx: Index to load from.
-
-        Returns:
-            SIMD vector loaded from the buffer.
-        """
-        return self.ptr.load[width=width](idx)
-
-    def unsafe_store[
-        width: Int = 1
-    ](self, idx: Int, value: SIMD[Self.element_type, width]):
-        """
-        Unsafely store a SIMD vector to the buffer at the given index.
-
-        Parameters:
-            width: Width of the SIMD vector.
-
-        Args:
-            idx: Index to store to.
-            value: SIMD vector to store.
-        """
-        self.ptr.store[width=width](idx, value)
 
     def unsafe_load[
         width: Int = 1
@@ -957,21 +835,6 @@ struct IndexBuffer(
                 return True
         return False
 
-    # TODO: We can remove this overload once Mojo unified Scalar[DType.int] with Int
-    def __contains__(self, value: Int) -> Bool:
-        """
-        Check if the IndexBuffer contains the given value.
-
-        Args:
-            value: Value to check for.
-
-        Returns:
-            True if the value is in the IndexBuffer, False otherwise.
-        """
-        for i in range(self.ndim):
-            if self.ptr[i] == Scalar[Self.element_type](value):
-                return True
-        return False
 
     def __eq__(self, other: IndexBuffer) -> Bool:
         """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -109,7 +109,7 @@ struct IndexBuffer(
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).unsafe_write(values[i])
+            (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
     def __init__(out self, values: List[Scalar[Self.element_type]]):
         """
@@ -126,7 +126,7 @@ struct IndexBuffer(
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).unsafe_write(values[i])
+            (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
 
     def __init__(out self, values: VariadicList[Scalar[Self.element_type], _]):
@@ -144,7 +144,7 @@ struct IndexBuffer(
             return
         self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
-            (self.ptr + i).unsafe_write(values[i])
+            (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
 
     def __init__(out self, *, copy: Self):
@@ -199,7 +199,7 @@ struct IndexBuffer(
         Returns:
             UnsafePointer offset by the given amount.
         """
-        return self.ptr + offset
+        return self.ptr.unsafe_offset(offset)
 
 
     def __getitem__(
@@ -524,7 +524,7 @@ struct IndexBuffer(
         offset += self.ndim
         for i in range(len(others)):
             unsafe_memcpy(
-                dest=res.ptr + offset, src=others[i].ptr, count=others[i].ndim
+                dest=res.ptr.unsafe_offset(offset), src=others[i].ptr, count=others[i].ndim
             )
             offset += others[i].ndim
         return res^
@@ -549,7 +549,7 @@ struct IndexBuffer(
         offset += self.ndim
         for i in range(len(others)):
             unsafe_memcpy(
-                dest=res.ptr + offset, src=others[i].ptr, count=others[i].ndim
+                dest=res.ptr.unsafe_offset(offset), src=others[i].ptr, count=others[i].ndim
             )
             offset += others[i].ndim
         return res^
@@ -878,7 +878,7 @@ struct IndexBuffer(
             value: Value to set.
         """
         # self.ptr[idx] = value
-        (self.ptr + idx).unsafe_write(value)
+        (self.ptr.unsafe_offset(idx)).unsafe_write(value)
 
     def tolist(self) -> List[Scalar[Self.element_type]]:
         """

--- a/numojo/core/indexing/index_buffer.mojo
+++ b/numojo/core/indexing/index_buffer.mojo
@@ -14,6 +14,7 @@ small helpers for pointer access and SIMD load/store.
 """
 
 from std.memory import UnsafePointer, unsafe_memcpy, unsafe_memset_zero
+from std.memory.alloc import unsafe_alloc
 from std.sys import simd_width_of
 from std.algorithm.functional import vectorize
 from std.os import abort
@@ -65,7 +66,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
         else:
-            self.ptr = alloc[Scalar[Self.element_type]](size)
+            self.ptr = unsafe_alloc[Scalar[Self.element_type]](size)
             unsafe_memset_zero(self.ptr, size)
 
     def __init__(
@@ -107,7 +108,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
+        self.ptr = unsafe_alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
             (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
@@ -124,7 +125,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
+        self.ptr = unsafe_alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
             (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
@@ -142,7 +143,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
-        self.ptr = alloc[Scalar[Self.element_type]](self.ndim)
+        self.ptr = unsafe_alloc[Scalar[Self.element_type]](self.ndim)
         for i in range(self.ndim):
             (self.ptr.unsafe_offset(i)).unsafe_write(values[i])
 
@@ -160,7 +161,7 @@ struct IndexBuffer(
                 Scalar[Self.element_type], Self._origin
             ].unsafe_dangling()
             return
-        self.ptr = alloc[Scalar[Self.element_type]](copy.ndim)
+        self.ptr = unsafe_alloc[Scalar[Self.element_type]](copy.ndim)
         unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.ndim)
 
     def __deinit__(deinit self):

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -14,7 +14,12 @@ It is used for multi-dimensional indexing, such as `arr[Item(1, 2, 3)]` to acces
 """
 
 from std.builtin.int import index as convert_to_int
-from std.memory import unsafe_memcpy, unsafe_memset_zero, UnsafePointer, unsafe_memcmp
+from std.memory import (
+    unsafe_memcpy,
+    unsafe_memset_zero,
+    UnsafePointer,
+    unsafe_memcmp,
+)
 from std.os import abort
 from std.sys import simd_width_of
 from std.utils import Variant
@@ -522,7 +527,6 @@ struct Item(
             True if the value is in the Item, False otherwise.
         """
         return val in self._buf
-
 
     # ===----------------------------------------------------------------------=== #
     # Utility Methods

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -14,7 +14,7 @@ It is used for multi-dimensional indexing, such as `arr[Item(1, 2, 3)]` to acces
 """
 
 from std.builtin.int import index as convert_to_int
-from std.memory import memcpy, memset_zero, UnsafePointer, memcmp
+from std.memory import unsafe_memcpy, unsafe_memset_zero, UnsafePointer, unsafe_memcmp
 from std.os import abort
 from std.sys import simd_width_of
 from std.utils import Variant
@@ -158,7 +158,7 @@ struct Item(
         """
         self.ndim = ndim
         self._buf = IndexBuffer(size=ndim)
-        memset_zero(self._buf.ptr, ndim)
+        unsafe_memset_zero(self._buf.ptr, ndim)
 
     @always_inline("nodebug")
     def __init__(out self, *, copy: Self):
@@ -169,7 +169,7 @@ struct Item(
         """
         self.ndim = copy.ndim
         self._buf = IndexBuffer(size=self.ndim)
-        memcpy(dest=self._buf.ptr, src=copy._buf.ptr, count=copy.ndim)
+        unsafe_memcpy(dest=self._buf.ptr, src=copy._buf.ptr, count=copy.ndim)
 
     # ===----------------------------------------------------------------------=== #
     # Element Access Methods
@@ -584,7 +584,7 @@ struct Item(
 
 
 struct _ItemIter[
-    origin: ImmutOrigin = ImmutUntrackedOrigin,
+    origin: ImmOrigin = ImmUntrackedOrigin,
     forward: Bool = True,
 ](ImplicitlyCopyable, Movable):
     """Iterator for Item.

--- a/numojo/core/indexing/item.mojo
+++ b/numojo/core/indexing/item.mojo
@@ -523,18 +523,6 @@ struct Item(
         """
         return val in self._buf
 
-    @always_inline("nodebug")
-    def __contains__(self, val: Int) -> Bool:
-        """
-        Checks if the given value is present in the item.
-
-        Args:
-            val: The value to search for.
-
-        Returns:
-            True if the given value is present in the item.
-        """
-        return val in self._buf
 
     # ===----------------------------------------------------------------------=== #
     # Utility Methods

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -17,6 +17,7 @@ from std.memory import UnsafePointer
 from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.indexing.offset import IndexMethods
 from numojo.core.error import NumojoError
+from numojo.core.ndarray import NDArray
 
 
 struct TraverseMethods:

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -25,7 +25,7 @@ struct TraverseMethods:
     def traverse_buffer_according_to_shape_and_strides[
         origin: MutOrigin
     ](
-        mut ptr: UnsafePointer[Scalar[DType.int], origin=origin],
+        mut ptr: Pointer[Scalar[DType.int], origin=origin],
         shape: NDArrayShape,
         strides: NDArrayStrides,
         current_dim: Int = 0,
@@ -52,7 +52,7 @@ struct TraverseMethods:
                 strides[current_dim]
             )
             if current_dim >= shape.ndim - 1:
-                ptr.init_pointee_copy(Scalar[DType.int](current_sum))
+                ptr.unsafe_write(Scalar[DType.int](current_sum))
                 ptr += 1
             else:
                 Self.traverse_buffer_according_to_shape_and_strides(
@@ -106,7 +106,7 @@ struct TraverseMethods:
             if narr_idx - narr.offset >= total_elements:
                 raise Error("Invalid index: index out of bound")
 
-            narr._buf.ptr.store(narr_idx, orig._buf.ptr.load[width=1](orig_idx))
+            narr._buf.ptr.unsafe_store(narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx))
 
             for d in range(ndim.__len__() - 1, -1, -1):
                 index[d] += 1
@@ -155,7 +155,7 @@ struct TraverseMethods:
             for i in range(len(index)):
                 narr_idx += index[i] * coefficients[i]
 
-            narr._buf.ptr.store(narr_idx, orig._buf.ptr.load[width=1](orig_idx))
+            narr._buf.ptr.unsafe_store(narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx))
 
             for d in range(ndim.__len__() - 1, -1, -1):
                 index[d] += 1

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -53,7 +53,7 @@ struct TraverseMethods:
             )
             if current_dim >= shape.ndim - 1:
                 ptr.unsafe_write(Scalar[DType.int](current_sum))
-                ptr += 1
+                ptr = ptr.unsafe_offset(1)
             else:
                 Self.traverse_buffer_according_to_shape_and_strides(
                     ptr,

--- a/numojo/core/indexing/traversal.mojo
+++ b/numojo/core/indexing/traversal.mojo
@@ -106,7 +106,9 @@ struct TraverseMethods:
             if narr_idx - narr.offset >= total_elements:
                 raise Error("Invalid index: index out of bound")
 
-            narr._buf.ptr.unsafe_store(narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx))
+            narr._buf.ptr.unsafe_store(
+                narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx)
+            )
 
             for d in range(ndim.__len__() - 1, -1, -1):
                 index[d] += 1
@@ -155,7 +157,9 @@ struct TraverseMethods:
             for i in range(len(index)):
                 narr_idx += index[i] * coefficients[i]
 
-            narr._buf.ptr.unsafe_store(narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx))
+            narr._buf.ptr.unsafe_store(
+                narr_idx, orig._buf.ptr.unsafe_load[width=1](orig_idx)
+            )
 
             for d in range(ndim.__len__() - 1, -1, -1):
                 index[d] += 1

--- a/numojo/core/indexing/utility.mojo
+++ b/numojo/core/indexing/utility.mojo
@@ -14,7 +14,8 @@ SECTIONS OF THE FILE:
 2. Numojo.NDArray to other collections.
 3. Miscellaneous utility functions.
 """
-from std.algorithm.functional import vectorize, parallelize
+from std.algorithm.functional import vectorize
+from max.algorithm import parallelize
 from std.collections import Dict
 from std.memory import memcpy
 from std.memory import UnsafePointer

--- a/numojo/core/indexing/utility.mojo
+++ b/numojo/core/indexing/utility.mojo
@@ -17,7 +17,7 @@ SECTIONS OF THE FILE:
 from std.algorithm.functional import vectorize
 from max.algorithm import parallelize
 from std.collections import Dict
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 from std.memory import UnsafePointer
 from std.python import Python, PythonObject
 from std.sys import simd_width_of
@@ -95,9 +95,9 @@ def bool_to_numeric[
     for i in range(array.size):
         var t: Bool = array.item(i)
         if t:
-            result._buf.ptr[i] = 1
+            result._buf.ptr[unsafe_offset=i] = 1
         else:
-            result._buf.ptr[i] = 0
+            result._buf.ptr[unsafe_offset=i] = 0
     return result^
 
 
@@ -174,7 +174,7 @@ def to_numpy[dtype: DType](array: NDArray[dtype]) raises -> PythonObject:
         var pointer_d = numpyarray.__array_interface__[PythonObject("data")][
             0
         ].unsafe_get_as_pointer[dtype]()
-        memcpy(dest=pointer_d, src=array.unsafe_ptr(), count=array.size)
+        unsafe_memcpy(dest=pointer_d, src=array.unsafe_ptr(), count=array.size)
         _ = array
 
         return numpyarray^

--- a/numojo/core/layout/flags.mojo
+++ b/numojo/core/layout/flags.mojo
@@ -12,6 +12,7 @@ Implements Flags type to represent the memory layout information of NuMojo array
 
 from numojo.core.layout.ndshape import NDArrayShape
 from numojo.core.layout.ndstrides import NDArrayStrides
+from numojo.core.error import NumojoError
 
 
 struct Flags(ImplicitlyCopyable, RegisterPassable):

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -287,21 +287,6 @@ struct NDArrayShape(
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
 
-    @always_inline("nodebug")
-    def __getitem__(self, index: Int) raises -> Int:
-        """
-        Gets shape dimension at specified index.
-
-        Args:
-          index: Index to get the shape.
-
-        Returns:
-           Shape value at the given index.
-
-        Raises:
-           Error: Index out of bound.
-        """
-        return Int(self._buf[index])
 
     @always_inline("nodebug")
     def __getitem__(
@@ -349,19 +334,6 @@ struct NDArrayShape(
         """
         self._buf[index] = val
 
-    @always_inline("nodebug")
-    def __setitem__(mut self, index: Int, val: Int) raises:
-        """
-        Sets shape at specified index.
-
-        Args:
-          index: Index to set the shape.
-          val: Value to set at the given index.
-
-        Raises:
-           Error: Index out of bound.
-        """
-        self._buf[index] = val
 
     def load[
         width: Int = 1
@@ -815,18 +787,6 @@ struct NDArrayShape(
         """
         return not self.__eq__(other)
 
-    @always_inline("nodebug")
-    def __contains__(self, val: Int) -> Bool:
-        """
-        Checks if the given value is present in the shape dimensions.
-
-        Args:
-            val: The value to search for.
-
-        Returns:
-          True if the given value is present in the shape.
-        """
-        return val in self._buf
 
     @always_inline("nodebug")
     def __contains__(self, val: Scalar[Self.element_type]) -> Bool:

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -287,7 +287,6 @@ struct NDArrayShape(
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
 
-
     @always_inline("nodebug")
     def __getitem__(
         self, index: Scalar[Self.element_type]
@@ -333,7 +332,6 @@ struct NDArrayShape(
            Error: Index out of bound.
         """
         self._buf[index] = val
-
 
     def load[
         width: Int = 1
@@ -786,7 +784,6 @@ struct NDArrayShape(
            True if both shapes do not have identical dimensions or values.
         """
         return not self.__eq__(other)
-
 
     @always_inline("nodebug")
     def __contains__(self, val: Scalar[Self.element_type]) -> Bool:

--- a/numojo/core/layout/ndshape.mojo
+++ b/numojo/core/layout/ndshape.mojo
@@ -13,7 +13,7 @@ The NDArrayShape provides methods for element access, shape transformations (e.g
 and properties like size and rank.
 """
 
-from std.memory import memcpy, memcmp, UnsafePointer
+from std.memory import unsafe_memcpy, unsafe_memcmp, UnsafePointer
 
 from numojo.core.indexing.index_buffer import IndexBuffer
 from numojo.core.layout.ndstrides import NDArrayStrides
@@ -208,7 +208,7 @@ struct NDArrayShape(
         """
         self.ndim = shape.ndim
         self._buf = IndexBuffer(size=self.ndim)
-        memcpy(dest=self._buf.ptr, src=shape._buf.ptr, count=shape.ndim)
+        unsafe_memcpy(dest=self._buf.ptr, src=shape._buf.ptr, count=shape.ndim)
 
     @always_inline("nodebug")
     def __init__(
@@ -277,7 +277,7 @@ struct NDArrayShape(
             self._buf.init_value(0, 0)
         else:
             self._buf = IndexBuffer(size=copy.ndim)
-            memcpy(
+            unsafe_memcpy(
                 dest=self._buf.ptr,
                 src=copy._buf.ptr,
                 count=copy.ndim,
@@ -365,7 +365,7 @@ struct NDArrayShape(
                     location="Shape.load",
                 )
             )
-        return self._buf.ptr.load[width=width](idx)
+        return self._buf.ptr.unsafe_load[width=width](idx)
 
     def store[
         width: Int = 1
@@ -395,7 +395,7 @@ struct NDArrayShape(
                     location="Shape.store",
                 )
             )
-        self._buf.ptr.store[width=width](idx, value)
+        self._buf.ptr.unsafe_store[width=width](idx, value)
 
     def unsafe_load[
         width: Int = 1
@@ -747,7 +747,7 @@ struct NDArrayShape(
         """
         var result: String = "("
         for i in range(self.ndim):
-            result += String(self._buf.ptr[i])
+            result += String(self._buf.ptr[unsafe_offset=i])
             if i < self.ndim - 1:
                 result += ", "
         result += ")"
@@ -865,7 +865,7 @@ struct NDArrayShape(
 # NDArrayShape Iterator
 # ===----------------------------------------------------------------------=== #
 struct _ShapeIter[
-    origin: ImmutOrigin = ImmutUntrackedOrigin,
+    origin: ImmOrigin = ImmUntrackedOrigin,
     forward: Bool = True,
 ](ImplicitlyCopyable, Movable):
     """Iterator for NDArrayShape.

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -346,7 +346,6 @@ struct NDArrayStrides(
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
 
-
     @always_inline("nodebug")
     def __getitem__(
         self, index: Scalar[Self.element_type]
@@ -392,7 +391,6 @@ struct NDArrayStrides(
            Error: Index out of bound.
         """
         self._buf[Int(index)] = Int(val)
-
 
     def load[
         width: Int = 1
@@ -760,7 +758,6 @@ struct NDArrayStrides(
            True if both strides do not have identical dimensions or values.
         """
         return not self.__eq__(other)
-
 
     @always_inline("nodebug")
     def __contains__(self, val: Scalar[Self.element_type]) -> Bool:

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -346,18 +346,6 @@ struct NDArrayStrides(
     # Element Access Methods
     # ===----------------------------------------------------------------------=== #
 
-    @always_inline("nodebug")
-    def __getitem__(self, index: Int) raises -> Int:
-        """
-        Gets stride at specified index.
-
-        Args:
-          index: Index to get the stride.
-
-        Returns:
-           Stride value at the given index.
-        """
-        return Int(self._buf[index])
 
     @always_inline("nodebug")
     def __getitem__(
@@ -405,19 +393,6 @@ struct NDArrayStrides(
         """
         self._buf[Int(index)] = Int(val)
 
-    @always_inline("nodebug")
-    def __setitem__(mut self, index: Int, val: Int) raises:
-        """
-        Sets stride at specified index.
-
-        Args:
-          index: Index to set the shape.
-          val: Value to set at the given index.
-
-        Raises:
-           Error: Index out of bound.
-        """
-        self._buf[index] = val
 
     def load[
         width: Int = 1
@@ -786,18 +761,6 @@ struct NDArrayStrides(
         """
         return not self.__eq__(other)
 
-    @always_inline("nodebug")
-    def __contains__(self, val: Int) -> Bool:
-        """
-        Checks if the given value is present in the strides.
-
-        Args:
-            val: The value to search for.
-
-        Returns:
-          True if the given value is present in the strides.
-        """
-        return val in self._buf
 
     @always_inline("nodebug")
     def __contains__(self, val: Scalar[Self.element_type]) -> Bool:

--- a/numojo/core/layout/ndstrides.mojo
+++ b/numojo/core/layout/ndstrides.mojo
@@ -11,7 +11,7 @@ Implements NDArrayStrides type. NDArrayStrides represents the strides of an NDAr
 which is used to calculate the memory offset for each dimension when indexing into the array.
 """
 
-from std.memory import memcmp, memcpy, UnsafePointer
+from std.memory import unsafe_memcmp, unsafe_memcpy, UnsafePointer
 
 from numojo.core.indexing.index_buffer import IndexBuffer
 from numojo.core.layout.ndshape import NDArrayShape
@@ -172,7 +172,7 @@ struct NDArrayStrides(
         """
         self.ndim = strides.ndim
         self._buf = IndexBuffer(size=self.ndim)
-        memcpy(
+        unsafe_memcpy(
             dest=self._buf.ptr,
             src=strides._buf.ptr,
             count=strides.ndim,
@@ -336,7 +336,7 @@ struct NDArrayStrides(
             self._buf.init_value(0, 0)
         else:
             self._buf = IndexBuffer(size=copy.ndim)
-            memcpy(
+            unsafe_memcpy(
                 dest=self._buf.ptr,
                 src=copy._buf.ptr,
                 count=copy.ndim,
@@ -880,7 +880,7 @@ struct NDArrayStrides(
 
 
 struct _StrideIter[
-    origin: ImmutOrigin = ImmutUntrackedOrigin,
+    origin: ImmOrigin = ImmUntrackedOrigin,
     forward: Bool = True,
 ](ImplicitlyCopyable, Movable):
     """Iterator for NDArrayStrides.

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -438,7 +438,7 @@ struct Matrix[
         self.flags = take.flags^
 
     @always_inline("nodebug")
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """
         Destructor for the matrix instance.
 
@@ -5082,7 +5082,7 @@ def _arithmetic_func_matrix_matrix_to_matrix[
 
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
-    def vec_func[simd_width: Int](i: Int) {mut res, read A, read B}:
+    def vec_func[simd_width: Int](i: Int) {mut res, imm A, imm B}:
         res._buf.ptr.unsafe_store(
             i,
             simd_func(
@@ -5121,7 +5121,7 @@ def _arithmetic_func_matrix_to_matrix[
 
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
-    def vec_func[simd_width: Int](i: Int) {mut C, read A}:
+    def vec_func[simd_width: Int](i: Int) {mut C, imm A}:
         C._buf.ptr.unsafe_store(i, simd_func(A._buf.ptr.unsafe_load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
@@ -5188,7 +5188,7 @@ def _logic_func_matrix_matrix_to_matrix[
 
     # Use vectorized comparison for better performance
     # Process elements using input dtype width, then store results as bool
-    def vec_compare[w: Int](i: Int) {mut C, read A, read B}:
+    def vec_compare[w: Int](i: Int) {mut C, imm A, imm B}:
         var a_vec = A._buf.ptr.unsafe_load[width=w](i)
         var b_vec = B._buf.ptr.unsafe_load[width=w](i)
         var result = simd_func[dtype, w](a_vec, b_vec)

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -21,7 +21,7 @@ Use this module to create, manipulate, and analyze matrices with high performanc
 
 from std.algorithm import vectorize
 from max.algorithm import parallelize
-from std.memory import UnsafePointer, memcpy, memset_zero
+from std.memory import UnsafePointer, unsafe_memcpy, unsafe_memset_zero
 from std.random import random_float64
 from std.sys import simd_width_of
 from std.python import PythonObject, Python
@@ -253,7 +253,7 @@ struct Matrix[
         """
         self = Self(data.shape, data.order())
         if data.is_c_contiguous() or data.is_f_contiguous():
-            memcpy(
+            unsafe_memcpy(
                 dest=self._buf.ptr,
                 src=data._buf.ptr + data.offset,
                 count=data.size,
@@ -316,7 +316,7 @@ struct Matrix[
         self.flags = Flags(
             self.shape, self.strides, owndata=True, writeable=True
         )
-        memcpy(
+        unsafe_memcpy(
             dest=self._buf.ptr,
             src=data._buf.ptr,
             count=self.size,
@@ -615,7 +615,7 @@ struct Matrix[
         )
         if self.is_c_contiguous():
             var ptr = self._buf.offset(self.offset + x_norm * self.strides[0])
-            memcpy(dest=result._buf.ptr, src=ptr, count=self.shape[1])
+            unsafe_memcpy(dest=result._buf.ptr, src=ptr, count=self.shape[1])
         else:
             for j in range(self.shape[1]):
                 result[0, j] = self[x_norm, j]
@@ -1000,14 +1000,14 @@ struct Matrix[
                 )
             )
         var idx_norm = Validator.normalize(idx, self.size)
-        return self._buf.ptr.load[width=width](self.offset + idx_norm)
+        return self._buf.ptr.unsafe_load[width=width](self.offset + idx_norm)
 
     def _load[width: Int = 1](self, x: Int, y: Int) -> SIMD[Self.dtype, width]:
         """
         `__getitem__` with width.
         Unsafe: No boundary check!
         """
-        return self._buf.ptr.load[width=width](
+        return self._buf.ptr.unsafe_load[width=width](
             self.offset + x * self.strides[0] + y * self.strides[1]
         )
 
@@ -1016,7 +1016,7 @@ struct Matrix[
         `__getitem__` with width.
         Unsafe: No boundary check!
         """
-        return self._buf.ptr.load[width=width](self.offset + idx)
+        return self._buf.ptr.unsafe_load[width=width](self.offset + idx)
 
     def __setitem__(mut self, x: Int, y: Int, value: Scalar[Self.dtype]) raises:
         """
@@ -1141,7 +1141,7 @@ struct Matrix[
                 var dest_ptr = self._buf.offset(
                     self.offset + x * self.strides[0]
                 )
-                memcpy(
+                unsafe_memcpy(
                     dest=dest_ptr,
                     src=value._buf.ptr + value.offset,
                     count=self.shape[1],
@@ -1156,8 +1156,8 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._buf.offset(
                         self.offset + x + j * self.strides[1]
-                    ).store(
-                        value._buf.ptr.load(value.offset + j * value.strides[1])
+                    ).unsafe_store(
+                        value._buf.ptr.unsafe_load(value.offset + j * value.strides[1])
                     )
             else:
                 for j in range(self.shape[1]):
@@ -1235,7 +1235,7 @@ struct Matrix[
                 var dest_ptr = self._buf.offset(
                     self.offset + x * self.strides[0]
                 )
-                memcpy(
+                unsafe_memcpy(
                     dest=dest_ptr,
                     src=value._buf.ptr + value.offset,
                     count=self.shape[1],
@@ -1250,8 +1250,8 @@ struct Matrix[
                 for j in range(self.shape[1]):
                     self._buf.offset(
                         self.offset + x + j * self.strides[1]
-                    ).store(
-                        value._buf.ptr.load(value.offset + j * value.strides[1])
+                    ).unsafe_store(
+                        value._buf.ptr.unsafe_load(value.offset + j * value.strides[1])
                     )
             else:
                 for j in range(self.shape[1]):
@@ -1692,7 +1692,7 @@ struct Matrix[
         `__setitem__` with width.
         Unsafe: No boundary check!
         """
-        self._buf.ptr.store(
+        self._buf.ptr.unsafe_store(
             self.offset + x * self.strides[0] + y * self.strides[1], simd
         )
 
@@ -1703,7 +1703,7 @@ struct Matrix[
         `__setitem__` with width.
         Unsafe: No boundary check!
         """
-        self._buf.ptr.store(self.offset + idx, val)
+        self._buf.ptr.unsafe_store(self.offset + idx, val)
 
     def store[
         width: Int = 1
@@ -1743,7 +1743,7 @@ struct Matrix[
                 )
             )
         var idx_norm = Validator.normalize(idx, self.size)
-        self._buf.ptr.store[width=width](self.offset + idx_norm, val)
+        self._buf.ptr.unsafe_store[width=width](self.offset + idx_norm, val)
 
     # ===-------------------------------------------------------------------===#
     # Other dunders and auxiliary methods
@@ -2255,8 +2255,8 @@ struct Matrix[
         comptime width = simd_width_of[Self.dtype]()
 
         def vec_pow[w: Int](i: Int) {mut result, self, rhs}:
-            var vec = self._buf.ptr.load[width=w](i)
-            result._buf.ptr.store(i, vec.__pow__(rhs))
+            var vec = self._buf.ptr.unsafe_load[width=w](i)
+            result._buf.ptr.unsafe_store(i, vec.__pow__(rhs))
 
         vectorize[width](self.size, vec_pow)
         return result^
@@ -2301,9 +2301,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_add[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a + b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a + b)
 
             vectorize[width](self.size, vec_add)
         else:
@@ -2329,8 +2329,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_add_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a + other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a + other)
 
             vectorize[width](self.size, vec_add_scalar)
         else:
@@ -2378,9 +2378,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_sub[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a - b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a - b)
 
             vectorize[width](self.size, vec_sub)
         else:
@@ -2406,8 +2406,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_sub_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a - other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a - other)
 
             vectorize[width](self.size, vec_sub_scalar)
         else:
@@ -2455,9 +2455,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_mul[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a * b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a * b)
 
             vectorize[width](self.size, vec_mul)
         else:
@@ -2483,8 +2483,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_mul_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a * other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a * other)
 
             vectorize[width](self.size, vec_mul_scalar)
         else:
@@ -2532,9 +2532,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_div[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a / b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a / b)
 
             vectorize[width](self.size, vec_div)
         else:
@@ -2560,8 +2560,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_div_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a / other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a / other)
 
             vectorize[width](self.size, vec_div_scalar)
         else:
@@ -2680,9 +2680,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_floordiv[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a // b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a // b)
 
             vectorize[width](self.size, vec_floordiv)
         else:
@@ -2708,8 +2708,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_floordiv_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a // other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a // other)
 
             vectorize[width](self.size, vec_floordiv_scalar)
         else:
@@ -2823,9 +2823,9 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_mod[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                var b = other._buf.ptr.load[width=w](other.offset + i)
-                self._buf.ptr.store(self.offset + i, a % b)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                var b = other._buf.ptr.unsafe_load[width=w](other.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a % b)
 
             vectorize[width](self.size, vec_mod)
         else:
@@ -2851,8 +2851,8 @@ struct Matrix[
             comptime width = simd_width_of[Self.dtype]()
 
             def vec_mod_scalar[w: Int](i: Int) {mut self, other}:
-                var a = self._buf.ptr.load[width=w](self.offset + i)
-                self._buf.ptr.store(self.offset + i, a % other)
+                var a = self._buf.ptr.unsafe_load[width=w](self.offset + i)
+                self._buf.ptr.unsafe_store(self.offset + i, a % other)
 
             vectorize[width](self.size, vec_mod_scalar)
         else:
@@ -3484,7 +3484,7 @@ struct Matrix[
             shape=(src.shape[0], src.shape[1]), order=src.order()
         )
         for i in range(src.size):
-            casted_matrix._buf.ptr[i] = src._buf.ptr[i].cast[asdtype]()
+            casted_matrix._buf.ptr[unsafe_offset=i] = src._buf.ptr[unsafe_offset=i].cast[asdtype]()
         return casted_matrix^
 
     def cumprod(self) raises -> Matrix[Self.dtype]:
@@ -3578,7 +3578,7 @@ struct Matrix[
         """
         if self.is_c_contiguous():
             for i in range(self.size):
-                (self._buf.ptr + self.offset + i).init_pointee_copy(fill_value)
+                (self._buf.ptr + self.offset + i).unsafe_write(fill_value)
         else:
             for i in range(self.shape[0]):
                 for j in range(self.shape[1]):
@@ -3601,7 +3601,7 @@ struct Matrix[
         """
         var src = self.contiguous()
         var res = Matrix[Self.dtype](shape=(1, src.size), order=src.order())
-        memcpy(dest=res._buf.ptr, src=src._buf.ptr, count=res.size)
+        unsafe_memcpy(dest=res._buf.ptr, src=src._buf.ptr, count=res.size)
         return res^
 
     def inv(self) raises -> Matrix[Self.dtype]:
@@ -3704,7 +3704,7 @@ struct Matrix[
         """
         var result = Self(shape=self.shape, order="C")
         if self.is_c_contiguous():
-            memcpy(
+            unsafe_memcpy(
                 dest=result._buf.ptr,
                 src=self._buf.ptr + self.offset,
                 count=self.size,
@@ -3921,19 +3921,19 @@ struct Matrix[
             var k = 0
             for row in range(self.shape[0]):
                 for col in range(self.shape[1]):
-                    var val = self._buf.ptr[
+                    var val = self._buf.ptr[unsafe_offset=
                         self.offset
                         + row * self.strides[0]
                         + col * self.strides[1]
                     ]
                     var dest_row = Int(k // shape[1])
                     var dest_col = k % shape[1]
-                    res._buf.ptr[
+                    res._buf.ptr[unsafe_offset=
                         dest_row * res.strides[0] + dest_col * res.strides[1]
                     ] = val
                     k += 1
         else:
-            memcpy(
+            unsafe_memcpy(
                 dest=res._buf.ptr,
                 src=self._buf.ptr + self.offset,
                 count=res.size,
@@ -3967,29 +3967,29 @@ struct Matrix[
         if shape[0] * shape[1] > self.size:
             var other = Matrix[Self.dtype](shape=shape, order=self.order())
             if self.is_c_contiguous():
-                memcpy(
+                unsafe_memcpy(
                     dest=other._buf.ptr,
                     src=self._buf.ptr + self.offset,
                     count=self.size,
                 )
                 for i in range(self.size, other.size):
-                    other._buf.ptr[i] = 0
+                    other._buf.ptr[unsafe_offset=i] = 0
             else:
                 var min_rows = min(self.shape[0], shape[0])
                 var min_cols = min(self.shape[1], shape[1])
 
                 for j in range(min_cols):
                     for i in range(min_rows):
-                        other._buf.ptr[i + j * shape[0]] = self._buf.ptr[
+                        other._buf.ptr[unsafe_offset=i + j * shape[0]] = self._buf.ptr[unsafe_offset=
                             self.offset + i + j * self.shape[0]
                         ]
                     for i in range(min_rows, shape[0]):
-                        other._buf.ptr[i + j * shape[0]] = 0
+                        other._buf.ptr[unsafe_offset=i + j * shape[0]] = 0
 
                 # Zero the additional columns
                 for j in range(min_cols, shape[1]):
                     for i in range(shape[0]):
-                        other._buf.ptr[i + j * shape[0]] = 0
+                        other._buf.ptr[unsafe_offset=i + j * shape[0]] = 0
 
             self = other^
         else:
@@ -4261,7 +4261,7 @@ struct Matrix[
         var ndarray: NDArray[Self.dtype] = NDArray[Self.dtype](
             shape=NDArrayShape(src.shape[0], src.shape[1]), order=src.order()
         )
-        memcpy(dest=ndarray._buf.ptr, src=src._buf.ptr, count=ndarray.size)
+        unsafe_memcpy(dest=ndarray._buf.ptr, src=src._buf.ptr, count=ndarray.size)
 
         return ndarray^
 
@@ -4329,7 +4329,7 @@ struct Matrix[
             var pointer_d = numpyarray.__array_interface__[
                 PythonObject("data")
             ][0].unsafe_get_as_pointer[Self.dtype]()
-            memcpy(dest=pointer_d, src=src._buf.get_ptr(), count=src.size)
+            unsafe_memcpy(dest=pointer_d, src=src._buf.get_ptr(), count=src.size)
 
             return numpyarray^
 
@@ -4371,7 +4371,7 @@ struct Matrix[
         comptime width = simd_width_of[datatype]()
 
         def vec_fill[w: Int](i: Int) {mut matrix, fill_value}:
-            matrix._buf.ptr.store(i, SIMD[datatype, w](fill_value))
+            matrix._buf.ptr.unsafe_store(i, SIMD[datatype, w](fill_value))
 
         vectorize[width](matrix.size, vec_fill)
         return matrix^
@@ -4398,7 +4398,7 @@ struct Matrix[
         """
 
         var res = Matrix[datatype](shape, order)
-        memset_zero(res._buf.ptr, res.size)
+        unsafe_memset_zero(res._buf.ptr, res.size)
         return res^
 
     @staticmethod
@@ -4447,7 +4447,7 @@ struct Matrix[
         """
         var matrix = Matrix.zeros[datatype]((len, len), order)
         for i in range(len):
-            matrix._buf.ptr.store(
+            matrix._buf.ptr.unsafe_store(
                 i * matrix.strides[0] + i * matrix.strides[1], 1
             )
         return matrix^
@@ -4479,7 +4479,7 @@ struct Matrix[
             var rand_vec = SIMD[datatype, w]()
             for j in range(w):
                 rand_vec[j] = random_float64(0, 1).cast[datatype]()
-            result._buf.ptr.store(i, rand_vec)
+            result._buf.ptr.unsafe_store(i, rand_vec)
 
         vectorize[width](result.size, vec_rand)
         return result^
@@ -4582,7 +4582,7 @@ struct Matrix[
 
         var result = Matrix[datatype](shape=(1, num_elements), order=order)
         for i in range(num_elements):
-            result._buf.ptr[i] = start + Scalar[datatype](i) * step
+            result._buf.ptr[unsafe_offset=i] = start + Scalar[datatype](i) * step
 
         return result^
 
@@ -4632,7 +4632,7 @@ struct Matrix[
         var step = (stop - start) / Scalar[datatype](num - 1)
 
         for i in range(num):
-            result._buf.ptr[i] = start + Scalar[datatype](i) * step
+            result._buf.ptr[unsafe_offset=i] = start + Scalar[datatype](i) * step
 
         return result^
 
@@ -4668,25 +4668,25 @@ struct Matrix[
             var size = diagonal.shape[1]
             var result = Matrix.zeros[datatype]((size, size), order)
             for i in range(size):
-                result._buf.ptr[
+                result._buf.ptr[unsafe_offset=
                     i * result.strides[0] + i * result.strides[1]
-                ] = diagonal._buf.ptr[i]
+                ] = diagonal._buf.ptr[unsafe_offset=i]
             return result^
         elif diagonal.shape[1] == 1:
             # Column vector: create diagonal matrix
             var size = diagonal.shape[0]
             var result = Matrix.zeros[datatype]((size, size), order)
             for i in range(size):
-                result._buf.ptr[
+                result._buf.ptr[unsafe_offset=
                     i * result.strides[0] + i * result.strides[1]
-                ] = diagonal._buf.ptr[i]
+                ] = diagonal._buf.ptr[unsafe_offset=i]
             return result^
         else:
             # Matrix: extract diagonal
             var size = min(diagonal.shape[0], diagonal.shape[1])
             var result = Matrix[datatype](shape=(1, size), order=order)
             for i in range(size):
-                result._buf.ptr[i] = diagonal._buf.ptr[
+                result._buf.ptr[unsafe_offset=i] = diagonal._buf.ptr[unsafe_offset=
                     i * diagonal.strides[0] + i * diagonal.strides[1]
                 ]
             return result^
@@ -4789,7 +4789,7 @@ struct Matrix[
 
         if (shape[0] == 0) and (shape[1] == 0):
             var M = Matrix[datatype](shape=(1, len(object)))
-            memcpy(dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size)
+            unsafe_memcpy(dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size)
             return M^
 
         if shape[0] * shape[1] != len(object):
@@ -4807,7 +4807,7 @@ struct Matrix[
                 )
             )
         var M = Matrix[datatype](shape=shape, order="C")
-        memcpy(dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size)
+        unsafe_memcpy(dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size)
         if order == "F":
             M = M.reorder_layout()
         return M^
@@ -4896,7 +4896,7 @@ struct Matrix[
 
         var result = Matrix[datatype](shape=shape)
         for i in range(len(data)):
-            result._buf.ptr[i] = data[i]
+            result._buf.ptr[unsafe_offset=i] = data[i]
         return result^
 
 
@@ -5083,11 +5083,11 @@ def _arithmetic_func_matrix_matrix_to_matrix[
     var res = Matrix[dtype](shape=A.shape, order=A.order())
 
     def vec_func[simd_width: Int](i: Int) {mut res, read A, read B}:
-        res._buf.ptr.store(
+        res._buf.ptr.unsafe_store(
             i,
             simd_func(
-                A._buf.ptr.load[width=simd_width](i),
-                B._buf.ptr.load[width=simd_width](i),
+                A._buf.ptr.unsafe_load[width=simd_width](i),
+                B._buf.ptr.unsafe_load[width=simd_width](i),
             ),
         )
 
@@ -5122,7 +5122,7 @@ def _arithmetic_func_matrix_to_matrix[
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
     def vec_func[simd_width: Int](i: Int) {mut C, read A}:
-        C._buf.ptr.store(i, simd_func(A._buf.ptr.load[width=simd_width](i)))
+        C._buf.ptr.unsafe_store(i, simd_func(A._buf.ptr.unsafe_load[width=simd_width](i)))
 
     vectorize[simd_width](A.size, vec_func)
 
@@ -5189,14 +5189,14 @@ def _logic_func_matrix_matrix_to_matrix[
     # Use vectorized comparison for better performance
     # Process elements using input dtype width, then store results as bool
     def vec_compare[w: Int](i: Int) {mut C, read A, read B}:
-        var a_vec = A._buf.ptr.load[width=w](i)
-        var b_vec = B._buf.ptr.load[width=w](i)
+        var a_vec = A._buf.ptr.unsafe_load[width=w](i)
+        var b_vec = B._buf.ptr.unsafe_load[width=w](i)
         var result = simd_func[dtype, w](a_vec, b_vec)
 
         # Store bool results element by element to avoid width mismatch
         for j in range(w):
             if i + j < A.size:
-                C._buf.ptr[i + j] = result[j]
+                C._buf.ptr[unsafe_offset=i + j] = result[j]
 
     vectorize[width](A.size, vec_compare)
     return C^

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -415,7 +415,7 @@ struct Matrix[
         )
 
     @always_inline("nodebug")
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """
         Transfer ownership of resources from `other` to `self`.
 
@@ -424,18 +424,18 @@ struct Matrix[
         is left in an invalid state and should not be used.
 
         Args:
-            take: The source matrix instance whose resources will be moved.
+            move: The source matrix instance whose resources will be moved.
 
         Notes:
             - This operation is efficient as it avoids copying data.
             - The `other` instance is deinitialized as part of this operation.
         """
-        self.shape = take.shape^
-        self.strides = take.strides^
-        self.size = take.size
-        self._buf = take._buf^
-        self.offset = take.offset
-        self.flags = take.flags^
+        self.shape = move.shape^
+        self.strides = move.strides^
+        self.size = move.size
+        self._buf = move._buf^
+        self.offset = move.offset
+        self.flags = move.flags^
 
     @always_inline("nodebug")
     def __deinit__(deinit self):
@@ -645,8 +645,8 @@ struct Matrix[
             var slice_view = mat.get(Slice(1, 3), Slice(0, 2))  # Get a view of the submatrix
             ```
         """
-        start_x, end_x, step_x = x.indices(self.shape[0])
-        start_y, end_y, step_y = y.indices(self.shape[1])
+        var start_x, end_x, step_x = x.indices(self.shape[0])
+        var start_y, end_y, step_y = y.indices(self.shape[1])
 
         var offset = start_x * self.strides[0] + start_y * self.strides[1]
         return Matrix[Self.dtype](

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -1157,7 +1157,9 @@ struct Matrix[
                     self._buf.offset(
                         self.offset + x + j * self.strides[1]
                     ).unsafe_store(
-                        value._buf.ptr.unsafe_load(value.offset + j * value.strides[1])
+                        value._buf.ptr.unsafe_load(
+                            value.offset + j * value.strides[1]
+                        )
                     )
             else:
                 for j in range(self.shape[1]):
@@ -1251,7 +1253,9 @@ struct Matrix[
                     self._buf.offset(
                         self.offset + x + j * self.strides[1]
                     ).unsafe_store(
-                        value._buf.ptr.unsafe_load(value.offset + j * value.strides[1])
+                        value._buf.ptr.unsafe_load(
+                            value.offset + j * value.strides[1]
+                        )
                     )
             else:
                 for j in range(self.shape[1]):
@@ -3484,7 +3488,9 @@ struct Matrix[
             shape=(src.shape[0], src.shape[1]), order=src.order()
         )
         for i in range(src.size):
-            casted_matrix._buf.ptr[unsafe_offset=i] = src._buf.ptr[unsafe_offset=i].cast[asdtype]()
+            casted_matrix._buf.ptr[unsafe_offset=i] = src._buf.ptr[
+                unsafe_offset=i
+            ].cast[asdtype]()
         return casted_matrix^
 
     def cumprod(self) raises -> Matrix[Self.dtype]:
@@ -3578,7 +3584,9 @@ struct Matrix[
         """
         if self.is_c_contiguous():
             for i in range(self.size):
-                ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)).unsafe_write(fill_value)
+                (
+                    (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)
+                ).unsafe_write(fill_value)
         else:
             for i in range(self.shape[0]):
                 for j in range(self.shape[1]):
@@ -3924,15 +3932,16 @@ struct Matrix[
             var k = 0
             for row in range(self.shape[0]):
                 for col in range(self.shape[1]):
-                    var val = self._buf.ptr[unsafe_offset=
-                        self.offset
+                    var val = self._buf.ptr[
+                        unsafe_offset=self.offset
                         + row * self.strides[0]
                         + col * self.strides[1]
                     ]
                     var dest_row = Int(k // shape[1])
                     var dest_col = k % shape[1]
-                    res._buf.ptr[unsafe_offset=
-                        dest_row * res.strides[0] + dest_col * res.strides[1]
+                    res._buf.ptr[
+                        unsafe_offset=dest_row * res.strides[0]
+                        + dest_col * res.strides[1]
                     ] = val
                     k += 1
         else:
@@ -3983,8 +3992,10 @@ struct Matrix[
 
                 for j in range(min_cols):
                     for i in range(min_rows):
-                        other._buf.ptr[unsafe_offset=i + j * shape[0]] = self._buf.ptr[unsafe_offset=
-                            self.offset + i + j * self.shape[0]
+                        other._buf.ptr[
+                            unsafe_offset=i + j * shape[0]
+                        ] = self._buf.ptr[
+                            unsafe_offset=self.offset + i + j * self.shape[0]
                         ]
                     for i in range(min_rows, shape[0]):
                         other._buf.ptr[unsafe_offset=i + j * shape[0]] = 0
@@ -4264,7 +4275,9 @@ struct Matrix[
         var ndarray: NDArray[Self.dtype] = NDArray[Self.dtype](
             shape=NDArrayShape(src.shape[0], src.shape[1]), order=src.order()
         )
-        unsafe_memcpy(dest=ndarray._buf.ptr, src=src._buf.ptr, count=ndarray.size)
+        unsafe_memcpy(
+            dest=ndarray._buf.ptr, src=src._buf.ptr, count=ndarray.size
+        )
         # `DataContainer.origin` is untracked, so the raw pointer above does
         # not keep `src` alive; hold it until the copy has finished.
         _ = src^
@@ -4335,7 +4348,9 @@ struct Matrix[
             var pointer_d = numpyarray.__array_interface__[
                 PythonObject("data")
             ][0].unsafe_get_as_pointer[Self.dtype]()
-            unsafe_memcpy(dest=pointer_d, src=src._buf.get_ptr(), count=src.size)
+            unsafe_memcpy(
+                dest=pointer_d, src=src._buf.get_ptr(), count=src.size
+            )
 
             return numpyarray^
 
@@ -4588,7 +4603,9 @@ struct Matrix[
 
         var result = Matrix[datatype](shape=(1, num_elements), order=order)
         for i in range(num_elements):
-            result._buf.ptr[unsafe_offset=i] = start + Scalar[datatype](i) * step
+            result._buf.ptr[unsafe_offset=i] = (
+                start + Scalar[datatype](i) * step
+            )
 
         return result^
 
@@ -4638,7 +4655,9 @@ struct Matrix[
         var step = (stop - start) / Scalar[datatype](num - 1)
 
         for i in range(num):
-            result._buf.ptr[unsafe_offset=i] = start + Scalar[datatype](i) * step
+            result._buf.ptr[unsafe_offset=i] = (
+                start + Scalar[datatype](i) * step
+            )
 
         return result^
 
@@ -4674,8 +4693,8 @@ struct Matrix[
             var size = diagonal.shape[1]
             var result = Matrix.zeros[datatype]((size, size), order)
             for i in range(size):
-                result._buf.ptr[unsafe_offset=
-                    i * result.strides[0] + i * result.strides[1]
+                result._buf.ptr[
+                    unsafe_offset=i * result.strides[0] + i * result.strides[1]
                 ] = diagonal._buf.ptr[unsafe_offset=i]
             return result^
         elif diagonal.shape[1] == 1:
@@ -4683,8 +4702,8 @@ struct Matrix[
             var size = diagonal.shape[0]
             var result = Matrix.zeros[datatype]((size, size), order)
             for i in range(size):
-                result._buf.ptr[unsafe_offset=
-                    i * result.strides[0] + i * result.strides[1]
+                result._buf.ptr[
+                    unsafe_offset=i * result.strides[0] + i * result.strides[1]
                 ] = diagonal._buf.ptr[unsafe_offset=i]
             return result^
         else:
@@ -4692,8 +4711,9 @@ struct Matrix[
             var size = min(diagonal.shape[0], diagonal.shape[1])
             var result = Matrix[datatype](shape=(1, size), order=order)
             for i in range(size):
-                result._buf.ptr[unsafe_offset=i] = diagonal._buf.ptr[unsafe_offset=
-                    i * diagonal.strides[0] + i * diagonal.strides[1]
+                result._buf.ptr[unsafe_offset=i] = diagonal._buf.ptr[
+                    unsafe_offset=i * diagonal.strides[0]
+                    + i * diagonal.strides[1]
                 ]
             return result^
 
@@ -4795,7 +4815,9 @@ struct Matrix[
 
         if (shape[0] == 0) and (shape[1] == 0):
             var M = Matrix[datatype](shape=(1, len(object)))
-            unsafe_memcpy(dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size)
+            unsafe_memcpy(
+                dest=M._buf.ptr, src=object.unsafe_ptr(), count=M.size
+            )
             return M^
 
         if shape[0] * shape[1] != len(object):
@@ -5128,7 +5150,9 @@ def _arithmetic_func_matrix_to_matrix[
     var C: Matrix[dtype] = Matrix[dtype](shape=A.shape, order=A.order())
 
     def vec_func[simd_width: Int](i: Int) {mut C, imm A}:
-        C._buf.ptr.unsafe_store(i, simd_func(A._buf.ptr.unsafe_load[width=simd_width](i)))
+        C._buf.ptr.unsafe_store(
+            i, simd_func(A._buf.ptr.unsafe_load[width=simd_width](i))
+        )
 
     vectorize[simd_width](A.size, vec_func)
 

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -255,7 +255,7 @@ struct Matrix[
         if data.is_c_contiguous() or data.is_f_contiguous():
             unsafe_memcpy(
                 dest=self._buf.ptr,
-                src=data._buf.ptr + data.offset,
+                src=data._buf.ptr.unsafe_offset(data.offset),
                 count=data.size,
             )
         else:
@@ -1143,7 +1143,7 @@ struct Matrix[
                 )
                 unsafe_memcpy(
                     dest=dest_ptr,
-                    src=value._buf.ptr + value.offset,
+                    src=value._buf.ptr.unsafe_offset(value.offset),
                     count=self.shape[1],
                 )
             else:
@@ -1237,7 +1237,7 @@ struct Matrix[
                 )
                 unsafe_memcpy(
                     dest=dest_ptr,
-                    src=value._buf.ptr + value.offset,
+                    src=value._buf.ptr.unsafe_offset(value.offset),
                     count=self.shape[1],
                 )
             else:
@@ -3578,7 +3578,7 @@ struct Matrix[
         """
         if self.is_c_contiguous():
             for i in range(self.size):
-                (self._buf.ptr + self.offset + i).unsafe_write(fill_value)
+                ((self._buf.ptr + self.offset).unsafe_offset(i)).unsafe_write(fill_value)
         else:
             for i in range(self.shape[0]):
                 for j in range(self.shape[1]):
@@ -3706,7 +3706,7 @@ struct Matrix[
         if self.is_c_contiguous():
             unsafe_memcpy(
                 dest=result._buf.ptr,
-                src=self._buf.ptr + self.offset,
+                src=self._buf.ptr.unsafe_offset(self.offset),
                 count=self.size,
             )
         else:
@@ -3935,7 +3935,7 @@ struct Matrix[
         else:
             unsafe_memcpy(
                 dest=res._buf.ptr,
-                src=self._buf.ptr + self.offset,
+                src=self._buf.ptr.unsafe_offset(self.offset),
                 count=res.size,
             )
         return res^
@@ -3969,7 +3969,7 @@ struct Matrix[
             if self.is_c_contiguous():
                 unsafe_memcpy(
                     dest=other._buf.ptr,
-                    src=self._buf.ptr + self.offset,
+                    src=self._buf.ptr.unsafe_offset(self.offset),
                     count=self.size,
                 )
                 for i in range(self.size, other.size):

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -3578,7 +3578,7 @@ struct Matrix[
         """
         if self.is_c_contiguous():
             for i in range(self.size):
-                ((self._buf.ptr + self.offset).unsafe_offset(i)).unsafe_write(fill_value)
+                ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)).unsafe_write(fill_value)
         else:
             for i in range(self.shape[0]):
                 for j in range(self.shape[1]):

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -19,7 +19,8 @@ Features:
 Use this module to create, manipulate, and analyze matrices with high performance and safety guarantees.
 """
 
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.memory import UnsafePointer, memcpy, memset_zero
 from std.random import random_float64
 from std.sys import simd_width_of
@@ -31,7 +32,7 @@ from numojo.core.ndarray import NDArray
 from numojo.core.indexing import Validator, InternalSlice
 from numojo.core.memory.data_container import DataContainer
 from numojo.core.traits.buffered import Buffered
-from numojo.routines.manipulation import broadcast_to, reorder_layout
+from numojo.routines.manipulation import broadcast_to, reorder_layout, transpose
 from numojo.routines.linalg.misc import issymmetric
 import numojo.routines.statistics as stat
 import numojo.routines.linalg as linalg
@@ -41,6 +42,9 @@ import numojo.routines.math.extrema as extrema
 import numojo.routines.math.rounding as rounding
 import numojo.routines.searching as searching
 import numojo.routines.sorting as sorting
+from numojo.core.indexing import IndexMethods
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.error import NumojoError
 
 
 # TODO: Currently the copyinit creates a ref counted view instead of a deep copy.
@@ -1826,7 +1830,7 @@ struct Matrix[
         Returns:
             A string showing the matrix contents, shape, strides, order, and ownership.
         """
-        return String.write(self)
+        return String(self)
 
     def write_to[W: Writer](self, mut writer: W):
         """

--- a/numojo/core/matrix/base.mojo
+++ b/numojo/core/matrix/base.mojo
@@ -3602,6 +3602,9 @@ struct Matrix[
         var src = self.contiguous()
         var res = Matrix[Self.dtype](shape=(1, src.size), order=src.order())
         unsafe_memcpy(dest=res._buf.ptr, src=src._buf.ptr, count=res.size)
+        # `DataContainer.origin` is untracked, so the raw pointer above does
+        # not keep `src` alive; hold it until the copy has finished.
+        _ = src^
         return res^
 
     def inv(self) raises -> Matrix[Self.dtype]:
@@ -4262,6 +4265,9 @@ struct Matrix[
             shape=NDArrayShape(src.shape[0], src.shape[1]), order=src.order()
         )
         unsafe_memcpy(dest=ndarray._buf.ptr, src=src._buf.ptr, count=ndarray.size)
+        # `DataContainer.origin` is untracked, so the raw pointer above does
+        # not keep `src` alive; hold it until the copy has finished.
+        _ = src^
 
         return ndarray^
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -12,6 +12,7 @@ DataContainer manages memory ownership and reference counting for shared or exte
 """
 
 from std.memory import UnsafePointer, unsafe_memcpy
+from std.memory.alloc import unsafe_alloc
 from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 
@@ -75,7 +76,7 @@ struct Ownership(ImplicitlyCopyable):
         writer.write(self.__str__())
 
 
-struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
+struct DataContainer[dtype: DType](Copyable & Sized & Writable):
     """
     Reference-counted container for a contiguous buffer of elements.
 
@@ -118,7 +119,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ptr = Pointer[
             Scalar[Self.dtype], Self.origin
         ].unsafe_dangling()
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
         self.size = 0
@@ -135,7 +136,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             abort("DataContainer: __init__() size must be non-negative")
 
         self.size = size
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
 
@@ -144,7 +145,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
-            self.ptr = alloc[Scalar[Self.dtype]](size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](size)
 
     @always_inline
     def __init__(
@@ -169,9 +170,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             abort("DataContainer: __init__() size must be non-negative")
         self.size = size
         if copy:
-            self._refcount = alloc[Atomic[DType.uint64]](1)
+            self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
             self._refcount[] = Atomic[DType.uint64](1)
-            self.ptr = alloc[Scalar[Self.dtype]](size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](size)
             unsafe_memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
@@ -217,30 +218,30 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         self.size = copy.size
         self.ownership = Ownership.Managed
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         if copy.size == 0:
             self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
-            self.ptr = alloc[Scalar[Self.dtype]](copy.size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](copy.size)
             unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """
         Move constructor.
 
         Transfers ownership without changing the reference count.
 
         Args:
-            take: DataContainer to move from.
+            move: DataContainer to move from.
         """
-        self.ptr = take.ptr
-        self._refcount = take._refcount
-        self.ownership = take.ownership
-        self.size = take.size
+        self.ptr = move.ptr
+        self._refcount = move._refcount
+        self.ownership = move.ownership
+        self.size = move.size
 
     @always_inline
     def __deinit__(deinit self):

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -344,7 +344,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
 
     @always_inline
     def store[
-        width: Int
+        width: Int = 1
     ](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """
         Store a SIMD vector of the specified width at the given offset.

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -291,7 +291,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Returns:
             Pointer to the element at the given offset.
         """
-        return self.ptr + offset
+        return self.ptr.unsafe_offset(offset)
 
     @always_inline
     def __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -243,7 +243,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = take.size
 
     @always_inline
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """
         Destructor.
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -116,9 +116,7 @@ struct DataContainer[dtype: DType](Copyable & Sized & Writable):
         """
         Create an empty, managed DataContainer.
         """
-        self.ptr = Pointer[
-            Scalar[Self.dtype], Self.origin
-        ].unsafe_dangling()
+        self.ptr = Pointer[Scalar[Self.dtype], Self.origin].unsafe_dangling()
         self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
@@ -280,9 +278,7 @@ struct DataContainer[dtype: DType](Copyable & Sized & Writable):
         return self.ptr
 
     @always_inline
-    def offset(
-        self, offset: Int
-    ) -> Pointer[Scalar[Self.dtype], Self.origin]:
+    def offset(self, offset: Int) -> Pointer[Scalar[Self.dtype], Self.origin]:
         """
         Return a pointer offset by the specified number of elements.
 

--- a/numojo/core/memory/data_container.mojo
+++ b/numojo/core/memory/data_container.mojo
@@ -11,7 +11,7 @@ A reference-counted container for contiguous data buffers, used for NDArray and 
 DataContainer manages memory ownership and reference counting for shared or external data.
 """
 
-from std.memory import UnsafePointer, memcpy
+from std.memory import UnsafePointer, unsafe_memcpy
 from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 
@@ -95,10 +95,10 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     comptime origin = MutUntrackedOrigin
     """Memory origin for the allocation."""
 
-    var ptr: UnsafePointer[Scalar[Self.dtype], Self.origin]
+    var ptr: Pointer[Scalar[Self.dtype], Self.origin]
     """Pointer to the data array."""
 
-    var _refcount: UnsafePointer[Atomic[DType.uint64], Self.origin]
+    var _refcount: Pointer[Atomic[DType.uint64], Self.origin]
     """Pointer to the atomic reference count."""
 
     var ownership: Ownership
@@ -115,7 +115,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         Create an empty, managed DataContainer.
         """
-        self.ptr = UnsafePointer[
+        self.ptr = Pointer[
             Scalar[Self.dtype], Self.origin
         ].unsafe_dangling()
         self._refcount = alloc[Atomic[DType.uint64]](1)
@@ -140,7 +140,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
@@ -149,7 +149,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
+        ptr: Pointer[Scalar[Self.dtype], Self.origin],
         size: Int,
         copy: Bool = False,
     ):
@@ -172,10 +172,10 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
             self._refcount = alloc[Atomic[DType.uint64]](1)
             self._refcount[] = Atomic[DType.uint64](1)
             self.ptr = alloc[Scalar[Self.dtype]](size)
-            memcpy(dest=self.ptr, src=ptr, count=size)
+            unsafe_memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[
+            self._refcount = Pointer[
                 Atomic[DType.uint64], Self.origin
             ].unsafe_dangling()
             self.ptr = ptr
@@ -185,9 +185,9 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     def __init__(
         out self,
         *,
-        ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
+        ptr: Pointer[Scalar[Self.dtype], Self.origin],
         size: Int,
-        refcount: UnsafePointer[Atomic[DType.uint64], Self.origin],
+        refcount: Pointer[Atomic[DType.uint64], Self.origin],
         ownership: Ownership,
     ):
         """Create a DataContainer that shares an existing buffer and refcount.
@@ -220,12 +220,12 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         self._refcount = alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         if copy.size == 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](copy.size)
-            memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
+            unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
     def __init__(out self, *, deinit take: Self):
@@ -260,8 +260,8 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
 
         fence[ordering=Ordering.ACQUIRE]()
         if self.size > 0:
-            self.ptr.free()
-        self._refcount.free()
+            self.ptr.unsafe_free()
+        self._refcount.unsafe_free()
 
     # ===----------------------------------------------------------------------===#
     # Data Access Methods
@@ -269,7 +269,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def get_ptr(
         ref self,
-    ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
+    ) -> ref[self.ptr] Pointer[Scalar[Self.dtype], Self.origin]:
         """
         Return a reference to the data pointer.
 
@@ -281,7 +281,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def offset(
         self, offset: Int
-    ) -> UnsafePointer[Scalar[Self.dtype], Self.origin]:
+    ) -> Pointer[Scalar[Self.dtype], Self.origin]:
         """
         Return a pointer offset by the specified number of elements.
 
@@ -307,7 +307,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Notes:
             No bounds checking is performed. Caller must ensure index is valid.
         """
-        return self.ptr[idx]
+        return self.ptr[unsafe_offset=idx]
 
     @always_inline
     def __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
@@ -321,7 +321,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Notes:
             No bounds checking is performed. Caller must ensure index is valid.
         """
-        self.ptr[idx] = val
+        self.ptr[unsafe_offset=idx] = val
 
     @always_inline
     def load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
@@ -340,7 +340,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Notes:
             No bounds checking is performed. Caller must ensure there are enough elements from `offset`.
         """
-        return self.ptr.load[width=width](offset)
+        return self.ptr.unsafe_load[width=width](offset)
 
     @always_inline
     def store[
@@ -359,7 +359,7 @@ struct DataContainer[dtype: DType](Copyable & Movable & Sized & Writable):
         Notes:
             No bounds checking is performed. Caller must ensure there are enough elements from `offset`.
         """
-        self.ptr.store[width=width](offset, value)
+        self.ptr.unsafe_store[width=width](offset, value)
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -41,6 +41,7 @@ Example:
 """
 
 from std.memory import UnsafePointer
+from std.memory.alloc import unsafe_alloc
 from std.sys.info import size_of
 from std.python import PythonObject, Python
 
@@ -469,11 +470,11 @@ def to_dlpack[
     """
     var buf = arr._buf.copy()
 
-    var shape_ptr = alloc[Int64](arr.ndim)
+    var shape_ptr = unsafe_alloc[Int64](arr.ndim)
     for i in range(arr.ndim):
         shape_ptr[unsafe_offset=i] = Int64(arr.shape[i])
 
-    var strides_ptr = alloc[Int64](arr.ndim)
+    var strides_ptr = unsafe_alloc[Int64](arr.ndim)
     for i in range(arr.ndim):
         strides_ptr[unsafe_offset=i] = Int64(arr.strides[i])
 
@@ -498,10 +499,10 @@ def to_dlpack[
         buf^,
     )
 
-    var ctx = alloc[DLPackMetadata[dtype]](1)
+    var ctx = unsafe_alloc[DLPackMetadata[dtype]](1)
     ctx.unsafe_write(metadata^)
 
-    var managed = alloc[DLManagedTensor](1)
+    var managed = unsafe_alloc[DLManagedTensor](1)
     managed.unsafe_write(
         DLManagedTensor(
             dl_tensor,

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -277,7 +277,7 @@ struct DLTensor(ImplicitlyCopyable, Movable):
         byte_offset: Byte offset from data pointer to first element.
     """
 
-    var data: UnsafePointer[NoneType, MutUntrackedOrigin]
+    var data: Pointer[NoneType, MutUntrackedOrigin]
     """Opaque pointer to the tensor data."""
     var device: DLDevice
     """Device where the data resides."""
@@ -285,21 +285,21 @@ struct DLTensor(ImplicitlyCopyable, Movable):
     """Number of dimensions."""
     var dtype: DLDataType
     """Element data type."""
-    var shape: UnsafePointer[Int64, MutUntrackedOrigin]
+    var shape: Pointer[Int64, MutUntrackedOrigin]
     """Shape array."""
-    var strides: UnsafePointer[Int64, MutUntrackedOrigin]
+    var strides: Pointer[Int64, MutUntrackedOrigin]
     """Strides in elements."""
     var byte_offset: UInt64
     """Byte offset from data pointer to first element."""
 
     def __init__(
         out self,
-        data: UnsafePointer[NoneType, MutUntrackedOrigin],
+        data: Pointer[NoneType, MutUntrackedOrigin],
         device: DLDevice,
         ndim: Int32,
         dtype: DLDataType,
-        shape: UnsafePointer[Int64, MutUntrackedOrigin],
-        strides: UnsafePointer[Int64, MutUntrackedOrigin],
+        shape: Pointer[Int64, MutUntrackedOrigin],
+        strides: Pointer[Int64, MutUntrackedOrigin],
         byte_offset: UInt64 = 0,
     ):
         self.data = data
@@ -312,7 +312,7 @@ struct DLTensor(ImplicitlyCopyable, Movable):
 
 
 comptime DLManagedTensorDeleter = def(
-    UnsafePointer[DLManagedTensor, MutUntrackedOrigin]
+    Pointer[DLManagedTensor, MutUntrackedOrigin]
 ) capturing -> None
 
 
@@ -340,7 +340,7 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
 
     var dl_tensor: DLTensor
     """The underlying tensor."""
-    var manager_ctx: UnsafePointer[NoneType, MutUntrackedOrigin]
+    var manager_ctx: Pointer[NoneType, MutUntrackedOrigin]
     """Context pointer for the deleter (stores metadata, refcount, etc.)."""
     var deleter: DLManagedTensorDeleter
     """Cleanup function called when consumer is done."""
@@ -348,7 +348,7 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
     def __init__(
         out self,
         dl_tensor: DLTensor,
-        manager_ctx: UnsafePointer[NoneType, MutUntrackedOrigin],
+        manager_ctx: Pointer[NoneType, MutUntrackedOrigin],
         deleter: DLManagedTensorDeleter,
     ):
         self.dl_tensor = dl_tensor.copy()
@@ -379,15 +379,15 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         data_container: Container managing the actual tensor data.
     """
 
-    var shape: UnsafePointer[Int64, MutUntrackedOrigin]
-    var strides: UnsafePointer[Int64, MutUntrackedOrigin]
+    var shape: Pointer[Int64, MutUntrackedOrigin]
+    var strides: Pointer[Int64, MutUntrackedOrigin]
     var ndim: Int
     var data_container: DataContainer[Self.dtype]
 
     def __init__(
         out self,
-        shape: UnsafePointer[Int64, MutUntrackedOrigin],
-        strides: UnsafePointer[Int64, MutUntrackedOrigin],
+        shape: Pointer[Int64, MutUntrackedOrigin],
+        strides: Pointer[Int64, MutUntrackedOrigin],
         ndim: Int,
         var data_container: DataContainer[Self.dtype],
     ):
@@ -404,9 +404,9 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 
     def __del__(deinit self):
         if Int(self.shape) != 0:
-            self.shape.free()
+            self.shape.unsafe_free()
         if Int(self.strides) != 0:
-            self.strides.free()
+            self.strides.unsafe_free()
         # TODO: note sure if we should free it explicitly, gotta check this with tests.
         _ = self.data_container^
 
@@ -419,7 +419,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 def _dlpack_deleter_impl[
     dtype: DType
 ](
-    managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutUntrackedOrigin]
+    managed_tensor_ptr: Pointer[DLManagedTensor, MutUntrackedOrigin]
 ) capturing -> None:
     """Type-specific deleter callback for DLManagedTensor."""
     if Int(managed_tensor_ptr) == 0:
@@ -427,11 +427,11 @@ def _dlpack_deleter_impl[
 
     var ctx = managed_tensor_ptr[].manager_ctx
     if Int(ctx) != 0:
-        var metadata_ptr = ctx.bitcast[DLPackMetadata[dtype]]()
-        metadata_ptr.destroy_pointee()
-        metadata_ptr.free()
+        var metadata_ptr = ctx.unsafe_bitcast[DLPackMetadata[dtype]]()
+        metadata_ptr.unsafe_deinit_pointee()
+        metadata_ptr.unsafe_free()
 
-    managed_tensor_ptr.free()
+    managed_tensor_ptr.unsafe_free()
 
 
 # ===-------------------------------------------------------------------===#
@@ -441,7 +441,7 @@ def _dlpack_deleter_impl[
 
 def to_dlpack[
     dtype: DType
-](arr: NDArray[dtype]) raises -> UnsafePointer[DLManagedTensor, MutUntrackedOrigin]:
+](arr: NDArray[dtype]) raises -> Pointer[DLManagedTensor, MutUntrackedOrigin]:
     """Exports a NuMojo NDArray to a DLPack managed tensor for zero-copy sharing.
 
     This function converts a NuMojo NDArray into a DLPack-compatible managed
@@ -471,15 +471,15 @@ def to_dlpack[
 
     var shape_ptr = alloc[Int64](arr.ndim)
     for i in range(arr.ndim):
-        shape_ptr[i] = Int64(arr.shape[i])
+        shape_ptr[unsafe_offset=i] = Int64(arr.shape[i])
 
     var strides_ptr = alloc[Int64](arr.ndim)
     for i in range(arr.ndim):
-        strides_ptr[i] = Int64(arr.strides[i])
+        strides_ptr[unsafe_offset=i] = Int64(arr.strides[i])
 
     var dl_dtype = DLDataType.from_dtype[dtype]()
     var device = DLDevice(DLDevice.CPU, 0)
-    var data_ptr = buf.get_ptr().bitcast[NoneType]()
+    var data_ptr = buf.get_ptr().unsafe_bitcast[NoneType]()
 
     var dl_tensor = DLTensor(
         data=data_ptr,
@@ -499,13 +499,13 @@ def to_dlpack[
     )
 
     var ctx = alloc[DLPackMetadata[dtype]](1)
-    ctx.init_pointee_move(metadata^)
+    ctx.unsafe_write(metadata^)
 
     var managed = alloc[DLManagedTensor](1)
-    managed.init_pointee_move(
+    managed.unsafe_write(
         DLManagedTensor(
             dl_tensor,
-            ctx.bitcast[NoneType](),
+            ctx.unsafe_bitcast[NoneType](),
             _dlpack_deleter_impl[dtype],
         )
     )
@@ -515,7 +515,7 @@ def to_dlpack[
 
 def _extract_dlpack_pointer(
     capsule: PythonObject,
-) raises -> UnsafePointer[DLManagedTensor, MutUntrackedOrigin]:
+) raises -> Pointer[DLManagedTensor, MutUntrackedOrigin]:
     """Extracts the DLManagedTensor pointer from a PyCapsule.
 
     This function uses the Python C API to extract the raw pointer from a
@@ -553,7 +553,7 @@ def _extract_dlpack_pointer(
             " - capsule may be invalid or already consumed"
         )
 
-    return p.bitcast[DLManagedTensor]().unsafe_origin_cast[
+    return p.unsafe_bitcast[DLManagedTensor]().unsafe_origin_cast[
         MutUntrackedOrigin
     ]()
 
@@ -562,7 +562,7 @@ def _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:
     ctypes = Python.import_module("ctypes")
 
     return ctypes.cast(
-        Int(s.as_c_string_slice().unsafe_ptr().bitcast[NoneType]()),
+        Int(s.as_c_string_slice().unsafe_ptr().unsafe_bitcast[NoneType]()),
         ctypes.c_char_p,
     )
 
@@ -635,17 +635,17 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
     var ndim = Int(dl_tensor.ndim)
     var shape = NDArrayShape(ndim=ndim, initialized=True)
     for i in range(ndim):
-        shape[i] = Int(dl_tensor.shape[i])
+        shape[i] = Int(dl_tensor.shape[unsafe_offset=i])
 
     var strides: NDArrayStrides
     if Int(dl_tensor.strides) != 0:
         strides = NDArrayStrides(ndim=ndim, initialized=True)
         for i in range(ndim):
-            strides[i] = Int(dl_tensor.strides[i])
+            strides[i] = Int(dl_tensor.strides[unsafe_offset=i])
     else:
         strides = NDArrayStrides(shape, order="C")
 
-    var data_ptr = dl_tensor.data.bitcast[Scalar[dtype]]()
+    var data_ptr = dl_tensor.data.unsafe_bitcast[Scalar[dtype]]()
     if dl_tensor.byte_offset > 0:
         data_ptr = data_ptr + Int(dl_tensor.byte_offset) // size_of[dtype]()
 

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -648,7 +648,9 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
 
     var data_ptr = dl_tensor.data.unsafe_bitcast[Scalar[dtype]]()
     if dl_tensor.byte_offset > 0:
-        data_ptr = data_ptr.unsafe_offset(Int(dl_tensor.byte_offset) // size_of[dtype]())
+        data_ptr = data_ptr.unsafe_offset(
+            Int(dl_tensor.byte_offset) // size_of[dtype]()
+        )
 
     var size = shape.size()
     var buf = DataContainer[dtype](

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -647,7 +647,7 @@ def from_dlpack[dtype: DType](capsule: PythonObject) raises -> NDArray[dtype]:
 
     var data_ptr = dl_tensor.data.unsafe_bitcast[Scalar[dtype]]()
     if dl_tensor.byte_offset > 0:
-        data_ptr = data_ptr + Int(dl_tensor.byte_offset) // size_of[dtype]()
+        data_ptr = data_ptr.unsafe_offset(Int(dl_tensor.byte_offset) // size_of[dtype]())
 
     var size = shape.size()
     var buf = DataContainer[dtype](

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -402,7 +402,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         self.ndim = copy.ndim
         self.data_container = copy.data_container.copy()
 
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         if Int(self.shape) != 0:
             self.shape.unsafe_free()
         if Int(self.strides) != 0:
@@ -534,14 +534,14 @@ def _extract_dlpack_pointer(
         Error: If PyCapsule_GetPointer returns NULL (capsule may be invalid or
         already consumed).
     """
-    ctypes = Python.import_module("ctypes")
+    var ctypes = Python.import_module("ctypes")
 
     ctypes.pythonapi.PyCapsule_GetPointer.argtypes = [
         ctypes.py_object,
         ctypes.c_char_p,
     ]
     ctypes.pythonapi.PyCapsule_GetPointer.restype = ctypes.c_void_p
-    result_obj = ctypes.pythonapi.PyCapsule_GetPointer(
+    var result_obj = ctypes.pythonapi.PyCapsule_GetPointer(
         capsule, _get_c_char_p_from_string["dltensor"]()
     )
 
@@ -559,7 +559,7 @@ def _extract_dlpack_pointer(
 
 
 def _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:
-    ctypes = Python.import_module("ctypes")
+    var ctypes = Python.import_module("ctypes")
 
     return ctypes.cast(
         Int(s.as_c_string_slice().unsafe_ptr().unsafe_bitcast[NoneType]()),

--- a/numojo/core/memory/dlpack.mojo
+++ b/numojo/core/memory/dlpack.mojo
@@ -277,7 +277,7 @@ struct DLTensor(ImplicitlyCopyable, Movable):
         byte_offset: Byte offset from data pointer to first element.
     """
 
-    var data: UnsafePointer[NoneType, MutAnyOrigin]
+    var data: UnsafePointer[NoneType, MutUntrackedOrigin]
     """Opaque pointer to the tensor data."""
     var device: DLDevice
     """Device where the data resides."""
@@ -285,21 +285,21 @@ struct DLTensor(ImplicitlyCopyable, Movable):
     """Number of dimensions."""
     var dtype: DLDataType
     """Element data type."""
-    var shape: UnsafePointer[Int64, MutAnyOrigin]
+    var shape: UnsafePointer[Int64, MutUntrackedOrigin]
     """Shape array."""
-    var strides: UnsafePointer[Int64, MutAnyOrigin]
+    var strides: UnsafePointer[Int64, MutUntrackedOrigin]
     """Strides in elements."""
     var byte_offset: UInt64
     """Byte offset from data pointer to first element."""
 
     def __init__(
         out self,
-        data: UnsafePointer[NoneType, MutAnyOrigin],
+        data: UnsafePointer[NoneType, MutUntrackedOrigin],
         device: DLDevice,
         ndim: Int32,
         dtype: DLDataType,
-        shape: UnsafePointer[Int64, MutAnyOrigin],
-        strides: UnsafePointer[Int64, MutAnyOrigin],
+        shape: UnsafePointer[Int64, MutUntrackedOrigin],
+        strides: UnsafePointer[Int64, MutUntrackedOrigin],
         byte_offset: UInt64 = 0,
     ):
         self.data = data
@@ -312,7 +312,7 @@ struct DLTensor(ImplicitlyCopyable, Movable):
 
 
 comptime DLManagedTensorDeleter = def(
-    UnsafePointer[DLManagedTensor, MutAnyOrigin]
+    UnsafePointer[DLManagedTensor, MutUntrackedOrigin]
 ) capturing -> None
 
 
@@ -340,7 +340,7 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
 
     var dl_tensor: DLTensor
     """The underlying tensor."""
-    var manager_ctx: UnsafePointer[NoneType, MutAnyOrigin]
+    var manager_ctx: UnsafePointer[NoneType, MutUntrackedOrigin]
     """Context pointer for the deleter (stores metadata, refcount, etc.)."""
     var deleter: DLManagedTensorDeleter
     """Cleanup function called when consumer is done."""
@@ -348,7 +348,7 @@ struct DLManagedTensor(ImplicitlyCopyable, Movable):
     def __init__(
         out self,
         dl_tensor: DLTensor,
-        manager_ctx: UnsafePointer[NoneType, MutAnyOrigin],
+        manager_ctx: UnsafePointer[NoneType, MutUntrackedOrigin],
         deleter: DLManagedTensorDeleter,
     ):
         self.dl_tensor = dl_tensor.copy()
@@ -379,15 +379,15 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
         data_container: Container managing the actual tensor data.
     """
 
-    var shape: UnsafePointer[Int64, MutAnyOrigin]
-    var strides: UnsafePointer[Int64, MutAnyOrigin]
+    var shape: UnsafePointer[Int64, MutUntrackedOrigin]
+    var strides: UnsafePointer[Int64, MutUntrackedOrigin]
     var ndim: Int
     var data_container: DataContainer[Self.dtype]
 
     def __init__(
         out self,
-        shape: UnsafePointer[Int64, MutAnyOrigin],
-        strides: UnsafePointer[Int64, MutAnyOrigin],
+        shape: UnsafePointer[Int64, MutUntrackedOrigin],
+        strides: UnsafePointer[Int64, MutUntrackedOrigin],
         ndim: Int,
         var data_container: DataContainer[Self.dtype],
     ):
@@ -419,7 +419,7 @@ struct DLPackMetadata[dtype: DType](ImplicitlyCopyable, Movable):
 def _dlpack_deleter_impl[
     dtype: DType
 ](
-    managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutAnyOrigin]
+    managed_tensor_ptr: UnsafePointer[DLManagedTensor, MutUntrackedOrigin]
 ) capturing -> None:
     """Type-specific deleter callback for DLManagedTensor."""
     if Int(managed_tensor_ptr) == 0:
@@ -441,7 +441,7 @@ def _dlpack_deleter_impl[
 
 def to_dlpack[
     dtype: DType
-](arr: NDArray[dtype]) raises -> UnsafePointer[DLManagedTensor, MutAnyOrigin]:
+](arr: NDArray[dtype]) raises -> UnsafePointer[DLManagedTensor, MutUntrackedOrigin]:
     """Exports a NuMojo NDArray to a DLPack managed tensor for zero-copy sharing.
 
     This function converts a NuMojo NDArray into a DLPack-compatible managed
@@ -515,7 +515,7 @@ def to_dlpack[
 
 def _extract_dlpack_pointer(
     capsule: PythonObject,
-) raises -> UnsafePointer[DLManagedTensor, MutAnyOrigin]:
+) raises -> UnsafePointer[DLManagedTensor, MutUntrackedOrigin]:
     """Extracts the DLManagedTensor pointer from a PyCapsule.
 
     This function uses the Python C API to extract the raw pointer from a
@@ -553,7 +553,9 @@ def _extract_dlpack_pointer(
             " - capsule may be invalid or already consumed"
         )
 
-    return p.bitcast[DLManagedTensor]()
+    return p.bitcast[DLManagedTensor]().unsafe_origin_cast[
+        MutUntrackedOrigin
+    ]()
 
 
 def _get_c_char_p_from_string[s: StringLiteral]() raises -> PythonObject:

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -206,7 +206,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.size = take.size
 
     @always_inline
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """Destructor.
 
         For managed containers the reference count is atomically

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -75,9 +75,7 @@ struct HostStorage[dtype: DType](Copyable & Sized & Writable):
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
-        self.ptr = Pointer[
-            Scalar[Self.dtype], Self.origin
-        ].unsafe_dangling()
+        self.ptr = Pointer[Scalar[Self.dtype], Self.origin].unsafe_dangling()
         self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
@@ -256,9 +254,7 @@ struct HostStorage[dtype: DType](Copyable & Sized & Writable):
         return self.ptr
 
     @always_inline
-    def offset(
-        self, offset: Int
-    ) -> Pointer[Scalar[Self.dtype], Self.origin]:
+    def offset(self, offset: Int) -> Pointer[Scalar[Self.dtype], Self.origin]:
         """Return a pointer advanced by `offset` elements.
 
         Args:
@@ -596,7 +592,11 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         Returns:
             An `UnsafePointer` to the first element on the device.
         """
-        return self.buffer.unsafe_ptr().unsafe_mut_cast[True]().as_unsafe_any_origin()
+        return (
+            self.buffer.unsafe_ptr()
+            .unsafe_mut_cast[True]()
+            .as_unsafe_any_origin()
+        )
 
     def share(self) raises -> DeviceStorage[Self.dtype, Self.device]:
         """Create a shallow handle sharing this device buffer."""
@@ -850,7 +850,9 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        return self.host_storage.unsafe_value().ptr.unsafe_load[width=width](offset)
+        return self.host_storage.unsafe_value().ptr.unsafe_load[width=width](
+            offset
+        )
 
     @always_inline
     def store[
@@ -872,7 +874,9 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        self.host_storage.unsafe_value().ptr.unsafe_store[width=width](offset, value)
+        self.host_storage.unsafe_value().ptr.unsafe_store[width=width](
+            offset, value
+        )
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -989,7 +993,9 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Returns:
             An `UnsafePointer` to the first element on the host.
         """
-        return self.host_storage.unsafe_value().unsafe_ptr().as_unsafe_any_origin()
+        return (
+            self.host_storage.unsafe_value().unsafe_ptr().as_unsafe_any_origin()
+        )
 
     def device_ptr(
         self,

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -22,6 +22,7 @@ from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
 from std.memory import unsafe_memcpy
+from std.memory.alloc import unsafe_alloc
 from max.gpu.host import DeviceBuffer, DeviceContext
 
 from numojo.core.accelerator import Device, DeviceHandle
@@ -35,7 +36,7 @@ from numojo.core.error import NumojoError
 # ===----------------------------------------------------------------------=== #
 
 
-struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
+struct HostStorage[dtype: DType](Copyable & Sized & Writable):
     """Reference-counted host (CPU) memory container.
 
     Manages a contiguous buffer of `Scalar[dtype]` elements with two ownership
@@ -77,7 +78,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ptr = Pointer[
             Scalar[Self.dtype], Self.origin
         ].unsafe_dangling()
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
         self.size = 0
@@ -96,7 +97,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             abort("HostStorage: __init__() size must be non-negative")
 
         self.size = size
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         self.ownership = Ownership.Managed
 
@@ -105,7 +106,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
-            self.ptr = alloc[Scalar[Self.dtype]](size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](size)
 
     @always_inline
     def __init__(
@@ -131,9 +132,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
 
         self.size = size
         if copy:
-            self._refcount = alloc[Atomic[DType.uint64]](1)
+            self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
             self._refcount[] = Atomic[DType.uint64](1)
-            self.ptr = alloc[Scalar[Self.dtype]](size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](size)
             unsafe_memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
@@ -181,29 +182,29 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         """
         self.size = copy.size
         self.ownership = Ownership.Managed
-        self._refcount = alloc[Atomic[DType.uint64]](1)
+        self._refcount = unsafe_alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         if copy.size == 0:
             self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
-            self.ptr = alloc[Scalar[Self.dtype]](copy.size)
+            self.ptr = unsafe_alloc[Scalar[Self.dtype]](copy.size)
             unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor.
 
         Transfers all fields without touching the reference count.
 
         Args:
-            take: The source container (consumed).
+            move: The source container (consumed).
         """
-        self.ptr = take.ptr
-        self._refcount = take._refcount
-        self.ownership = take.ownership
-        self.size = take.size
+        self.ptr = move.ptr
+        self._refcount = move._refcount
+        self.ownership = move.ownership
+        self.size = move.size
 
     @always_inline
     def __deinit__(deinit self):
@@ -524,17 +525,17 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
             abort("DeviceStorage: deep copy failed: " + String(e))
         self.size = copy.size
 
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor.
 
         Transfers the buffer handle without copying.
 
         Args:
-            take: The source storage (consumed).
+            move: The source storage (consumed).
         """
-        self.handle = take.handle^
-        self.buffer = take.buffer^
-        self.size = take.size
+        self.handle = move.handle^
+        self.buffer = move.buffer^
+        self.size = move.size
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -609,7 +610,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
 
 
 struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
-    Copyable & Movable & Sized & Writable
+    Copyable & Sized & Writable
 ):
     """Unified, reference-counted storage for Host (CPU) or Device (GPU) data.
 
@@ -756,17 +757,17 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         self.size = copy.size
 
     @always_inline
-    def __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit move: Self):
         """Move constructor.
 
         Transfers all fields without touching reference counts.
 
         Args:
-            take: The source container (consumed).
+            move: The source container (consumed).
         """
-        self.host_storage = take.host_storage^
-        self.device_storage = take.device_storage^
-        self.size = take.size
+        self.host_storage = move.host_storage^
+        self.device_storage = move.device_storage^
+        self.size = move.size
 
     # ===----------------------------------------------------------------------===#
     # Data Access (CPU)

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -22,7 +22,7 @@ from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
 from std.memory import memcpy
-from std.gpu.host import DeviceBuffer, DeviceContext
+from max.gpu.host import DeviceBuffer, DeviceContext
 
 from numojo.core.accelerator import Device, DeviceHandle
 from numojo.core.accelerator.device import is_accelerator_available
@@ -313,7 +313,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
 
     @always_inline
     def store[
-        width: Int
+        width: Int = 1
     ](mut self, offset: Int, value: SIMD[Self.dtype, width]):
         """Store a SIMD vector of `width` elements starting at `offset`.
 
@@ -595,7 +595,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         Returns:
             An `UnsafePointer` to the first element on the device.
         """
-        return self.buffer.unsafe_ptr()
+        return self.buffer.unsafe_ptr().unsafe_mut_cast[True]().as_unsafe_any_origin()
 
     def share(self) raises -> DeviceStorage[Self.dtype, Self.device]:
         """Create a shallow handle sharing this device buffer."""
@@ -853,7 +853,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
 
     @always_inline
     def store[
-        width: Int
+        width: Int = 1
     ](mut self, offset: Int, value: SIMD[Self.dtype, width]) where (
         Self.device.type == "cpu"
     ):
@@ -988,7 +988,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Returns:
             An `UnsafePointer` to the first element on the host.
         """
-        return self.host_storage.unsafe_value().unsafe_ptr()
+        return self.host_storage.unsafe_value().unsafe_ptr().as_unsafe_any_origin()
 
     def device_ptr(
         self,

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -21,7 +21,7 @@ from std.atomic import Atomic, Ordering, fence
 from std.os import abort
 from std.collections.optional import Optional
 from std.sys.info import has_accelerator
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 from max.gpu.host import DeviceBuffer, DeviceContext
 
 from numojo.core.accelerator import Device, DeviceHandle
@@ -54,10 +54,10 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     comptime origin = MutUntrackedOrigin
     """Memory origin for the allocation."""
 
-    var ptr: UnsafePointer[Scalar[Self.dtype], Self.origin]
+    var ptr: Pointer[Scalar[Self.dtype], Self.origin]
     """Pointer to the data array."""
 
-    var _refcount: UnsafePointer[Atomic[DType.uint64], Self.origin]
+    var _refcount: Pointer[Atomic[DType.uint64], Self.origin]
     """Pointer to the atomic reference count (null for external containers)."""
 
     var ownership: Ownership
@@ -74,7 +74,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __init__(out self):
         """Create an empty managed container with size 0 and refcount 1."""
-        self.ptr = UnsafePointer[
+        self.ptr = Pointer[
             Scalar[Self.dtype], Self.origin
         ].unsafe_dangling()
         self._refcount = alloc[Atomic[DType.uint64]](1)
@@ -101,7 +101,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self.ownership = Ownership.Managed
 
         if size == 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
@@ -110,7 +110,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
+        ptr: Pointer[Scalar[Self.dtype], Self.origin],
         size: Int,
         copy: Bool = False,
     ):
@@ -134,10 +134,10 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             self._refcount = alloc[Atomic[DType.uint64]](1)
             self._refcount[] = Atomic[DType.uint64](1)
             self.ptr = alloc[Scalar[Self.dtype]](size)
-            memcpy(dest=self.ptr, src=ptr, count=size)
+            unsafe_memcpy(dest=self.ptr, src=ptr, count=size)
             self.ownership = Ownership.Managed
         else:
-            self._refcount = UnsafePointer[
+            self._refcount = Pointer[
                 Atomic[DType.uint64], Self.origin
             ].unsafe_dangling()
             self.ptr = ptr
@@ -147,9 +147,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     def __init__(
         out self,
         *,
-        ptr: UnsafePointer[Scalar[Self.dtype], Self.origin],
+        ptr: Pointer[Scalar[Self.dtype], Self.origin],
         size: Int,
-        refcount: UnsafePointer[Atomic[DType.uint64], Self.origin],
+        refcount: Pointer[Atomic[DType.uint64], Self.origin],
         ownership: Ownership,
     ):
         """Create a HostStorage that shares an existing buffer and refcount.
@@ -184,12 +184,12 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         self._refcount = alloc[Atomic[DType.uint64]](1)
         self._refcount[] = Atomic[DType.uint64](1)
         if copy.size == 0:
-            self.ptr = UnsafePointer[
+            self.ptr = Pointer[
                 Scalar[Self.dtype], Self.origin
             ].unsafe_dangling()
         else:
             self.ptr = alloc[Scalar[Self.dtype]](copy.size)
-            memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
+            unsafe_memcpy(dest=self.ptr, src=copy.ptr, count=copy.size)
 
     @always_inline
     def __init__(out self, *, deinit take: Self):
@@ -226,8 +226,8 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
 
         fence[ordering=Ordering.ACQUIRE]()
         if self.size > 0:
-            self.ptr.free()
-        self._refcount.free()
+            self.ptr.unsafe_free()
+        self._refcount.unsafe_free()
 
     # ===----------------------------------------------------------------------===#
     # Data Access
@@ -236,7 +236,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def unsafe_ptr(
         ref self,
-    ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
+    ) -> ref[self.ptr] Pointer[Scalar[Self.dtype], Self.origin]:
         """Return a reference to the raw data pointer.
 
         Returns:
@@ -247,7 +247,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def get_ptr(
         ref self,
-    ) -> ref[self.ptr] UnsafePointer[Scalar[Self.dtype], Self.origin]:
+    ) -> ref[self.ptr] Pointer[Scalar[Self.dtype], Self.origin]:
         """Return a reference to the raw data pointer.
 
         This mirrors `DataContainer.get_ptr()`.
@@ -257,7 +257,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
     @always_inline
     def offset(
         self, offset: Int
-    ) -> UnsafePointer[Scalar[Self.dtype], Self.origin]:
+    ) -> Pointer[Scalar[Self.dtype], Self.origin]:
         """Return a pointer advanced by `offset` elements.
 
         Args:
@@ -280,7 +280,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         Returns:
             The scalar value at `idx`.
         """
-        return self.ptr[idx]
+        return self.ptr[unsafe_offset=idx]
 
     @always_inline
     def __setitem__(mut self, idx: Int, val: Scalar[Self.dtype]) raises:
@@ -292,7 +292,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             idx: Element index.
             val: Value to store.
         """
-        self.ptr[idx] = val
+        self.ptr[unsafe_offset=idx] = val
 
     @always_inline
     def load[width: Int](self, offset: Int) -> SIMD[Self.dtype, width]:
@@ -309,7 +309,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
         Returns:
             A SIMD vector of the requested width.
         """
-        return self.ptr.load[width=width](offset)
+        return self.ptr.unsafe_load[width=width](offset)
 
     @always_inline
     def store[
@@ -326,7 +326,7 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             offset: Element index of the first lane.
             value: The SIMD vector to write.
         """
-        self.ptr.store[width=width](offset, value)
+        self.ptr.unsafe_store[width=width](offset, value)
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -589,7 +589,7 @@ struct DeviceStorage[dtype: DType, device: Device](Copyable, Movable):
         """
         return self.buffer
 
-    def unsafe_ptr(ref self) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
+    def unsafe_ptr(ref self) -> Pointer[Scalar[Self.dtype], MutAnyOrigin]:
         """Return the raw device pointer to the buffer's data.
 
         Returns:
@@ -689,7 +689,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     @always_inline
     def __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        ptr: Pointer[Scalar[Self.dtype], MutAnyOrigin],
         size: Int,
         copy: Bool = False,
     ) raises:
@@ -775,7 +775,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
     @always_inline
     def offset(
         self, offset: Int
-    ) -> UnsafePointer[Scalar[Self.dtype], MutUntrackedOrigin] where (
+    ) -> Pointer[Scalar[Self.dtype], MutUntrackedOrigin] where (
         Self.device.type == "cpu"
     ):
         """Return a pointer advanced by `offset` elements.
@@ -808,7 +808,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        return self.host_storage.unsafe_value().ptr[idx]
+        return self.host_storage.unsafe_value().ptr[unsafe_offset=idx]
 
     @always_inline
     def __setitem__(
@@ -825,7 +825,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        self.host_storage.unsafe_value().ptr[idx] = val
+        self.host_storage.unsafe_value().ptr[unsafe_offset=idx] = val
 
     @always_inline
     def load[
@@ -849,7 +849,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        return self.host_storage.unsafe_value().ptr.load[width=width](offset)
+        return self.host_storage.unsafe_value().ptr.unsafe_load[width=width](offset)
 
     @always_inline
     def store[
@@ -871,7 +871,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        self.host_storage.unsafe_value().ptr.store[width=width](offset, value)
+        self.host_storage.unsafe_value().ptr.unsafe_store[width=width](offset, value)
 
     # ===----------------------------------------------------------------------===#
     # Trait Implementations
@@ -977,7 +977,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
 
     def host_ptr(
         self,
-    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+    ) -> Pointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device == Device.CPU
     ):
         """Return the raw host pointer to the CPU allocation.
@@ -992,7 +992,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
 
     def device_ptr(
         self,
-    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin] where (
+    ) -> Pointer[Scalar[Self.dtype], MutAnyOrigin] where (
         Self.device == Device.CUDA
         or Self.device == Device.ROCM
         or Self.device == Device.MPS

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -264,9 +264,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             offset: Number of elements to advance.
 
         Returns:
-            (`self.ptr + offset`.
+            `self.ptr + offset`.
         """
-        return self.ptr).unsafe_offset(offset)
+        return self.ptr.unsafe_offset(offset)
 
     @always_inline
     def __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:

--- a/numojo/core/memory/storage.mojo
+++ b/numojo/core/memory/storage.mojo
@@ -264,9 +264,9 @@ struct HostStorage[dtype: DType](Copyable & Movable & Sized & Writable):
             offset: Number of elements to advance.
 
         Returns:
-            `self.ptr + offset`.
+            (`self.ptr + offset`.
         """
-        return self.ptr + offset
+        return self.ptr).unsafe_offset(offset)
 
     @always_inline
     def __getitem__(self, idx: Int) raises -> Scalar[Self.dtype]:
@@ -789,7 +789,7 @@ struct AcceleratorDataContainer[dtype: DType, device: Device = Device.CPU](
         Constraints:
             CPU containers only.
         """
-        return self.host_storage.unsafe_value().ptr + offset
+        return self.host_storage.unsafe_value().ptr.unsafe_offset(offset)
 
     @always_inline
     def __getitem__(

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -691,7 +691,9 @@ struct NDArray[dtype: DType = DType.float64](
             var block = self.size // self.shape[0]
             unsafe_memcpy(
                 dest=result._buf.ptr,
-                src=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(norm * block),
+                src=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    norm * block
+                ),
                 count=block,
             )
             return result^
@@ -729,7 +731,9 @@ struct NDArray[dtype: DType = DType.float64](
             var dst_off = dst.offset
             for d in range(out_ndim):
                 dst_off += coords[d] * Int(dst.strides.unsafe_load(d))
-            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[unsafe_offset=off]
+            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[
+                unsafe_offset=off
+            ]
 
     def __getitem__(self, var *slices: Slice) raises -> Self:
         """Retrieves a slice or sub-array from the current array using variadic
@@ -1421,7 +1425,9 @@ struct NDArray[dtype: DType = DType.float64](
             if self.is_c_contiguous():
                 unsafe_memcpy(
                     dest=result._buf.ptr.unsafe_offset(i * size_per_item),
-                    src=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(normalized_idx * size_per_item),
+                    src=(
+                        self._buf.ptr.unsafe_offset(self.offset)
+                    ).unsafe_offset(normalized_idx * size_per_item),
                     count=size_per_item,
                 )
             else:
@@ -1616,7 +1622,9 @@ struct NDArray[dtype: DType = DType.float64](
             for i in range(mask.size):
                 if mask.item(i):
                     unsafe_memcpy(
-                        dest=result._buf.ptr.unsafe_offset(offset * size_per_item),
+                        dest=result._buf.ptr.unsafe_offset(
+                            offset * size_per_item
+                        ),
                         src=self_c._buf.ptr.unsafe_offset(i * size_per_item),
                         count=size_per_item,
                     )
@@ -1834,7 +1842,9 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         if self.is_c_contiguous() or self.ndim == 1:
-            return ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(index))[]
+            return (
+                (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(index)
+            )[]
 
         var remainder = index
         var item = Item(ndim=self.ndim)
@@ -1845,8 +1855,9 @@ struct NDArray[dtype: DType = DType.float64](
             )
             remainder = remainder // self.shape[i]
 
-        return self._buf.ptr[unsafe_offset=
-            self.offset + IndexMethods.get_1d_index(item, self.strides)
+        return self._buf.ptr[
+            unsafe_offset=self.offset
+            + IndexMethods.get_1d_index(item, self.strides)
         ]
 
     def item(self, *index: Int) raises -> Scalar[Self.dtype]:
@@ -1923,7 +1934,9 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
         return (
-            (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
+            (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                IndexMethods.get_1d_index(index, self.strides)
+            )
         )[]
 
     def unsafe_load[
@@ -2240,7 +2253,9 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous() and val.is_c_contiguous():
             var block = self.size // self.shape[0]
             unsafe_memcpy(
-                dest=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(norm * block),
+                dest=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    norm * block
+                ),
                 src=val._buf.ptr.unsafe_offset(val.offset),
                 count=block,
             )
@@ -2275,7 +2290,9 @@ struct NDArray[dtype: DType = DType.float64](
                 var c = coords[d]
                 dst_off += c * stride_dst
                 src_off += c * stride_src
-            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[unsafe_offset=src_off]
+            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[
+                unsafe_offset=src_off
+            ]
 
     def __setitem__(mut self, var index: Item, val: Scalar[Self.dtype]) raises:
         """Sets the value at the index list.
@@ -3036,7 +3053,9 @@ struct NDArray[dtype: DType = DType.float64](
                 return
 
             if val_c.size == 1:
-                var scalar_val = val_c._buf.ptr.unsafe_load[width=1](val_c.offset)
+                var scalar_val = val_c._buf.ptr.unsafe_load[width=1](
+                    val_c.offset
+                )
                 for i in range(mask_c.size):
                     if mask_c._buf.ptr.unsafe_load[width=1](i):
                         self.itemset(i, scalar_val)
@@ -3864,7 +3883,8 @@ struct NDArray[dtype: DType = DType.float64](
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
                 self._buf.ptr[unsafe_offset=idx] = func[Self.dtype, 1](
-                    self._buf.ptr[unsafe_offset=idx], other_c._buf.ptr[unsafe_offset=i]
+                    self._buf.ptr[unsafe_offset=idx],
+                    other_c._buf.ptr[unsafe_offset=i],
                 )
 
     # ===--- In-place arithmetic operators ---===#
@@ -4001,7 +4021,9 @@ struct NDArray[dtype: DType = DType.float64](
         var src = self.contiguous()
         var result: Self = Self(shape=self.shape, order="C")
         for i in range(src.size):
-            result._buf.ptr[unsafe_offset=i] = src._buf.ptr[unsafe_offset=i].__pow__(rhs)
+            result._buf.ptr[unsafe_offset=i] = src._buf.ptr[
+                unsafe_offset=i
+            ].__pow__(rhs)
         return result^
 
     def __pow__(self, p: Self) raises -> Self:
@@ -4053,7 +4075,9 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[unsafe_offset=idx] = builtin_math.pow(self._buf.ptr[unsafe_offset=idx], p)
+                self._buf.ptr[unsafe_offset=idx] = builtin_math.pow(
+                    self._buf.ptr[unsafe_offset=idx], p
+                )
 
     def _elementwise_pow(self, p: Int) raises -> Self:
         var src = self.contiguous()
@@ -4063,7 +4087,9 @@ struct NDArray[dtype: DType = DType.float64](
         ](index: Int) {mut src, imm p} -> None:
             src._buf.ptr.unsafe_store(
                 index,
-                builtin_math.pow(src._buf.ptr.unsafe_load[width=simd_width](index), p),
+                builtin_math.pow(
+                    src._buf.ptr.unsafe_load[width=simd_width](index), p
+                ),
             )
 
         vectorize[self.width](self.size, array_scalar_vectorize)
@@ -4400,7 +4426,11 @@ struct NDArray[dtype: DType = DType.float64](
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            unsafe_memcpy(dest=self._buf.ptr.unsafe_offset(base), src=src_ptr, count=size_per_item)
+            unsafe_memcpy(
+                dest=self._buf.ptr.unsafe_offset(base),
+                src=src_ptr,
+                count=size_per_item,
+            )
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4467,7 +4497,11 @@ struct NDArray[dtype: DType = DType.float64](
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            unsafe_memcpy(dest=dst_ptr, src=self._buf.ptr.unsafe_offset(base), count=size_per_item)
+            unsafe_memcpy(
+                dest=dst_ptr,
+                src=self._buf.ptr.unsafe_offset(base),
+                count=size_per_item,
+            )
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4631,7 +4665,9 @@ struct NDArray[dtype: DType = DType.float64](
             indices._buf[current_axis] = index_at_axis
             if current_axis == shape.ndim - 1:
                 var val = (
-                    (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(indices, strides))
+                    (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                        IndexMethods.get_1d_index(indices, strides)
+                    )
                 )[]
                 if val < 0:
                     negative_sign = True
@@ -4680,7 +4716,9 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result and builtin_bool.all(
-                ((a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
+                (
+                    (a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)
+                ).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_all)
@@ -4706,7 +4744,9 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result or builtin_bool.any(
-                ((a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
+                (
+                    (a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)
+                ).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_any)
@@ -4898,7 +4938,9 @@ struct NDArray[dtype: DType = DType.float64](
                 count=self.size,
             )
         elif self.ndim == 0:
-            result._buf.ptr[unsafe_offset=0] = self._buf.ptr[unsafe_offset=self.offset]
+            result._buf.ptr[unsafe_offset=0] = self._buf.ptr[
+                unsafe_offset=self.offset
+            ]
         else:
             # Stride-aware copy for non-contiguous views.
             var last_dim = self.ndim - 1
@@ -4923,7 +4965,9 @@ struct NDArray[dtype: DType = DType.float64](
                     mut result, imm self, base_offset, dest_base, last_stride
                 }:
                     var simd_data = (
-                        (self._buf.ptr.unsafe_offset(base_offset)).unsafe_offset(i * last_stride)
+                        (
+                            self._buf.ptr.unsafe_offset(base_offset)
+                        ).unsafe_offset(i * last_stride)
                     ).unsafe_strided_load[width=simd_w](last_stride)
                     result._buf.ptr.unsafe_store(dest_base + i, simd_data)
 
@@ -4959,7 +5003,9 @@ struct NDArray[dtype: DType = DType.float64](
                 + i * Int(self.strides[0])
                 + id * Int(self.strides[1])
             )
-            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[unsafe_offset=src_idx]
+            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[
+                unsafe_offset=src_idx
+            ]
         return buffer^
 
     def cumprod(self) raises -> NDArray[Self.dtype]:
@@ -5302,7 +5348,9 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
             for i in range(self.size):
-                ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)).unsafe_write(val)
+                (
+                    (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)
+                ).unsafe_write(val)
         else:
             for i in range(self.size):
                 var remainder = i
@@ -5878,7 +5926,9 @@ struct NDArray[dtype: DType = DType.float64](
                 + id * Int(self.strides[0])
                 + i * Int(self.strides[1])
             )
-            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[unsafe_offset=src_idx]
+            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[
+                unsafe_offset=src_idx
+            ]
         return buffer^
 
     def sort(mut self, axis: Int = -1, stable: Bool = False) raises:
@@ -5998,7 +6048,13 @@ struct NDArray[dtype: DType = DType.float64](
         var result = List[Scalar[Self.dtype]](capacity=self.size)
         if self.is_c_contiguous():
             for i in range(self.size):
-                result.append(((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i))[])
+                result.append(
+                    (
+                        (
+                            self._buf.ptr.unsafe_offset(self.offset)
+                        ).unsafe_offset(i)
+                    )[]
+                )
         else:
             for i in range(self.size):
                 var remainder = i
@@ -6277,9 +6333,9 @@ struct _NDArrayIter[
                     # (item._buf.ptr + self.dimension).init_pointee_copy(
                     #     Scalar[DType.int](current_index)
                     # )
-                    item._buf.ptr[unsafe_offset=self.dimension] = Scalar[DType.int](
-                        current_index
-                    )
+                    item._buf.ptr[unsafe_offset=self.dimension] = Scalar[
+                        DType.int
+                    ](current_index)
 
             # (result._buf.ptr + offset).init_pointee_copy(
             #     self._buf[IndexMethods.get_1d_index(item, self.strides)]
@@ -6335,13 +6391,13 @@ struct _NDArrayIter[
                         )
                         remainder = remainder // self.shape[i]
                     else:
-                        (item._buf.ptr.unsafe_offset(self.dimension)).unsafe_write(
-                            Scalar[DType.int](index)
-                        )
+                        (
+                            item._buf.ptr.unsafe_offset(self.dimension)
+                        ).unsafe_write(Scalar[DType.int](index))
 
                 (result._buf.ptr.unsafe_offset(offset)).unsafe_write(
-                    self._buf.ptr[unsafe_offset=
-                        self.offset
+                    self._buf.ptr[
+                        unsafe_offset=self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
                 )
@@ -6467,16 +6523,16 @@ struct _NDAxisIter[
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
-                        Scalar[DType.int](temp)
-                    )
+                    (
+                        self.strides_compatible._buf.ptr.unsafe_offset(i)
+                    ).unsafe_write(Scalar[DType.int](temp))
                     temp *= self.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
-                        Scalar[DType.int](temp)
-                    )
+                    (
+                        self.strides_compatible._buf.ptr.unsafe_offset(i)
+                    ).unsafe_write(Scalar[DType.int](temp))
                     temp *= self.shape[i]
 
         # Status of the iterator
@@ -6538,15 +6594,17 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=res._buf.ptr,
-                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    IndexMethods.get_1d_index(item, self.strides)
+                ),
                 count=self.size_of_item,
             )
 
         else:
             for j in range(self.size_of_item):
                 (res._buf.ptr.unsafe_offset(j)).unsafe_write(
-                    self.data.ptr[unsafe_offset=
-                        self.offset
+                    self.data.ptr[
+                        unsafe_offset=self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
                 )
@@ -6609,14 +6667,16 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    IndexMethods.get_1d_index(item, self.strides)
+                ),
                 count=self.size_of_item,
             )
         else:
             for j in range(self.size_of_item):
                 (elements._buf.ptr.unsafe_offset(j)).unsafe_write(
-                    self.data.ptr[unsafe_offset=
-                        self.offset
+                    self.data.ptr[
+                        unsafe_offset=self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
                 )
@@ -6670,7 +6730,9 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    IndexMethods.get_1d_index(item, self.strides)
+                ),
                 count=self.size_of_item,
             )
             var begin_offset = IndexMethods.get_1d_index(item, new_strides)
@@ -6685,7 +6747,9 @@ struct _NDAxisIter[
             # The memory layout is F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(
+                    IndexMethods.get_1d_index(item, self.strides)
+                ),
                 count=self.size_of_item,
             )
             for j in range(self.size_of_item):
@@ -6704,8 +6768,8 @@ struct _NDAxisIter[
                     )
                 )
                 (elements._buf.ptr.unsafe_offset(j)).unsafe_write(
-                    self.data.ptr[unsafe_offset=
-                        self.offset
+                    self.data.ptr[
+                        unsafe_offset=self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
                 )
@@ -6756,16 +6820,16 @@ struct _NDIter[
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
-                        Scalar[DType.int](temp)
-                    )
+                    (
+                        self.strides_compatible._buf.ptr.unsafe_offset(i)
+                    ).unsafe_write(Scalar[DType.int](temp))
                     temp *= a.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
-                        Scalar[DType.int](temp)
-                    )
+                    (
+                        self.strides_compatible._buf.ptr.unsafe_offset(i)
+                    ).unsafe_write(Scalar[DType.int](temp))
                     temp *= a.shape[i]
 
         self.index = 0
@@ -6812,8 +6876,9 @@ struct _NDIter[
                 Scalar[DType.int](remainder)
             )
 
-        return self.data.ptr[unsafe_offset=
-            self.offset + IndexMethods.get_1d_index(indices, self.strides)
+        return self.data.ptr[
+            unsafe_offset=self.offset
+            + IndexMethods.get_1d_index(indices, self.strides)
         ]
 
     def ith(self, index: Int) raises -> Scalar[Self.dtype]:
@@ -6863,6 +6928,7 @@ struct _NDIter[
                 Scalar[DType.int](remainder)
             )
 
-        return self.data.ptr[unsafe_offset=
-            self.offset + IndexMethods.get_1d_index(indices, self.strides)
+        return self.data.ptr[
+            unsafe_offset=self.offset
+            + IndexMethods.get_1d_index(indices, self.strides)
         ]

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -103,6 +103,7 @@ import numojo.routines.math as numojo_math
 from numojo.routines import math
 from numojo.routines.manipulation import ravel
 from numojo.routines.statistics import stddev
+from numojo.core.type_aliases import Shape
 
 comptime IndexTypes = Variant[Int, NewAxis, EllipsisType, Slice]
 """IndexTypes is used to represent the different kinds of indices that can be used for indexing and slicing operations on the NDArray.
@@ -386,20 +387,20 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
     @always_inline("nodebug")
-    def __init__(out self, *, deinit take: Self):
-        """Moves `take` into `self`.
+    def __init__(out self, *, deinit move: Self):
+        """Moves `move` into `self`.
 
         Args:
-            take: The NDArray to move from.
+            move: The NDArray to move from.
         """
-        self.ndim = take.ndim
-        self.shape = take.shape
-        self.size = take.size
-        self.strides = take.strides
-        self.offset = take.offset
-        self.flags = take.flags^
-        self._buf = take._buf^
-        self.print_options = take.print_options
+        self.ndim = move.ndim
+        self.shape = move.shape
+        self.size = move.size
+        self.strides = move.strides
+        self.offset = move.offset
+        self.flags = move.flags^
+        self._buf = move._buf^
+        self.print_options = move.print_options
 
     @always_inline("nodebug")
     def __deinit__(deinit self):

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -545,7 +545,7 @@ struct NDArray[dtype: DType = DType.float64](
                     location="NDArray.__getitem__()",
                 )
             )
-        return (self._buf.ptr + self.offset)[]
+        return (self._buf.ptr.unsafe_offset(self.offset))[]
 
     def __getitem__(self, index: Item) raises -> SIMD[Self.dtype, 1]:
         """Gets the value at the index list.
@@ -690,7 +690,7 @@ struct NDArray[dtype: DType = DType.float64](
             var block = self.size // self.shape[0]
             unsafe_memcpy(
                 dest=result._buf.ptr,
-                src=self._buf.ptr + self.offset + norm * block,
+                src=(self._buf.ptr + self.offset).unsafe_offset(norm * block),
                 count=block,
             )
             return result^
@@ -1419,17 +1419,16 @@ struct NDArray[dtype: DType = DType.float64](
 
             if self.is_c_contiguous():
                 unsafe_memcpy(
-                    dest=result._buf.ptr + i * size_per_item,
-                    src=self._buf.ptr
-                    + self.offset
-                    + normalized_idx * size_per_item,
+                    dest=result._buf.ptr.unsafe_offset(i * size_per_item),
+                    src=(self._buf.ptr
+                    + self.offset).unsafe_offset(normalized_idx * size_per_item),
                     count=size_per_item,
                 )
             else:
                 var selected = self[normalized_idx].contiguous()
                 unsafe_memcpy(
-                    dest=result._buf.ptr + i * size_per_item,
-                    src=selected._buf.ptr + selected.offset,
+                    dest=result._buf.ptr.unsafe_offset(i * size_per_item),
+                    src=selected._buf.ptr.unsafe_offset(selected.offset),
                     count=size_per_item,
                 )
 
@@ -1483,7 +1482,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var indices_array = NDArray[DType.int](shape=Shape(len(indices)))
         for i in range(len(indices)):
-            (indices_array._buf.ptr + i).unsafe_write(
+            (indices_array._buf.ptr.unsafe_offset(i)).unsafe_write(
                 Scalar[DType.int](indices[i])
             )
 
@@ -1585,7 +1584,7 @@ struct NDArray[dtype: DType = DType.float64](
             var offset = 0
             for i in range(mask.size):
                 if mask.item(i):
-                    (result._buf.ptr + offset).unsafe_write(
+                    (result._buf.ptr.unsafe_offset(offset)).unsafe_write(
                         self_c._buf.ptr[unsafe_offset=i]
                     )
                     offset += 1
@@ -1614,8 +1613,8 @@ struct NDArray[dtype: DType = DType.float64](
             for i in range(mask.size):
                 if mask.item(i):
                     unsafe_memcpy(
-                        dest=result._buf.ptr + offset * size_per_item,
-                        src=self_c._buf.ptr + i * size_per_item,
+                        dest=result._buf.ptr.unsafe_offset(offset * size_per_item),
+                        src=self_c._buf.ptr.unsafe_offset(i * size_per_item),
                         count=size_per_item,
                     )
                     offset += 1
@@ -1750,7 +1749,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var mask_array = NDArray[DType.bool](shape=Shape(len(mask)))
         for i in range(len(mask)):
-            (mask_array._buf.ptr + i).unsafe_write(mask[i])
+            (mask_array._buf.ptr.unsafe_offset(i)).unsafe_write(mask[i])
 
         return self[mask_array]
 
@@ -1828,13 +1827,13 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         if self.is_c_contiguous() or self.ndim == 1:
-            return (self._buf.ptr + self.offset + index)[]
+            return ((self._buf.ptr + self.offset).unsafe_offset(index))[]
 
         var remainder = index
         var item = Item(ndim=self.ndim)
 
         for i in range(self.ndim - 1, -1, -1):
-            (item._buf.ptr + i).unsafe_write(
+            (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                 Scalar[DType.int](remainder % self.shape[i])
             )
             remainder = remainder // self.shape[i]
@@ -1894,7 +1893,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # For 0-D array, return the scalar value.
         if self.ndim == 0:
-            return (self._buf.ptr + self.offset)[]
+            return (self._buf.ptr.unsafe_offset(self.offset))[]
 
         var list_index = List[Int]()
         for i in range(len(index)):
@@ -1917,9 +1916,8 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
         return (
-            self._buf.ptr
-            + self.offset
-            + IndexMethods.get_1d_index(index, self.strides)
+            (self._buf.ptr
+            + self.offset).unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
         )[]
 
     def unsafe_load[
@@ -2236,8 +2234,8 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous() and val.is_c_contiguous():
             var block = self.size // self.shape[0]
             unsafe_memcpy(
-                dest=self._buf.ptr + self.offset + norm * block,
-                src=val._buf.ptr + val.offset,
+                dest=(self._buf.ptr + self.offset).unsafe_offset(norm * block),
+                src=val._buf.ptr.unsafe_offset(val.offset),
                 count=block,
             )
             return
@@ -2982,8 +2980,8 @@ struct NDArray[dtype: DType = DType.float64](
                 var src_offset = val_c_for_slices.offset + i * per_slice_size
                 var slice = NDArray[Self.dtype](tail_shape)
                 unsafe_memcpy(
-                    dest=slice._buf.ptr + slice.offset,
-                    src=val_c_for_slices._buf.ptr + src_offset,
+                    dest=slice._buf.ptr.unsafe_offset(slice.offset),
+                    src=val_c_for_slices._buf.ptr.unsafe_offset(src_offset),
                     count=per_slice_size,
                 )
                 self.__setitem__(idx=idx, val=slice)
@@ -3504,7 +3502,7 @@ struct NDArray[dtype: DType = DType.float64](
         ```.
         """
         if (self.size == 1) or (self.ndim == 0):
-            return Bool((self._buf.ptr + self.offset)[])
+            return Bool((self._buf.ptr.unsafe_offset(self.offset))[])
 
         else:
             raise Error(
@@ -3542,7 +3540,7 @@ struct NDArray[dtype: DType = DType.float64](
         ```.
         """
         if (self.size == 1) or (self.ndim == 0):
-            return Int((self._buf.ptr + self.offset)[])
+            return Int((self._buf.ptr.unsafe_offset(self.offset))[])
         else:
             raise Error(
                 "\nError in `numojo.NDArray.__int__(self)`: "
@@ -3563,7 +3561,7 @@ struct NDArray[dtype: DType = DType.float64](
             Float representation of the array.
         """
         if (self.size == 1) or (self.ndim == 0):
-            return Float64((self._buf.ptr + self.offset)[])
+            return Float64((self._buf.ptr.unsafe_offset(self.offset))[])
         else:
             raise Error(
                 "\nError in `numojo.NDArray.__float__(self)`: "
@@ -4216,7 +4214,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.ndim == 0:
             # For 0-D array (numojo scalar), we can directly write the value
             writer.write(
-                String((self._buf.ptr + self.offset)[])
+                String((self._buf.ptr.unsafe_offset(self.offset))[])
                 + String(
                     "  (0darray["
                     + _concise_dtype_str(self.dtype)
@@ -4392,7 +4390,7 @@ struct NDArray[dtype: DType = DType.float64](
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            unsafe_memcpy(dest=self._buf.ptr + base, src=src_ptr, count=size_per_item)
+            unsafe_memcpy(dest=self._buf.ptr.unsafe_offset(base), src=src_ptr, count=size_per_item)
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4459,7 +4457,7 @@ struct NDArray[dtype: DType = DType.float64](
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            unsafe_memcpy(dest=dst_ptr, src=self._buf.ptr + base, count=size_per_item)
+            unsafe_memcpy(dest=dst_ptr, src=self._buf.ptr.unsafe_offset(base), count=size_per_item)
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4623,9 +4621,8 @@ struct NDArray[dtype: DType = DType.float64](
             indices._buf[current_axis] = index_at_axis
             if current_axis == shape.ndim - 1:
                 var val = (
-                    self._buf.ptr
-                    + self.offset
-                    + IndexMethods.get_1d_index(indices, strides)
+                    (self._buf.ptr
+                    + self.offset).unsafe_offset(IndexMethods.get_1d_index(indices, strides))
                 )[]
                 if val < 0:
                     negative_sign = True
@@ -4674,7 +4671,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result and builtin_bool.all(
-                (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
+                ((a._buf.ptr + a.offset).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_all)
@@ -4700,7 +4697,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result or builtin_bool.any(
-                (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
+                ((a._buf.ptr + a.offset).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_any)
@@ -4888,7 +4885,7 @@ struct NDArray[dtype: DType = DType.float64](
             # Fast path: single memcpy from (possibly offset) contiguous data
             unsafe_memcpy(
                 dest=result._buf.ptr,
-                src=self._buf.ptr + self.offset,
+                src=self._buf.ptr.unsafe_offset(self.offset),
                 count=self.size,
             )
         elif self.ndim == 0:
@@ -4917,7 +4914,7 @@ struct NDArray[dtype: DType = DType.float64](
                     mut result, imm self, base_offset, dest_base, last_stride
                 }:
                     var simd_data = (
-                        self._buf.ptr + base_offset + i * last_stride
+                        (self._buf.ptr + base_offset).unsafe_offset(i * last_stride)
                     ).unsafe_strided_load[width=simd_w](last_stride)
                     result._buf.ptr.unsafe_store(dest_base + i, simd_data)
 
@@ -5296,7 +5293,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
             for i in range(self.size):
-                (self._buf.ptr + self.offset + i).unsafe_write(val)
+                ((self._buf.ptr + self.offset).unsafe_offset(i)).unsafe_write(val)
         else:
             for i in range(self.size):
                 var remainder = i
@@ -5817,11 +5814,11 @@ struct NDArray[dtype: DType = DType.float64](
             var other = Self(shape=shape, order=order)
             unsafe_memcpy(
                 dest=other._buf.ptr,
-                src=self._buf.ptr + self.offset,
+                src=self._buf.ptr.unsafe_offset(self.offset),
                 count=self.size,
             )
             for i in range(self.size, other.size):
-                (other._buf.ptr + i).unsafe_write(0)
+                (other._buf.ptr.unsafe_offset(i)).unsafe_write(0)
             self = other^
         else:
             self.shape = shape
@@ -5992,7 +5989,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result = List[Scalar[Self.dtype]](capacity=self.size)
         if self.is_c_contiguous():
             for i in range(self.size):
-                result.append((self._buf.ptr + self.offset + i)[])
+                result.append(((self._buf.ptr + self.offset).unsafe_offset(i))[])
         else:
             for i in range(self.size):
                 var remainder = i
@@ -6324,16 +6321,16 @@ struct _NDArrayIter[
 
                 for i in range(self.ndim - 1, -1, -1):
                     if i != self.dimension:
-                        (item._buf.ptr + i).unsafe_write(
+                        (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                             Scalar[DType.int](remainder % self.shape[i])
                         )
                         remainder = remainder // self.shape[i]
                     else:
-                        (item._buf.ptr + self.dimension).unsafe_write(
+                        (item._buf.ptr.unsafe_offset(self.dimension)).unsafe_write(
                             Scalar[DType.int](index)
                         )
 
-                (result._buf.ptr + offset).unsafe_write(
+                (result._buf.ptr.unsafe_offset(offset)).unsafe_write(
                     self._buf.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
@@ -6456,19 +6453,19 @@ struct _NDAxisIter[
         self.strides_compatible = NDArrayStrides(
             ndim=self.ndim, initialized=True
         )
-        (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
+        (self.strides_compatible._buf.ptr.unsafe_offset(axis)).unsafe_write(1)
         var temp = self.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).unsafe_write(
+                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= self.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).unsafe_write(
+                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= self.shape[i]
@@ -6506,25 +6503,25 @@ struct _NDAxisIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (item._buf.ptr + i).unsafe_write(
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).unsafe_write(0)
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(0)
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (item._buf.ptr + i).unsafe_write(
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).unsafe_write(0)
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(0)
 
         if ((self.axis == self.ndim - 1) or (self.axis == 0)) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
@@ -6532,15 +6529,14 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=res._buf.ptr,
-                src=self.data.ptr
-                + self.offset
-                + IndexMethods.get_1d_index(item, self.strides),
+                src=(self.data.ptr
+                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
 
         else:
             for j in range(self.size_of_item):
-                (res._buf.ptr + j).unsafe_write(
+                (res._buf.ptr.unsafe_offset(j)).unsafe_write(
                     self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
@@ -6579,25 +6575,25 @@ struct _NDAxisIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (item._buf.ptr + i).unsafe_write(
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).unsafe_write(0)
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(0)
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (item._buf.ptr + i).unsafe_write(
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).unsafe_write(0)
+                    (item._buf.ptr.unsafe_offset(i)).unsafe_write(0)
 
         if ((self.axis == self.ndim - 1) or (self.axis == 0)) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
@@ -6605,14 +6601,13 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=self.data.ptr
-                + self.offset
-                + IndexMethods.get_1d_index(item, self.strides),
+                src=(self.data.ptr
+                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
         else:
             for j in range(self.size_of_item):
-                (elements._buf.ptr + j).unsafe_write(
+                (elements._buf.ptr.unsafe_offset(j)).unsafe_write(
                     self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
@@ -6668,14 +6663,13 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=self.data.ptr
-                + self.offset
-                + IndexMethods.get_1d_index(item, self.strides),
+                src=(self.data.ptr
+                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
             var begin_offset = IndexMethods.get_1d_index(item, new_strides)
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).unsafe_write(
+                (offsets._buf.ptr.unsafe_offset(j)).unsafe_write(
                     Scalar[DType.int](begin_offset + j)
                 )
 
@@ -6685,13 +6679,12 @@ struct _NDAxisIter[
             # The memory layout is F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=self.data.ptr
-                + self.offset
-                + IndexMethods.get_1d_index(item, self.strides),
+                src=(self.data.ptr
+                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).unsafe_write(
+                (offsets._buf.ptr.unsafe_offset(j)).unsafe_write(
                     Scalar[DType.int](
                         IndexMethods.get_1d_index(item, new_strides)
                     )
@@ -6700,12 +6693,12 @@ struct _NDAxisIter[
 
         else:
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).unsafe_write(
+                (offsets._buf.ptr.unsafe_offset(j)).unsafe_write(
                     Scalar[DType.int](
                         IndexMethods.get_1d_index(item, new_strides)
                     )
                 )
-                (elements._buf.ptr + j).unsafe_write(
+                (elements._buf.ptr.unsafe_offset(j)).unsafe_write(
                     self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
@@ -6753,19 +6746,19 @@ struct _NDIter[
         self.strides_compatible = NDArrayStrides(
             ndim=self.ndim, initialized=False
         )
-        (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
+        (self.strides_compatible._buf.ptr.unsafe_offset(axis)).unsafe_write(1)
         var temp = a.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).unsafe_write(
+                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= a.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).unsafe_write(
+                    (self.strides_compatible._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= a.shape[i]
@@ -6791,26 +6784,26 @@ struct _NDIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (indices._buf.ptr + i).unsafe_write(
+                    (indices._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).unsafe_write(
+            (indices._buf.ptr.unsafe_offset(self.axis)).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (indices._buf.ptr + i).unsafe_write(
+                    (indices._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).unsafe_write(
+            (indices._buf.ptr.unsafe_offset(self.axis)).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 
@@ -6843,25 +6836,25 @@ struct _NDIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (indices._buf.ptr + i).unsafe_write(
+                    (indices._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).unsafe_write(
+            (indices._buf.ptr.unsafe_offset(self.axis)).unsafe_write(
                 Scalar[DType.int](remainder)
             )
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (indices._buf.ptr + i).unsafe_write(
+                    (indices._buf.ptr.unsafe_offset(i)).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).unsafe_write(
+            (indices._buf.ptr.unsafe_offset(self.axis)).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -690,7 +690,7 @@ struct NDArray[dtype: DType = DType.float64](
             var block = self.size // self.shape[0]
             unsafe_memcpy(
                 dest=result._buf.ptr,
-                src=(self._buf.ptr + self.offset).unsafe_offset(norm * block),
+                src=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(norm * block),
                 count=block,
             )
             return result^
@@ -1420,8 +1420,7 @@ struct NDArray[dtype: DType = DType.float64](
             if self.is_c_contiguous():
                 unsafe_memcpy(
                     dest=result._buf.ptr.unsafe_offset(i * size_per_item),
-                    src=(self._buf.ptr
-                    + self.offset).unsafe_offset(normalized_idx * size_per_item),
+                    src=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(normalized_idx * size_per_item),
                     count=size_per_item,
                 )
             else:
@@ -1827,7 +1826,7 @@ struct NDArray[dtype: DType = DType.float64](
             )
 
         if self.is_c_contiguous() or self.ndim == 1:
-            return ((self._buf.ptr + self.offset).unsafe_offset(index))[]
+            return ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(index))[]
 
         var remainder = index
         var item = Item(ndim=self.ndim)
@@ -1916,8 +1915,7 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
         return (
-            (self._buf.ptr
-            + self.offset).unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
+            (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(index, self.strides))
         )[]
 
     def unsafe_load[
@@ -2234,7 +2232,7 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous() and val.is_c_contiguous():
             var block = self.size // self.shape[0]
             unsafe_memcpy(
-                dest=(self._buf.ptr + self.offset).unsafe_offset(norm * block),
+                dest=(self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(norm * block),
                 src=val._buf.ptr.unsafe_offset(val.offset),
                 count=block,
             )
@@ -4621,8 +4619,7 @@ struct NDArray[dtype: DType = DType.float64](
             indices._buf[current_axis] = index_at_axis
             if current_axis == shape.ndim - 1:
                 var val = (
-                    (self._buf.ptr
-                    + self.offset).unsafe_offset(IndexMethods.get_1d_index(indices, strides))
+                    (self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(indices, strides))
                 )[]
                 if val < 0:
                     negative_sign = True
@@ -4671,7 +4668,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result and builtin_bool.all(
-                ((a._buf.ptr + a.offset).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
+                ((a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_all)
@@ -4697,7 +4694,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
             result = result or builtin_bool.any(
-                ((a._buf.ptr + a.offset).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
+                ((a._buf.ptr.unsafe_offset(a.offset)).unsafe_offset(idx)).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_any)
@@ -4914,7 +4911,7 @@ struct NDArray[dtype: DType = DType.float64](
                     mut result, imm self, base_offset, dest_base, last_stride
                 }:
                     var simd_data = (
-                        (self._buf.ptr + base_offset).unsafe_offset(i * last_stride)
+                        (self._buf.ptr.unsafe_offset(base_offset)).unsafe_offset(i * last_stride)
                     ).unsafe_strided_load[width=simd_w](last_stride)
                     result._buf.ptr.unsafe_store(dest_base + i, simd_data)
 
@@ -5293,7 +5290,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
             for i in range(self.size):
-                ((self._buf.ptr + self.offset).unsafe_offset(i)).unsafe_write(val)
+                ((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i)).unsafe_write(val)
         else:
             for i in range(self.size):
                 var remainder = i
@@ -5989,7 +5986,7 @@ struct NDArray[dtype: DType = DType.float64](
         var result = List[Scalar[Self.dtype]](capacity=self.size)
         if self.is_c_contiguous():
             for i in range(self.size):
-                result.append(((self._buf.ptr + self.offset).unsafe_offset(i))[])
+                result.append(((self._buf.ptr.unsafe_offset(self.offset)).unsafe_offset(i))[])
         else:
             for i in range(self.size):
                 var remainder = i
@@ -6529,8 +6526,7 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=res._buf.ptr,
-                src=(self.data.ptr
-                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
 
@@ -6601,8 +6597,7 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous or F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr
-                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
         else:
@@ -6663,8 +6658,7 @@ struct _NDAxisIter[
             # The memory layout is C-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr
-                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
             var begin_offset = IndexMethods.get_1d_index(item, new_strides)
@@ -6679,8 +6673,7 @@ struct _NDAxisIter[
             # The memory layout is F-contiguous
             unsafe_memcpy(
                 dest=elements._buf.ptr,
-                src=(self.data.ptr
-                + self.offset).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
+                src=(self.data.ptr.unsafe_offset(self.offset)).unsafe_offset(IndexMethods.get_1d_index(item, self.strides)),
                 count=self.size_of_item,
             )
             for j in range(self.size_of_item):

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -37,7 +37,7 @@ import std.builtin.bool as builtin_bool
 import std.math as builtin_math
 from std.collections.optional import Optional
 from std.math import log10
-from std.memory import memset_zero, memcpy
+from std.memory import unsafe_memset_zero, unsafe_memcpy
 from std.python import PythonObject
 from std.sys import simd_width_of
 from std.utils import Variant
@@ -243,7 +243,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.strides = NDArrayStrides(strides=strides)
         self.offset = offset
         self._buf = DataContainer[Self.dtype](self.size)
-        memset_zero(self._buf.ptr, self.size)
+        unsafe_memset_zero(self._buf.ptr, self.size)
         self.flags = Flags(
             self.shape, self.strides, owndata=True, writeable=True
         )
@@ -486,7 +486,7 @@ struct NDArray[dtype: DType = DType.float64](
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
         index_of_buffer += self.offset
-        return self._buf.ptr[index_of_buffer]
+        return self._buf.ptr[unsafe_offset=index_of_buffer]
 
     def _getitem(self, indices: List[Int]) -> Scalar[Self.dtype]:
         """Gets the item at indices, bypassing all boundary checks.
@@ -515,7 +515,7 @@ struct NDArray[dtype: DType = DType.float64](
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
         index_of_buffer += self.offset
-        return self._buf.ptr[index_of_buffer]
+        return self._buf.ptr[unsafe_offset=index_of_buffer]
 
     def __getitem__(self) raises -> SIMD[Self.dtype, 1]:
         """Gets the value of the 0-D array.
@@ -599,7 +599,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
 
         var idx: Int = IndexMethods.get_1d_index(index, self.strides)
-        return self._buf.ptr.load[width=1](self.offset + idx)
+        return self._buf.ptr.unsafe_load[width=1](self.offset + idx)
 
     # Can be faster if we only return a view since we are not copying the data.
     def __getitem__(self, idx: Int) raises -> Self:
@@ -676,7 +676,7 @@ struct NDArray[dtype: DType = DType.float64](
         # 1-D -> scalar (0-D array wrapper)
         if self.ndim == 1:
             return creation._0darray[Self.dtype](
-                self._buf.ptr[self.offset + norm]
+                self._buf.ptr[unsafe_offset=self.offset + norm]
             )
 
         var out_shape = self.shape[1:]
@@ -688,7 +688,7 @@ struct NDArray[dtype: DType = DType.float64](
         # Fast path for C-contiguous arrays
         if self.is_c_contiguous():
             var block = self.size // self.shape[0]
-            memcpy(
+            unsafe_memcpy(
                 dest=result._buf.ptr,
                 src=self._buf.ptr + self.offset + norm * block,
                 count=block,
@@ -728,7 +728,7 @@ struct NDArray[dtype: DType = DType.float64](
             var dst_off = dst.offset
             for d in range(out_ndim):
                 dst_off += coords[d] * Int(dst.strides.unsafe_load(d))
-            dst._buf.ptr[dst_off] = src._buf.ptr[off]
+            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[unsafe_offset=off]
 
     def __getitem__(self, var *slices: Slice) raises -> Self:
         """Retrieves a slice or sub-array from the current array using variadic
@@ -1400,7 +1400,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         # Fill in the values (advanced indexing on axis 0).
         for i in range(indices_c.size):
-            var raw_idx = Int(indices_c._buf.ptr[i])
+            var raw_idx = Int(indices_c._buf.ptr[unsafe_offset=i])
             if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                 raise Error(
                     NumojoError(
@@ -1418,7 +1418,7 @@ struct NDArray[dtype: DType = DType.float64](
                 normalized_idx += self.shape[0]
 
             if self.is_c_contiguous():
-                memcpy(
+                unsafe_memcpy(
                     dest=result._buf.ptr + i * size_per_item,
                     src=self._buf.ptr
                     + self.offset
@@ -1427,7 +1427,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             else:
                 var selected = self[normalized_idx].contiguous()
-                memcpy(
+                unsafe_memcpy(
                     dest=result._buf.ptr + i * size_per_item,
                     src=selected._buf.ptr + selected.offset,
                     count=size_per_item,
@@ -1483,7 +1483,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var indices_array = NDArray[DType.int](shape=Shape(len(indices)))
         for i in range(len(indices)):
-            (indices_array._buf.ptr + i).init_pointee_copy(
+            (indices_array._buf.ptr + i).unsafe_write(
                 Scalar[DType.int](indices[i])
             )
 
@@ -1585,8 +1585,8 @@ struct NDArray[dtype: DType = DType.float64](
             var offset = 0
             for i in range(mask.size):
                 if mask.item(i):
-                    (result._buf.ptr + offset).init_pointee_copy(
-                        self_c._buf.ptr[i]
+                    (result._buf.ptr + offset).unsafe_write(
+                        self_c._buf.ptr[unsafe_offset=i]
                     )
                     offset += 1
 
@@ -1613,7 +1613,7 @@ struct NDArray[dtype: DType = DType.float64](
             var offset = 0
             for i in range(mask.size):
                 if mask.item(i):
-                    memcpy(
+                    unsafe_memcpy(
                         dest=result._buf.ptr + offset * size_per_item,
                         src=self_c._buf.ptr + i * size_per_item,
                         count=size_per_item,
@@ -1654,7 +1654,7 @@ struct NDArray[dtype: DType = DType.float64](
             # Count True entries in the mask.
             var true_count = 0
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     true_count += 1
 
             # Build result shape: (true_count, *self.shape[k:])
@@ -1672,7 +1672,7 @@ struct NDArray[dtype: DType = DType.float64](
             var coords = List[Int](length=k, fill=0)
             var out_offset = 0
             for flat in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](flat):
+                if mask_c._buf.ptr.unsafe_load[width=1](flat):
                     var rem = flat
                     for d in range(k - 1, -1, -1):
                         var dim = Int(self.shape.unsafe_load(d))
@@ -1750,7 +1750,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         var mask_array = NDArray[DType.bool](shape=Shape(len(mask)))
         for i in range(len(mask)):
-            (mask_array._buf.ptr + i).init_pointee_copy(mask[i])
+            (mask_array._buf.ptr + i).unsafe_write(mask[i])
 
         return self[mask_array]
 
@@ -1834,12 +1834,12 @@ struct NDArray[dtype: DType = DType.float64](
         var item = Item(ndim=self.ndim)
 
         for i in range(self.ndim - 1, -1, -1):
-            (item._buf.ptr + i).init_pointee_copy(
+            (item._buf.ptr + i).unsafe_write(
                 Scalar[DType.int](remainder % self.shape[i])
             )
             remainder = remainder // self.shape[i]
 
-        return self._buf.ptr[
+        return self._buf.ptr[unsafe_offset=
             self.offset + IndexMethods.get_1d_index(item, self.strides)
         ]
 
@@ -1937,7 +1937,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The SIMD element at the index.
         """
-        return self._buf.ptr.load[width=width](self.offset + index)
+        return self._buf.ptr.unsafe_load[width=width](self.offset + index)
 
     def load(self, var index: Int) raises -> Scalar[Self.dtype]:
         """Safely retrieves the i-th item from the underlying buffer.
@@ -1983,7 +1983,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        return self._buf.ptr[self.offset + index]
+        return self._buf.ptr[unsafe_offset=self.offset + index]
 
     def load[
         width: Int = 1
@@ -2021,7 +2021,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        return self._buf.ptr.load[width=width](self.offset + index)
+        return self._buf.ptr.unsafe_load[width=width](self.offset + index)
 
     def load[
         width: Int = 1
@@ -2090,7 +2090,7 @@ struct NDArray[dtype: DType = DType.float64](
         # indices_list already built above
 
         var idx: Int = IndexMethods.get_1d_index(indices_list, self.strides)
-        return self._buf.ptr.load[width=width](self.offset + idx)
+        return self._buf.ptr.unsafe_load[width=width](self.offset + idx)
 
     # ===-------------------------------------------------------------------===#
     # Setter dunders and other setter methods
@@ -2153,7 +2153,7 @@ struct NDArray[dtype: DType = DType.float64](
         var index_of_buffer: Int = 0
         for i in range(self.ndim):
             index_of_buffer += indices[i] * Int(self.strides.unsafe_load(i))
-        self._buf.ptr[self.offset + index_of_buffer] = val
+        self._buf.ptr[unsafe_offset=self.offset + index_of_buffer] = val
 
     def __setitem__(self, idx: Int, val: Self) raises:
         """Assigns a single first-axis slice.
@@ -2235,7 +2235,7 @@ struct NDArray[dtype: DType = DType.float64](
         # Fast path for C-contiguous arrays (single block)
         if self.is_c_contiguous() and val.is_c_contiguous():
             var block = self.size // self.shape[0]
-            memcpy(
+            unsafe_memcpy(
                 dest=self._buf.ptr + self.offset + norm * block,
                 src=val._buf.ptr + val.offset,
                 count=block,
@@ -2271,7 +2271,7 @@ struct NDArray[dtype: DType = DType.float64](
                 var c = coords[d]
                 dst_off += c * stride_dst
                 src_off += c * stride_src
-            dst._buf.ptr[dst_off] = src._buf.ptr[src_off]
+            dst._buf.ptr[unsafe_offset=dst_off] = src._buf.ptr[unsafe_offset=src_off]
 
     def __setitem__(mut self, var index: Item, val: Scalar[Self.dtype]) raises:
         """Sets the value at the index list.
@@ -2325,7 +2325,7 @@ struct NDArray[dtype: DType = DType.float64](
             index[i] = self.normalize(index[i], self.shape[i])
 
         var idx: Int = IndexMethods.get_1d_index(index, self.strides)
-        self._buf.ptr.store(self.offset + idx, val)
+        self._buf.ptr.unsafe_store(self.offset + idx, val)
 
     def set(
         mut self, mask: NDArray[DType.bool], *, val: Scalar[Self.dtype]
@@ -2361,7 +2361,7 @@ struct NDArray[dtype: DType = DType.float64](
         # CASE 1: exact shape match — write scalar at every True position.
         if mask.shape == self.shape:
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     self.itemset(i, value)
             return
 
@@ -2372,7 +2372,7 @@ struct NDArray[dtype: DType = DType.float64](
         if mask.ndim == 1 and mask.shape[0] == self.shape[0]:
             var stride0 = Int(self.strides.unsafe_load(0))
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     self._fill_block_in_self(
                         base=self.offset + i * stride0,
                         axis_start=1,
@@ -2401,7 +2401,7 @@ struct NDArray[dtype: DType = DType.float64](
             var k = mask.ndim
             var coords = List[Int](length=k, fill=0)
             for flat in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](flat):
+                if mask_c._buf.ptr.unsafe_load[width=1](flat):
                     var rem = flat
                     for d in range(k - 1, -1, -1):
                         var dim = Int(self.shape.unsafe_load(d))
@@ -2699,7 +2699,7 @@ struct NDArray[dtype: DType = DType.float64](
                 buf_idx += (
                     slice_list[d].start + coords[d] * slice_list[d].step
                 ) * self.strides[d]
-            self._buf.ptr.store(buf_idx, val)
+            self._buf.ptr.unsafe_store(buf_idx, val)
 
             for d in range(self.ndim - 1, -1, -1):
                 coords[d] += 1
@@ -2865,7 +2865,7 @@ struct NDArray[dtype: DType = DType.float64](
             if val.size == 1:
                 var scalar_val = val.item(0)
                 for i in range(index_c.size):
-                    var raw_idx = Int(index_c._buf.ptr[i])
+                    var raw_idx = Int(index_c._buf.ptr[unsafe_offset=i])
                     if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                         raise Error(
                             NumojoError(
@@ -2907,7 +2907,7 @@ struct NDArray[dtype: DType = DType.float64](
 
             var val_c = val.contiguous()
             for i in range(index_c.size):
-                var raw_idx = Int(index_c._buf.ptr[i])
+                var raw_idx = Int(index_c._buf.ptr[unsafe_offset=i])
                 if raw_idx < -self.shape[0] or raw_idx >= self.shape[0]:
                     raise Error(
                         NumojoError(
@@ -2925,7 +2925,7 @@ struct NDArray[dtype: DType = DType.float64](
                 var idx = raw_idx
                 if idx < 0:
                     idx += self.shape[0]
-                self.itemset(idx, val_c._buf.ptr[i])
+                self.itemset(idx, val_c._buf.ptr[unsafe_offset=i])
             return
 
         var tail_shape = self.shape.pop(0)
@@ -2959,7 +2959,7 @@ struct NDArray[dtype: DType = DType.float64](
         )
 
         for i in range(index_c.size):
-            var idx = Int(index_c._buf.ptr[i])
+            var idx = Int(index_c._buf.ptr[unsafe_offset=i])
             if idx < -self.shape[0] or idx >= self.shape[0]:
                 raise Error(
                     NumojoError(
@@ -2981,7 +2981,7 @@ struct NDArray[dtype: DType = DType.float64](
             else:
                 var src_offset = val_c_for_slices.offset + i * per_slice_size
                 var slice = NDArray[Self.dtype](tail_shape)
-                memcpy(
+                unsafe_memcpy(
                     dest=slice._buf.ptr + slice.offset,
                     src=val_c_for_slices._buf.ptr + src_offset,
                     count=per_slice_size,
@@ -3023,27 +3023,27 @@ struct NDArray[dtype: DType = DType.float64](
         if mask.shape == self.shape:
             if val_c.shape == self.shape:
                 for i in range(mask_c.size):
-                    if mask_c._buf.ptr.load[width=1](i):
-                        self.itemset(i, val_c._buf.ptr.load[width=1](i))
+                    if mask_c._buf.ptr.unsafe_load[width=1](i):
+                        self.itemset(i, val_c._buf.ptr.unsafe_load[width=1](i))
                 return
 
             if val_c.size == 1:
-                var scalar_val = val_c._buf.ptr.load[width=1](val_c.offset)
+                var scalar_val = val_c._buf.ptr.unsafe_load[width=1](val_c.offset)
                 for i in range(mask_c.size):
-                    if mask_c._buf.ptr.load[width=1](i):
+                    if mask_c._buf.ptr.unsafe_load[width=1](i):
                         self.itemset(i, scalar_val)
                 return
 
             var true_count = 0
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     true_count += 1
 
             if val_c.ndim == 1 and val_c.size == true_count:
                 var j = 0
                 for i in range(mask_c.size):
-                    if mask_c._buf.ptr.load[width=1](i):
-                        self.itemset(i, val_c._buf.ptr.load[width=1](j))
+                    if mask_c._buf.ptr.unsafe_load[width=1](i):
+                        self.itemset(i, val_c._buf.ptr.unsafe_load[width=1](j))
                         j += 1
                 return
 
@@ -3065,7 +3065,7 @@ struct NDArray[dtype: DType = DType.float64](
             var size_per_item = self._trailing_size(1)
             var true_count = 0
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     true_count += 1
 
             # val must be either a single sub-array (shape self.shape[1:])
@@ -3093,7 +3093,7 @@ struct NDArray[dtype: DType = DType.float64](
             var stride0 = Int(self.strides.unsafe_load(0))
             var out_row = 0
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     var src_ptr = val_c._buf.ptr.unsafe_offset(
                         out_row * size_per_item if val_is_per_index else 0
                     ).as_unsafe_any_origin()
@@ -3129,7 +3129,7 @@ struct NDArray[dtype: DType = DType.float64](
 
             var true_count = 0
             for i in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](i):
+                if mask_c._buf.ptr.unsafe_load[width=1](i):
                     true_count += 1
 
             var tail_shape = NDArrayShape(self.shape[k:])
@@ -3160,7 +3160,7 @@ struct NDArray[dtype: DType = DType.float64](
             var coords = List[Int](length=k, fill=0)
             var out_row = 0
             for flat in range(mask_c.size):
-                if mask_c._buf.ptr.load[width=1](flat):
+                if mask_c._buf.ptr.unsafe_load[width=1](flat):
                     var rem = flat
                     for d in range(k - 1, -1, -1):
                         var dim = Int(self.shape.unsafe_load(d))
@@ -3237,13 +3237,13 @@ struct NDArray[dtype: DType = DType.float64](
                     var coordinate = norm_idx // c_stride[i]
                     norm_idx = norm_idx - c_stride[i] * coordinate
                     c_coordinates.append(coordinate)
-                self._buf.ptr.store(
+                self._buf.ptr.unsafe_store(
                     self.offset
                     + IndexMethods.get_1d_index(c_coordinates, self.strides),
                     item,
                 )
             else:
-                self._buf.ptr.store(self.offset + norm_idx, item)
+                self._buf.ptr.unsafe_store(self.offset + norm_idx, item)
         else:
             raise Error(
                 NumojoError(
@@ -3324,7 +3324,7 @@ struct NDArray[dtype: DType = DType.float64](
                     )
                 )
             indices[i] = norm_idx
-        self._buf.ptr.store(
+        self._buf.ptr.unsafe_store(
             self.offset + IndexMethods.get_1d_index(indices, self.strides),
             item,
         )
@@ -3343,7 +3343,7 @@ struct NDArray[dtype: DType = DType.float64](
             val: The value to store.
         """
 
-        self._buf.ptr.store(self.offset + index, val)
+        self._buf.ptr.unsafe_store(self.offset + index, val)
 
     def store(self, var index: Int, val: Scalar[Self.dtype]) raises:
         """Safely stores a scalar to the i-th item of the underlying buffer.
@@ -3382,7 +3382,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        self._buf.ptr[self.offset + index] = val
+        self._buf.ptr[unsafe_offset=self.offset + index] = val
 
     def store[
         width: Int = 1
@@ -3423,7 +3423,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
             )
 
-        self._buf.ptr.store(self.offset + index, val)
+        self._buf.ptr.unsafe_store(self.offset + index, val)
 
     def store[
         width: Int = 1
@@ -3482,7 +3482,7 @@ struct NDArray[dtype: DType = DType.float64](
                 )
 
         var idx: Int = IndexMethods.get_1d_index(indices, self.strides)
-        self._buf.ptr.store(self.offset + idx, val)
+        self._buf.ptr.unsafe_store(self.offset + idx, val)
 
     # ===-------------------------------------------------------------------===#
     # Operator dunders
@@ -3781,10 +3781,10 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             def vec_op[w: Int](i: Int) {mut self, read other}:
-                self._buf.ptr.store(
+                self._buf.ptr.unsafe_store(
                     self.offset + i,
                     func[Self.dtype, w](
-                        self._buf.ptr.load[width=w](self.offset + i),
+                        self._buf.ptr.unsafe_load[width=w](self.offset + i),
                         SIMD[Self.dtype, w](other),
                     ),
                 )
@@ -3799,8 +3799,8 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[idx] = func[Self.dtype, 1](
-                    self._buf.ptr[idx], other
+                self._buf.ptr[unsafe_offset=idx] = func[Self.dtype, 1](
+                    self._buf.ptr[unsafe_offset=idx], other
                 )
 
     def _inplace_array_op[
@@ -3837,11 +3837,11 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             def vec_op[w: Int](i: Int) {mut self, read other_c}:
-                self._buf.ptr.store(
+                self._buf.ptr.unsafe_store(
                     self.offset + i,
                     func[Self.dtype, w](
-                        self._buf.ptr.load[width=w](self.offset + i),
-                        other_c._buf.ptr.load[width=w](i),
+                        self._buf.ptr.unsafe_load[width=w](self.offset + i),
+                        other_c._buf.ptr.unsafe_load[width=w](i),
                     ),
                 )
 
@@ -3855,8 +3855,8 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[idx] = func[Self.dtype, 1](
-                    self._buf.ptr[idx], other_c._buf.ptr[i]
+                self._buf.ptr[unsafe_offset=idx] = func[Self.dtype, 1](
+                    self._buf.ptr[unsafe_offset=idx], other_c._buf.ptr[unsafe_offset=i]
                 )
 
     # ===--- In-place arithmetic operators ---===#
@@ -3993,7 +3993,7 @@ struct NDArray[dtype: DType = DType.float64](
         var src = self.contiguous()
         var result: Self = Self(shape=self.shape, order="C")
         for i in range(src.size):
-            result._buf.ptr[i] = src._buf.ptr[i].__pow__(rhs)
+            result._buf.ptr[unsafe_offset=i] = src._buf.ptr[unsafe_offset=i].__pow__(rhs)
         return result^
 
     def __pow__(self, p: Self) raises -> Self:
@@ -4014,10 +4014,10 @@ struct NDArray[dtype: DType = DType.float64](
         def vectorized_pow[
             simd_width: Int
         ](index: Int) {mut result, read src, read p_c}:
-            result._buf.ptr.store(
+            result._buf.ptr.unsafe_store(
                 index,
-                src._buf.ptr.load[width=simd_width](index)
-                ** p_c._buf.ptr.load[width=simd_width](index),
+                src._buf.ptr.unsafe_load[width=simd_width](index)
+                ** p_c._buf.ptr.unsafe_load[width=simd_width](index),
             )
 
         vectorize[self.width](self.size, vectorized_pow)
@@ -4028,10 +4028,10 @@ struct NDArray[dtype: DType = DType.float64](
         if self.is_c_contiguous():
 
             def vec_pow[w: Int](i: Int) {mut self, read p}:
-                self._buf.ptr.store(
+                self._buf.ptr.unsafe_store(
                     self.offset + i,
                     builtin_math.pow(
-                        self._buf.ptr.load[width=w](self.offset + i), p
+                        self._buf.ptr.unsafe_load[width=w](self.offset + i), p
                     ),
                 )
 
@@ -4045,7 +4045,7 @@ struct NDArray[dtype: DType = DType.float64](
                     var coord = remainder % dim_size
                     remainder //= dim_size
                     idx += coord * Int(self.strides.unsafe_load(dim))
-                self._buf.ptr[idx] = builtin_math.pow(self._buf.ptr[idx], p)
+                self._buf.ptr[unsafe_offset=idx] = builtin_math.pow(self._buf.ptr[unsafe_offset=idx], p)
 
     def _elementwise_pow(self, p: Int) raises -> Self:
         var src = self.contiguous()
@@ -4053,9 +4053,9 @@ struct NDArray[dtype: DType = DType.float64](
         def array_scalar_vectorize[
             simd_width: Int
         ](index: Int) {mut src, read p} -> None:
-            src._buf.ptr.store(
+            src._buf.ptr.unsafe_store(
                 index,
-                builtin_math.pow(src._buf.ptr.load[width=simd_width](index), p),
+                builtin_math.pow(src._buf.ptr.unsafe_load[width=simd_width](index), p),
             )
 
         vectorize[self.width](self.size, array_scalar_vectorize)
@@ -4381,18 +4381,18 @@ struct NDArray[dtype: DType = DType.float64](
         mut self,
         base: Int,
         axis_start: Int,
-        src_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        src_ptr: Pointer[Scalar[Self.dtype], MutAnyOrigin],
     ) raises:
         """Writes a C-contiguous source block of `prod(shape[axis_start:])`
         elements into self at offset `base`, following `self.strides[axis_start:]`.
         """
         var n_trail = self.ndim - axis_start
         if n_trail <= 0:
-            self._buf.ptr.store(base, src_ptr.load[width=1](0))
+            self._buf.ptr.unsafe_store(base, src_ptr.unsafe_load[width=1](0))
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            memcpy(dest=self._buf.ptr + base, src=src_ptr, count=size_per_item)
+            unsafe_memcpy(dest=self._buf.ptr + base, src=src_ptr, count=size_per_item)
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4402,7 +4402,7 @@ struct NDArray[dtype: DType = DType.float64](
                 off += tcoords[d] * Int(
                     self.strides.unsafe_load(axis_start + d)
                 )
-            self._buf.ptr.store(off, src_ptr.load[width=1](j))
+            self._buf.ptr.unsafe_store(off, src_ptr.unsafe_load[width=1](j))
             j += 1
             var d = n_trail - 1
             while d >= 0:
@@ -4424,7 +4424,7 @@ struct NDArray[dtype: DType = DType.float64](
         `base` with `value`, following `self.strides[axis_start:]`."""
         var n_trail = self.ndim - axis_start
         if n_trail <= 0:
-            self._buf.ptr.store(base, value)
+            self._buf.ptr.unsafe_store(base, value)
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         while True:
@@ -4433,7 +4433,7 @@ struct NDArray[dtype: DType = DType.float64](
                 off += tcoords[d] * Int(
                     self.strides.unsafe_load(axis_start + d)
                 )
-            self._buf.ptr.store(off, value)
+            self._buf.ptr.unsafe_store(off, value)
             var d = n_trail - 1
             while d >= 0:
                 tcoords[d] += 1
@@ -4448,18 +4448,18 @@ struct NDArray[dtype: DType = DType.float64](
         self,
         base: Int,
         axis_start: Int,
-        dst_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        dst_ptr: Pointer[Scalar[Self.dtype], MutAnyOrigin],
     ) raises:
         """Reads `prod(shape[axis_start:])` elements from self starting at
         offset `base` (following `self.strides[axis_start:]`) into the
         C-contiguous destination block `dst_ptr`."""
         var n_trail = self.ndim - axis_start
         if n_trail <= 0:
-            dst_ptr.store(0, self._buf.ptr.load[width=1](base))
+            dst_ptr.unsafe_store(0, self._buf.ptr.unsafe_load[width=1](base))
             return
         var size_per_item = self._trailing_size(axis_start)
         if self._trailing_is_contig(axis_start):
-            memcpy(dest=dst_ptr, src=self._buf.ptr + base, count=size_per_item)
+            unsafe_memcpy(dest=dst_ptr, src=self._buf.ptr + base, count=size_per_item)
             return
         var tcoords = List[Int](length=n_trail, fill=0)
         var j = 0
@@ -4469,7 +4469,7 @@ struct NDArray[dtype: DType = DType.float64](
                 off += tcoords[d] * Int(
                     self.strides.unsafe_load(axis_start + d)
                 )
-            dst_ptr.store(j, self._buf.ptr.load[width=1](off))
+            dst_ptr.unsafe_store(j, self._buf.ptr.unsafe_load[width=1](off))
             j += 1
             var d = n_trail - 1
             while d >= 0:
@@ -4674,7 +4674,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
             result = result and builtin_bool.all(
-                (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
+                (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_all)
@@ -4700,7 +4700,7 @@ struct NDArray[dtype: DType = DType.float64](
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
             result = result or builtin_bool.any(
-                (a._buf.ptr + a.offset + idx).strided_load[width=simd_width](1)
+                (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
             )
 
         vectorize[a.width](a.size, vectorized_any)
@@ -4886,13 +4886,13 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
             # Fast path: single memcpy from (possibly offset) contiguous data
-            memcpy(
+            unsafe_memcpy(
                 dest=result._buf.ptr,
                 src=self._buf.ptr + self.offset,
                 count=self.size,
             )
         elif self.ndim == 0:
-            result._buf.ptr[0] = self._buf.ptr[self.offset]
+            result._buf.ptr[unsafe_offset=0] = self._buf.ptr[unsafe_offset=self.offset]
         else:
             # Stride-aware copy for non-contiguous views.
             var last_dim = self.ndim - 1
@@ -4918,8 +4918,8 @@ struct NDArray[dtype: DType = DType.float64](
                 }:
                     var simd_data = (
                         self._buf.ptr + base_offset + i * last_stride
-                    ).strided_load[width=simd_w](last_stride)
-                    result._buf.ptr.store(dest_base + i, simd_data)
+                    ).unsafe_strided_load[width=simd_w](last_stride)
+                    result._buf.ptr.unsafe_store(dest_base + i, simd_data)
 
                 vectorize[width](last_extent, closure)
 
@@ -4953,7 +4953,7 @@ struct NDArray[dtype: DType = DType.float64](
                 + i * Int(self.strides[0])
                 + id * Int(self.strides[1])
             )
-            buffer._buf.ptr[i] = self._buf.ptr[src_idx]
+            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[unsafe_offset=src_idx]
         return buffer^
 
     def cumprod(self) raises -> NDArray[Self.dtype]:
@@ -5296,7 +5296,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
             for i in range(self.size):
-                (self._buf.ptr + self.offset + i).init_pointee_copy(val)
+                (self._buf.ptr + self.offset + i).unsafe_write(val)
         else:
             for i in range(self.size):
                 var remainder = i
@@ -5308,7 +5308,7 @@ struct NDArray[dtype: DType = DType.float64](
                     index_of_buffer += coord * Int(
                         self.strides.unsafe_load(dim)
                     )
-                self._buf.ptr[index_of_buffer] = val
+                self._buf.ptr[unsafe_offset=index_of_buffer] = val
 
     def flatten(self, order: String = "C") raises -> Self:
         """Returns a copy of the array collapsed into one dimension.
@@ -5815,13 +5815,13 @@ struct NDArray[dtype: DType = DType.float64](
 
         if shape.size() > self.size:
             var other = Self(shape=shape, order=order)
-            memcpy(
+            unsafe_memcpy(
                 dest=other._buf.ptr,
                 src=self._buf.ptr + self.offset,
                 count=self.size,
             )
             for i in range(self.size, other.size):
-                (other._buf.ptr + i).init_pointee_copy(0)
+                (other._buf.ptr + i).unsafe_write(0)
             self = other^
         else:
             self.shape = shape
@@ -5872,7 +5872,7 @@ struct NDArray[dtype: DType = DType.float64](
                 + id * Int(self.strides[0])
                 + i * Int(self.strides[1])
             )
-            buffer._buf.ptr[i] = self._buf.ptr[src_idx]
+            buffer._buf.ptr[unsafe_offset=i] = self._buf.ptr[unsafe_offset=src_idx]
         return buffer^
 
     def sort(mut self, axis: Int = -1, stable: Bool = False) raises:
@@ -6004,7 +6004,7 @@ struct NDArray[dtype: DType = DType.float64](
                     index_of_buffer += coord * Int(
                         self.strides.unsafe_load(dim)
                     )
-                result.append(self._buf.ptr[index_of_buffer])
+                result.append(self._buf.ptr[unsafe_offset=index_of_buffer])
         return result^
 
     def to_numpy(self) raises -> PythonObject:
@@ -6081,7 +6081,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     def unsafe_ptr(
         ref self,
-    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
+    ) -> Pointer[Scalar[Self.dtype], MutAnyOrigin]:
         """Retrieves the pointer to the logical start of the array data.
 
         For views with a non-zero offset, this returns a pointer to
@@ -6263,7 +6263,7 @@ struct _NDArrayIter[
                     # (item._buf.ptr + i).init_pointee_copy(
                     #     Scalar[DType.int](remainder % self.shape[i])
                     # )
-                    item._buf.ptr[i] = Scalar[DType.int](
+                    item._buf.ptr[unsafe_offset=i] = Scalar[DType.int](
                         remainder % self.shape[i]
                     )
                     remainder = remainder // self.shape[i]
@@ -6271,14 +6271,14 @@ struct _NDArrayIter[
                     # (item._buf.ptr + self.dimension).init_pointee_copy(
                     #     Scalar[DType.int](current_index)
                     # )
-                    item._buf.ptr[self.dimension] = Scalar[DType.int](
+                    item._buf.ptr[unsafe_offset=self.dimension] = Scalar[DType.int](
                         current_index
                     )
 
             # (result._buf.ptr + offset).init_pointee_copy(
             #     self._buf[IndexMethods.get_1d_index(item, self.strides)]
             # )
-            result._buf.ptr[offset] = self._buf[
+            result._buf.ptr[unsafe_offset=offset] = self._buf[
                 self.offset + IndexMethods.get_1d_index(item, self.strides)
             ]
         return result^
@@ -6324,17 +6324,17 @@ struct _NDArrayIter[
 
                 for i in range(self.ndim - 1, -1, -1):
                     if i != self.dimension:
-                        (item._buf.ptr + i).init_pointee_copy(
+                        (item._buf.ptr + i).unsafe_write(
                             Scalar[DType.int](remainder % self.shape[i])
                         )
                         remainder = remainder // self.shape[i]
                     else:
-                        (item._buf.ptr + self.dimension).init_pointee_copy(
+                        (item._buf.ptr + self.dimension).unsafe_write(
                             Scalar[DType.int](index)
                         )
 
-                (result._buf.ptr + offset).init_pointee_copy(
-                    self._buf.ptr[
+                (result._buf.ptr + offset).unsafe_write(
+                    self._buf.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
@@ -6343,7 +6343,7 @@ struct _NDArrayIter[
 
         else:  # 0-D array
             var result: NDArray[Self.dtype] = creation._0darray[Self.dtype](
-                self._buf.ptr[self.offset + index]
+                self._buf.ptr[unsafe_offset=self.offset + index]
             )
             return result^
 
@@ -6456,19 +6456,19 @@ struct _NDAxisIter[
         self.strides_compatible = NDArrayStrides(
             ndim=self.ndim, initialized=True
         )
-        (self.strides_compatible._buf.ptr + axis).init_pointee_copy(1)
+        (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
         temp = self.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).init_pointee_copy(
+                    (self.strides_compatible._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= self.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).init_pointee_copy(
+                    (self.strides_compatible._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= self.shape[i]
@@ -6506,31 +6506,31 @@ struct _NDAxisIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (item._buf.ptr + i).init_pointee_copy(
+                    (item._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).init_pointee_copy(0)
+                    (item._buf.ptr + i).unsafe_write(0)
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (item._buf.ptr + i).init_pointee_copy(
+                    (item._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).init_pointee_copy(0)
+                    (item._buf.ptr + i).unsafe_write(0)
 
         if ((self.axis == self.ndim - 1) or (self.axis == 0)) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
         ):
             # The memory layout is C-contiguous or F-contiguous
-            memcpy(
+            unsafe_memcpy(
                 dest=res._buf.ptr,
                 src=self.data.ptr
                 + self.offset
@@ -6540,8 +6540,8 @@ struct _NDAxisIter[
 
         else:
             for j in range(self.size_of_item):
-                (res._buf.ptr + j).init_pointee_copy(
-                    self.data.ptr[
+                (res._buf.ptr + j).unsafe_write(
+                    self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
@@ -6579,31 +6579,31 @@ struct _NDAxisIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (item._buf.ptr + i).init_pointee_copy(
+                    (item._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).init_pointee_copy(0)
+                    (item._buf.ptr + i).unsafe_write(0)
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (item._buf.ptr + i).init_pointee_copy(
+                    (item._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible[i]
                         )
                     )
                     remainder %= self.strides_compatible[i]
                 else:
-                    (item._buf.ptr + i).init_pointee_copy(0)
+                    (item._buf.ptr + i).unsafe_write(0)
 
         if ((self.axis == self.ndim - 1) or (self.axis == 0)) & (
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
         ):
             # The memory layout is C-contiguous or F-contiguous
-            memcpy(
+            unsafe_memcpy(
                 dest=elements._buf.ptr,
                 src=self.data.ptr
                 + self.offset
@@ -6612,8 +6612,8 @@ struct _NDAxisIter[
             )
         else:
             for j in range(self.size_of_item):
-                (elements._buf.ptr + j).init_pointee_copy(
-                    self.data.ptr[
+                (elements._buf.ptr + j).unsafe_write(
+                    self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
@@ -6666,7 +6666,7 @@ struct _NDAxisIter[
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
         ):
             # The memory layout is C-contiguous
-            memcpy(
+            unsafe_memcpy(
                 dest=elements._buf.ptr,
                 src=self.data.ptr
                 + self.offset
@@ -6675,7 +6675,7 @@ struct _NDAxisIter[
             )
             var begin_offset = IndexMethods.get_1d_index(item, new_strides)
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).init_pointee_copy(
+                (offsets._buf.ptr + j).unsafe_write(
                     Scalar[DType.int](begin_offset + j)
                 )
 
@@ -6683,7 +6683,7 @@ struct _NDAxisIter[
             (self.shape[self.axis] == 1) or (self.strides[self.axis] == 1)
         ):
             # The memory layout is F-contiguous
-            memcpy(
+            unsafe_memcpy(
                 dest=elements._buf.ptr,
                 src=self.data.ptr
                 + self.offset
@@ -6691,7 +6691,7 @@ struct _NDAxisIter[
                 count=self.size_of_item,
             )
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).init_pointee_copy(
+                (offsets._buf.ptr + j).unsafe_write(
                     Scalar[DType.int](
                         IndexMethods.get_1d_index(item, new_strides)
                     )
@@ -6700,13 +6700,13 @@ struct _NDAxisIter[
 
         else:
             for j in range(self.size_of_item):
-                (offsets._buf.ptr + j).init_pointee_copy(
+                (offsets._buf.ptr + j).unsafe_write(
                     Scalar[DType.int](
                         IndexMethods.get_1d_index(item, new_strides)
                     )
                 )
-                (elements._buf.ptr + j).init_pointee_copy(
-                    self.data.ptr[
+                (elements._buf.ptr + j).unsafe_write(
+                    self.data.ptr[unsafe_offset=
                         self.offset
                         + IndexMethods.get_1d_index(item, self.strides)
                     ]
@@ -6753,19 +6753,19 @@ struct _NDIter[
         self.strides_compatible = NDArrayStrides(
             ndim=self.ndim, initialized=False
         )
-        (self.strides_compatible._buf.ptr + axis).init_pointee_copy(1)
+        (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
         temp = a.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).init_pointee_copy(
+                    (self.strides_compatible._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= a.shape[i]
         else:
             for i in range(self.ndim):
                 if i != axis:
-                    (self.strides_compatible._buf.ptr + i).init_pointee_copy(
+                    (self.strides_compatible._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](temp)
                     )
                     temp *= a.shape[i]
@@ -6791,30 +6791,30 @@ struct _NDIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (indices._buf.ptr + i).init_pointee_copy(
+                    (indices._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).init_pointee_copy(
+            (indices._buf.ptr + self.axis).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (indices._buf.ptr + i).init_pointee_copy(
+                    (indices._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).init_pointee_copy(
+            (indices._buf.ptr + self.axis).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 
-        return self.data.ptr[
+        return self.data.ptr[unsafe_offset=
             self.offset + IndexMethods.get_1d_index(indices, self.strides)
         ]
 
@@ -6843,28 +6843,28 @@ struct _NDIter[
         if self.order == "C":
             for i in range(self.ndim):
                 if i != self.axis:
-                    (indices._buf.ptr + i).init_pointee_copy(
+                    (indices._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).init_pointee_copy(
+            (indices._buf.ptr + self.axis).unsafe_write(
                 Scalar[DType.int](remainder)
             )
         else:
             for i in range(self.ndim - 1, -1, -1):
                 if i != self.axis:
-                    (indices._buf.ptr + i).init_pointee_copy(
+                    (indices._buf.ptr + i).unsafe_write(
                         Scalar[DType.int](
                             remainder // self.strides_compatible._buf[i]
                         )
                     )
                     remainder %= Int(self.strides_compatible._buf[i])
-            (indices._buf.ptr + self.axis).init_pointee_copy(
+            (indices._buf.ptr + self.axis).unsafe_write(
                 Scalar[DType.int](remainder)
             )
 
-        return self.data.ptr[
+        return self.data.ptr[unsafe_offset=
             self.offset + IndexMethods.get_1d_index(indices, self.strides)
         ]

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -402,7 +402,7 @@ struct NDArray[dtype: DType = DType.float64](
         self.print_options = take.print_options
 
     @always_inline("nodebug")
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """Destroys all elements and frees memory."""
         _ = self._buf^
 
@@ -3780,7 +3780,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            def vec_op[w: Int](i: Int) {mut self, read other}:
+            def vec_op[w: Int](i: Int) {mut self, imm other}:
                 self._buf.ptr.unsafe_store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -3836,7 +3836,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         if self.is_c_contiguous():
 
-            def vec_op[w: Int](i: Int) {mut self, read other_c}:
+            def vec_op[w: Int](i: Int) {mut self, imm other_c}:
                 self._buf.ptr.unsafe_store(
                     self.offset + i,
                     func[Self.dtype, w](
@@ -4013,7 +4013,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         def vectorized_pow[
             simd_width: Int
-        ](index: Int) {mut result, read src, read p_c}:
+        ](index: Int) {mut result, imm src, imm p_c}:
             result._buf.ptr.unsafe_store(
                 index,
                 src._buf.ptr.unsafe_load[width=simd_width](index)
@@ -4027,7 +4027,7 @@ struct NDArray[dtype: DType = DType.float64](
         """Enables `array **= int`. View-safe: modifies buffer in-place."""
         if self.is_c_contiguous():
 
-            def vec_pow[w: Int](i: Int) {mut self, read p}:
+            def vec_pow[w: Int](i: Int) {mut self, imm p}:
                 self._buf.ptr.unsafe_store(
                     self.offset + i,
                     builtin_math.pow(
@@ -4052,7 +4052,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         def array_scalar_vectorize[
             simd_width: Int
-        ](index: Int) {mut src, read p} -> None:
+        ](index: Int) {mut src, imm p} -> None:
             src._buf.ptr.unsafe_store(
                 index,
                 builtin_math.pow(src._buf.ptr.unsafe_load[width=simd_width](index), p),
@@ -4672,7 +4672,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         def vectorized_all[
             simd_width: Int
-        ](idx: Int) {mut result, read a} -> None:
+        ](idx: Int) {mut result, imm a} -> None:
             result = result and builtin_bool.all(
                 (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
             )
@@ -4698,7 +4698,7 @@ struct NDArray[dtype: DType = DType.float64](
 
         def vectorized_any[
             simd_width: Int
-        ](idx: Int) {mut result, read a} -> None:
+        ](idx: Int) {mut result, imm a} -> None:
             result = result or builtin_bool.any(
                 (a._buf.ptr + a.offset + idx).unsafe_strided_load[width=simd_width](1)
             )
@@ -4914,7 +4914,7 @@ struct NDArray[dtype: DType = DType.float64](
                 def closure[
                     simd_w: Int
                 ](i: Int) {
-                    mut result, read self, base_offset, dest_base, last_stride
+                    mut result, imm self, base_offset, dest_base, last_stride
                 }:
                     var simd_data = (
                         self._buf.ptr + base_offset + i * last_stride
@@ -5554,7 +5554,7 @@ struct NDArray[dtype: DType = DType.float64](
 
     def iter_over_dimension[
         forward: Bool = True
-    ](read self, dimension: Int) raises -> _NDArrayIter[
+    ](imm self, dimension: Int) raises -> _NDArrayIter[
         origin_of(self), Self.dtype, forward
     ]:
         """Returns an iterator yielding `ndim-1` arrays over the given
@@ -6457,7 +6457,7 @@ struct _NDAxisIter[
             ndim=self.ndim, initialized=True
         )
         (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
-        temp = self.shape[axis]
+        var temp = self.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:
@@ -6754,7 +6754,7 @@ struct _NDIter[
             ndim=self.ndim, initialized=False
         )
         (self.strides_compatible._buf.ptr + axis).unsafe_write(1)
-        temp = a.shape[axis]
+        var temp = a.shape[axis]
         if order == "C":
             for i in range(self.ndim - 1, -1, -1):
                 if i != axis:

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -30,7 +30,8 @@ Iterators of `NDArray`:
 # ===----------------------------------------------------------------------===#
 # Stdlib
 # ===----------------------------------------------------------------------===#
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.sys.info import num_performance_cores
 import std.builtin.bool as builtin_bool
 import std.math as builtin_math
@@ -99,6 +100,9 @@ from numojo.routines.indexing import (
 from numojo.routines.math.misc import clip
 from numojo.routines.manipulation import reshape
 import numojo.routines.math as numojo_math
+from numojo.routines import math
+from numojo.routines.manipulation import ravel
+from numojo.routines.statistics import stddev
 
 comptime IndexTypes = Variant[Int, NewAxis, EllipsisType, Slice]
 """IndexTypes is used to represent the different kinds of indices that can be used for indexing and slicing operations on the NDArray.
@@ -1680,7 +1684,9 @@ struct NDArray[dtype: DType = DType.float64](
                     self._read_block_from_self(
                         base=src_base,
                         axis_start=k,
-                        dst_ptr=result._buf.ptr + out_offset * size_per_item,
+                        dst_ptr=result._buf.ptr.unsafe_offset(
+                            out_offset * size_per_item
+                        ).as_unsafe_any_origin(),
                     )
                     out_offset += 1
 
@@ -3088,9 +3094,9 @@ struct NDArray[dtype: DType = DType.float64](
             var out_row = 0
             for i in range(mask_c.size):
                 if mask_c._buf.ptr.load[width=1](i):
-                    var src_ptr = val_c._buf.ptr + (
+                    var src_ptr = val_c._buf.ptr.unsafe_offset(
                         out_row * size_per_item if val_is_per_index else 0
-                    )
+                    ).as_unsafe_any_origin()
                     self._write_block_into_self(
                         base=self.offset + i * stride0,
                         axis_start=1,
@@ -3163,9 +3169,9 @@ struct NDArray[dtype: DType = DType.float64](
                     var lead = self.offset
                     for d in range(k):
                         lead += coords[d] * Int(self.strides.unsafe_load(d))
-                    var src_ptr = val_c._buf.ptr + (
+                    var src_ptr = val_c._buf.ptr.unsafe_offset(
                         out_row * size_per_item if val_is_per_index else 0
-                    )
+                    ).as_unsafe_any_origin()
                     self._write_block_into_self(
                         base=lead, axis_start=k, src_ptr=src_ptr
                     )
@@ -3379,7 +3385,7 @@ struct NDArray[dtype: DType = DType.float64](
         self._buf.ptr[self.offset + index] = val
 
     def store[
-        width: Int
+        width: Int = 1
     ](mut self, index: Int, val: SIMD[Self.dtype, width]) raises:
         """Safely stores a SIMD element of size `width` at `index` of the
         underlying buffer.
@@ -5641,7 +5647,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The median of the array.
         """
-        return median[returned_dtype](self)
+        return statistics.median[returned_dtype](self)
 
     def median[
         returned_dtype: DType = DType.float64
@@ -5654,7 +5660,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An NDArray.
         """
-        return median[returned_dtype](self, axis)
+        return statistics.median[returned_dtype](self, axis)
 
     def min(self) raises -> Scalar[Self.dtype]:
         """Finds the min value of an array.
@@ -5932,7 +5938,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             A scalar.
         """
-        return sum(self)
+        return numojo_math.sum(self)
 
     def sum(self, axis: Int) raises -> Self:
         """Computes the sum of array elements over a given axis.
@@ -5943,7 +5949,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An NDArray.
         """
-        return sum(self, axis=axis)
+        return numojo_math.sum(self, axis=axis)
 
     def T(self, axes: List[Int]) raises -> Self:
         """Transposes the array of any number of dimensions according to an
@@ -6085,9 +6091,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             An unsafe pointer to the logical start of the data.
         """
-        return UnsafePointer[Scalar[Self.dtype], MutAnyOrigin](
-            self._buf.ptr + self.offset
-        )
+        return self._buf.ptr.unsafe_offset(self.offset).as_unsafe_any_origin()
 
     def variance[
         returned_dtype: DType = DType.float64
@@ -6103,7 +6107,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The variance of the array.
         """
-        return variance[returned_dtype](self, ddof=ddof)
+        return statistics.variance[returned_dtype](self, ddof=ddof)
 
     def variance[
         returned_dtype: DType = DType.float64
@@ -6121,7 +6125,7 @@ struct NDArray[dtype: DType = DType.float64](
         Returns:
             The variance of the array along the axis.
         """
-        return variance[returned_dtype](self, axis=axis, ddof=ddof)
+        return statistics.variance[returned_dtype](self, axis=axis, ddof=ddof)
 
     def squeeze(mut self, axis: Int) raises:
         """Removes (squeezes) a single dimension of size 1 from the array shape.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -1431,6 +1431,9 @@ struct NDArray[dtype: DType = DType.float64](
                     src=selected._buf.ptr.unsafe_offset(selected.offset),
                     count=size_per_item,
                 )
+                # `DataContainer.origin` is untracked, so the raw pointer above does
+                # not keep `selected` alive; hold it until the copy has finished.
+                _ = selected^
 
         return result^
 
@@ -1618,6 +1621,10 @@ struct NDArray[dtype: DType = DType.float64](
                         count=size_per_item,
                     )
                     offset += 1
+
+            # `DataContainer.origin` is untracked, so the raw pointers above
+            # do not keep `self_c` alive; hold it until the loop is done.
+            _ = self_c^
 
             return result^
 
@@ -2984,6 +2991,10 @@ struct NDArray[dtype: DType = DType.float64](
                     count=per_slice_size,
                 )
                 self.__setitem__(idx=idx, val=slice)
+
+        # `DataContainer.origin` is untracked, so the raw pointers above do
+        # not keep `val_c_for_slices` alive; hold it until the loop is done.
+        _ = val_c_for_slices^
 
     def set(
         mut self, mask: NDArray[DType.bool], *, val: NDArray[Self.dtype]

--- a/numojo/core/traits/backend.mojo
+++ b/numojo/core/traits/backend.mojo
@@ -6,7 +6,7 @@
 from numojo.core.ndarray import NDArray
 
 
-trait Backend(ImplicitlyDestructible):
+trait Backend(Deinitable):
     """
     A trait that defines backends for calculations in the rest of the library.
     """

--- a/numojo/core/traits/indexer_collection_element.mojo
+++ b/numojo/core/traits/indexer_collection_element.mojo
@@ -1,4 +1,4 @@
-comptime IndexerCollectionElement = Indexer & Copyable & Movable
+comptime IndexerCollectionElement = Indexer & Copyable
 
 # trait IndexerCollectionElement(Copyable, Indexer, Movable):
 #     """The IndexerCollectionElement trait denotes a trait composition

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -22,19 +22,19 @@ Notes / conventions:
   stable and widely used.
 """
 
-import .linalg
-import .logic
-import .math
-import .statistics
-import .bitwise
-import .creation
-import .indexing
-import .manipulation
-import .random
-import .sorting
-import .searching
-import .functional
-import .operations
+from . import linalg
+from . import logic
+from . import math
+from . import statistics
+from . import bitwise
+from . import creation
+from . import indexing
+from . import manipulation
+from . import random
+from . import sorting
+from . import searching
+from . import functional
+from . import operations
 
 from .io import (
     loadtxt,

--- a/numojo/routines/constants.mojo
+++ b/numojo/routines/constants.mojo
@@ -36,7 +36,7 @@ struct Constants(AnyType, Copyable, Movable):
         """
         pass
 
-    def __del__(deinit self):
+    def __deinit__(deinit self):
         """
         Deletes the constants.
         """

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -124,7 +124,7 @@ def arange[
     var size: Int = Int(stop)  # TODO: handle negative values.
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(size))
     for i in range(size):
-        (result._buf.ptr + i).unsafe_write(Scalar[dtype](i))
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(Scalar[dtype](i))
 
     return result^
 
@@ -2203,7 +2203,7 @@ def astype[
         def vectorized_astype[
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
-            (result.unsafe_ptr() + idx).unsafe_strided_store[width=simd_width](
+            (result.unsafe_ptr().unsafe_offset(idx)).unsafe_strided_store[width=simd_width](
                 a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target](), 1
             )
 
@@ -2217,7 +2217,7 @@ def astype[
             ](idx: Int) {mut result, imm a} -> None:
                 result._buf.ptr.unsafe_store(
                     idx,
-                    (a._buf.ptr + idx)
+                    (a._buf.ptr.unsafe_offset(idx))
                     .unsafe_strided_load[width=simd_width](1)
                     .cast[target](),
                 )

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -26,12 +26,12 @@ overload for each function. This makes maintenance easier. Example:
 If overloads are needed, it is better to call the default signature in other overloads. Example: `zeros(shape: NDArrayShape)`. All other overloads call this function. So it is easy for modification.
 """
 
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.math import pow
 from std.collections import Dict
 from std.collections.optional import Optional
 from std.memory import UnsafePointer, memset_zero, memset, memcpy
-from std.algorithm.memory import parallel_memcpy
 from std.python import PythonObject, Python
 from std.sys import simd_width_of
 
@@ -39,9 +39,14 @@ from std.sys import simd_width_of
 from numojo.core.layout import Flags
 from numojo.core.layout import Flags
 from numojo.core.ndarray import NDArray
+from numojo.core.complex.complex_ndarray import ComplexNDArray
+from numojo.core.dtype.complex_dtype import ComplexDType
 from numojo.core.type_aliases import ComplexScalar
 from numojo.core.layout import NDArrayShape
 from numojo.core.memory import DataContainer
+from numojo.core.complex.complex_simd import ComplexSIMD
+from numojo.core.layout.ndstrides import NDArrayStrides
+from numojo.core.type_aliases import Shape
 
 
 # ===------------------------------------------------------------------------===#

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -2202,7 +2202,7 @@ def astype[
 
         def vectorized_astype[
             simd_width: Int
-        ](idx: Int) {mut result, read a} -> None:
+        ](idx: Int) {mut result, imm a} -> None:
             (result.unsafe_ptr() + idx).unsafe_strided_store[width=simd_width](
                 a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target](), 1
             )
@@ -2214,7 +2214,7 @@ def astype[
 
             def vectorized_astypenb_from_b[
                 simd_width: Int
-            ](idx: Int) {mut result, read a} -> None:
+            ](idx: Int) {mut result, imm a} -> None:
                 result._buf.ptr.unsafe_store(
                     idx,
                     (a._buf.ptr + idx)
@@ -2228,7 +2228,7 @@ def astype[
 
             def vectorized_astypenb[
                 simd_width: Int
-            ](idx: Int) {mut result, read a} -> None:
+            ](idx: Int) {mut result, imm a} -> None:
                 result._buf.ptr.unsafe_store(
                     idx, a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target]()
                 )
@@ -2515,7 +2515,7 @@ def array[
         raise Error(
             "Error in array: Real and imaginary data must have the same length!"
         )
-    A = ComplexNDArray[cdtype](shape=shape, order=order)
+    var A = ComplexNDArray[cdtype](shape=shape, order=order)
     for i in range(A.size):
         A._re._buf.ptr[unsafe_offset=i] = data[i].re
         A._im._buf.ptr[unsafe_offset=i] = data[i].im

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -31,7 +31,7 @@ from max.algorithm import parallelize
 from std.math import pow
 from std.collections import Dict
 from std.collections.optional import Optional
-from std.memory import UnsafePointer, memset_zero, memset, memcpy
+from std.memory import UnsafePointer, unsafe_memset_zero, unsafe_memset, unsafe_memcpy
 from std.python import PythonObject, Python
 from std.sys import simd_width_of
 
@@ -90,7 +90,7 @@ def arange[
     var num: Int = ((stop - start) / step).__int__()
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(num))
     for idx in range(num):
-        result._buf.ptr[idx] = start + step * Scalar[dtype](idx)
+        result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](idx)
 
     return result^
 
@@ -124,7 +124,7 @@ def arange[
     var size: Int = Int(stop)  # TODO: handle negative values.
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(size))
     for i in range(size):
-        (result._buf.ptr + i).init_pointee_copy(Scalar[dtype](i))
+        (result._buf.ptr + i).unsafe_write(Scalar[dtype](i))
 
     return result^
 
@@ -296,12 +296,12 @@ def _linspace_serial[
     if endpoint:
         var step: SIMD[dtype, 1] = (stop - start) / Scalar[dtype](num - 1)
         for i in range(num):
-            result._buf.ptr[i] = start + step * Scalar[dtype](i)
+            result._buf.ptr[unsafe_offset=i] = start + step * Scalar[dtype](i)
 
     else:
         var step: SIMD[dtype, 1] = (stop - start) / Scalar[dtype](num)
         for i in range(num):
-            result._buf.ptr[i] = start + step * Scalar[dtype](i)
+            result._buf.ptr[unsafe_offset=i] = start + step * Scalar[dtype](i)
 
     return result^
 
@@ -335,7 +335,7 @@ def _linspace_parallel[
 
         @parameter
         def parallelized_linspace(idx: Int) -> None:
-            result._buf.ptr[idx] = start + step * Scalar[dtype](idx)
+            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](idx)
 
         parallelize[parallelized_linspace](num)
 
@@ -344,7 +344,7 @@ def _linspace_parallel[
 
         @parameter
         def parallelized_linspace1(idx: Int) -> None:
-            result._buf.ptr[idx] = start + step * Scalar[dtype](idx)
+            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](idx)
 
         parallelize[parallelized_linspace1](num)
 
@@ -616,11 +616,11 @@ def _logspace_serial[
     if endpoint:
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num - 1)
         for i in range(num):
-            result._buf.ptr[i] = base ** (start + step * Scalar[dtype](i))
+            result._buf.ptr[unsafe_offset=i] = base ** (start + step * Scalar[dtype](i))
     else:
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num)
         for i in range(num):
-            result._buf.ptr[i] = base ** (start + step * Scalar[dtype](i))
+            result._buf.ptr[unsafe_offset=i] = base ** (start + step * Scalar[dtype](i))
     return result^
 
 
@@ -656,7 +656,7 @@ def _logspace_parallel[
 
         @parameter
         def parallelized_logspace(idx: Int) -> None:
-            result._buf.ptr[idx] = base ** (start + step * Scalar[dtype](idx))
+            result._buf.ptr[unsafe_offset=idx] = base ** (start + step * Scalar[dtype](idx))
 
         parallelize[parallelized_logspace](num)
 
@@ -665,7 +665,7 @@ def _logspace_parallel[
 
         @parameter
         def parallelized_logspace1(idx: Int) -> None:
-            result._buf.ptr[idx] = base ** (start + step * Scalar[dtype](idx))
+            result._buf.ptr[unsafe_offset=idx] = base ** (start + step * Scalar[dtype](idx))
 
         parallelize[parallelized_logspace1](num)
 
@@ -897,7 +897,7 @@ def geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num - 1)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result._buf.ptr[i] = a * r**i
+            result._buf.ptr[unsafe_offset=i] = a * r**i
         return result^
 
     else:
@@ -906,7 +906,7 @@ def geomspace[
         var power: Scalar[dtype] = 1 / Scalar[dtype](num)
         var r: Scalar[dtype] = base**power
         for i in range(num):
-            result._buf.ptr[i] = a * r**i
+            result._buf.ptr[unsafe_offset=i] = a * r**i
         return result^
 
 
@@ -1566,7 +1566,7 @@ def full[
 
     var A = NDArray[dtype](shape=shape, order=order)
     for i in range(A.size):
-        A._buf.ptr[i] = fill_value
+        A._buf.ptr[unsafe_offset=i] = fill_value
     return A^
 
 
@@ -1671,8 +1671,8 @@ def full[
     """
     var A = ComplexNDArray[cdtype](shape=shape, order=order)
     for i in range(A.size):
-        A._re._buf.ptr.store(i, fill_value.re)
-        A._im._buf.ptr.store(i, fill_value.im)
+        A._re._buf.ptr.unsafe_store(i, fill_value.re)
+        A._im._buf.ptr.unsafe_store(i, fill_value.im)
     return A^
 
 
@@ -1797,13 +1797,13 @@ def diag[
         )
         if k >= 0:
             for i in range(n):
-                result._buf.ptr[i * (n + abs(k) + 1) + k] = v_c._buf.ptr[i]
+                result._buf.ptr[unsafe_offset=i * (n + abs(k) + 1) + k] = v_c._buf.ptr[unsafe_offset=i]
             return result^
         else:
             for i in range(n):
-                result._buf.ptr[
+                result._buf.ptr[unsafe_offset=
                     result.size - 1 - i * (result.shape[1] + 1) + k
-                ] = v_c._buf.ptr[n - 1 - i]
+                ] = v_c._buf.ptr[unsafe_offset=n - 1 - i]
         return result^
     elif v.ndim == 2:
         var v_c = v.contiguous()
@@ -1812,10 +1812,10 @@ def diag[
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(n - abs(k)))
         if k >= 0:
             for i in range(n - abs(k)):
-                result._buf.ptr[i] = v_c._buf.ptr[i * (n + 1) + k]
+                result._buf.ptr[unsafe_offset=i] = v_c._buf.ptr[unsafe_offset=i * (n + 1) + k]
         else:
             for i in range(n - abs(k)):
-                result._buf.ptr[m - abs(k) - 1 - i] = v_c._buf.ptr[
+                result._buf.ptr[unsafe_offset=m - abs(k) - 1 - i] = v_c._buf.ptr[unsafe_offset=
                     v_c.size - 1 - i * (v_c.shape[1] + 1) + k
                 ]
         return result^
@@ -1880,12 +1880,12 @@ def diagflat[
     )
     if k >= 0:
         for i in range(n):
-            result.store((n + k + 1) * i + k, v._buf.ptr[i])
+            result.store((n + k + 1) * i + k, v._buf.ptr[unsafe_offset=i])
     else:
         for i in range(n):
             result.store(
                 result.size - 1 - (n + abs(k) + 1) * i + k,
-                v._buf.ptr[v.size - 1 - i],
+                v._buf.ptr[unsafe_offset=v.size - 1 - i],
             )
     return result^
 
@@ -2005,7 +2005,7 @@ def tril[
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(i + 1 + k, m.shape[1]):
-                result._buf.ptr[i * m.shape[1] + j] = Scalar[dtype](0)
+                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[dtype](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
             initial_offset *= m.shape[i]
@@ -2014,7 +2014,7 @@ def tril[
         for offset in range(initial_offset):
             for i in range(m.shape[-2]):
                 for j in range(i + 1 + k, m.shape[-1]):
-                    result._buf.ptr[
+                    result._buf.ptr[unsafe_offset=
                         offset * final_offset + j + i * m.shape[-1]
                     ] = Scalar[dtype](0)
     else:
@@ -2068,7 +2068,7 @@ def triu[
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(0, i + k):
-                result._buf.ptr[i * m.shape[1] + j] = Scalar[dtype](0)
+                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[dtype](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
             initial_offset *= m.shape[i]
@@ -2077,7 +2077,7 @@ def triu[
         for offset in range(initial_offset):
             for i in range(m.shape[-2]):
                 for j in range(0, i + k):
-                    result._buf.ptr[
+                    result._buf.ptr[unsafe_offset=
                         offset * final_offset + j + i * m.shape[-1]
                     ] = Scalar[dtype](0)
     else:
@@ -2135,7 +2135,7 @@ def vander[
     var n_cols = N.value() if N else n_rows
     var result: NDArray[dtype] = ones[dtype](NDArrayShape(n_rows, n_cols))
     for i in range(n_rows):
-        var x_i = x._buf.ptr[i]
+        var x_i = x._buf.ptr[unsafe_offset=i]
         if increasing:
             for j in range(n_cols):
                 result.store(i, j, val=x_i**j)
@@ -2203,8 +2203,8 @@ def astype[
         def vectorized_astype[
             simd_width: Int
         ](idx: Int) {mut result, read a} -> None:
-            (result.unsafe_ptr() + idx).strided_store[width=simd_width](
-                a._buf.ptr.load[width=simd_width](idx).cast[target](), 1
+            (result.unsafe_ptr() + idx).unsafe_strided_store[width=simd_width](
+                a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target](), 1
             )
 
         vectorize[a.width](a.size, vectorized_astype)
@@ -2215,10 +2215,10 @@ def astype[
             def vectorized_astypenb_from_b[
                 simd_width: Int
             ](idx: Int) {mut result, read a} -> None:
-                result._buf.ptr.store(
+                result._buf.ptr.unsafe_store(
                     idx,
                     (a._buf.ptr + idx)
-                    .strided_load[width=simd_width](1)
+                    .unsafe_strided_load[width=simd_width](1)
                     .cast[target](),
                 )
 
@@ -2229,8 +2229,8 @@ def astype[
             def vectorized_astypenb[
                 simd_width: Int
             ](idx: Int) {mut result, read a} -> None:
-                result._buf.ptr.store(
-                    idx, a._buf.ptr.load[width=simd_width](idx).cast[target]()
+                result._buf.ptr.unsafe_store(
+                    idx, a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target]()
                 )
 
             vectorize[a.width](a.size, vectorized_astypenb)
@@ -2470,7 +2470,7 @@ def array[
     """
     var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(shape), order)
     for i in range(result.size):
-        result._buf.ptr[i] = data[i]
+        result._buf.ptr[unsafe_offset=i] = data[i]
     return result^
 
 
@@ -2517,8 +2517,8 @@ def array[
         )
     A = ComplexNDArray[cdtype](shape=shape, order=order)
     for i in range(A.size):
-        A._re._buf.ptr[i] = data[i].re
-        A._im._buf.ptr[i] = data[i].im
+        A._re._buf.ptr[unsafe_offset=i] = data[i].re
+        A._im._buf.ptr[unsafe_offset=i] = data[i].im
     return A^
 
 
@@ -2591,7 +2591,7 @@ def array[
         0
     ].unsafe_get_as_pointer[dtype]()
     var A: NDArray[dtype] = NDArray[dtype](array_shape, order)
-    memcpy[Scalar[dtype]](dest=A._buf.ptr, src=pointer, count=A.size)
+    unsafe_memcpy[Scalar[dtype]](dest=A._buf.ptr, src=pointer, count=A.size)
     return A^
 
 
@@ -2678,8 +2678,8 @@ def array[
         0
     ].unsafe_get_as_pointer[dtype]()
     var A: ComplexNDArray[cdtype] = ComplexNDArray[cdtype](array_shape, order)
-    memcpy[Scalar[dtype]](dest=A._re._buf.ptr, src=pointer, count=A._re.size)
-    memcpy[Scalar[dtype]](
+    unsafe_memcpy[Scalar[dtype]](dest=A._re._buf.ptr, src=pointer, count=A._re.size)
+    unsafe_memcpy[Scalar[dtype]](
         dest=A._im._buf.ptr, src=pointer_imag, count=A._im.size
     )
     return A^
@@ -2761,7 +2761,7 @@ def meshgrid[
                     var idx = (
                         outer * dim_size * inner_size + k * inner_size + inner
                     )
-                    grid._buf.ptr[idx] = arrays[i]._buf.ptr[k]
+                    grid._buf.ptr[unsafe_offset=idx] = arrays[i]._buf.ptr[unsafe_offset=k]
 
         parallelize[closure](outer_size, outer_size)
         grids.append(grid^)
@@ -2795,7 +2795,7 @@ def _0darray[
         ),
     )
     b._buf = DataContainer[dtype](1)
-    b._buf.ptr.init_pointee_copy(val)
+    b._buf.ptr.unsafe_write(val)
     b.flags.OWNDATA = True
     return b^
 
@@ -2823,7 +2823,7 @@ def _0darray[
     # TODO: initialize the values of buffers directly without going through copy, this also removes the need for MutExternalOrigin.
     b._re._buf = DataContainer[cdtype.dtype](1)
     b._im._buf = DataContainer[cdtype.dtype](1)
-    b._re._buf.ptr.init_pointee_copy(val.re)
-    b._im._buf.ptr.init_pointee_copy(val.im)
+    b._re._buf.ptr.unsafe_write(val.re)
+    b._im._buf.ptr.unsafe_write(val.im)
     b.flags.OWNDATA = True
     return b^

--- a/numojo/routines/creation.mojo
+++ b/numojo/routines/creation.mojo
@@ -31,7 +31,12 @@ from max.algorithm import parallelize
 from std.math import pow
 from std.collections import Dict
 from std.collections.optional import Optional
-from std.memory import UnsafePointer, unsafe_memset_zero, unsafe_memset, unsafe_memcpy
+from std.memory import (
+    UnsafePointer,
+    unsafe_memset_zero,
+    unsafe_memset,
+    unsafe_memcpy,
+)
 from std.python import PythonObject, Python
 from std.sys import simd_width_of
 
@@ -335,7 +340,9 @@ def _linspace_parallel[
 
         @parameter
         def parallelized_linspace(idx: Int) -> None:
-            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](idx)
+            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](
+                idx
+            )
 
         parallelize[parallelized_linspace](num)
 
@@ -344,7 +351,9 @@ def _linspace_parallel[
 
         @parameter
         def parallelized_linspace1(idx: Int) -> None:
-            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](idx)
+            result._buf.ptr[unsafe_offset=idx] = start + step * Scalar[dtype](
+                idx
+            )
 
         parallelize[parallelized_linspace1](num)
 
@@ -616,11 +625,15 @@ def _logspace_serial[
     if endpoint:
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num - 1)
         for i in range(num):
-            result._buf.ptr[unsafe_offset=i] = base ** (start + step * Scalar[dtype](i))
+            result._buf.ptr[unsafe_offset=i] = base ** (
+                start + step * Scalar[dtype](i)
+            )
     else:
         var step: Scalar[dtype] = (stop - start) / Scalar[dtype](num)
         for i in range(num):
-            result._buf.ptr[unsafe_offset=i] = base ** (start + step * Scalar[dtype](i))
+            result._buf.ptr[unsafe_offset=i] = base ** (
+                start + step * Scalar[dtype](i)
+            )
     return result^
 
 
@@ -656,7 +669,9 @@ def _logspace_parallel[
 
         @parameter
         def parallelized_logspace(idx: Int) -> None:
-            result._buf.ptr[unsafe_offset=idx] = base ** (start + step * Scalar[dtype](idx))
+            result._buf.ptr[unsafe_offset=idx] = base ** (
+                start + step * Scalar[dtype](idx)
+            )
 
         parallelize[parallelized_logspace](num)
 
@@ -665,7 +680,9 @@ def _logspace_parallel[
 
         @parameter
         def parallelized_logspace1(idx: Int) -> None:
-            result._buf.ptr[unsafe_offset=idx] = base ** (start + step * Scalar[dtype](idx))
+            result._buf.ptr[unsafe_offset=idx] = base ** (
+                start + step * Scalar[dtype](idx)
+            )
 
         parallelize[parallelized_logspace1](num)
 
@@ -1797,12 +1814,17 @@ def diag[
         )
         if k >= 0:
             for i in range(n):
-                result._buf.ptr[unsafe_offset=i * (n + abs(k) + 1) + k] = v_c._buf.ptr[unsafe_offset=i]
+                result._buf.ptr[
+                    unsafe_offset=i * (n + abs(k) + 1) + k
+                ] = v_c._buf.ptr[unsafe_offset=i]
             return result^
         else:
             for i in range(n):
-                result._buf.ptr[unsafe_offset=
-                    result.size - 1 - i * (result.shape[1] + 1) + k
+                result._buf.ptr[
+                    unsafe_offset=result.size
+                    - 1
+                    - i * (result.shape[1] + 1)
+                    + k
                 ] = v_c._buf.ptr[unsafe_offset=n - 1 - i]
         return result^
     elif v.ndim == 2:
@@ -1812,11 +1834,15 @@ def diag[
         var result: NDArray[dtype] = NDArray[dtype](NDArrayShape(n - abs(k)))
         if k >= 0:
             for i in range(n - abs(k)):
-                result._buf.ptr[unsafe_offset=i] = v_c._buf.ptr[unsafe_offset=i * (n + 1) + k]
+                result._buf.ptr[unsafe_offset=i] = v_c._buf.ptr[
+                    unsafe_offset=i * (n + 1) + k
+                ]
         else:
             for i in range(n - abs(k)):
-                result._buf.ptr[unsafe_offset=m - abs(k) - 1 - i] = v_c._buf.ptr[unsafe_offset=
-                    v_c.size - 1 - i * (v_c.shape[1] + 1) + k
+                result._buf.ptr[
+                    unsafe_offset=m - abs(k) - 1 - i
+                ] = v_c._buf.ptr[
+                    unsafe_offset=v_c.size - 1 - i * (v_c.shape[1] + 1) + k
                 ]
         return result^
     else:
@@ -2005,7 +2031,9 @@ def tril[
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(i + 1 + k, m.shape[1]):
-                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[dtype](0)
+                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[
+                    dtype
+                ](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
             initial_offset *= m.shape[i]
@@ -2014,8 +2042,10 @@ def tril[
         for offset in range(initial_offset):
             for i in range(m.shape[-2]):
                 for j in range(i + 1 + k, m.shape[-1]):
-                    result._buf.ptr[unsafe_offset=
-                        offset * final_offset + j + i * m.shape[-1]
+                    result._buf.ptr[
+                        unsafe_offset=offset * final_offset
+                        + j
+                        + i * m.shape[-1]
                     ] = Scalar[dtype](0)
     else:
         raise Error(
@@ -2068,7 +2098,9 @@ def triu[
     if m.ndim == 2:
         for i in range(m.shape[0]):
             for j in range(0, i + k):
-                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[dtype](0)
+                result._buf.ptr[unsafe_offset=i * m.shape[1] + j] = Scalar[
+                    dtype
+                ](0)
     elif m.ndim >= 2:
         for i in range(m.ndim - 2):
             initial_offset *= m.shape[i]
@@ -2077,8 +2109,10 @@ def triu[
         for offset in range(initial_offset):
             for i in range(m.shape[-2]):
                 for j in range(0, i + k):
-                    result._buf.ptr[unsafe_offset=
-                        offset * final_offset + j + i * m.shape[-1]
+                    result._buf.ptr[
+                        unsafe_offset=offset * final_offset
+                        + j
+                        + i * m.shape[-1]
                     ] = Scalar[dtype](0)
     else:
         raise Error(
@@ -2203,9 +2237,9 @@ def astype[
         def vectorized_astype[
             simd_width: Int
         ](idx: Int) {mut result, imm a} -> None:
-            (result.unsafe_ptr().unsafe_offset(idx)).unsafe_strided_store[width=simd_width](
-                a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target](), 1
-            )
+            (result.unsafe_ptr().unsafe_offset(idx)).unsafe_strided_store[
+                width=simd_width
+            ](a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target](), 1)
 
         vectorize[a.width](a.size, vectorized_astype)
 
@@ -2230,7 +2264,10 @@ def astype[
                 simd_width: Int
             ](idx: Int) {mut result, imm a} -> None:
                 result._buf.ptr.unsafe_store(
-                    idx, a._buf.ptr.unsafe_load[width=simd_width](idx).cast[target]()
+                    idx,
+                    a._buf.ptr.unsafe_load[width=simd_width](idx).cast[
+                        target
+                    ](),
                 )
 
             vectorize[a.width](a.size, vectorized_astypenb)
@@ -2678,7 +2715,9 @@ def array[
         0
     ].unsafe_get_as_pointer[dtype]()
     var A: ComplexNDArray[cdtype] = ComplexNDArray[cdtype](array_shape, order)
-    unsafe_memcpy[Scalar[dtype]](dest=A._re._buf.ptr, src=pointer, count=A._re.size)
+    unsafe_memcpy[Scalar[dtype]](
+        dest=A._re._buf.ptr, src=pointer, count=A._re.size
+    )
     unsafe_memcpy[Scalar[dtype]](
         dest=A._im._buf.ptr, src=pointer_imag, count=A._im.size
     )
@@ -2761,7 +2800,9 @@ def meshgrid[
                     var idx = (
                         outer * dim_size * inner_size + k * inner_size + inner
                     )
-                    grid._buf.ptr[unsafe_offset=idx] = arrays[i]._buf.ptr[unsafe_offset=k]
+                    grid._buf.ptr[unsafe_offset=idx] = arrays[i]._buf.ptr[
+                        unsafe_offset=k
+                    ]
 
         parallelize[closure](outer_size, outer_size)
         grids.append(grid^)

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -12,7 +12,7 @@ This module implements functional programming utilities for NDArray operations, 
 
 from std.algorithm.functional import vectorize
 from max.algorithm import parallelize
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 from std.sys import simd_width_of
 
 from numojo.core.layout import Flags, NDArrayShape, NDArrayStrides
@@ -112,7 +112,7 @@ def apply_along_axis_reduce_to_int[
 
     if a.ndim == 1:
         res = _0darray[DType.int](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
+        (res._buf.ptr).unsafe_write(func1d[dtype](a))
 
     else:
         res = NDArray[DType.int](a.shape.pop(axis=axis))
@@ -120,7 +120,7 @@ def apply_along_axis_reduce_to_int[
         @parameter
         def parallelized_func(i: Int):
             try:
-                (res._buf.ptr + i).init_pointee_copy(
+                (res._buf.ptr + i).unsafe_write(
                     func1d[dtype](iterator.ith(i))
                 )
             except e:
@@ -163,7 +163,7 @@ def apply_along_axis_reduce[
 
     if a.ndim == 1:
         res = _0darray[dtype](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype](a))
+        (res._buf.ptr).unsafe_write(func1d[dtype](a))
 
     else:
         var new_shape = a.shape.pop(axis=axis)
@@ -225,7 +225,7 @@ def apply_along_axis_reduce_with_dtype[
 
     if a.ndim == 1:
         res = _0darray[returned_dtype](0)
-        (res._buf.ptr).init_pointee_copy(func1d[dtype, returned_dtype](a))
+        (res._buf.ptr).unsafe_write(func1d[dtype, returned_dtype](a))
 
     else:
         res = NDArray[returned_dtype](a.shape.pop(axis=axis))
@@ -233,7 +233,7 @@ def apply_along_axis_reduce_with_dtype[
         @parameter
         def parallelized_func(i: Int):
             try:
-                (res._buf.ptr + i).init_pointee_copy(
+                (res._buf.ptr + i).unsafe_write(
                     func1d[dtype, returned_dtype](iterator.ith(i))
                 )
             except e:
@@ -281,7 +281,7 @@ def apply_along_axis_preserve[
         def parallelized_func_c(i: Int):
             try:
                 var elements: NDArray[dtype] = func1d[dtype](iterator.ith(i))
-                memcpy(
+                unsafe_memcpy(
                     dest=result._buf.ptr + i * elements.size,
                     src=elements._buf.ptr,
                     count=elements.size,
@@ -309,7 +309,7 @@ def apply_along_axis_preserve[
                 var res_along_axis: NDArray[dtype] = func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (result._buf.ptr + Int(indices[j])).init_pointee_copy(
+                    (result._buf.ptr + Int(indices[j])).unsafe_write(
                         (res_along_axis._buf.ptr + j)[]
                     )
             except e:
@@ -355,7 +355,7 @@ def apply_along_axis_inplace[
             try:
                 var elements: NDArray[dtype] = iterator.ith(i)
                 func1d[dtype](elements)
-                memcpy(
+                unsafe_memcpy(
                     dest=a._buf.ptr + i * elements.size,
                     src=elements._buf.ptr,
                     count=elements.size,
@@ -382,7 +382,7 @@ def apply_along_axis_inplace[
                 func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (a._buf.ptr + Int(indices[j])).init_pointee_copy(
+                    (a._buf.ptr + Int(indices[j])).unsafe_write(
                         (elements._buf.ptr + j)[]
                     )
             except e:
@@ -430,7 +430,7 @@ def apply_along_axis_indices[
                 var elements: NDArray[DType.int] = func1d[dtype](
                     iterator.ith(i)
                 )
-                memcpy(
+                unsafe_memcpy(
                     dest=res._buf.ptr + i * elements.size,
                     src=elements._buf.ptr,
                     count=elements.size,
@@ -457,7 +457,7 @@ def apply_along_axis_indices[
                 var res_along_axis: NDArray[DType.int] = func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (res._buf.ptr + Int(indices[j])).init_pointee_copy(
+                    (res._buf.ptr + Int(indices[j])).unsafe_write(
                         (res_along_axis._buf.ptr + j)[]
                     )
             except e:

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -120,7 +120,7 @@ def apply_along_axis_reduce_to_int[
         @parameter
         def parallelized_func(i: Int):
             try:
-                (res._buf.ptr + i).unsafe_write(
+                (res._buf.ptr.unsafe_offset(i)).unsafe_write(
                     func1d[dtype](iterator.ith(i))
                 )
             except e:
@@ -233,7 +233,7 @@ def apply_along_axis_reduce_with_dtype[
         @parameter
         def parallelized_func(i: Int):
             try:
-                (res._buf.ptr + i).unsafe_write(
+                (res._buf.ptr.unsafe_offset(i)).unsafe_write(
                     func1d[dtype, returned_dtype](iterator.ith(i))
                 )
             except e:
@@ -282,7 +282,7 @@ def apply_along_axis_preserve[
             try:
                 var elements: NDArray[dtype] = func1d[dtype](iterator.ith(i))
                 unsafe_memcpy(
-                    dest=result._buf.ptr + i * elements.size,
+                    dest=result._buf.ptr.unsafe_offset(i * elements.size),
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
@@ -309,8 +309,8 @@ def apply_along_axis_preserve[
                 var res_along_axis: NDArray[dtype] = func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (result._buf.ptr + Int(indices[j])).unsafe_write(
-                        (res_along_axis._buf.ptr + j)[]
+                    (result._buf.ptr.unsafe_offset(Int(indices[j]))).unsafe_write(
+                        (res_along_axis._buf.ptr.unsafe_offset(j))[]
                     )
             except e:
                 print("Error in parallelized_func", e)
@@ -356,7 +356,7 @@ def apply_along_axis_inplace[
                 var elements: NDArray[dtype] = iterator.ith(i)
                 func1d[dtype](elements)
                 unsafe_memcpy(
-                    dest=a._buf.ptr + i * elements.size,
+                    dest=a._buf.ptr.unsafe_offset(i * elements.size),
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
@@ -382,8 +382,8 @@ def apply_along_axis_inplace[
                 func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (a._buf.ptr + Int(indices[j])).unsafe_write(
-                        (elements._buf.ptr + j)[]
+                    (a._buf.ptr.unsafe_offset(Int(indices[j]))).unsafe_write(
+                        (elements._buf.ptr.unsafe_offset(j))[]
                     )
             except e:
                 print("Error in parallelized_func", e)
@@ -431,7 +431,7 @@ def apply_along_axis_indices[
                     iterator.ith(i)
                 )
                 unsafe_memcpy(
-                    dest=res._buf.ptr + i * elements.size,
+                    dest=res._buf.ptr.unsafe_offset(i * elements.size),
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
@@ -457,8 +457,8 @@ def apply_along_axis_indices[
                 var res_along_axis: NDArray[DType.int] = func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (res._buf.ptr + Int(indices[j])).unsafe_write(
-                        (res_along_axis._buf.ptr + j)[]
+                    (res._buf.ptr.unsafe_offset(Int(indices[j]))).unsafe_write(
+                        (res_along_axis._buf.ptr.unsafe_offset(j))[]
                     )
             except e:
                 print("Error in parallelized_func", e)

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -10,7 +10,8 @@
 This module implements functional programming utilities for NDArray operations, such as `apply_along_axis`.
 """
 
-from std.algorithm.functional import vectorize, parallelize
+from std.algorithm.functional import vectorize
+from max.algorithm import parallelize
 from std.memory import memcpy
 from std.sys import simd_width_of
 

--- a/numojo/routines/functional.mojo
+++ b/numojo/routines/functional.mojo
@@ -286,6 +286,10 @@ def apply_along_axis_preserve[
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
+                # `DataContainer.origin` is untracked, so the raw pointer
+                # above does not keep `elements` alive; hold it until the
+                # copy has finished.
+                _ = elements^
             except e:
                 print("Error in parallelized_func", e)
 
@@ -309,9 +313,9 @@ def apply_along_axis_preserve[
                 var res_along_axis: NDArray[dtype] = func1d[dtype](elements)
 
                 for j in range(a.shape[axis]):
-                    (result._buf.ptr.unsafe_offset(Int(indices[j]))).unsafe_write(
-                        (res_along_axis._buf.ptr.unsafe_offset(j))[]
-                    )
+                    (
+                        result._buf.ptr.unsafe_offset(Int(indices[j]))
+                    ).unsafe_write((res_along_axis._buf.ptr.unsafe_offset(j))[])
             except e:
                 print("Error in parallelized_func", e)
 
@@ -360,6 +364,10 @@ def apply_along_axis_inplace[
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
+                # `DataContainer.origin` is untracked, so the raw pointer
+                # above does not keep `elements` alive; hold it until the
+                # copy has finished.
+                _ = elements^
             except e:
                 print("Error in parallelized_func", e)
 
@@ -435,6 +443,10 @@ def apply_along_axis_indices[
                     src=elements._buf.ptr,
                     count=elements.size,
                 )
+                # `DataContainer.origin` is untracked, so the raw pointer
+                # above does not keep `elements` alive; hold it until the
+                # copy has finished.
+                _ = elements^
             except e:
                 print("Error in parallelized_func", e)
 

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -13,7 +13,7 @@
 - Iterating over arrays.
 """
 
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 from std.sys import simd_width_of
 from std.algorithm import vectorize
 
@@ -51,7 +51,7 @@ def `where`[
     var mask_c = mask.contiguous()
 
     for i in range(x.size):
-        if mask_c._buf.ptr[i] == True:
+        if mask_c._buf.ptr[unsafe_offset=i] == True:
             x.itemset(i, scalar)
 
 
@@ -81,8 +81,8 @@ def `where`[
     var y_c = y.contiguous()
 
     for i in range(x.size):
-        if mask_c._buf.ptr[i] == True:
-            x.itemset(i, y_c._buf.ptr[i])
+        if mask_c._buf.ptr[unsafe_offset=i] == True:
+            x.itemset(i, y_c._buf.ptr[unsafe_offset=i])
 
 
 def `where`[
@@ -154,10 +154,10 @@ def `where`[
 
     var result = NDArray[dtype](cond_c.shape)
     for i in range(result.size):
-        if cond_c._buf.ptr[i]:
-            result._buf.ptr[i] = x_c._buf.ptr[i]
+        if cond_c._buf.ptr[unsafe_offset=i]:
+            result._buf.ptr[unsafe_offset=i] = x_c._buf.ptr[unsafe_offset=i]
         else:
-            result._buf.ptr[i] = y_c._buf.ptr[i]
+            result._buf.ptr[unsafe_offset=i] = y_c._buf.ptr[unsafe_offset=i]
     return result^
 
 
@@ -203,7 +203,7 @@ def `where`[
 
     var result = NDArray[dtype](bc_shape)
     for i in range(result.size):
-        result._buf.ptr[i] = x_c._buf.ptr[i] if cond_c._buf.ptr[i] else y
+        result._buf.ptr[unsafe_offset=i] = x_c._buf.ptr[unsafe_offset=i] if cond_c._buf.ptr[unsafe_offset=i] else y
     return result^
 
 
@@ -249,7 +249,7 @@ def `where`[
 
     var result = NDArray[dtype](bc_shape)
     for i in range(result.size):
-        result._buf.ptr[i] = x if cond_c._buf.ptr[i] else y_c._buf.ptr[i]
+        result._buf.ptr[unsafe_offset=i] = x if cond_c._buf.ptr[unsafe_offset=i] else y_c._buf.ptr[unsafe_offset=i]
     return result^
 
 
@@ -339,7 +339,7 @@ def fancy_index[
     for i in range(out_size):
         var coords = List[Int](capacity=n_idx)
         for k in range(n_idx):
-            var raw = Int(bc_indices[k]._buf.ptr[i])
+            var raw = Int(bc_indices[k]._buf.ptr[unsafe_offset=i])
             var ax_size = a.shape[k]
             if raw < -ax_size or raw >= ax_size:
                 raise Error(
@@ -351,7 +351,7 @@ def fancy_index[
             if raw < 0:
                 raw += ax_size
             coords.append(raw)
-        result._buf.ptr[i] = a._getitem(coords)
+        result._buf.ptr[unsafe_offset=i] = a._getitem(coords)
 
     return result^
 
@@ -459,7 +459,7 @@ def compress[
 
     var number_of_true: Int = 0
     for i in range(condition.size):
-        number_of_true += Int(condition._buf.ptr[i])
+        number_of_true += Int(condition._buf.ptr[unsafe_offset=i])
 
     var shape_of_res: NDArrayShape = a.shape
     shape_of_res[normalized_axis] = number_of_true
@@ -471,9 +471,9 @@ def compress[
     var temp: Scalar[DType.int] = 1
     for i in range(result.ndim - 1, -1, -1):
         if i != normalized_axis:
-            (res_strides._buf.ptr + i).init_pointee_copy(temp)
+            (res_strides._buf.ptr + i).unsafe_write(temp)
             temp *= Scalar[DType.int](result.shape[i])
-    (res_strides._buf.ptr + normalized_axis).init_pointee_copy(temp)
+    (res_strides._buf.ptr + normalized_axis).unsafe_write(temp)
 
     var iterator = a.iter_over_dimension(normalized_axis)
 
@@ -488,7 +488,7 @@ def compress[
 
                 # First along the axis
                 var j = normalized_axis
-                (item._buf.ptr + j).init_pointee_copy(
+                (item._buf.ptr + j).unsafe_write(
                     remainder // res_strides.unsafe_load(j)
                 )
                 remainder %= res_strides.unsafe_load(j)
@@ -496,7 +496,7 @@ def compress[
                 # Then along other axes
                 for j in range(result.ndim):
                     if j != normalized_axis:
-                        (item._buf.ptr + j).init_pointee_copy(
+                        (item._buf.ptr + j).unsafe_write(
                             remainder // res_strides.unsafe_load(j)
                         )
                         remainder %= res_strides.unsafe_load(j)
@@ -504,7 +504,7 @@ def compress[
                 (
                     result._buf.ptr
                     + IndexMethods.get_1d_index(item, result.strides)
-                ).init_pointee_copy(current_slice._buf.ptr[offset])
+                ).unsafe_write(current_slice._buf.ptr[unsafe_offset=offset])
 
                 count += 1
 
@@ -655,7 +655,7 @@ def take_along_axis[
             var arr_slice_after_applying_indices: NDArray[dtype] = arr_slice[
                 indices_slice
             ]
-            memcpy(
+            unsafe_memcpy(
                 dest=result._buf.ptr + i * result.shape[normalized_axis],
                 src=arr_slice_after_applying_indices._buf.ptr,
                 count=result.shape[normalized_axis],
@@ -675,8 +675,8 @@ def take_along_axis[
             for j in range(arr_slice_after_applying_indices.size):
                 (
                     result._buf.ptr + Int(indices_slice_offsets[j])
-                ).init_pointee_copy(
-                    arr_slice_after_applying_indices._buf.ptr[j]
+                ).unsafe_write(
+                    arr_slice_after_applying_indices._buf.ptr[unsafe_offset=j]
                 )
 
     return result^
@@ -769,7 +769,7 @@ def take[
 
     for outer in range(outer_size):
         for i in range(n_idx):
-            var raw = Int(indices_c._buf.ptr[i])
+            var raw = Int(indices_c._buf.ptr[unsafe_offset=i])
             if raw < -axis_size or raw >= axis_size:
                 raise Error(
                     String(
@@ -785,7 +785,7 @@ def take[
                 outer * axis_size * inner_size + norm_idx * inner_size
             )
             var dst_base = outer * n_idx * inner_size + i * inner_size
-            memcpy(
+            unsafe_memcpy(
                 dest=result._buf.ptr + dst_base,
                 src=a_c._buf.ptr + src_base,
                 count=inner_size,
@@ -928,7 +928,7 @@ def put[
     var values_c = values.contiguous()
 
     for i in range(indices_c.size):
-        var raw = Int(indices_c._buf.ptr[i])
+        var raw = Int(indices_c._buf.ptr[unsafe_offset=i])
         if raw < -a.size or raw >= a.size:
             raise Error(
                 String(
@@ -940,7 +940,7 @@ def put[
         if norm_idx < 0:
             norm_idx += a.size
 
-        a.itemset(norm_idx, values_c._buf.ptr[i % values_c.size])
+        a.itemset(norm_idx, values_c._buf.ptr[unsafe_offset=i % values_c.size])
 
 
 def put[
@@ -985,7 +985,7 @@ def put[
     var indices_c = indices.contiguous()
 
     for i in range(indices_c.size):
-        var raw = Int(indices_c._buf.ptr[i])
+        var raw = Int(indices_c._buf.ptr[unsafe_offset=i])
         if raw < -a.size or raw >= a.size:
             raise Error(
                 String(
@@ -1092,7 +1092,7 @@ def unravel_index(
         result.append(NDArray[DType.int](indices.shape))
 
     for i in range(indices_c.size):
-        var raw = Int(indices_c._buf.ptr[i])
+        var raw = Int(indices_c._buf.ptr[unsafe_offset=i])
         if raw < 0 or raw >= size:
             raise Error(
                 String(
@@ -1105,12 +1105,12 @@ def unravel_index(
         if order == "C":
             for d in range(shape.ndim - 1, -1, -1):
                 var dim = shape[d]
-                result[d]._buf.ptr[i] = Scalar[DType.int](rem % dim)
+                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](rem % dim)
                 rem //= dim
         elif order == "F":
             for d in range(shape.ndim):
                 var dim = shape[d]
-                result[d]._buf.ptr[i] = Scalar[DType.int](rem % dim)
+                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](rem % dim)
                 rem //= dim
 
     return result^
@@ -1198,7 +1198,7 @@ def ravel_multi_index(
         var flat = 0
         if order == "C":
             for d in range(shape.ndim):
-                var coord = Int(bc_indices[d]._buf.ptr[i])
+                var coord = Int(bc_indices[d]._buf.ptr[unsafe_offset=i])
                 var dim = shape[d]
                 if coord < 0 or coord >= dim:
                     raise Error(
@@ -1211,7 +1211,7 @@ def ravel_multi_index(
         elif order == "F":
             var stride = 1
             for d in range(shape.ndim):
-                var coord = Int(bc_indices[d]._buf.ptr[i])
+                var coord = Int(bc_indices[d]._buf.ptr[unsafe_offset=i])
                 var dim = shape[d]
                 if coord < 0 or coord >= dim:
                     raise Error(
@@ -1223,7 +1223,7 @@ def ravel_multi_index(
                 flat += coord * stride
                 stride *= dim
 
-        result._buf.ptr[i] = Scalar[DType.int](flat)
+        result._buf.ptr[unsafe_offset=i] = Scalar[DType.int](flat)
 
     return result^
 
@@ -1256,14 +1256,14 @@ def flatnonzero[
 
     var count: Int = 0
     for i in range(a_c.size):
-        if a_c._buf.ptr[i] != 0:
+        if a_c._buf.ptr[unsafe_offset=i] != 0:
             count += 1
 
     var result = NDArray[DType.int](NDArrayShape(count))
     var out_idx = 0
     for i in range(a_c.size):
-        if a_c._buf.ptr[i] != 0:
-            result._buf.ptr[out_idx] = Scalar[DType.int](i)
+        if a_c._buf.ptr[unsafe_offset=i] != 0:
+            result._buf.ptr[unsafe_offset=out_idx] = Scalar[DType.int](i)
             out_idx += 1
 
     return result^
@@ -1307,7 +1307,7 @@ def nonzero[
 
     var count: Int = 0
     for i in range(a_c.size):
-        if a_c._buf.ptr[i] != 0:
+        if a_c._buf.ptr[unsafe_offset=i] != 0:
             count += 1
 
     var result = List[NDArray[DType.int]]()
@@ -1316,12 +1316,12 @@ def nonzero[
 
     var out_idx = 0
     for flat in range(a_c.size):
-        if a_c._buf.ptr[flat] != 0:
+        if a_c._buf.ptr[unsafe_offset=flat] != 0:
             var rem = flat
             for d in range(a.ndim - 1, -1, -1):
                 var coord = rem % a.shape[d]
                 rem //= a.shape[d]
-                result[d]._buf.ptr[out_idx] = Scalar[DType.int](coord)
+                result[d]._buf.ptr[unsafe_offset=out_idx] = Scalar[DType.int](coord)
             out_idx += 1
 
     return result^
@@ -1392,24 +1392,24 @@ def searchsorted[
     var result = NDArray[DType.int](Shape(v_c.shape))
 
     for i in range(v_c.size):
-        var target = v_c._buf.ptr[i]
+        var target = v_c._buf.ptr[unsafe_offset=i]
         var lo = 0
         var hi = n
         if side == "left":
             while lo < hi:
                 var mid = (lo + hi) // 2
-                if a_c._buf.ptr[mid] < target:
+                if a_c._buf.ptr[unsafe_offset=mid] < target:
                     lo = mid + 1
                 else:
                     hi = mid
         else:
             while lo < hi:
                 var mid = (lo + hi) // 2
-                if a_c._buf.ptr[mid] <= target:
+                if a_c._buf.ptr[unsafe_offset=mid] <= target:
                     lo = mid + 1
                 else:
                     hi = mid
-        result._buf.ptr[i] = Scalar[DType.int](lo)
+        result._buf.ptr[unsafe_offset=i] = Scalar[DType.int](lo)
 
     return result^
 
@@ -1471,14 +1471,14 @@ def searchsorted[
     if side == "left":
         while lo < hi:
             var mid = (lo + hi) // 2
-            if a_c._buf.ptr[mid] < v:
+            if a_c._buf.ptr[unsafe_offset=mid] < v:
                 lo = mid + 1
             else:
                 hi = mid
     else:
         while lo < hi:
             var mid = (lo + hi) // 2
-            if a_c._buf.ptr[mid] <= v:
+            if a_c._buf.ptr[unsafe_offset=mid] <= v:
                 lo = mid + 1
             else:
                 hi = mid

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -471,9 +471,9 @@ def compress[
     var temp: Scalar[DType.int] = 1
     for i in range(result.ndim - 1, -1, -1):
         if i != normalized_axis:
-            (res_strides._buf.ptr + i).unsafe_write(temp)
+            (res_strides._buf.ptr.unsafe_offset(i)).unsafe_write(temp)
             temp *= Scalar[DType.int](result.shape[i])
-    (res_strides._buf.ptr + normalized_axis).unsafe_write(temp)
+    (res_strides._buf.ptr.unsafe_offset(normalized_axis)).unsafe_write(temp)
 
     var iterator = a.iter_over_dimension(normalized_axis)
 
@@ -488,7 +488,7 @@ def compress[
 
                 # First along the axis
                 var j = normalized_axis
-                (item._buf.ptr + j).unsafe_write(
+                (item._buf.ptr.unsafe_offset(j)).unsafe_write(
                     remainder // res_strides.unsafe_load(j)
                 )
                 remainder %= res_strides.unsafe_load(j)
@@ -496,14 +496,13 @@ def compress[
                 # Then along other axes
                 for j in range(result.ndim):
                     if j != normalized_axis:
-                        (item._buf.ptr + j).unsafe_write(
+                        (item._buf.ptr.unsafe_offset(j)).unsafe_write(
                             remainder // res_strides.unsafe_load(j)
                         )
                         remainder %= res_strides.unsafe_load(j)
 
                 (
-                    result._buf.ptr
-                    + IndexMethods.get_1d_index(item, result.strides)
+                    result._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(item, result.strides))
                 ).unsafe_write(current_slice._buf.ptr[unsafe_offset=offset])
 
                 count += 1
@@ -656,7 +655,7 @@ def take_along_axis[
                 indices_slice
             ]
             unsafe_memcpy(
-                dest=result._buf.ptr + i * result.shape[normalized_axis],
+                dest=result._buf.ptr.unsafe_offset(i * result.shape[normalized_axis]),
                 src=arr_slice_after_applying_indices._buf.ptr,
                 count=result.shape[normalized_axis],
             )
@@ -674,7 +673,7 @@ def take_along_axis[
             var arr_slice_after_applying_indices = arr_slice[indices_slice]
             for j in range(arr_slice_after_applying_indices.size):
                 (
-                    result._buf.ptr + Int(indices_slice_offsets[j])
+                    result._buf.ptr.unsafe_offset(Int(indices_slice_offsets[j]))
                 ).unsafe_write(
                     arr_slice_after_applying_indices._buf.ptr[unsafe_offset=j]
                 )
@@ -786,8 +785,8 @@ def take[
             )
             var dst_base = outer * n_idx * inner_size + i * inner_size
             unsafe_memcpy(
-                dest=result._buf.ptr + dst_base,
-                src=a_c._buf.ptr + src_base,
+                dest=result._buf.ptr.unsafe_offset(dst_base),
+                src=a_c._buf.ptr.unsafe_offset(src_base),
                 count=inner_size,
             )
 

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -23,6 +23,8 @@ from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.indexing import IndexMethods
 import numojo.routines.manipulation as manipulation
 from numojo.routines.creation import array as _array_creation_from_list
+from numojo.core.type_aliases import Shape
+from numojo.core.indexing.item import Item
 
 # ===----------------------------------------------------------------------=== #
 # Generating index arrays

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -204,7 +204,9 @@ def `where`[
 
     var result = NDArray[dtype](bc_shape)
     for i in range(result.size):
-        result._buf.ptr[unsafe_offset=i] = x_c._buf.ptr[unsafe_offset=i] if cond_c._buf.ptr[unsafe_offset=i] else y
+        result._buf.ptr[unsafe_offset=i] = x_c._buf.ptr[
+            unsafe_offset=i
+        ] if cond_c._buf.ptr[unsafe_offset=i] else y
     return result^
 
 
@@ -250,7 +252,9 @@ def `where`[
 
     var result = NDArray[dtype](bc_shape)
     for i in range(result.size):
-        result._buf.ptr[unsafe_offset=i] = x if cond_c._buf.ptr[unsafe_offset=i] else y_c._buf.ptr[unsafe_offset=i]
+        result._buf.ptr[unsafe_offset=i] = x if cond_c._buf.ptr[
+            unsafe_offset=i
+        ] else y_c._buf.ptr[unsafe_offset=i]
     return result^
 
 
@@ -503,7 +507,9 @@ def compress[
                         remainder %= res_strides.unsafe_load(j)
 
                 (
-                    result._buf.ptr.unsafe_offset(IndexMethods.get_1d_index(item, result.strides))
+                    result._buf.ptr.unsafe_offset(
+                        IndexMethods.get_1d_index(item, result.strides)
+                    )
                 ).unsafe_write(current_slice._buf.ptr[unsafe_offset=offset])
 
                 count += 1
@@ -656,7 +662,9 @@ def take_along_axis[
                 indices_slice
             ]
             unsafe_memcpy(
-                dest=result._buf.ptr.unsafe_offset(i * result.shape[normalized_axis]),
+                dest=result._buf.ptr.unsafe_offset(
+                    i * result.shape[normalized_axis]
+                ),
                 src=arr_slice_after_applying_indices._buf.ptr,
                 count=result.shape[normalized_axis],
             )
@@ -1112,12 +1120,16 @@ def unravel_index(
         if order == "C":
             for d in range(shape.ndim - 1, -1, -1):
                 var dim = shape[d]
-                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](rem % dim)
+                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](
+                    rem % dim
+                )
                 rem //= dim
         elif order == "F":
             for d in range(shape.ndim):
                 var dim = shape[d]
-                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](rem % dim)
+                result[d]._buf.ptr[unsafe_offset=i] = Scalar[DType.int](
+                    rem % dim
+                )
                 rem //= dim
 
     return result^
@@ -1328,7 +1340,9 @@ def nonzero[
             for d in range(a.ndim - 1, -1, -1):
                 var coord = rem % a.shape[d]
                 rem //= a.shape[d]
-                result[d]._buf.ptr[unsafe_offset=out_idx] = Scalar[DType.int](coord)
+                result[d]._buf.ptr[unsafe_offset=out_idx] = Scalar[DType.int](
+                    coord
+                )
             out_idx += 1
 
     return result^

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -25,6 +25,7 @@ import numojo.routines.manipulation as manipulation
 from numojo.routines.creation import array as _array_creation_from_list
 from numojo.core.type_aliases import Shape
 from numojo.core.indexing.item import Item
+from numojo.routines.manipulation import ravel
 
 # ===----------------------------------------------------------------------=== #
 # Generating index arrays

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -660,6 +660,9 @@ def take_along_axis[
                 src=arr_slice_after_applying_indices._buf.ptr,
                 count=result.shape[normalized_axis],
             )
+            # `DataContainer.origin` is untracked, so the raw pointer above does
+            # not keep `arr_slice_after_applying_indices` alive; hold it until the copy has finished.
+            _ = arr_slice_after_applying_indices^
     else:
         # If axis is not the last axis, the data is not contiguous.
         for i in range(length_of_iterator):
@@ -790,6 +793,10 @@ def take[
                 src=a_c._buf.ptr.unsafe_offset(src_base),
                 count=inner_size,
             )
+
+    # `DataContainer.origin` is untracked, so the raw pointers above do not
+    # keep `a_c` alive; hold it until the loops are done.
+    _ = a_c^
 
     return result^
 

--- a/numojo/routines/io/files.mojo
+++ b/numojo/routines/io/files.mojo
@@ -11,8 +11,11 @@ This module provides functions for reading and writing arrays to and from files.
 """
 from std.collections.optional import Optional
 from std.python import Python, PythonObject
-from std.memory import UnsafePointer, Span
+from std.memory import UnsafePointer
+from std.collections.span import Span
 
+from numojo.core.dtype import f64
+from numojo.core.ndarray import NDArray
 from numojo.routines.creation import fromstring, array
 
 # We call into the numpy backend for now, this at least let's people go back and forth smoothly.

--- a/numojo/routines/io/formatting.mojo
+++ b/numojo/routines/io/formatting.mojo
@@ -14,6 +14,8 @@ import std.math as mt
 from std.utils.numerics import isnan, isinf
 
 from numojo.core.dtype.utility import is_inttype, is_floattype
+from numojo.core.dtype.complex_dtype import ComplexDType
+from numojo.core.complex.complex_simd import ComplexSIMD
 
 comptime DEFAULT_PRECISION = 4
 comptime DEFAULT_SUPPRESS_SMALL = False

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -48,7 +48,7 @@ def _compute_householder[
 
     norm = builtin_math.sqrt(norm)
     if work_index == rRows - 1 or norm == 0:
-        first_element = H._load(work_index, work_index)
+        var first_element = H._load(work_index, work_index)
         R._store(work_index, work_index, -first_element)
         H._store(work_index, work_index, sqrt2)
         return

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -32,7 +32,7 @@ def _compute_householder[
     comptime sqrt2: Scalar[dtype] = 1.4142135623730951
     var rRows = R.shape[0]
 
-    def load_store_vec[n_elements: Int](i: Int) {mut H, mut R, read work_index}:
+    def load_store_vec[n_elements: Int](i: Int) {mut H, mut R, imm work_index}:
         var r_value = R._load[n_elements](i + work_index, work_index)
         H._store[n_elements](i + work_index, work_index, r_value)
         R._store[n_elements](i + work_index, work_index, 0.0)
@@ -41,7 +41,7 @@ def _compute_householder[
 
     var norm = Scalar[dtype](0)
 
-    def calculate_norm[width: Int](i: Int) {mut norm, read H, read work_index}:
+    def calculate_norm[width: Int](i: Int) {mut norm, imm H, imm work_index}:
         norm += (H._load[width=width](i, work_index) ** 2).reduce_add()
 
     vectorize[simd_width](rRows, calculate_norm)
@@ -61,21 +61,21 @@ def _compute_householder[
 
     def scaling_factor_vec[
         simd_width: Int
-    ](i: Int) {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, imm work_index, imm scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
 
     vectorize[simd_width](rRows, scaling_factor_vec)
 
-    increment = H._load(work_index, work_index) + 1.0
+    var increment = H._load(work_index, work_index) + 1.0
     H._store(work_index, work_index, increment)
 
     scaling_factor = builtin_math.sqrt(1.0 / increment)
 
     def scaling_factor_increment_vec[
         simd_width: Int
-    ](i: Int) {mut H, read work_index, read scaling_factor}:
+    ](i: Int) {mut H, imm work_index, imm scaling_factor}:
         H._store[simd_width](
             i, work_index, H._load[simd_width](i, work_index) * scaling_factor
         )
@@ -101,7 +101,7 @@ def _apply_householder[
 
         def calculate_norm[
             width: Int
-        ](i: Int) {mut dot, read H, read A, read work_index, read j}:
+        ](i: Int) {mut dot, imm H, imm A, imm work_index, imm j}:
             dot += (
                 H._load[width=width](i, work_index) * A._load[width=width](i, j)
             ).reduce_add()
@@ -110,8 +110,8 @@ def _apply_householder[
 
         def closure[
             width: Int
-        ](i: Int) {mut A, read H, read work_index, read j, read dot}:
-            val = A._load[width](i, j) - H._load[width](i, work_index) * dot
+        ](i: Int) {mut A, imm H, imm work_index, imm j, imm dot}:
+            var val = A._load[width](i, j) - H._load[width](i, work_index) * dot
             A._store(i, j, val)
 
         vectorize[simdwidth](aRows, closure)

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -12,7 +12,7 @@ This module provides functions for matrix decompositions, including LU decomposi
 from std.sys import simd_width_of
 from std.algorithm import vectorize
 from max.algorithm import parallelize
-from std.memory import UnsafePointer, memcpy, memset_zero
+from std.memory import UnsafePointer, unsafe_memcpy, unsafe_memset_zero
 import std.math as builtin_math
 
 from numojo.core.ndarray import NDArray

--- a/numojo/routines/linalg/decompositions.mojo
+++ b/numojo/routines/linalg/decompositions.mojo
@@ -10,7 +10,8 @@
 This module provides functions for matrix decompositions, including LU decomposition, QR decomposition, and eigenvalue decomposition for symmetric matrices.
 """
 from std.sys import simd_width_of
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.memory import UnsafePointer, memcpy, memset_zero
 import std.math as builtin_math
 
@@ -18,6 +19,9 @@ from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 from numojo.core.matrix.base import issymmetric
 from numojo.routines.creation import zeros, eye, full
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.indexing.item import Item
+from numojo.routines.creation import identity
 
 
 @always_inline

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -126,8 +126,8 @@ def diagonal[
     if a.ndim == 2 and norm_axis1 == 0 and norm_axis2 == 1:
         var result2d = NDArray[dtype](Shape(diag_len))
         for i in range(diag_len):
-            result2d._buf.ptr[unsafe_offset=i] = a._buf.ptr[unsafe_offset=
-                (i + start_row) * n + (i + start_col)
+            result2d._buf.ptr[unsafe_offset=i] = a._buf.ptr[
+                unsafe_offset=(i + start_row) * n + (i + start_col)
             ]
         return result2d^
 
@@ -175,7 +175,9 @@ def diagonal[
                 + (i + start_row) * a_strides[norm_axis1]
                 + (i + start_col) * a_strides[norm_axis2]
             )
-            result._buf.ptr[unsafe_offset=outer * diag_len + i] = a._buf.ptr[unsafe_offset=src_offset]
+            result._buf.ptr[unsafe_offset=outer * diag_len + i] = a._buf.ptr[
+                unsafe_offset=src_offset
+            ]
 
     return result^
 

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -126,7 +126,7 @@ def diagonal[
     if a.ndim == 2 and norm_axis1 == 0 and norm_axis2 == 1:
         var result2d = NDArray[dtype](Shape(diag_len))
         for i in range(diag_len):
-            result2d._buf.ptr[i] = a._buf.ptr[
+            result2d._buf.ptr[unsafe_offset=i] = a._buf.ptr[unsafe_offset=
                 (i + start_row) * n + (i + start_col)
             ]
         return result2d^
@@ -175,7 +175,7 @@ def diagonal[
                 + (i + start_row) * a_strides[norm_axis1]
                 + (i + start_col) * a_strides[norm_axis2]
             )
-            result._buf.ptr[outer * diag_len + i] = a._buf.ptr[src_offset]
+            result._buf.ptr[unsafe_offset=outer * diag_len + i] = a._buf.ptr[unsafe_offset=src_offset]
 
     return result^
 

--- a/numojo/routines/linalg/misc.mojo
+++ b/numojo/routines/linalg/misc.mojo
@@ -11,7 +11,8 @@ This module provides miscellaneous linear algebra routines, such as extracting d
 """
 
 from std.sys import simd_width_of
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -124,8 +124,8 @@ def trace[
     for i in range(diag_length):
         var row = i if offset >= 0 else i - offset
         var col = i + offset if offset >= 0 else i
-        result._buf.ptr.store(
-            0, result._buf.ptr.load(0) + array._buf.ptr[row * cols + col]
+        result._buf.ptr.unsafe_store(
+            0, result._buf.ptr.unsafe_load(0) + array._buf.ptr[unsafe_offset=row * cols + col]
         )
 
     return result^

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -125,7 +125,9 @@ def trace[
         var row = i if offset >= 0 else i - offset
         var col = i + offset if offset >= 0 else i
         result._buf.ptr.unsafe_store(
-            0, result._buf.ptr.unsafe_load(0) + array._buf.ptr[unsafe_offset=row * cols + col]
+            0,
+            result._buf.ptr.unsafe_load(0)
+            + array._buf.ptr[unsafe_offset=row * cols + col],
         )
 
     return result^

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -16,6 +16,7 @@ from numojo.routines.linalg.decompositions import (
     lu_decomposition,
     partial_pivoting,
 )
+from numojo.core.type_aliases import Shape
 
 
 def det[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:

--- a/numojo/routines/linalg/norms.mojo
+++ b/numojo/routines/linalg/norms.mojo
@@ -68,8 +68,8 @@ def det[dtype: DType](A: Matrix[dtype]) raises -> Scalar[dtype]:
     var U: Matrix[dtype]
     var L: Matrix[dtype]
     var A_pivoted_s = partial_pivoting(A.copy())
-    A_pivoted = A_pivoted_s[0].copy()
-    s = A_pivoted_s[2].copy()
+    var A_pivoted = A_pivoted_s[0].copy()
+    var s = A_pivoted_s[2].copy()
     var L_U: Tuple[Matrix[dtype], Matrix[dtype]] = lu_decomposition[dtype](
         A_pivoted
     )

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -101,7 +101,7 @@ def dot[
 
         def vectorized_dot[
             simd_width: Int
-        ](idx: Int) {mut result, read array1, read array2} -> None:
+        ](idx: Int) {mut result, imm array1, imm array2} -> None:
             result._buf.ptr.unsafe_store(
                 idx,
                 array1._buf.ptr.unsafe_load[width=simd_width](idx)
@@ -157,13 +157,13 @@ def matmul_tiled_unrolled_parallelized[
                     simd_width: Int
                 ](n: Int) {
                     mut result,
-                    read A,
-                    read B,
-                    read t1,
-                    read t2,
-                    read x,
-                    read m,
-                    read k,
+                    imm A,
+                    imm B,
+                    imm t1,
+                    imm t2,
+                    imm x,
+                    imm m,
+                    imm k,
                 } -> None:
                     result._buf.ptr.unsafe_store(
                         m * t2 + (n + x),
@@ -286,7 +286,7 @@ def matmul_2darray[
             def dot[
                 simd_width: Int
             ](n: Int) {
-                mut result, read A, read B, read t2, read t1, read k, read m
+                mut result, imm A, imm B, imm t2, imm t1, imm k, imm m
             } -> None:
                 result._buf.ptr.unsafe_store(
                     m * t2 + n,
@@ -434,7 +434,7 @@ def matmul[
 
                 def dot[
                     simd_width: Int
-                ](n: Int) {mut result, read A, read B, read m, read k} -> None:
+                ](n: Int) {mut result, imm A, imm B, imm m, imm k} -> None:
                     result._store[simd_width](
                         m,
                         n,
@@ -456,7 +456,7 @@ def matmul[
 
                 def dot_F[
                     simd_width: Int
-                ](m: Int) {mut result, read A, read B, read n, read k} -> None:
+                ](m: Int) {mut result, imm A, imm B, imm n, imm k} -> None:
                     result._store[simd_width](
                         m,
                         n,
@@ -479,7 +479,7 @@ def matmul[
 
                 def dot_product[
                     simd_width: Int
-                ](k: Int) {mut sum, read A, read B, read m, read n} -> None:
+                ](k: Int) {mut sum, imm A, imm B, imm m, imm n} -> None:
                     sum += (
                         A._load[simd_width](m, k) * B._load[simd_width](k, n)
                     ).reduce_add()

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -15,7 +15,7 @@ from std.algorithm import vectorize
 from max.algorithm import parallelize
 from std.algorithm import Static2DTileUnitFunc as Tile2DFunc
 from std.sys import simd_width_of
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 
 from numojo.core.ndarray import NDArray
 from numojo.core.layout import NDArrayShape
@@ -102,10 +102,10 @@ def dot[
         def vectorized_dot[
             simd_width: Int
         ](idx: Int) {mut result, read array1, read array2} -> None:
-            result._buf.ptr.store(
+            result._buf.ptr.unsafe_store(
                 idx,
-                array1._buf.ptr.load[width=simd_width](idx)
-                * array2._buf.ptr.load[width=simd_width](idx),
+                array1._buf.ptr.unsafe_load[width=simd_width](idx)
+                * array2._buf.ptr.unsafe_load[width=simd_width](idx),
             )
 
         vectorize[width](array1.size, vectorized_dot)
@@ -165,13 +165,13 @@ def matmul_tiled_unrolled_parallelized[
                     read m,
                     read k,
                 } -> None:
-                    result._buf.ptr.store(
+                    result._buf.ptr.unsafe_store(
                         m * t2 + (n + x),
-                        val=result._buf.ptr.load[width=simd_width](
+                        val=result._buf.ptr.unsafe_load[width=simd_width](
                             m * t2 + (n + x)
                         )
-                        + A._buf.ptr.load(m * t1 + k)
-                        * B._buf.ptr.load[width=simd_width](k * t2 + (n + x)),
+                        + A._buf.ptr.unsafe_load(m * t1 + k)
+                        * B._buf.ptr.unsafe_load[width=simd_width](k * t2 + (n + x)),
                     )
 
                 comptime unroll_factor = tile_x // width
@@ -203,7 +203,7 @@ def matmul_1darray[
             ).format(A.size, B.size)
         )
     else:
-        result._buf.ptr.init_pointee_copy(sum(A * B))
+        result._buf.ptr.unsafe_write(sum(A * B))
 
     return result^
 
@@ -288,11 +288,11 @@ def matmul_2darray[
             ](n: Int) {
                 mut result, read A, read B, read t2, read t1, read k, read m
             } -> None:
-                result._buf.ptr.store(
+                result._buf.ptr.unsafe_store(
                     m * t2 + n,
-                    val=result._buf.ptr.load[width=simd_width](m * t2 + n)
-                    + A._buf.ptr.load[width=simd_width](m * t1 + k)
-                    * B._buf.ptr.load[width=simd_width](k * t2 + n),
+                    val=result._buf.ptr.unsafe_load[width=simd_width](m * t2 + n)
+                    + A._buf.ptr.unsafe_load[width=simd_width](m * t1 + k)
+                    * B._buf.ptr.unsafe_load[width=simd_width](k * t2 + n),
                 )
 
             vectorize[width](t2, dot)
@@ -377,18 +377,18 @@ def matmul[
     )
 
     for i in range(result.size // result_sub_matrix.size):
-        memcpy(
+        unsafe_memcpy(
             dest=A_sub_matrix._buf.ptr,
             src=A._buf.ptr + (i * A_sub_matrix.size),
             count=A_sub_matrix.size,
         )
-        memcpy(
+        unsafe_memcpy(
             dest=B_sub_matrix._buf.ptr,
             src=B._buf.ptr + (i * B_sub_matrix.size),
             count=B_sub_matrix.size,
         )
         result_sub_matrix = matmul_2darray(A_sub_matrix, B_sub_matrix)
-        memcpy(
+        unsafe_memcpy(
             dest=result._buf.ptr + (i * result_sub_matrix.size),
             src=result_sub_matrix._buf.ptr,
             count=result_sub_matrix.size,

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -171,7 +171,9 @@ def matmul_tiled_unrolled_parallelized[
                             m * t2 + (n + x)
                         )
                         + A._buf.ptr.unsafe_load(m * t1 + k)
-                        * B._buf.ptr.unsafe_load[width=simd_width](k * t2 + (n + x)),
+                        * B._buf.ptr.unsafe_load[width=simd_width](
+                            k * t2 + (n + x)
+                        ),
                     )
 
                 comptime unroll_factor = tile_x // width
@@ -290,7 +292,9 @@ def matmul_2darray[
             } -> None:
                 result._buf.ptr.unsafe_store(
                     m * t2 + n,
-                    val=result._buf.ptr.unsafe_load[width=simd_width](m * t2 + n)
+                    val=result._buf.ptr.unsafe_load[width=simd_width](
+                        m * t2 + n
+                    )
                     + A._buf.ptr.unsafe_load[width=simd_width](m * t1 + k)
                     * B._buf.ptr.unsafe_load[width=simd_width](k * t2 + n),
                 )
@@ -393,6 +397,13 @@ def matmul[
             src=result_sub_matrix._buf.ptr,
             count=result_sub_matrix.size,
         )
+
+    # `DataContainer.origin` is untracked, so the raw pointers above do not
+    # keep the sub-matrices alive; hold them until the loop is done.
+    _ = result_sub_matrix^
+    _ = A_sub_matrix^
+    _ = B_sub_matrix^
+
     return result^
 
 

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -379,17 +379,17 @@ def matmul[
     for i in range(result.size // result_sub_matrix.size):
         unsafe_memcpy(
             dest=A_sub_matrix._buf.ptr,
-            src=A._buf.ptr + (i * A_sub_matrix.size),
+            src=A._buf.ptr.unsafe_offset((i * A_sub_matrix.size)),
             count=A_sub_matrix.size,
         )
         unsafe_memcpy(
             dest=B_sub_matrix._buf.ptr,
-            src=B._buf.ptr + (i * B_sub_matrix.size),
+            src=B._buf.ptr.unsafe_offset((i * B_sub_matrix.size)),
             count=B_sub_matrix.size,
         )
         result_sub_matrix = matmul_2darray(A_sub_matrix, B_sub_matrix)
         unsafe_memcpy(
-            dest=result._buf.ptr + (i * result_sub_matrix.size),
+            dest=result._buf.ptr.unsafe_offset((i * result_sub_matrix.size)),
             src=result_sub_matrix._buf.ptr,
             count=result_sub_matrix.size,
         )

--- a/numojo/routines/linalg/products.mojo
+++ b/numojo/routines/linalg/products.mojo
@@ -11,7 +11,8 @@ This module provides functions for computing products of vectors and matrices, s
 """
 
 import std.math
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.algorithm import Static2DTileUnitFunc as Tile2DFunc
 from std.sys import simd_width_of
 from std.memory import memcpy

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -16,7 +16,7 @@ Provides:
     - Determinant.
 """
 
-from std.algorithm import parallelize
+from max.algorithm import parallelize
 
 from numojo.core.ndarray import NDArray
 from numojo.core.indexing import Item
@@ -27,6 +27,7 @@ from numojo.routines.linalg.decompositions import (
     partial_pivoting,
     lu_decomposition,
 )
+from numojo.core.type_aliases import Shape
 
 
 def forward_substitution[

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -183,23 +183,23 @@ def inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     def calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
-            var _temp = Y._buf.ptr.load(i * m + col)
+            var _temp = Y._buf.ptr.unsafe_load(i * m + col)
             for j in range(i):  # col of L
-                _temp = _temp - L._buf.ptr.load(i * m + j) * Z._buf.ptr.load(
+                _temp = _temp - L._buf.ptr.unsafe_load(i * m + j) * Z._buf.ptr.unsafe_load(
                     j * m + col
                 )
-            _temp = _temp / L._buf.ptr.load(i * m + i)
-            Z._buf.ptr.store(i * m + col, _temp)
+            _temp = _temp / L._buf.ptr.unsafe_load(i * m + i)
+            Z._buf.ptr.unsafe_store(i * m + col, _temp)
 
         # Solve `UZ = Z` for `X` for each col
         for i in range(m - 1, -1, -1):
-            var _temp2 = Z._buf.ptr.load(i * m + col)
+            var _temp2 = Z._buf.ptr.unsafe_load(i * m + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U._buf.ptr.load(i * m + j) * X._buf.ptr.load(
+                _temp2 = _temp2 - U._buf.ptr.unsafe_load(i * m + j) * X._buf.ptr.unsafe_load(
                     j * m + col
                 )
-            _temp2 = _temp2 / U._buf.ptr.load(i * m + i)
-            X._buf.ptr.store(i * m + col, _temp2)
+            _temp2 = _temp2 / U._buf.ptr.unsafe_load(i * m + i)
+            X._buf.ptr.unsafe_store(i * m + col, _temp2)
 
     parallelize[calculate_X](m, m)
 
@@ -326,23 +326,23 @@ def solve[
     def calculate_X(col: Int) -> None:
         # Solve `LZ = Y` for `Z` for each col
         for i in range(m):  # row of L
-            var _temp = Y._buf.ptr.load(i * n + col)
+            var _temp = Y._buf.ptr.unsafe_load(i * n + col)
             for j in range(i):  # col of L
-                _temp = _temp - L._buf.ptr.load(i * m + j) * Z._buf.ptr.load(
+                _temp = _temp - L._buf.ptr.unsafe_load(i * m + j) * Z._buf.ptr.unsafe_load(
                     j * n + col
                 )
-            _temp = _temp / L._buf.ptr.load(i * m + i)
-            Z._buf.ptr.store(i * n + col, _temp)
+            _temp = _temp / L._buf.ptr.unsafe_load(i * m + i)
+            Z._buf.ptr.unsafe_store(i * n + col, _temp)
 
         # Solve `UZ = Z` for `X` for each col
         for i in range(m - 1, -1, -1):
-            var _temp2 = Z._buf.ptr.load(i * n + col)
+            var _temp2 = Z._buf.ptr.unsafe_load(i * n + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U._buf.ptr.load(i * m + j) * X._buf.ptr.load(
+                _temp2 = _temp2 - U._buf.ptr.unsafe_load(i * m + j) * X._buf.ptr.unsafe_load(
                     j * n + col
                 )
-            _temp2 = _temp2 / U._buf.ptr.load(i * m + i)
-            X._buf.ptr.store(i * n + col, _temp2)
+            _temp2 = _temp2 / U._buf.ptr.unsafe_load(i * m + i)
+            X._buf.ptr.unsafe_store(i * n + col, _temp2)
 
     parallelize[calculate_X](n, n)
 

--- a/numojo/routines/linalg/solving.mojo
+++ b/numojo/routines/linalg/solving.mojo
@@ -185,9 +185,9 @@ def inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         for i in range(m):  # row of L
             var _temp = Y._buf.ptr.unsafe_load(i * m + col)
             for j in range(i):  # col of L
-                _temp = _temp - L._buf.ptr.unsafe_load(i * m + j) * Z._buf.ptr.unsafe_load(
-                    j * m + col
-                )
+                _temp = _temp - L._buf.ptr.unsafe_load(
+                    i * m + j
+                ) * Z._buf.ptr.unsafe_load(j * m + col)
             _temp = _temp / L._buf.ptr.unsafe_load(i * m + i)
             Z._buf.ptr.unsafe_store(i * m + col, _temp)
 
@@ -195,9 +195,9 @@ def inv_lu[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
         for i in range(m - 1, -1, -1):
             var _temp2 = Z._buf.ptr.unsafe_load(i * m + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U._buf.ptr.unsafe_load(i * m + j) * X._buf.ptr.unsafe_load(
-                    j * m + col
-                )
+                _temp2 = _temp2 - U._buf.ptr.unsafe_load(
+                    i * m + j
+                ) * X._buf.ptr.unsafe_load(j * m + col)
             _temp2 = _temp2 / U._buf.ptr.unsafe_load(i * m + i)
             X._buf.ptr.unsafe_store(i * m + col, _temp2)
 
@@ -328,9 +328,9 @@ def solve[
         for i in range(m):  # row of L
             var _temp = Y._buf.ptr.unsafe_load(i * n + col)
             for j in range(i):  # col of L
-                _temp = _temp - L._buf.ptr.unsafe_load(i * m + j) * Z._buf.ptr.unsafe_load(
-                    j * n + col
-                )
+                _temp = _temp - L._buf.ptr.unsafe_load(
+                    i * m + j
+                ) * Z._buf.ptr.unsafe_load(j * n + col)
             _temp = _temp / L._buf.ptr.unsafe_load(i * m + i)
             Z._buf.ptr.unsafe_store(i * n + col, _temp)
 
@@ -338,9 +338,9 @@ def solve[
         for i in range(m - 1, -1, -1):
             var _temp2 = Z._buf.ptr.unsafe_load(i * n + col)
             for j in range(i + 1, m):
-                _temp2 = _temp2 - U._buf.ptr.unsafe_load(i * m + j) * X._buf.ptr.unsafe_load(
-                    j * n + col
-                )
+                _temp2 = _temp2 - U._buf.ptr.unsafe_load(
+                    i * m + j
+                ) * X._buf.ptr.unsafe_load(j * n + col)
             _temp2 = _temp2 / U._buf.ptr.unsafe_load(i * m + i)
             X._buf.ptr.unsafe_store(i * n + col, _temp2)
 

--- a/numojo/routines/logic/comparison.mojo
+++ b/numojo/routines/logic/comparison.mojo
@@ -584,8 +584,8 @@ def allclose[
         )
 
     for i in range(a.size):
-        val_a: Scalar[dtype] = a.load(i)
-        val_b: Scalar[dtype] = b.load(i)
+        var val_a: Scalar[dtype] = a.load(i)
+        var val_b: Scalar[dtype] = b.load(i)
         if equal_nan and (math.isnan(val_a) and math.isnan(val_b)):
             continue
         if abs(val_a - val_b) <= atol + rtol * abs(val_b):
@@ -653,8 +653,8 @@ def isclose[
 
     var res: NDArray[DType.bool] = NDArray[DType.bool](a.shape)
     for i in range(a.size):
-        val_a: Scalar[dtype] = a.load(i)
-        val_b: Scalar[dtype] = b.load(i)
+        var val_a: Scalar[dtype] = a.load(i)
+        var val_b: Scalar[dtype] = b.load(i)
         if equal_nan and (math.isnan(val_a) and math.isnan(val_b)):
             res.store(i, True)
             continue
@@ -723,8 +723,8 @@ def allclose[
         )
 
     for i in range(a.size):
-        val_a: Scalar[dtype] = a.load(i)
-        val_b: Scalar[dtype] = b.load(i)
+        var val_a: Scalar[dtype] = a.load(i)
+        var val_b: Scalar[dtype] = b.load(i)
         if equal_nan and (math.isnan(val_a) and math.isnan(val_b)):
             continue
         if abs(val_a - val_b) <= atol + rtol * abs(val_b):
@@ -792,8 +792,8 @@ def isclose[
 
     var res: Matrix[DType.bool] = Matrix[DType.bool](a.shape)
     for i in range(a.size):
-        val_a: Scalar[dtype] = a.load(i)
-        val_b: Scalar[dtype] = b.load(i)
+        var val_a: Scalar[dtype] = a.load(i)
+        var val_b: Scalar[dtype] = b.load(i)
         if equal_nan and (math.isnan(val_a) and math.isnan(val_b)):
             res._store_idx(i, val=True)
             continue

--- a/numojo/routines/logic/logical_ops.mojo
+++ b/numojo/routines/logic/logical_ops.mojo
@@ -12,6 +12,10 @@ This module implements element-wise logical operations for NDArray, ComplexNDArr
 
 from numojo.routines import HostExecutor
 from numojo.core.error import NumojoError
+from numojo.core.dtype.complex_dtype import ComplexDType
+from numojo.core.matrix import Matrix
+from numojo.core.ndarray import NDArray
+from numojo.core.complex.complex_ndarray import ComplexNDArray
 
 # TODO: add `where` argument support to logical operations
 # FIXME: Make all SIMD vectorized operations once bool bit-packing issue is resolved.

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -46,7 +46,7 @@ def all(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](True)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    def closure[simd_width: Int](idx: Int) {mut result, read array} -> None:
+    def closure[simd_width: Int](idx: Int) {mut result, imm array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result & simd_data).reduce_and()
 
@@ -76,7 +76,7 @@ def any(array: NDArray[DType.bool]) raises -> Scalar[DType.bool]:
     var result = Scalar[DType.bool](False)
     comptime opt_nelts: Int = simd_width_of[DType.bool]()
 
-    def closure[simd_width: Int](idx: Int) {mut result, read array} -> None:
+    def closure[simd_width: Int](idx: Int) {mut result, imm array} -> None:
         var simd_data = array.unsafe_load[width=simd_width](idx)
         result = (result | simd_data).reduce_or()
 
@@ -102,7 +102,7 @@ def all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](1)
     comptime width: Int = simd_width_of[dtype]()
 
-    def closure[width: Int](i: Int) {mut res, read A}:
+    def closure[width: Int](i: Int) {mut res, imm A}:
         res = (res & A._buf.ptr.unsafe_load[width=width](i)).reduce_and()
 
     vectorize[width](A.size, closure)
@@ -121,7 +121,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, imm A, imm i}:
                 B._store[width](
                     0, j, B._load[width](0, j) & A._load[width](i, j)
                 )
@@ -135,7 +135,7 @@ def all[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, imm A, imm i}:
                 B._store(
                     i,
                     0,
@@ -163,7 +163,7 @@ def any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     var res = Scalar[dtype](0)
     comptime width: Int = simd_width_of[dtype]()
 
-    def cal_and[width: Int](i: Int) {mut res, read A}:
+    def cal_and[width: Int](i: Int) {mut res, imm A}:
         res = res | A._buf.ptr.unsafe_load[width=width](i).reduce_or()
 
     vectorize[width](A.size, cal_and)
@@ -182,7 +182,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         for i in range(A.shape[0]):
 
-            def cal_vec_sum[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_vec_sum[width: Int](j: Int) {mut B, imm A, imm i}:
                 B._store[width](
                     0, j, B._load[width](0, j) | A._load[width](i, j)
                 )
@@ -196,7 +196,7 @@ def any[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
 
         @parameter
         def cal_rows(i: Int):
-            def cal_sum[width: Int](j: Int) {mut B, read A, read i}:
+            def cal_sum[width: Int](j: Int) {mut B, imm A, imm i}:
                 B._store(
                     i,
                     0,

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -10,7 +10,8 @@
 This module implements the truth value testing functions, such as `all` and `any`, for both `NDArray` and `Matrix`.
 """
 
-from std.algorithm import vectorize, parallelize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.sys import simd_width_of
 
 from numojo.core.ndarray import NDArray

--- a/numojo/routines/logic/truth.mojo
+++ b/numojo/routines/logic/truth.mojo
@@ -103,7 +103,7 @@ def all[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     def closure[width: Int](i: Int) {mut res, read A}:
-        res = (res & A._buf.ptr.load[width=width](i)).reduce_and()
+        res = (res & A._buf.ptr.unsafe_load[width=width](i)).reduce_and()
 
     vectorize[width](A.size, closure)
     return res
@@ -164,7 +164,7 @@ def any[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     def cal_and[width: Int](i: Int) {mut res, read A}:
-        res = res | A._buf.ptr.load[width=width](i).reduce_or()
+        res = res | A._buf.ptr.unsafe_load[width=width](i).reduce_or()
 
     vectorize[width](A.size, cal_and)
     return res

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -25,6 +25,8 @@ from numojo.core.indexing import TraverseMethods
 from numojo.core.indexing.utility import (
     _list_of_flipped_range,
 )
+from numojo.core.dtype.complex_dtype import ComplexDType
+from numojo.core.error import NumojoError
 
 # ===----------------------------------------------------------------------=== #
 # Basic operations

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -10,7 +10,7 @@
 This module implements routines that manipulate the shape and layout of arrays, such as reshaping, transposing, broadcasting, and flipping.
 """
 
-from std.memory import UnsafePointer, memcpy
+from std.memory import UnsafePointer, unsafe_memcpy
 from std.sys import simd_width_of
 from std.algorithm import vectorize
 
@@ -51,7 +51,7 @@ def copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
         )
 
     if dst.is_c_contiguous() and src.is_c_contiguous():
-        memcpy(
+        unsafe_memcpy(
             dest=dst._buf.ptr + dst.offset,
             src=src._buf.ptr + src.offset,
             count=src.size,
@@ -66,7 +66,7 @@ def copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
                 remainder = remainder // dst.shape[dim]
                 src_offset += coord * src.strides[dim]
                 dst_offset += coord * dst.strides[dim]
-            dst._buf.ptr[dst_offset] = src._buf.ptr[src_offset]
+            dst._buf.ptr[unsafe_offset=dst_offset] = src._buf.ptr[unsafe_offset=src_offset]
 
 
 def ndim[dtype: DType](array: NDArray[dtype]) -> Int:
@@ -190,11 +190,11 @@ def reshape[
     if array_order != order:
         var temp: NDArray[dtype] = ravel(A, order=order)
         B = NDArray[dtype](shape=shape, order=order)
-        memcpy(dest=B._buf.ptr, src=temp._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=B._buf.ptr, src=temp._buf.ptr, count=A.size)
     else:
         # Write in this order into the new array
         B = NDArray[dtype](shape=shape, order=order)
-        memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
 
     return B^
 
@@ -233,7 +233,7 @@ def ravel[
 
     for i in range(length_of_iterator):
         var sub = iterator.ith(i)
-        memcpy(
+        unsafe_memcpy(
             dest=res._buf.ptr + i * length_of_elements,
             src=sub._buf.ptr + sub.offset,
             count=length_of_elements,
@@ -266,7 +266,7 @@ def _set_values_according_to_shape_and_strides(
             previous_sum + index_of_axis * new_strides[current_dim]
         )
         if current_dim >= new_shape.ndim - 1:
-            I._buf.ptr[index] = Scalar[DType.int](current_sum)
+            I._buf.ptr[unsafe_offset=index] = Scalar[DType.int](current_sum)
             index = index + 1
         else:
             _set_values_according_to_shape_and_strides(
@@ -340,7 +340,7 @@ def transpose[
 
     var B = NDArray[dtype](new_shape, order=array_order)
     for i in range(B.size):
-        B._buf.ptr[i] = (A._buf.ptr + A.offset)[Int(I._buf.ptr[i])]
+        B._buf.ptr[unsafe_offset=i] = (A._buf.ptr + A.offset)[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i])]
     return B^
 
 
@@ -360,7 +360,7 @@ def transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
         var array_order = "C" if A.is_c_contiguous() else "F"
         var B = NDArray[dtype](Shape(A.shape[1], A.shape[0]), order=array_order)
         if A.shape[0] == 1 or A.shape[1] == 1:
-            memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
+            unsafe_memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
         else:
             for i in range(B.shape[0]):
                 for j in range(B.shape[1]):
@@ -385,7 +385,7 @@ def transpose[dtype: DType](A: Matrix[dtype]) -> Matrix[dtype]:
     var B = Matrix[dtype](Tuple(A.shape[1], A.shape[0]), order=order)
 
     if A.shape[0] == 1 or A.shape[1] == 1:
-        memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
     else:
         for i in range(B.shape[0]):
             for j in range(B.shape[1]):
@@ -542,12 +542,12 @@ def broadcast_to[
 
     var B: Matrix[dtype] = Matrix[dtype](shape, order=ord)
     if (A.shape[0] == shape[0]) and (A.shape[1] == shape[1]):
-        memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=B._buf.ptr, src=A._buf.ptr, count=A.size)
     elif (A.shape[0] == 1) and (A.shape[1] == 1):
         B = Matrix[dtype].full(shape, A[0, 0], order=ord)
     elif (A.shape[0] == 1) and (A.shape[1] == shape[1]):
         for i in range(shape[0]):
-            memcpy(
+            unsafe_memcpy(
                 dest=B._buf.offset(shape[1] * i),
                 src=A._buf.ptr,
                 count=shape[1],
@@ -555,7 +555,7 @@ def broadcast_to[
     elif (A.shape[1] == 1) and (A.shape[0] == shape[0]):
         for i in range(shape[0]):
             for j in range(shape[1]):
-                B._store(i, j, A._buf.ptr[i])
+                B._store(i, j, A._buf.ptr[unsafe_offset=i])
     else:
         var message = String(
             "Cannot broadcast shape {}x{} to shape {}x{}!"
@@ -630,9 +630,9 @@ def flip[dtype: DType](array: NDArray[dtype]) raises -> NDArray[dtype]:
     """
     var A = array.contiguous()  # Owned, C-contiguous copy
     for i in range(A.size // 2):
-        var temp = A._buf.ptr[i]
-        A._buf.ptr[i] = A._buf.ptr[A.size - 1 - i]
-        A._buf.ptr[A.size - 1 - i] = temp
+        var temp = A._buf.ptr[unsafe_offset=i]
+        A._buf.ptr[unsafe_offset=i] = A._buf.ptr[unsafe_offset=A.size - 1 - i]
+        A._buf.ptr[unsafe_offset=A.size - 1 - i] = temp
 
     return A^
 
@@ -670,11 +670,11 @@ def flip[
 
     for i in range(0, A.size, A.shape[axis]):
         for j in range(A.shape[axis] // 2):
-            var temp = A._buf.ptr[I._buf.ptr[i + j]]
-            A._buf.ptr[I._buf.ptr[i + j]] = A._buf.ptr[
-                I._buf.ptr[i + A.shape[axis] - 1 - j]
+            var temp = A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]]
+            A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]] = A._buf.ptr[unsafe_offset=
+                I._buf.ptr[unsafe_offset=i + A.shape[axis] - 1 - j]
             ]
-            A._buf.ptr[I._buf.ptr[i + A.shape[axis] - 1 - j]] = temp
+            A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + A.shape[axis] - 1 - j]] = temp
 
     return A^
 
@@ -794,7 +794,7 @@ def _concatenate_list[
         # Adjust the coordinate along the concat axis to be local.
         nd_index[ax] = coord_along_axis - boundaries[src_idx]
 
-        result._buf.ptr[flat_idx] = arrays[src_idx]._getitem(nd_index)
+        result._buf.ptr[unsafe_offset=flat_idx] = arrays[src_idx]._getitem(nd_index)
 
     return result^
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -52,8 +52,8 @@ def copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
 
     if dst.is_c_contiguous() and src.is_c_contiguous():
         unsafe_memcpy(
-            dest=dst._buf.ptr + dst.offset,
-            src=src._buf.ptr + src.offset,
+            dest=dst._buf.ptr.unsafe_offset(dst.offset),
+            src=src._buf.ptr.unsafe_offset(src.offset),
             count=src.size,
         )
     else:
@@ -234,8 +234,8 @@ def ravel[
     for i in range(length_of_iterator):
         var sub = iterator.ith(i)
         unsafe_memcpy(
-            dest=res._buf.ptr + i * length_of_elements,
-            src=sub._buf.ptr + sub.offset,
+            dest=res._buf.ptr.unsafe_offset(i * length_of_elements),
+            src=sub._buf.ptr.unsafe_offset(sub.offset),
             count=length_of_elements,
         )
 
@@ -340,7 +340,7 @@ def transpose[
 
     var B = NDArray[dtype](new_shape, order=array_order)
     for i in range(B.size):
-        B._buf.ptr[unsafe_offset=i] = (A._buf.ptr + A.offset)[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i])]
+        B._buf.ptr[unsafe_offset=i] = (A._buf.ptr.unsafe_offset(A.offset))[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i])]
     return B^
 
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -66,7 +66,9 @@ def copy_to[dtype: DType](dst: NDArray[dtype], src: NDArray[dtype]) raises:
                 remainder = remainder // dst.shape[dim]
                 src_offset += coord * src.strides[dim]
                 dst_offset += coord * dst.strides[dim]
-            dst._buf.ptr[unsafe_offset=dst_offset] = src._buf.ptr[unsafe_offset=src_offset]
+            dst._buf.ptr[unsafe_offset=dst_offset] = src._buf.ptr[
+                unsafe_offset=src_offset
+            ]
 
 
 def ndim[dtype: DType](array: NDArray[dtype]) -> Int:
@@ -346,7 +348,9 @@ def transpose[
 
     var B = NDArray[dtype](new_shape, order=array_order)
     for i in range(B.size):
-        B._buf.ptr[unsafe_offset=i] = (A._buf.ptr.unsafe_offset(A.offset))[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i])]
+        B._buf.ptr[unsafe_offset=i] = (A._buf.ptr.unsafe_offset(A.offset))[
+            unsafe_offset=Int(I._buf.ptr[unsafe_offset=i])
+        ]
     return B^
 
 
@@ -677,10 +681,18 @@ def flip[
     for i in range(0, A.size, A.shape[axis]):
         for j in range(A.shape[axis] // 2):
             var temp = A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]]
-            A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]] = A._buf.ptr[unsafe_offset=
-                I._buf.ptr[unsafe_offset=i + A.shape[axis] - 1 - j]
+            A._buf.ptr[
+                unsafe_offset=I._buf.ptr[unsafe_offset=i + j]
+            ] = A._buf.ptr[
+                unsafe_offset=I._buf.ptr[
+                    unsafe_offset=i + A.shape[axis] - 1 - j
+                ]
             ]
-            A._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + A.shape[axis] - 1 - j]] = temp
+            A._buf.ptr[
+                unsafe_offset=I._buf.ptr[
+                    unsafe_offset=i + A.shape[axis] - 1 - j
+                ]
+            ] = temp
 
     return A^
 
@@ -800,7 +812,9 @@ def _concatenate_list[
         # Adjust the coordinate along the concat axis to be local.
         nd_index[ax] = coord_along_axis - boundaries[src_idx]
 
-        result._buf.ptr[unsafe_offset=flat_idx] = arrays[src_idx]._getitem(nd_index)
+        result._buf.ptr[unsafe_offset=flat_idx] = arrays[src_idx]._getitem(
+            nd_index
+        )
 
     return result^
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -367,7 +367,7 @@ def transpose[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
                     B._setitem(i, j, val=A._getitem(j, i))
         return B^
     else:
-        flipped_axes = List[Int]()
+        var flipped_axes = List[Int]()
         for i in range(A.ndim - 1, -1, -1):
             flipped_axes.append(i)
 

--- a/numojo/routines/manipulation.mojo
+++ b/numojo/routines/manipulation.mojo
@@ -191,6 +191,9 @@ def reshape[
         var temp: NDArray[dtype] = ravel(A, order=order)
         B = NDArray[dtype](shape=shape, order=order)
         unsafe_memcpy(dest=B._buf.ptr, src=temp._buf.ptr, count=A.size)
+        # `DataContainer.origin` is untracked, so the raw pointer above does
+        # not keep `temp` alive; hold it until the copy has finished.
+        _ = temp^
     else:
         # Write in this order into the new array
         B = NDArray[dtype](shape=shape, order=order)
@@ -238,6 +241,9 @@ def ravel[
             src=sub._buf.ptr.unsafe_offset(sub.offset),
             count=length_of_elements,
         )
+        # `DataContainer.origin` is untracked, so the raw pointer above does
+        # not keep `sub` alive; hold it until the copy has finished.
+        _ = sub^
 
     return res^
 

--- a/numojo/routines/math/arithmetic.mojo
+++ b/numojo/routines/math/arithmetic.mojo
@@ -131,9 +131,9 @@ def add[
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
             # TODO: Figure out how to remove this unnecessary copy here (even though we take values as owned.
-            array_list.append(values[i].copy().unsafe_take[NDArray[dtype]]())
+            array_list.append(values[i].copy().unsafe_unwrap[NDArray[dtype]]())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part += values[i].copy().unsafe_take[Scalar[dtype]]()
+            scalar_part += values[i].copy().unsafe_unwrap[Scalar[dtype]]()
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:add(*values:Variant[NDArray[dtype],Scalar[dtype]]):"
@@ -439,9 +439,9 @@ def mul[
     var scalar_part: Scalar[dtype] = 1
     for i in range(len(values)):
         if values[i].isa[NDArray[dtype]]():
-            array_list.append(values[i].copy().unsafe_take[NDArray[dtype]]())
+            array_list.append(values[i].copy().unsafe_unwrap[NDArray[dtype]]())
         elif values[i].isa[Scalar[dtype]]():
-            scalar_part *= values[i].copy().unsafe_take[Scalar[dtype]]()
+            scalar_part *= values[i].copy().unsafe_unwrap[Scalar[dtype]]()
     if len(array_list) == 0:
         raise Error(
             "math:arithmetic:mul(*values:Variant[NDArray[dtype],Scalar[dtype]]):"

--- a/numojo/routines/math/differences.mojo
+++ b/numojo/routines/math/differences.mojo
@@ -11,11 +11,12 @@ Implements gradient and trapezoidal integration helpers for numerical differenti
 """
 
 import std.math
-from std.algorithm import parallelize
+from max.algorithm import parallelize
 
 from numojo.routines.creation import arange
 from numojo.core.ndarray import NDArray
 from numojo.core.dtype.utility import is_inttype, is_floattype
+from numojo.core.layout.ndshape import NDArrayShape
 
 # TODO:
 # 1) add a Variant[NDArray, Scalar, ...] to include all possibilities

--- a/numojo/routines/math/exponents.mojo
+++ b/numojo/routines/math/exponents.mojo
@@ -11,7 +11,7 @@ Implements element-wise exponential and logarithmic transformations for NDArrays
 """
 
 import std.math as math
-from std.algorithm import parallelize
+from max.algorithm import parallelize
 from std.algorithm import Static2DTileUnitFunc as Tile2DFunc
 from std.utils import Variant
 

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -11,7 +11,8 @@ Contains min/max helpers for NDArrays and Matrices, including axis-aware reducti
 and element-wise comparisons.
 """
 
-from std.algorithm import vectorize, parallelize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 import std.math.math as stdlib_math
 from std.math import max as builtin_max
 from std.math import min as builtin_min

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -62,7 +62,7 @@ def extrema_1d[
     comptime if is_max:
 
         def vectorize_max[simd_width: Int](offset: Int) {mut value, a}:
-            var temp = a._buf.ptr.load[width=simd_width](offset).reduce_max()
+            var temp = a._buf.ptr.unsafe_load[width=simd_width](offset).reduce_max()
             if temp >= value:
                 value = temp
 
@@ -73,7 +73,7 @@ def extrema_1d[
     else:
 
         def vectorize_min[simd_width: Int](offset: Int) {mut value, a} -> None:
-            var temp = a._buf.ptr.load[width=simd_width](offset).reduce_min()
+            var temp = a._buf.ptr.unsafe_load[width=simd_width](offset).reduce_min()
             if temp < value:
                 value = temp
 

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -62,7 +62,9 @@ def extrema_1d[
     comptime if is_max:
 
         def vectorize_max[simd_width: Int](offset: Int) {mut value, a}:
-            var temp = a._buf.ptr.unsafe_load[width=simd_width](offset).reduce_max()
+            var temp = a._buf.ptr.unsafe_load[width=simd_width](
+                offset
+            ).reduce_max()
             if temp >= value:
                 value = temp
 
@@ -73,7 +75,9 @@ def extrema_1d[
     else:
 
         def vectorize_min[simd_width: Int](offset: Int) {mut value, a} -> None:
-            var temp = a._buf.ptr.unsafe_load[width=simd_width](offset).reduce_min()
+            var temp = a._buf.ptr.unsafe_load[width=simd_width](
+                offset
+            ).reduce_min()
             if temp < value:
                 value = temp
 

--- a/numojo/routines/math/misc.mojo
+++ b/numojo/routines/math/misc.mojo
@@ -74,10 +74,10 @@ def clip[
     var result = a.contiguous()  # Owned, C-contiguous copy
 
     for i in range(result.size):
-        if result._buf.ptr[i] < a_min:
-            result._buf.ptr[i] = a_min
-        if result._buf.ptr[i] > a_max:
-            result._buf.ptr[i] = a_max
+        if result._buf.ptr[unsafe_offset=i] < a_min:
+            result._buf.ptr[unsafe_offset=i] = a_min
+        if result._buf.ptr[unsafe_offset=i] > a_max:
+            result._buf.ptr[unsafe_offset=i] = a_max
 
     return result^
 

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -236,7 +236,9 @@ def cumprod[
 
     for i in range(0, B.size, B.shape[axis]):
         for j in range(B.shape[axis] - 1):
-            B._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j + 1]] *= B._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]]
+            B._buf.ptr[
+                unsafe_offset=I._buf.ptr[unsafe_offset=i + j + 1]
+            ] *= B._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]]
 
     return B^
 

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -13,7 +13,7 @@ Implements product and cumulative product reductions for NDArrays and Matrices.
 from std.algorithm.functional import vectorize
 from max.algorithm import parallelize
 from std.sys import simd_width_of
-from std.memory import UnsafePointer, memcpy, memset_zero
+from std.memory import UnsafePointer, unsafe_memcpy, unsafe_memset_zero
 
 from numojo.core.ndarray import NDArray
 import numojo.core.matrix as matrix
@@ -53,7 +53,7 @@ def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var res = Scalar[dtype](1)
 
     def cal_vec[width: Int](i: Int) {mut res, A}:
-        res *= A._buf.ptr.load[width=width](i).reduce_mul()
+        res *= A._buf.ptr.unsafe_load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
     return res
@@ -112,7 +112,7 @@ def prod[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     def cal_vec[width: Int](i: Int) {mut res, A}:
-        res = res * A._buf.ptr.load[width=width](i).reduce_mul()
+        res = res * A._buf.ptr.unsafe_load[width=width](i).reduce_mul()
 
     vectorize[width](A.size, cal_vec)
     return res
@@ -192,7 +192,7 @@ def cumprod[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     if A.ndim == 1:
         var B = A.contiguous()
         for i in range(A.size - 1):
-            B._buf.ptr[i + 1] *= B._buf.ptr[i]
+            B._buf.ptr[unsafe_offset=i + 1] *= B._buf.ptr[unsafe_offset=i]
         return B^
 
     else:
@@ -236,7 +236,7 @@ def cumprod[
 
     for i in range(0, B.size, B.shape[axis]):
         for j in range(B.shape[axis] - 1):
-            B._buf.ptr[I._buf.ptr[i + j + 1]] *= B._buf.ptr[I._buf.ptr[i + j]]
+            B._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j + 1]] *= B._buf.ptr[unsafe_offset=I._buf.ptr[unsafe_offset=i + j]]
 
     return B^
 
@@ -261,14 +261,14 @@ def cumprod[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     var result: Matrix[dtype] = Matrix.zeros[dtype](A.shape, "C")
 
     if A.is_c_contiguous():
-        memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
     else:
         for i in range(A.shape[0]):
             for j in range(A.shape[1]):
                 result[i, j] = A[i, j]
 
     for i in range(1, A.size):
-        result._buf.ptr[i] *= result._buf.ptr[i - 1]
+        result._buf.ptr[unsafe_offset=i] *= result._buf.ptr[unsafe_offset=i - 1]
 
     result.resize(shape=(1, result.size))
     return result^
@@ -297,7 +297,7 @@ def cumprod[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     var result: Matrix[dtype] = Matrix.zeros[dtype](A.shape, order)
 
     if order == "C":
-        memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
+        unsafe_memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
     else:
         for j in range(result.shape[1]):
 

--- a/numojo/routines/math/products.mojo
+++ b/numojo/routines/math/products.mojo
@@ -10,7 +10,8 @@
 Implements product and cumulative product reductions for NDArrays and Matrices.
 """
 
-from std.algorithm.functional import parallelize, vectorize
+from std.algorithm.functional import vectorize
+from max.algorithm import parallelize
 from std.sys import simd_width_of
 from std.memory import UnsafePointer, memcpy, memset_zero
 
@@ -19,6 +20,8 @@ import numojo.core.matrix as matrix
 from numojo.core.matrix import Matrix
 from numojo.core.indexing import TraverseMethods
 from numojo.routines.creation import ones
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.type_aliases import Shape
 
 
 def prod[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -31,7 +31,7 @@ def round[dtype: DType](A: Matrix[dtype], decimals: Int = 0) -> Matrix[dtype]:
         return round(A.contiguous(), decimals)
     var res = Matrix.zeros[dtype](A.shape)
     for i in range(A.size):
-        res._buf.ptr[i] = builtin_math.round(A._buf.ptr[i], ndigits=decimals)
+        res._buf.ptr[unsafe_offset=i] = builtin_math.round(A._buf.ptr[unsafe_offset=i], ndigits=decimals)
     return res^
 
 

--- a/numojo/routines/math/rounding.mojo
+++ b/numojo/routines/math/rounding.mojo
@@ -31,7 +31,9 @@ def round[dtype: DType](A: Matrix[dtype], decimals: Int = 0) -> Matrix[dtype]:
         return round(A.contiguous(), decimals)
     var res = Matrix.zeros[dtype](A.shape)
     for i in range(A.size):
-        res._buf.ptr[unsafe_offset=i] = builtin_math.round(A._buf.ptr[unsafe_offset=i], ndigits=decimals)
+        res._buf.ptr[unsafe_offset=i] = builtin_math.round(
+            A._buf.ptr[unsafe_offset=i], ndigits=decimals
+        )
     return res^
 
 

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -13,7 +13,7 @@ Provides sum reductions along axes for NDArrays and Matrices, covering both flat
 from std.sys import simd_width_of
 from std.algorithm import vectorize
 from max.algorithm import parallelize
-from std.memory import UnsafePointer, memset_zero, memcpy
+from std.memory import UnsafePointer, unsafe_memset_zero, unsafe_memcpy
 
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
@@ -52,7 +52,7 @@ def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:
     var result: Scalar[dtype] = Scalar[dtype](0)
 
     def cal_vec[width: Int](i: Int) {mut result, A}:
-        result += A._buf.ptr.load[width=width](i).reduce_add()
+        result += A._buf.ptr.unsafe_load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
     return result
@@ -148,7 +148,7 @@ def sum[dtype: DType](A: Matrix[dtype]) -> Scalar[dtype]:
     comptime width: Int = simd_width_of[dtype]()
 
     def cal_vec[width: Int](i: Int) {mut res, A}:
-        res = res + A._buf.ptr.load[width=width](i).reduce_add()
+        res = res + A._buf.ptr.unsafe_load[width=width](i).reduce_add()
 
     vectorize[width](A.size, cal_vec)
     return res
@@ -250,7 +250,7 @@ def cumsum[dtype: DType](A: NDArray[dtype]) raises -> NDArray[dtype]:
     if A.ndim == 1:
         var B = A.contiguous()
         for i in range(A.size - 1):
-            B._buf.ptr[i + 1] += B._buf.ptr[i]
+            B._buf.ptr[unsafe_offset=i + 1] += B._buf.ptr[unsafe_offset=i]
         return B^
 
     else:
@@ -295,8 +295,8 @@ def cumsum[
 
     for i in range(0, B.size, B.shape[axis]):
         for j in range(B.shape[axis] - 1):
-            B._buf.ptr[Int(I._buf.ptr[i + j + 1])] += B._buf.ptr[
-                Int(I._buf.ptr[i + j])
+            B._buf.ptr[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i + j + 1])] += B._buf.ptr[unsafe_offset=
+                Int(I._buf.ptr[unsafe_offset=i + j])
             ]
 
     return B^
@@ -323,7 +323,7 @@ def cumsum[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     var reorder = False
     var order = "C" if A.is_c_contiguous() else "F"
     var result: Matrix[dtype] = Matrix.zeros[dtype](A.shape, order)
-    memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
+    unsafe_memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
 
     if A.is_f_contiguous():
         reorder = True
@@ -332,7 +332,7 @@ def cumsum[dtype: DType](A: Matrix[dtype]) raises -> Matrix[dtype]:
     result.resize(shape=(1, A.size))
 
     for i in range(1, A.size):
-        result._buf.ptr[i] += result._buf.ptr[i - 1]
+        result._buf.ptr[unsafe_offset=i] += result._buf.ptr[unsafe_offset=i - 1]
 
     if reorder:
         result = result.reorder_layout()
@@ -362,7 +362,7 @@ def cumsum[dtype: DType](A: Matrix[dtype], axis: Int) raises -> Matrix[dtype]:
     comptime width: Int = simd_width_of[dtype]()
     var order = "C" if A.is_c_contiguous() else "F"
     var result: Matrix[dtype] = Matrix.zeros[dtype](A.shape, order)
-    memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
+    unsafe_memcpy(dest=result._buf.ptr, src=A._buf.ptr, count=A.size)
 
     if axis == 0:
         if result.is_c_contiguous():

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -11,13 +11,17 @@ Provides sum reductions along axes for NDArrays and Matrices, covering both flat
 """
 
 from std.sys import simd_width_of
-from std.algorithm import parallelize, vectorize
+from std.algorithm import vectorize
+from max.algorithm import parallelize
 from std.memory import UnsafePointer, memset_zero, memcpy
 
 from numojo.core.ndarray import NDArray
 from numojo.core.matrix import Matrix
 from numojo.core.indexing import TraverseMethods
 from numojo.routines.creation import zeros
+from numojo.core.layout.ndshape import NDArrayShape
+from numojo.core.error import NumojoError
+from numojo.core.type_aliases import Shape
 
 
 def sum[dtype: DType](A: NDArray[dtype]) raises -> Scalar[dtype]:

--- a/numojo/routines/math/sums.mojo
+++ b/numojo/routines/math/sums.mojo
@@ -295,9 +295,9 @@ def cumsum[
 
     for i in range(0, B.size, B.shape[axis]):
         for j in range(B.shape[axis] - 1):
-            B._buf.ptr[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i + j + 1])] += B._buf.ptr[unsafe_offset=
-                Int(I._buf.ptr[unsafe_offset=i + j])
-            ]
+            B._buf.ptr[
+                unsafe_offset=Int(I._buf.ptr[unsafe_offset=i + j + 1])
+            ] += B._buf.ptr[unsafe_offset=Int(I._buf.ptr[unsafe_offset=i + j])]
 
     return B^
 

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -60,7 +60,9 @@ def _apply_unary_chunk[
 ):
     var i = start
     while i + width <= end:
-        dst.unsafe_store(i, kernel[dtype, width](src.unsafe_load[width=width](i)))
+        dst.unsafe_store(
+            i, kernel[dtype, width](src.unsafe_load[width=width](i))
+        )
         i += width
     while i < end:
         dst.unsafe_store(i, kernel[dtype, 1](src.unsafe_load[width=1](i)))
@@ -86,14 +88,17 @@ def _apply_binary_chunk[
         dst.unsafe_store(
             i,
             kernel[dtype, width](
-                src1.unsafe_load[width=width](i), src2.unsafe_load[width=width](i)
+                src1.unsafe_load[width=width](i),
+                src2.unsafe_load[width=width](i),
             ),
         )
         i += width
     while i < end:
         dst.unsafe_store(
             i,
-            kernel[dtype, 1](src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)),
+            kernel[dtype, 1](
+                src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)
+            ),
         )
         i += 1
 
@@ -147,10 +152,14 @@ def _apply_binary_int_chunk[
 ):
     var i = start
     while i + width <= end:
-        dst.unsafe_store(i, kernel[dtype, width](src.unsafe_load[width=width](i), intval))
+        dst.unsafe_store(
+            i, kernel[dtype, width](src.unsafe_load[width=width](i), intval)
+        )
         i += width
     while i < end:
-        dst.unsafe_store(i, kernel[dtype, 1](src.unsafe_load[width=1](i), intval))
+        dst.unsafe_store(
+            i, kernel[dtype, 1](src.unsafe_load[width=1](i), intval)
+        )
         i += 1
 
 
@@ -174,7 +183,8 @@ def _apply_binary_predicate_chunk[
             dst,
             i,
             kernel[dtype, width](
-                src1.unsafe_load[width=width](i), src2.unsafe_load[width=width](i)
+                src1.unsafe_load[width=width](i),
+                src2.unsafe_load[width=width](i),
             ),
         )
         i += width
@@ -182,7 +192,9 @@ def _apply_binary_predicate_chunk[
         bool_simd_store[1](
             dst,
             i,
-            kernel[dtype, 1](src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)),
+            kernel[dtype, 1](
+                src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)
+            ),
         )
         i += 1
 
@@ -215,7 +227,9 @@ def _apply_binary_predicate_scalar_chunk[
         bool_simd_store[1](
             dst,
             i,
-            kernel[dtype, 1](src.unsafe_load[width=1](i), SIMD[dtype, 1](scalar)),
+            kernel[dtype, 1](
+                src.unsafe_load[width=1](i), SIMD[dtype, 1](scalar)
+            ),
         )
         i += 1
 
@@ -240,7 +254,9 @@ def _apply_unary_predicate_chunk[
         )
         i += width
     while i < end:
-        bool_simd_store[1](dst, i, kernel[dtype, 1](src.unsafe_load[width=1](i)))
+        bool_simd_store[1](
+            dst, i, kernel[dtype, 1](src.unsafe_load[width=1](i))
+        )
         i += 1
 
 
@@ -466,7 +482,9 @@ struct HostExecutor:
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
             var result_array = _0darray(
-                val=kernel[dtype, 1]((array._buf.ptr.unsafe_offset(array.offset))[])
+                val=kernel[dtype, 1](
+                    (array._buf.ptr.unsafe_offset(array.offset))[]
+                )
             )
             return result_array^
 
@@ -1098,4 +1116,6 @@ def bool_simd_store[
         start: Start position in the pointer.
         val: SIMD boolean value to store.
     """
-    (ptr.unsafe_offset(start)).unsafe_strided_store[width=simd_width](val=val, stride=1)
+    (ptr.unsafe_offset(start)).unsafe_strided_store[width=simd_width](
+        val=val, stride=1
+    )

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -10,7 +10,8 @@
 Defines vectorized backend structures and reusable SIMD math primitives consumed by the math submodules.
 """
 
-from std.algorithm.functional import parallelize, vectorize
+from std.algorithm.functional import vectorize
+from max.algorithm import parallelize
 from std.sys import simd_width_of
 from std.sys.info import num_performance_cores
 from std.builtin.simd import FastMathFlag
@@ -272,7 +273,7 @@ def _apply_ternary_chunk[
     while i < end:
         dst.store(
             i,
-            kernel(
+            kernel[dtype, 1](
                 src1.load[width=1](i),
                 src2.load[width=1](i),
                 src3.load[width=1](i),
@@ -310,7 +311,7 @@ def _apply_ternary_scalar_chunk[
     while i < end:
         dst.store(
             i,
-            kernel(
+            kernel[dtype, 1](
                 src1.load[width=1](i),
                 src2.load[width=1](i),
                 SIMD[dtype, 1](scalar),

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -53,17 +53,17 @@ def _apply_unary_chunk[
         type, simd_w
     ],
 ](
-    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        dst.store(i, kernel[dtype, width](src.load[width=width](i)))
+        dst.unsafe_store(i, kernel[dtype, width](src.unsafe_load[width=width](i)))
         i += width
     while i < end:
-        dst.store(i, kernel[dtype, 1](src.load[width=1](i)))
+        dst.unsafe_store(i, kernel[dtype, 1](src.unsafe_load[width=1](i)))
         i += 1
 
 
@@ -75,25 +75,25 @@ def _apply_binary_chunk[
         SIMD[type, simd_w], SIMD[type, simd_w]
     ) capturing -> SIMD[type, simd_w],
 ](
-    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src1: Pointer[Scalar[dtype], MutAnyOrigin],
+    src2: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        dst.store(
+        dst.unsafe_store(
             i,
             kernel[dtype, width](
-                src1.load[width=width](i), src2.load[width=width](i)
+                src1.unsafe_load[width=width](i), src2.unsafe_load[width=width](i)
             ),
         )
         i += width
     while i < end:
-        dst.store(
+        dst.unsafe_store(
             i,
-            kernel[dtype, 1](src1.load[width=1](i), src2.load[width=1](i)),
+            kernel[dtype, 1](src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)),
         )
         i += 1
 
@@ -108,26 +108,26 @@ def _apply_binary_scalar_chunk[
     *,
     scalar_first: Bool,
 ](
-    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     scalar: Scalar[dtype],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        var data = src.load[width=width](i)
+        var data = src.unsafe_load[width=width](i)
         comptime if scalar_first:
-            dst.store(i, kernel[dtype, width](scalar, data))
+            dst.unsafe_store(i, kernel[dtype, width](scalar, data))
         else:
-            dst.store(i, kernel[dtype, width](data, scalar))
+            dst.unsafe_store(i, kernel[dtype, width](data, scalar))
         i += width
     while i < end:
-        var data = src.load[width=1](i)
+        var data = src.unsafe_load[width=1](i)
         comptime if scalar_first:
-            dst.store(i, kernel[dtype, 1](scalar, data))
+            dst.unsafe_store(i, kernel[dtype, 1](scalar, data))
         else:
-            dst.store(i, kernel[dtype, 1](data, scalar))
+            dst.unsafe_store(i, kernel[dtype, 1](data, scalar))
         i += 1
 
 
@@ -139,18 +139,18 @@ def _apply_binary_int_chunk[
         SIMD[type, simd_w], Int
     ) capturing -> SIMD[type, simd_w],
 ](
-    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     intval: Int,
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        dst.store(i, kernel[dtype, width](src.load[width=width](i), intval))
+        dst.unsafe_store(i, kernel[dtype, width](src.unsafe_load[width=width](i), intval))
         i += width
     while i < end:
-        dst.store(i, kernel[dtype, 1](src.load[width=1](i), intval))
+        dst.unsafe_store(i, kernel[dtype, 1](src.unsafe_load[width=1](i), intval))
         i += 1
 
 
@@ -162,9 +162,9 @@ def _apply_binary_predicate_chunk[
         SIMD[type, simd_w], SIMD[type, simd_w]
     ) capturing -> SIMD[DType.bool, simd_w],
 ](
-    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    src1: Pointer[Scalar[dtype], MutAnyOrigin],
+    src2: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[DType.bool], MutAnyOrigin],
     start: Int,
     end: Int,
 ):
@@ -174,7 +174,7 @@ def _apply_binary_predicate_chunk[
             dst,
             i,
             kernel[dtype, width](
-                src1.load[width=width](i), src2.load[width=width](i)
+                src1.unsafe_load[width=width](i), src2.unsafe_load[width=width](i)
             ),
         )
         i += width
@@ -182,7 +182,7 @@ def _apply_binary_predicate_chunk[
         bool_simd_store[1](
             dst,
             i,
-            kernel[dtype, 1](src1.load[width=1](i), src2.load[width=1](i)),
+            kernel[dtype, 1](src1.unsafe_load[width=1](i), src2.unsafe_load[width=1](i)),
         )
         i += 1
 
@@ -195,8 +195,8 @@ def _apply_binary_predicate_scalar_chunk[
         SIMD[type, simd_w], SIMD[type, simd_w]
     ) capturing -> SIMD[DType.bool, simd_w],
 ](
-    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[DType.bool], MutAnyOrigin],
     scalar: Scalar[dtype],
     start: Int,
     end: Int,
@@ -207,7 +207,7 @@ def _apply_binary_predicate_scalar_chunk[
             dst,
             i,
             kernel[dtype, width](
-                src.load[width=width](i), SIMD[dtype, width](scalar)
+                src.unsafe_load[width=width](i), SIMD[dtype, width](scalar)
             ),
         )
         i += width
@@ -215,7 +215,7 @@ def _apply_binary_predicate_scalar_chunk[
         bool_simd_store[1](
             dst,
             i,
-            kernel[dtype, 1](src.load[width=1](i), SIMD[dtype, 1](scalar)),
+            kernel[dtype, 1](src.unsafe_load[width=1](i), SIMD[dtype, 1](scalar)),
         )
         i += 1
 
@@ -228,19 +228,19 @@ def _apply_unary_predicate_chunk[
         DType.bool, simd_w
     ],
 ](
-    src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[DType.bool], MutAnyOrigin],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
         bool_simd_store[width](
-            dst, i, kernel[dtype, width](src.load[width=width](i))
+            dst, i, kernel[dtype, width](src.unsafe_load[width=width](i))
         )
         i += width
     while i < end:
-        bool_simd_store[1](dst, i, kernel[dtype, 1](src.load[width=1](i)))
+        bool_simd_store[1](dst, i, kernel[dtype, 1](src.unsafe_load[width=1](i)))
         i += 1
 
 
@@ -252,31 +252,31 @@ def _apply_ternary_chunk[
         SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
     ) capturing -> SIMD[type, simd_w],
 ](
-    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src3: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src1: Pointer[Scalar[dtype], MutAnyOrigin],
+    src2: Pointer[Scalar[dtype], MutAnyOrigin],
+    src3: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        dst.store(
+        dst.unsafe_store(
             i,
             kernel(
-                src1.load[width=width](i),
-                src2.load[width=width](i),
-                src3.load[width=width](i),
+                src1.unsafe_load[width=width](i),
+                src2.unsafe_load[width=width](i),
+                src3.unsafe_load[width=width](i),
             ),
         )
         i += width
     while i < end:
-        dst.store(
+        dst.unsafe_store(
             i,
             kernel[dtype, 1](
-                src1.load[width=1](i),
-                src2.load[width=1](i),
-                src3.load[width=1](i),
+                src1.unsafe_load[width=1](i),
+                src2.unsafe_load[width=1](i),
+                src3.unsafe_load[width=1](i),
             ),
         )
         i += 1
@@ -290,30 +290,30 @@ def _apply_ternary_scalar_chunk[
         SIMD[type, simd_w], SIMD[type, simd_w], SIMD[type, simd_w]
     ) capturing -> SIMD[type, simd_w],
 ](
-    src1: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src2: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dst: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    src1: Pointer[Scalar[dtype], MutAnyOrigin],
+    src2: Pointer[Scalar[dtype], MutAnyOrigin],
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
     scalar: Scalar[dtype],
     start: Int,
     end: Int,
 ):
     var i = start
     while i + width <= end:
-        dst.store(
+        dst.unsafe_store(
             i,
             kernel(
-                src1.load[width=width](i),
-                src2.load[width=width](i),
+                src1.unsafe_load[width=width](i),
+                src2.unsafe_load[width=width](i),
                 SIMD[dtype, width](scalar),
             ),
         )
         i += width
     while i < end:
-        dst.store(
+        dst.unsafe_store(
             i,
             kernel[dtype, 1](
-                src1.load[width=1](i),
-                src2.load[width=1](i),
+                src1.unsafe_load[width=1](i),
+                src2.unsafe_load[width=1](i),
                 SIMD[dtype, 1](scalar),
             ),
         )
@@ -1082,7 +1082,7 @@ def bool_simd_store[
     //,
     simd_width: Int,
 ](
-    ptr: UnsafePointer[Scalar[DType.bool], ptr_origin],
+    ptr: Pointer[Scalar[DType.bool], ptr_origin],
     start: Int,
     val: SIMD[DType.bool, simd_width],
 ):
@@ -1098,4 +1098,4 @@ def bool_simd_store[
         start: Start position in the pointer.
         val: SIMD boolean value to store.
     """
-    (ptr + start).strided_store[width=simd_width](val=val, stride=1)
+    (ptr + start).unsafe_strided_store[width=simd_width](val=val, stride=1)

--- a/numojo/routines/operations/backend.mojo
+++ b/numojo/routines/operations/backend.mojo
@@ -466,7 +466,7 @@ struct HostExecutor:
         # Treat it as a scalar and apply the function
         if array.ndim == 0:
             var result_array = _0darray(
-                val=kernel[dtype, 1]((array._buf.ptr + array.offset)[])
+                val=kernel[dtype, 1]((array._buf.ptr.unsafe_offset(array.offset))[])
             )
             return result_array^
 
@@ -1098,4 +1098,4 @@ def bool_simd_store[
         start: Start position in the pointer.
         val: SIMD boolean value to store.
     """
-    (ptr + start).unsafe_strided_store[width=simd_width](val=val, stride=1)
+    (ptr.unsafe_offset(start)).unsafe_strided_store[width=simd_width](val=val, stride=1)

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -19,6 +19,8 @@ import std.math as mt
 from std.random import random as builtin_random
 
 from numojo.core.ndarray import NDArray
+from numojo.core.dtype.default_dtype import f64
+from numojo.core.layout.ndshape import NDArrayShape
 
 # ===----------------------------------------------------------------------=== #
 # Uniform distribution

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -64,7 +64,7 @@ def rand[
         var temp: Scalar[dtype] = builtin_random.random_float64(0, 1).cast[
             dtype
         ]()
-        (result._buf.ptr + i).init_pointee_copy(temp)
+        (result._buf.ptr + i).unsafe_write(temp)
 
     return result^
 
@@ -141,7 +141,7 @@ def rand[
     var result: NDArray[dtype] = NDArray[dtype](shape)
 
     for i in range(result.size):
-        (result._buf.ptr + i).init_pointee_copy(
+        (result._buf.ptr + i).unsafe_write(
             builtin_random.random_float64(
                 min.cast[DType.float64](), max.cast[DType.float64]()
             ).cast[dtype]()
@@ -420,7 +420,7 @@ def exponential[
 
     for i in range(result.size):
         var u = builtin_random.random_float64().cast[dtype]()
-        (result._buf.ptr + i).init_pointee_copy(-mt.log(u) / scale)
+        (result._buf.ptr + i).unsafe_write(-mt.log(u) / scale)
 
     return result^
 
@@ -492,7 +492,7 @@ def randbool(
 
     for i in range(result.size):
         var val = builtin_random.random_float64(0.0, 1.0) < p
-        (result._buf.ptr + i).init_pointee_copy(val)
+        (result._buf.ptr + i).unsafe_write(val)
 
     return result^
 
@@ -565,4 +565,4 @@ def _float_rand_func[
         var temp: Scalar[dtype] = builtin_random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
-        (result._buf.ptr + i).init_pointee_copy(temp)
+        (result._buf.ptr + i).unsafe_write(temp)

--- a/numojo/routines/random.mojo
+++ b/numojo/routines/random.mojo
@@ -64,7 +64,7 @@ def rand[
         var temp: Scalar[dtype] = builtin_random.random_float64(0, 1).cast[
             dtype
         ]()
-        (result._buf.ptr + i).unsafe_write(temp)
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(temp)
 
     return result^
 
@@ -141,7 +141,7 @@ def rand[
     var result: NDArray[dtype] = NDArray[dtype](shape)
 
     for i in range(result.size):
-        (result._buf.ptr + i).unsafe_write(
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(
             builtin_random.random_float64(
                 min.cast[DType.float64](), max.cast[DType.float64]()
             ).cast[dtype]()
@@ -420,7 +420,7 @@ def exponential[
 
     for i in range(result.size):
         var u = builtin_random.random_float64().cast[dtype]()
-        (result._buf.ptr + i).unsafe_write(-mt.log(u) / scale)
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(-mt.log(u) / scale)
 
     return result^
 
@@ -492,7 +492,7 @@ def randbool(
 
     for i in range(result.size):
         var val = builtin_random.random_float64(0.0, 1.0) < p
-        (result._buf.ptr + i).unsafe_write(val)
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(val)
 
     return result^
 
@@ -565,4 +565,4 @@ def _float_rand_func[
         var temp: Scalar[dtype] = builtin_random.random_float64(
             min.cast[f64](), max.cast[f64]()
         ).cast[dtype]()
-        (result._buf.ptr + i).unsafe_write(temp)
+        (result._buf.ptr.unsafe_offset(i)).unsafe_write(temp)

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -52,7 +52,7 @@ def argmax_1d[
         if ptr[] > value:
             result = i
             value = ptr[]
-        ptr += 1
+        ptr = ptr.unsafe_offset(1)
 
     return Scalar[DType.int](result)
 
@@ -84,7 +84,7 @@ def argmin_1d[
         if ptr[] < value:
             result = i
             value = ptr[]
-        ptr += 1
+        ptr = ptr.unsafe_offset(1)
 
     return Scalar[DType.int](result)
 

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -23,6 +23,7 @@ from numojo.core.dtype.utility import is_inttype, is_floattype
 from numojo.routines.sorting import binary_sort
 from numojo.routines.math.extrema import _max, _min
 from numojo.routines.functional import apply_along_axis_reduce_to_int
+from numojo.routines.manipulation import ravel
 
 
 def argmax_1d[

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -359,9 +359,14 @@ def binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     var result: NDArray[dtype] = a.contiguous()
     for end in range(result.size, 1, -1):
         for i in range(1, end):
-            if result._buf.ptr[unsafe_offset=i - 1] > result._buf.ptr[unsafe_offset=i]:
+            if (
+                result._buf.ptr[unsafe_offset=i - 1]
+                > result._buf.ptr[unsafe_offset=i]
+            ):
                 var temp = result._buf.ptr[unsafe_offset=i - 1]
-                result._buf.ptr[unsafe_offset=i - 1] = result._buf.ptr[unsafe_offset=i]
+                result._buf.ptr[unsafe_offset=i - 1] = result._buf.ptr[
+                    unsafe_offset=i
+                ]
                 result._buf.ptr[unsafe_offset=i] = temp
     return result^
 
@@ -440,11 +445,13 @@ def bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 
     for i in range(length):
         for j in range(length - i - 1):
-            if result._buf.ptr.unsafe_load[width=1](j) > result._buf.ptr.unsafe_load[width=1](
-                j + 1
-            ):
+            if result._buf.ptr.unsafe_load[width=1](
+                j
+            ) > result._buf.ptr.unsafe_load[width=1](j + 1):
                 var temp = result._buf.ptr.unsafe_load[width=1](j)
-                result._buf.ptr.unsafe_store(j, result._buf.ptr.unsafe_load[width=1](j + 1))
+                result._buf.ptr.unsafe_store(
+                    j, result._buf.ptr.unsafe_load[width=1](j + 1)
+                )
                 result._buf.ptr.unsafe_store(j + 1, temp)
 
     return result^
@@ -607,7 +614,9 @@ def _partition_in_range(
 
     for i in range(left, right):
         if A._buf.ptr[unsafe_offset=i] < pivot_value:
-            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[
+                unsafe_offset=i
+            ] = (
                 A._buf.ptr[unsafe_offset=i],
                 A._buf.ptr[unsafe_offset=store_index],
             )
@@ -659,11 +668,15 @@ def _partition_in_range(
 
     for i in range(left, right):
         if A._buf.ptr[unsafe_offset=i] < pivot_value:
-            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[
+                unsafe_offset=i
+            ] = (
                 A._buf.ptr[unsafe_offset=i],
                 A._buf.ptr[unsafe_offset=store_index],
             )
-            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=i] = (
+            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[
+                unsafe_offset=i
+            ] = (
                 I._buf.ptr[unsafe_offset=i],
                 I._buf.ptr[unsafe_offset=store_index],
             )
@@ -722,11 +735,15 @@ def _quick_sort_partition(
 
     for i in range(left, right):
         if A._buf.ptr[unsafe_offset=i] < pivot_value:
-            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[
+                unsafe_offset=i
+            ] = (
                 A._buf.ptr[unsafe_offset=i],
                 A._buf.ptr[unsafe_offset=store_index],
             )
-            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=i] = (
+            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[
+                unsafe_offset=i
+            ] = (
                 I._buf.ptr[unsafe_offset=i],
                 I._buf.ptr[unsafe_offset=store_index],
             )
@@ -942,4 +959,6 @@ def _quick_sort_stable_inplace[
         a._buf.ptr[unsafe_offset=i] = left._buf.ptr[unsafe_offset=i]
     a._buf.ptr[unsafe_offset=left_index] = pivot_value
     for i in range(right_index):
-        a._buf.ptr[unsafe_offset=left_index + 1 + i] = right._buf.ptr[unsafe_offset=i]
+        a._buf.ptr[unsafe_offset=left_index + 1 + i] = right._buf.ptr[
+            unsafe_offset=i
+        ]

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -286,7 +286,7 @@ def argsort[dtype: DType](A: Matrix[dtype]) raises -> Matrix[DType.int]:
     """
     var I = Matrix[DType.int](shape=(1, A.size), order=A.order())
     for i in range(I.size):
-        I._buf.ptr[i] = Scalar[DType.int](i)
+        I._buf.ptr[unsafe_offset=i] = Scalar[DType.int](i)
     var B: Matrix[dtype]
     if A.order() == "C":
         B = A.flatten()
@@ -358,10 +358,10 @@ def binary_sort_1d[dtype: DType](a: NDArray[dtype]) raises -> NDArray[dtype]:
     var result: NDArray[dtype] = a.contiguous()
     for end in range(result.size, 1, -1):
         for i in range(1, end):
-            if result._buf.ptr[i - 1] > result._buf.ptr[i]:
-                var temp = result._buf.ptr[i - 1]
-                result._buf.ptr[i - 1] = result._buf.ptr[i]
-                result._buf.ptr[i] = temp
+            if result._buf.ptr[unsafe_offset=i - 1] > result._buf.ptr[unsafe_offset=i]:
+                var temp = result._buf.ptr[unsafe_offset=i - 1]
+                result._buf.ptr[unsafe_offset=i - 1] = result._buf.ptr[unsafe_offset=i]
+                result._buf.ptr[unsafe_offset=i] = temp
     return result^
 
 
@@ -439,12 +439,12 @@ def bubble_sort[dtype: DType](ndarray: NDArray[dtype]) raises -> NDArray[dtype]:
 
     for i in range(length):
         for j in range(length - i - 1):
-            if result._buf.ptr.load[width=1](j) > result._buf.ptr.load[width=1](
+            if result._buf.ptr.unsafe_load[width=1](j) > result._buf.ptr.unsafe_load[width=1](
                 j + 1
             ):
-                var temp = result._buf.ptr.load[width=1](j)
-                result._buf.ptr.store(j, result._buf.ptr.load[width=1](j + 1))
-                result._buf.ptr.store(j + 1, temp)
+                var temp = result._buf.ptr.unsafe_load[width=1](j)
+                result._buf.ptr.unsafe_store(j, result._buf.ptr.unsafe_load[width=1](j + 1))
+                result._buf.ptr.unsafe_store(j + 1, temp)
 
     return result^
 
@@ -595,26 +595,26 @@ def _partition_in_range(
         New pivot index.
     """
 
-    var pivot_value = A._buf.ptr[pivot_index]
+    var pivot_value = A._buf.ptr[unsafe_offset=pivot_index]
 
-    A._buf.ptr[pivot_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[pivot_index],
+    A._buf.ptr[unsafe_offset=pivot_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=pivot_index],
     )
 
     var store_index = left
 
     for i in range(left, right):
-        if A._buf.ptr[i] < pivot_value:
-            A._buf.ptr[store_index], A._buf.ptr[i] = (
-                A._buf.ptr[i],
-                A._buf.ptr[store_index],
+        if A._buf.ptr[unsafe_offset=i] < pivot_value:
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+                A._buf.ptr[unsafe_offset=i],
+                A._buf.ptr[unsafe_offset=store_index],
             )
             store_index = store_index + 1
 
-    A._buf.ptr[store_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[store_index],
+    A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=store_index],
     )
 
     return store_index
@@ -643,38 +643,38 @@ def _partition_in_range(
         New pivot index.
     """
 
-    var pivot_value = A._buf.ptr[pivot_index]
+    var pivot_value = A._buf.ptr[unsafe_offset=pivot_index]
 
-    A._buf.ptr[pivot_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[pivot_index],
+    A._buf.ptr[unsafe_offset=pivot_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=pivot_index],
     )
-    I._buf.ptr[pivot_index], I._buf.ptr[right] = (
-        I._buf.ptr[right],
-        I._buf.ptr[pivot_index],
+    I._buf.ptr[unsafe_offset=pivot_index], I._buf.ptr[unsafe_offset=right] = (
+        I._buf.ptr[unsafe_offset=right],
+        I._buf.ptr[unsafe_offset=pivot_index],
     )
 
     var store_index = left
 
     for i in range(left, right):
-        if A._buf.ptr[i] < pivot_value:
-            A._buf.ptr[store_index], A._buf.ptr[i] = (
-                A._buf.ptr[i],
-                A._buf.ptr[store_index],
+        if A._buf.ptr[unsafe_offset=i] < pivot_value:
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+                A._buf.ptr[unsafe_offset=i],
+                A._buf.ptr[unsafe_offset=store_index],
             )
-            I._buf.ptr[store_index], I._buf.ptr[i] = (
-                I._buf.ptr[i],
-                I._buf.ptr[store_index],
+            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=i] = (
+                I._buf.ptr[unsafe_offset=i],
+                I._buf.ptr[unsafe_offset=store_index],
             )
             store_index = store_index + 1
 
-    A._buf.ptr[store_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[store_index],
+    A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=store_index],
     )
-    I._buf.ptr[store_index], I._buf.ptr[right] = (
-        I._buf.ptr[right],
-        I._buf.ptr[store_index],
+    I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=right] = (
+        I._buf.ptr[unsafe_offset=right],
+        I._buf.ptr[unsafe_offset=store_index],
     )
 
     return store_index
@@ -706,38 +706,38 @@ def _quick_sort_partition(
             ).format(left, right, pivot_index, A.size)
         )
 
-    var pivot_value = A._buf.ptr[pivot_index]
+    var pivot_value = A._buf.ptr[unsafe_offset=pivot_index]
 
-    A._buf.ptr[pivot_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[pivot_index],
+    A._buf.ptr[unsafe_offset=pivot_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=pivot_index],
     )
-    I._buf.ptr[pivot_index], I._buf.ptr[right] = (
-        I._buf.ptr[right],
-        I._buf.ptr[pivot_index],
+    I._buf.ptr[unsafe_offset=pivot_index], I._buf.ptr[unsafe_offset=right] = (
+        I._buf.ptr[unsafe_offset=right],
+        I._buf.ptr[unsafe_offset=pivot_index],
     )
 
     var store_index = left
 
     for i in range(left, right):
-        if A._buf.ptr[i] < pivot_value:
-            A._buf.ptr[store_index], A._buf.ptr[i] = (
-                A._buf.ptr[i],
-                A._buf.ptr[store_index],
+        if A._buf.ptr[unsafe_offset=i] < pivot_value:
+            A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=i] = (
+                A._buf.ptr[unsafe_offset=i],
+                A._buf.ptr[unsafe_offset=store_index],
             )
-            I._buf.ptr[store_index], I._buf.ptr[i] = (
-                I._buf.ptr[i],
-                I._buf.ptr[store_index],
+            I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=i] = (
+                I._buf.ptr[unsafe_offset=i],
+                I._buf.ptr[unsafe_offset=store_index],
             )
             store_index = store_index + 1
 
-    A._buf.ptr[store_index], A._buf.ptr[right] = (
-        A._buf.ptr[right],
-        A._buf.ptr[store_index],
+    A._buf.ptr[unsafe_offset=store_index], A._buf.ptr[unsafe_offset=right] = (
+        A._buf.ptr[unsafe_offset=right],
+        A._buf.ptr[unsafe_offset=store_index],
     )
-    I._buf.ptr[store_index], I._buf.ptr[right] = (
-        I._buf.ptr[right],
-        I._buf.ptr[store_index],
+    I._buf.ptr[unsafe_offset=store_index], I._buf.ptr[unsafe_offset=right] = (
+        I._buf.ptr[unsafe_offset=right],
+        I._buf.ptr[unsafe_offset=store_index],
     )
 
     return store_index
@@ -907,7 +907,7 @@ def _quick_sort_stable_inplace[
         )
 
     var pivot_index = size // 2
-    var pivot_value = a._buf.ptr[pivot_index]
+    var pivot_value = a._buf.ptr[unsafe_offset=pivot_index]
 
     var left = NDArray[dtype](shape=NDArrayShape(size), order="C")
     var right = NDArray[dtype](shape=NDArrayShape(size), order="C")
@@ -917,19 +917,19 @@ def _quick_sort_stable_inplace[
     # Put items to either left or right arrays
     for i in range(size):
         if i != pivot_index:
-            var value = a._buf.ptr[i]
+            var value = a._buf.ptr[unsafe_offset=i]
             if value < pivot_value:
-                left._buf.ptr[left_index] = value
+                left._buf.ptr[unsafe_offset=left_index] = value
                 left_index += 1
             elif value > pivot_value:
-                right._buf.ptr[right_index] = value
+                right._buf.ptr[unsafe_offset=right_index] = value
                 right_index += 1
             else:  # value == pivot_value
                 if i < pivot_index:
-                    left._buf.ptr[left_index] = value
+                    left._buf.ptr[unsafe_offset=left_index] = value
                     left_index += 1
                 else:
-                    right._buf.ptr[right_index] = value
+                    right._buf.ptr[unsafe_offset=right_index] = value
                     right_index += 1
 
     # Sort left and right arrays
@@ -938,7 +938,7 @@ def _quick_sort_stable_inplace[
 
     # Combine the sorted arrays
     for i in range(left_index):
-        a._buf.ptr[i] = left._buf.ptr[i]
-    a._buf.ptr[left_index] = pivot_value
+        a._buf.ptr[unsafe_offset=i] = left._buf.ptr[unsafe_offset=i]
+    a._buf.ptr[unsafe_offset=left_index] = pivot_value
     for i in range(right_index):
-        a._buf.ptr[left_index + 1 + i] = right._buf.ptr[i]
+        a._buf.ptr[unsafe_offset=left_index + 1 + i] = right._buf.ptr[unsafe_offset=i]

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -227,6 +227,7 @@ def argsort[dtype: DType](a: NDArray[dtype]) raises -> NDArray[DType.int]:
         Indices that would sort an array.
     """
 
+    var a_flattened: NDArray[dtype]
     if a.ndim == 1:
         a_flattened = a.contiguous()
     else:

--- a/numojo/routines/sorting.mojo
+++ b/numojo/routines/sorting.mojo
@@ -35,6 +35,7 @@ from numojo.routines.functional import (
     apply_along_axis_inplace,
     apply_along_axis_indices,
 )
+from numojo.routines.creation import arange
 
 
 # ===----------------------------------------------------------------------=== #

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -378,9 +378,9 @@ def stddev[
                 ).format(ddof, A.shape[i], i)
             )
 
-    return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** Scalar[
-        returned_dtype
-    ](0.5)
+    return variance[returned_dtype](
+        A, axis=normalized_axis, ddof=ddof
+    ) ** Scalar[returned_dtype](0.5)
 
 
 def stddev[

--- a/numojo/routines/statistics/averages.mojo
+++ b/numojo/routines/statistics/averages.mojo
@@ -26,6 +26,7 @@ from numojo.routines.functional import (
     apply_along_axis_reduce_with_dtype,
     apply_along_axis_reduce,
 )
+from numojo.routines.manipulation import ravel
 
 
 # not sure what's the side effect of using a returned dtype and casting to it. There could be some precision loss?
@@ -377,7 +378,9 @@ def stddev[
                 ).format(ddof, A.shape[i], i)
             )
 
-    return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** 0.5
+    return variance[returned_dtype](A, axis=normalized_axis, ddof=ddof) ** Scalar[
+        returned_dtype
+    ](0.5)
 
 
 def stddev[

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,1186 +1,1201 @@
 version: 7
 platforms:
-  - name: linux-64
-  - name: osx-arm64
+- name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
+- name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
 environments:
   default:
     channels:
-      - url: https://conda.modular.com/max/
-      - url: https://conda.anaconda.org/conda-forge/
-      - url: https://conda.modular.com/max-nightly/
-      - url: https://repo.prefix.dev/modular-community/
+    - url: https://conda.modular.com/max/
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.modular.com/max-nightly/
+    - url: https://repo.prefix.dev/modular-community/
     packages:
       linux-64:
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
-        - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-        - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
-        - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
-        - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-        - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
       osx-arm64:
-        - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
-        - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
-        - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-        - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
-        - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
-        - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
 packages:
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-    build_number: 20
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgomp >=7.5.0
-    constrains:
-      - openmp_impl <0.0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 28948
-    timestamp: 1770939786096
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-    sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
-    md5: d2ffd7602c02f2b316fd921d39876885
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    license: bzip2-1.0.6
-    license_family: BSD
-    size: 260182
-    timestamp: 1771350215188
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-    sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
-    md5: b38117a3c920364aff79f870c984b4a3
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=13
-    license: LGPL-2.1-or-later
-    size: 134088
-    timestamp: 1754905959823
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
-    sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
-    md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - keyutils >=1.6.3,<2.0a0
-      - libedit >=3.1.20250104,<3.2.0a0
-      - libedit >=3.1.20250104,<4.0a0
-      - libgcc >=14
-      - libstdcxx >=14
-      - openssl >=3.5.7,<4.0a0
-    license: MIT
-    license_family: MIT
-    size: 1388990
-    timestamp: 1781859420533
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-    sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
-    md5: 18335a698559cdbcd86150a48bf54ba6
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - zstd >=1.5.7,<1.6.0a0
-    constrains:
-      - binutils_impl_linux-64 2.45.1
-    license: GPL-3.0-only
-    license_family: GPL
-    size: 728002
-    timestamp: 1774197446916
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
-    build_number: 8
-    sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
-    md5: 00fc660ab1b2f5ca07e92b4900d10c79
-    depends:
-      - libopenblas >=0.3.33,<0.3.34.0a0
-      - libopenblas >=0.3.33,<1.0a0
-    constrains:
-      - blas 2.308   openblas
-      - mkl <2027
-      - libcblas   3.11.0   8*_openblas
-      - liblapack  3.11.0   8*_openblas
-      - liblapacke 3.11.0   8*_openblas
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18804
-    timestamp: 1779859100675
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
-    build_number: 8
-    sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
-    md5: 33a413f1095f8325e5c30fde3b0d2445
-    depends:
-      - libblas 3.11.0 8_h4a7cf45_openblas
-    constrains:
-      - blas 2.308   openblas
-      - liblapacke 3.11.0   8*_openblas
-      - liblapack  3.11.0   8*_openblas
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18778
-    timestamp: 1779859107964
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-    sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
-    md5: c277e0a4d549b03ac1e9d6cbbe3d017b
-    depends:
-      - ncurses
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=13
-      - ncurses >=6.5,<7.0a0
-    license: BSD-2-Clause
-    license_family: BSD
-    size: 134676
-    timestamp: 1738479519902
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-    md5: b24d3c612f71e7aa74158d92106318b2
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    constrains:
-      - expat 2.8.1.*
-    license: MIT
-    license_family: MIT
-    size: 77856
-    timestamp: 1781203599810
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-    sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
-    md5: a360c33a5abe61c07959e449fa1453eb
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    license: MIT
-    license_family: MIT
-    size: 58592
-    timestamp: 1769456073053
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-    sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
-    md5: 57736f29cc2b0ec0b6c2952d3f101b6a
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - _openmp_mutex >=4.5
-    constrains:
-      - libgcc-ng ==15.2.0=*_19
-      - libgomp 15.2.0 he0feb66_19
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 1041084
-    timestamp: 1778269013026
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
-    sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
-    md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
-    depends:
-      - libgfortran5 15.2.0 h68bc16d_19
-    constrains:
-      - libgfortran-ng ==15.2.0=*_19
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 27655
-    timestamp: 1778269042954
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
-    sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
-    md5: 85072b0ad177c966294f129b7c04a2d5
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=15.2.0
-    constrains:
-      - libgfortran 15.2.0
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 2483673
-    timestamp: 1778269025089
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-    sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
-    md5: faac990cb7aedc7f3a2224f2c9b0c26c
-    depends:
-      - __glibc >=2.17,<3.0.a0
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 603817
-    timestamp: 1778268942614
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
-    build_number: 8
-    sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
-    md5: 809be8ba8712c77bc7d44c2d99390dc4
-    depends:
-      - libblas 3.11.0 8_h4a7cf45_openblas
-    constrains:
-      - blas 2.308   openblas
-      - libcblas   3.11.0   8*_openblas
-      - liblapacke 3.11.0   8*_openblas
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18790
-    timestamp: 1779859115086
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-    sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
-    md5: b88d90cad08e6bc8ad540cb310a761fb
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    constrains:
-      - xz 5.8.3.*
-    license: 0BSD
-    size: 113478
-    timestamp: 1775825492909
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-    sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
-    md5: 2c21e66f50753a083cbe6b80f38268fa
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    license: BSD-2-Clause
-    license_family: BSD
-    size: 92400
-    timestamp: 1769482286018
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
-    sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
-    md5: 2d3278b721e40468295ca755c3b84070
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-      - libgfortran
-      - libgfortran5 >=14.3.0
-    constrains:
-      - openblas >=0.3.33,<0.3.34.0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 5931919
-    timestamp: 1776993658641
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
-    sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
-    md5: 965e4d531b588b2e42f66fd8e48b056c
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    license: ISC
-    size: 269272
-    timestamp: 1779163468406
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-    sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
-    md5: 062b0ac602fb0adf250e3dfa86f221c4
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-      - libzlib >=1.3.2,<2.0a0
-    license: blessing
-    size: 957849
-    timestamp: 1780574429573
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
-    sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
-    md5: 5794b3bdc38177caf969dabd3af08549
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc 15.2.0 he0feb66_19
-    constrains:
-      - libstdcxx-ng ==15.2.0=*_19
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 5852044
-    timestamp: 1778269036376
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-    sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
-    md5: 01bb81d12c957de066ea7362007df642
-    depends:
-      - libgcc >=14
-      - __glibc >=2.17,<3.0.a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 40017
-    timestamp: 1781625522462
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-    sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
-    md5: d87ff7921124eccd67248aa483c23fec
-    depends:
-      - __glibc >=2.17,<3.0.a0
-    constrains:
-      - zlib 1.3.2 *_2
-    license: Zlib
-    license_family: Other
-    size: 63629
-    timestamp: 1774072609062
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-    sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
-    md5: fc21868a1a5aacc937e7a18747acb8a5
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-    license: X11 AND BSD-3-Clause
-    size: 918956
-    timestamp: 1777422145199
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
-    sha256: 7caba80d1515ef3a697a96fa23a1f14fceffd76f3261f0daea510d5a2209b064
-    md5: 508c839b99562e2354917a6c83ab195b
-    depends:
-      - python
-      - libgcc >=14
-      - __glibc >=2.17,<3.0.a0
-      - libstdcxx >=14
-      - python_abi 3.13.* *_cp313
-      - libblas >=3.9.0,<4.0a0
-      - liblapack >=3.9.0,<4.0a0
-      - libcblas >=3.9.0,<4.0a0
-    constrains:
-      - numpy-base <0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 9005587
-    timestamp: 1782112542305
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-    sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
-    md5: 79dd2074b5cd5c5c6b2930514a11e22d
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - ca-certificates
-      - libgcc >=14
-    license: Apache-2.0
-    license_family: Apache
-    size: 3159683
-    timestamp: 1781069855778
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
-    build_number: 100
-    sha256: f2146aff59ce4b571a8f1d1acf94f9bed6cc18ab5632d7dcc940fb48ecdeef99
-    md5: 93762cd272814a142cf21d794f8fb0c1
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - bzip2 >=1.0.8,<2.0a0
-      - ld_impl_linux-64 >=2.36.1
-      - libexpat >=2.8.1,<3.0a0
-      - libffi >=3.5.2,<3.6.0a0
-      - libgcc >=14
-      - liblzma >=5.8.3,<6.0a0
-      - libmpdec >=4.0.0,<5.0a0
-      - libsqlite >=3.53.2,<4.0a0
-      - libuuid >=2.42.1,<3.0a0
-      - libzlib >=1.3.2,<2.0a0
-      - ncurses >=6.6,<7.0a0
-      - openssl >=3.5.7,<4.0a0
-      - python_abi 3.13.* *_cp313
-      - readline >=8.3,<9.0a0
-      - tk >=8.6.13,<8.7.0a0
-      - tzdata
-    license: Python-2.0
-    size: 37398694
-    timestamp: 1781258934574
-    python_site_packages_path: lib/python3.13/site-packages
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
-    noarch: python
-    sha256: 970b2a1d12983d8d1cc05d914ad88a0b6ef1fa14038c9649aa834dd6ebee65d7
-    md5: acd216255e1370e9aeab5351b831f07c
-    depends:
-      - python
-      - libgcc >=14
-      - libstdcxx >=14
-      - __glibc >=2.17,<3.0.a0
-      - _python_abi3_support 1.*
-      - cpython >=3.12
-      - zeromq >=4.3.5,<4.4.0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 210896
-    timestamp: 1779483879367
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-    sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
-    md5: d7d95fc8287ea7bf33e0e7116d2b95ec
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-      - ncurses >=6.5,<7.0a0
-    license: GPL-3.0-only
-    license_family: GPL
-    size: 345073
-    timestamp: 1765813471974
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
-    sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
-    md5: a32f88181ff9a3451c71be1f17a7c799
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libblas >=3.9.0,<4.0a0
-      - libcblas >=3.9.0,<4.0a0
-      - libgcc >=14
-      - libgfortran
-      - libgfortran5 >=14.3.0
-      - liblapack >=3.9.0,<4.0a0
-      - libstdcxx >=14
-      - numpy <2.7
-      - numpy >=1.23,<3
-      - numpy >=2.0.0
-      - python >=3.13,<3.14.0a0
-      - python_abi 3.13.* *_cp313
-    license: BSD-3-Clause
-    license_family: BSD
-    run_exports: {}
-    size: 17171066
-    timestamp: 1781912954186
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-    sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
-    md5: cffd3bdd58090148f4cfcd831f4b26ab
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-      - libzlib >=1.3.1,<2.0a0
-    constrains:
-      - xorg-libx11 >=1.8.12,<2.0a0
-    license: TCL
-    license_family: BSD
-    size: 3301196
-    timestamp: 1769460227866
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
-    sha256: ed2f17b2bc92389187b47e7444aa7d6ab6c70c3f3ba6bf2ced508027e60e82cb
-    md5: 9665531f18d2bcbc946e3ba0cf53ea91
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libgcc >=14
-      - python >=3.13,<3.14.0a0
-      - python_abi 3.13.* *_cp313
-    license: Apache-2.0
-    license_family: Apache
-    size: 885824
-    timestamp: 1781006802459
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
-    sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
-    md5: 96b08867e21d4694fa5c2c226e6581b0
-    depends:
-      - libgcc >=14
-      - __glibc >=2.17,<3.0.a0
-      - libstdcxx >=14
-      - krb5 >=1.22.2,<1.23.0a0
-      - libsodium >=1.0.22,<1.0.23.0a0
-    license: MPL-2.0
-    license_family: MOZILLA
-    size: 311184
-    timestamp: 1779123989774
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-    sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
-    md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
-    depends:
-      - __glibc >=2.17,<3.0.a0
-      - libzlib >=1.3.1,<2.0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 601375
-    timestamp: 1764777111296
-  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
-    sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
-    md5: aaa2a381ccc56eac91d63b6c1240312f
-    depends:
-      - cpython
-      - python-gil
-    license: MIT
-    license_family: MIT
-    size: 8191
-    timestamp: 1744137672556
-  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-    sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
-    md5: a9965dd99f683c5f444428f896635716
-    depends:
-      - __unix
-    license: ISC
-    size: 128866
-    timestamp: 1781708962055
-  - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
-    sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
-    md5: 554304a07e581a85891b15e39ea9f268
-    depends:
-      - __unix
-      - python
-      - python >=3.10
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 104999
-    timestamp: 1779900548735
-  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
-    noarch: generic
-    sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
-    md5: 22ff6a23190a29024b0df04b4caa0c66
-    depends:
-      - python >=3.13,<3.14.0a0
-      - python_abi * *_cp313
-    license: Python-2.0
-    size: 48337
-    timestamp: 1781257766256
-  - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
-    sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
-    md5: ffc17e785d64e12fc311af9184221839
-    depends:
-      - python >=3.10
-      - zipp >=3.20
-      - python
-    license: Apache-2.0
-    license_family: APACHE
-    size: 34766
-    timestamp: 1779714582554
-  - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
-    sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
-    md5: 4ebae00eae9705b0c3d6d1018a81d047
-    depends:
-      - importlib-metadata >=4.8.3
-      - jupyter_core >=4.12,!=5.0.*
-      - python >=3.9
-      - python-dateutil >=2.8.2
-      - pyzmq >=23.0
-      - tornado >=6.2
-      - traitlets >=5.3
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 106342
-    timestamp: 1733441040958
-  - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-    sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
-    md5: b38fe4e78ee75def7e599843ef4c1ab0
-    depends:
-      - __unix
-      - python
-      - platformdirs >=2.5
-      - python >=3.10
-      - traitlets >=5.3
-      - python
-    constrains:
-      - pywin32 >=300
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 65503
-    timestamp: 1760643864586
-  - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-    sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
-    md5: e9c622e0d00fa24a6292279af3ab6d06
-    depends:
-      - python >=3.9
-    license: MIT
-    license_family: MIT
-    size: 11766
-    timestamp: 1745776666688
-  - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-    sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
-    md5: 4c06a92e74452cfa53623a81592e8934
-    depends:
-      - python >=3.8
-      - python
-    license: Apache-2.0
-    license_family: APACHE
-    size: 91574
-    timestamp: 1777103621679
-  - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-    sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
-    md5: 11adc78451c998c0fd162584abfa3559
-    depends:
-      - python >=3.10
-    license: MPL-2.0
-    license_family: MOZILLA
-    size: 56559
-    timestamp: 1777271601895
-  - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
-    sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
-    md5: 2c5ef45db85d34799771629bd5860fd7
-    depends:
-      - python >=3.10
-      - python
-    license: MIT
-    license_family: MIT
-    size: 26308
-    timestamp: 1779972894916
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-    sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
-    md5: 5b8d21249ff20967101ffa321cab24e8
-    depends:
-      - python >=3.9
-      - six >=1.5
-      - python
-    license: Apache-2.0
-    license_family: APACHE
-    size: 233310
-    timestamp: 1751104122689
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
-    sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
-    md5: 200323d73f85b9c5c411db8c8c4942db
-    depends:
-      - cpython 3.13.14.*
-      - python_abi * *_cp313
-    license: Python-2.0
-    size: 48307
-    timestamp: 1781257788601
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
-    build_number: 8
-    sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
-    md5: 94305520c52a4aa3f6c2b1ff6008d9f8
-    constrains:
-      - python 3.13.* *_cp313
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 7002
-    timestamp: 1752805902938
-  - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-    sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
-    md5: 3339e3b65d58accf4ca4fb8748ab16b3
-    depends:
-      - python >=3.9
-      - python
-    license: MIT
-    license_family: MIT
-    size: 18455
-    timestamp: 1753199211006
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-    sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
-    md5: b5325cf06a000c5b14970462ff5e4d58
-    depends:
-      - python >=3.10
-      - python
-    license: MIT
-    license_family: MIT
-    size: 21561
-    timestamp: 1774492402955
-  - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
-    sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
-    md5: 37e3be7b6e2977d37b8fa5da229f5dc0
-    depends:
-      - python >=3.10
-      - python
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 115158
-    timestamp: 1780507822178
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-    sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
-    md5: ad659d0a2b3e47e38d829aa8cad2d610
-    license: LicenseRef-Public-Domain
-    size: 119135
-    timestamp: 1767016325805
-  - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-    sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
-    md5: ba3dcdc8584155c97c648ae9c044b7a3
-    depends:
-      - python >=3.10
-      - python
-    license: MIT
-    license_family: MIT
-    size: 24190
-    timestamp: 1779159948016
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-    build_number: 7
-    sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
-    md5: a44032f282e7d2acdeb1c240308052dd
-    depends:
-      - llvm-openmp >=9.0.1
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 8325
-    timestamp: 1764092507920
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-    sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
-    md5: 620b85a3f45526a8bc4d23fd78fc22f0
-    depends:
-      - __osx >=11.0
-    license: bzip2-1.0.6
-    license_family: BSD
-    size: 124834
-    timestamp: 1771350416561
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-    sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
-    md5: f1182c91c0de31a7abd40cedf6a5ebef
-    depends:
-      - __osx >=11.0
-    license: MIT
-    license_family: MIT
-    size: 12361647
-    timestamp: 1773822915649
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
-    sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
-    md5: 8780f41b013d19219faef9c82260744b
-    depends:
-      - __osx >=11.0
-      - libcxx >=19
-      - libedit >=3.1.20250104,<3.2.0a0
-      - libedit >=3.1.20250104,<4.0a0
-      - openssl >=3.5.7,<4.0a0
-    license: MIT
-    license_family: MIT
-    size: 1159780
-    timestamp: 1781859501654
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
-    build_number: 8
-    sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
-    md5: dbfe729181a32741ae63ecb41eefbac6
-    depends:
-      - libopenblas >=0.3.33,<0.3.34.0a0
-      - libopenblas >=0.3.33,<1.0a0
-    constrains:
-      - blas 2.308   openblas
-      - liblapack  3.11.0   8*_openblas
-      - liblapacke 3.11.0   8*_openblas
-      - libcblas   3.11.0   8*_openblas
-      - mkl <2027
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18949
-    timestamp: 1779859141315
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
-    build_number: 8
-    sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
-    md5: 03a2ef3491da9e5b4d18c03e9f4b3109
-    depends:
-      - libblas 3.11.0 8_h51639a9_openblas
-    constrains:
-      - blas 2.308   openblas
-      - liblapack  3.11.0   8*_openblas
-      - liblapacke 3.11.0   8*_openblas
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18911
-    timestamp: 1779859147634
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-    sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
-    md5: 89f76a2a21a3ec3ec983b5eb237c4113
-    depends:
-      - __osx >=11.0
-    license: Apache-2.0 WITH LLVM-exception
-    license_family: Apache
-    size: 569349
-    timestamp: 1781670209146
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-    sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
-    md5: 44083d2d2c2025afca315c7a172eab2b
-    depends:
-      - ncurses
-      - __osx >=11.0
-      - ncurses >=6.5,<7.0a0
-    license: BSD-2-Clause
-    license_family: BSD
-    size: 107691
-    timestamp: 1738479560845
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    depends:
-      - __osx >=11.0
-    constrains:
-      - expat 2.8.1.*
-    license: MIT
-    license_family: MIT
-    size: 69362
-    timestamp: 1781203631990
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-    sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
-    md5: 43c04d9cb46ef176bb2a4c77e324d599
-    depends:
-      - __osx >=11.0
-    license: MIT
-    license_family: MIT
-    size: 40979
-    timestamp: 1769456747661
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-    sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
-    md5: 644058123986582db33aebd4ae2ca184
-    depends:
-      - _openmp_mutex
-    constrains:
-      - libgcc-ng ==15.2.0=*_19
-      - libgomp 15.2.0 19
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 404080
-    timestamp: 1778273064154
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
-    sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
-    md5: 1ea03f87cdb1078fbc0e2b2deb63752c
-    depends:
-      - libgfortran5 15.2.0 hdae7583_19
-    constrains:
-      - libgfortran-ng ==15.2.0=*_19
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 139675
-    timestamp: 1778273280875
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-    sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
-    md5: ba36d8c606a6a53fe0b8c12d47267b3d
-    depends:
-      - libgcc >=15.2.0
-    constrains:
-      - libgfortran 15.2.0
-    license: GPL-3.0-only WITH GCC-exception-3.1
-    license_family: GPL
-    size: 599691
-    timestamp: 1778273075448
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
-    build_number: 8
-    sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
-    md5: 85adeb3d469d082dbd9c8c39e36dec57
-    depends:
-      - libblas 3.11.0 8_h51639a9_openblas
-    constrains:
-      - libcblas   3.11.0   8*_openblas
-      - blas 2.308   openblas
-      - liblapacke 3.11.0   8*_openblas
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 18925
-    timestamp: 1779859153970
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-    sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
-    md5: b1fd823b5ae54fbec272cea0811bd8a9
-    depends:
-      - __osx >=11.0
-    constrains:
-      - xz 5.8.3.*
-    license: 0BSD
-    size: 92472
-    timestamp: 1775825802659
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-    sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
-    md5: 57c4be259f5e0b99a5983799a228ae55
-    depends:
-      - __osx >=11.0
-    license: BSD-2-Clause
-    license_family: BSD
-    size: 73690
-    timestamp: 1769482560514
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
-    sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
-    md5: 909e41855c29f0d52ae630198cd57135
-    depends:
-      - __osx >=11.0
-      - libgfortran
-      - libgfortran5 >=14.3.0
-      - llvm-openmp >=19.1.7
-    constrains:
-      - openblas >=0.3.33,<0.3.34.0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 4304965
-    timestamp: 1776995497368
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
-    sha256: 202be45db5726757a8ea1f374f85aacc18c504f5ff15b2558496dff4c8779c48
-    md5: 9ed5ab909c449bdcae72322e44875a18
-    depends:
-      - __osx >=11.0
-    license: ISC
-    size: 247352
-    timestamp: 1779164136206
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-    sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
-    md5: 1ebde5c677f00765233a17e278571177
-    depends:
-      - __osx >=11.0
-      - icu >=78.3,<79.0a0
-      - libzlib >=1.3.2,<2.0a0
-    license: blessing
-    size: 927724
-    timestamp: 1780575223548
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-    sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
-    md5: bc5a5721b6439f2f62a84f2548136082
-    depends:
-      - __osx >=11.0
-    constrains:
-      - zlib 1.3.2 *_2
-    license: Zlib
-    license_family: Other
-    size: 47759
-    timestamp: 1774072956767
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
-    sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
-    md5: a9c118f6343fb6301b6f3b4e94c4c562
-    depends:
-      - __osx >=11.0
-    constrains:
-      - intel-openmp <0.0a0
-      - openmp 22.1.8|22.1.8.*
-    license: Apache-2.0 WITH LLVM-exception
-    license_family: APACHE
-    size: 286313
-    timestamp: 1781736516782
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-    sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
-    md5: 343d10ed5b44030a2f67193905aea159
-    depends:
-      - __osx >=11.0
-    license: X11 AND BSD-3-Clause
-    size: 805509
-    timestamp: 1777423252320
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
-    sha256: 9192f87dfc1d57249ed8d7367353de6ab6caa8525d6fd6efa03d83758f46adad
-    md5: cb5c510ee24c7966001e122abe8d85b8
-    depends:
-      - python
-      - libcxx >=19
-      - __osx >=11.0
-      - python_abi 3.13.* *_cp313
-      - libcblas >=3.9.0,<4.0a0
-      - liblapack >=3.9.0,<4.0a0
-      - libblas >=3.9.0,<4.0a0
-    constrains:
-      - numpy-base <0a0
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 7055163
-    timestamp: 1782112549179
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-    sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
-    md5: 8187a86242741725bfa74785fe812979
-    depends:
-      - __osx >=11.0
-      - ca-certificates
-    license: Apache-2.0
-    license_family: Apache
-    size: 3102584
-    timestamp: 1781069820667
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
-    build_number: 100
-    sha256: c89eedab6b293fae654d75483d8f3e5eb3ff9ce2478134d902676c1dd20c7dfd
-    md5: e556c07deaa168043f8430bb046092e2
-    depends:
-      - __osx >=11.0
-      - bzip2 >=1.0.8,<2.0a0
-      - libexpat >=2.8.1,<3.0a0
-      - libffi >=3.5.2,<3.6.0a0
-      - liblzma >=5.8.3,<6.0a0
-      - libmpdec >=4.0.0,<5.0a0
-      - libsqlite >=3.53.2,<4.0a0
-      - libzlib >=1.3.2,<2.0a0
-      - ncurses >=6.6,<7.0a0
-      - openssl >=3.5.7,<4.0a0
-      - python_abi 3.13.* *_cp313
-      - readline >=8.3,<9.0a0
-      - tk >=8.6.13,<8.7.0a0
-      - tzdata
-    license: Python-2.0
-    size: 17017633
-    timestamp: 1781257915644
-    python_site_packages_path: lib/python3.13/site-packages
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
-    noarch: python
-    sha256: 086cc67ec57afb7c9c09b5e09e7356b536b5b1af6c2e97117dc022cd22f0d472
-    md5: 73f22bde4991f30ae2bfac3811577c15
-    depends:
-      - python
-      - libcxx >=19
-      - __osx >=11.0
-      - zeromq >=4.3.5,<4.4.0a0
-      - _python_abi3_support 1.*
-      - cpython >=3.12
-    license: BSD-3-Clause
-    license_family: BSD
-    size: 191432
-    timestamp: 1779484184540
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-    sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
-    md5: f8381319127120ce51e081dce4865cf4
-    depends:
-      - __osx >=11.0
-      - ncurses >=6.5,<7.0a0
-    license: GPL-3.0-only
-    license_family: GPL
-    size: 313930
-    timestamp: 1765813902568
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
-    sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
-    md5: 110ff05ffef908af95192bb17c4006a0
-    depends:
-      - __osx >=11.0
-      - libblas >=3.9.0,<4.0a0
-      - libcblas >=3.9.0,<4.0a0
-      - libcxx >=19
-      - libgfortran
-      - libgfortran5 >=14.3.0
-      - liblapack >=3.9.0,<4.0a0
-      - numpy <2.7
-      - numpy >=1.23,<3
-      - numpy >=2.0.0
-      - python >=3.13,<3.14.0a0
-      - python_abi 3.13.* *_cp313
-    license: BSD-3-Clause
-    license_family: BSD
-    run_exports: {}
-    size: 14094513
-    timestamp: 1781912946907
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-    sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
-    md5: a9d86bc62f39b94c4661716624eb21b0
-    depends:
-      - __osx >=11.0
-      - libzlib >=1.3.1,<2.0a0
-    license: TCL
-    license_family: BSD
-    size: 3127137
-    timestamp: 1769460817696
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
-    sha256: 02c7b05be4d74da0d7329f92445646e3489634f0c3e59b26efefd846662ac20a
-    md5: dbc95e65c936251c3d32111c867d84e1
-    depends:
-      - __osx >=11.0
-      - python >=3.13,<3.14.0a0
-      - python >=3.13,<3.14.0a0 *_cp313
-      - python_abi 3.13.* *_cp313
-    license: Apache-2.0
-    license_family: Apache
-    size: 889689
-    timestamp: 1781007967544
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
-    sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
-    md5: d31c0e54c4f9c51100ec8c812ee925d1
-    depends:
-      - libcxx >=19
-      - __osx >=11.0
-      - krb5 >=1.22.2,<1.23.0a0
-      - libsodium >=1.0.22,<1.0.23.0a0
-    license: MPL-2.0
-    license_family: MOZILLA
-    size: 245404
-    timestamp: 1779124076307
-  - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0b2-release.conda
-    sha256: 7553366c138bae2fcf8617582f1bb6d6b6742087bd6a83ea83aa41c023499382
-    md5: 8d4390edde2dcf29880c57b3088f15aa
-    depends:
-      - python >=3.10
-      - mojo-compiler ==1.0.0b2
-      - mblack ==26.4.0
-      - jupyter_client >=8.6.2,<8.7
-    license: LicenseRef-Modular-Proprietary
-    size: 96475709
-    timestamp: 1781237127405
-  - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0b2-release.conda
-    sha256: 87f8e9ef573f37072423aeb56a7c468bdb5f5889476bce4aa7c3396665c651fe
-    md5: 6be85d17872f5c2370015ca4ec07dd0d
-    depends:
-      - mojo-python ==1.0.0b2
-    license: LicenseRef-Modular-Proprietary
-    size: 85342385
-    timestamp: 1781237127405
-  - conda: https://conda.modular.com/max/noarch/mblack-26.4.0-release.conda
-    noarch: python
-    sha256: e2497cbefbf5d962cd0db8c1b893e7e48d8f3603cab84a9d8bad0030b5bb26b1
-    md5: ec6bf2b9588f5ba4bd3472c0773c4892
-    depends:
-      - python >=3.10
-      - click >=8.0.0
-      - mypy_extensions >=0.4.3
-      - packaging >=22.0
-      - pathspec >=0.9.0
-      - platformdirs >=2
-      - tomli >=1.1.0
-    license: LicenseRef-Modular-Proprietary
-    size: 135301
-    timestamp: 1781220755102
-  - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0b2-release.conda
-    noarch: python
-    sha256: 37bf44a74edcd2ebaec7fe8299ef183e006ad051bfcf21caa06becc0e0eeffd5
-    md5: 8781bd673909835fa59ce818e3835839
-    depends:
-      - python >=3.10
-    license: LicenseRef-Modular-Proprietary
-    size: 24682
-    timestamp: 1781220753246
-  - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0b2-release.conda
-    sha256: 39bb59a309af5e4c78c077263e5824e33bba8159a1e0fc39ff2786a1f9d5762b
-    md5: 1a6b6dd12763032e46b956407b39ab48
-    depends:
-      - python >=3.10
-      - mojo-compiler ==1.0.0b2
-      - mblack ==26.4.0
-      - jupyter_client >=8.6.2,<8.7
-    license: LicenseRef-Modular-Proprietary
-    size: 84573003
-    timestamp: 1781237324882
-  - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0b2-release.conda
-    sha256: 91c4d590a152ec2e26846955fcd7ec02796dfaffefa006a1c0c5790575be2051
-    md5: cd8d3f4a22e5f14dd909d0d5570c4940
-    depends:
-      - mojo-python ==1.0.0b2
-    license: LicenseRef-Modular-Proprietary
-    size: 62655166
-    timestamp: 1781237320083
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
+  md5: b38117a3c920364aff79f870c984b4a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  size: 134088
+  timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1388990
+  timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 728002
+  timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  build_number: 8
+  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+  md5: 00fc660ab1b2f5ca07e92b4900d10c79
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - mkl <2027
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18804
+  timestamp: 1779859100675
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  build_number: 8
+  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+  md5: 33a413f1095f8325e5c30fde3b0d2445
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18778
+  timestamp: 1779859107964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
+  md5: c277e0a4d549b03ac1e9d6cbbe3d017b
+  depends:
+  - ncurses
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134676
+  timestamp: 1738479519902
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 77856
+  timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1041084
+  timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+  sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+  md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+  depends:
+  - libgfortran5 15.2.0 h68bc16d_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27655
+  timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+  sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+  md5: 85072b0ad177c966294f129b7c04a2d5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2483673
+  timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603817
+  timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  build_number: 8
+  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+  md5: 809be8ba8712c77bc7d44c2d99390dc4
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18790
+  timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92400
+  timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+  sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+  md5: 2d3278b721e40468295ca755c3b84070
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5931919
+  timestamp: 1776993658641
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+  sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
+  md5: 965e4d531b588b2e42f66fd8e48b056c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: ISC
+  size: 269272
+  timestamp: 1779163468406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  sha256: 1ab603b6ec93933e76027e1f23b21b22b858ba1b56f1e1695ef6fe5e80cb7358
+  md5: 062b0ac602fb0adf250e3dfa86f221c4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 957849
+  timestamp: 1780574429573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+  md5: 5794b3bdc38177caf969dabd3af08549
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_19
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852044
+  timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40017
+  timestamp: 1781625522462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.0-py313hf6604e3_0.conda
+  sha256: 7caba80d1515ef3a697a96fa23a1f14fceffd76f3261f0daea510d5a2209b064
+  md5: 508c839b99562e2354917a6c83ab195b
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - python_abi 3.13.* *_cp313
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9005587
+  timestamp: 1782112542305
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+  sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+  md5: 79dd2074b5cd5c5c6b2930514a11e22d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3159683
+  timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
+  build_number: 100
+  sha256: f2146aff59ce4b571a8f1d1acf94f9bed6cc18ab5632d7dcc940fb48ecdeef99
+  md5: 93762cd272814a142cf21d794f8fb0c1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.13.* *_cp313
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  license: Python-2.0
+  size: 37398694
+  timestamp: 1781258934574
+  python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_3.conda
+  noarch: python
+  sha256: 970b2a1d12983d8d1cc05d914ad88a0b6ef1fa14038c9649aa834dd6ebee65d7
+  md5: acd216255e1370e9aeab5351b831f07c
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - _python_abi3_support 1.*
+  - cpython >=3.12
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210896
+  timestamp: 1779483879367
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+  sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
+  md5: a32f88181ff9a3451c71be1f17a7c799
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 17171066
+  timestamp: 1781912954186
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+  sha256: ed2f17b2bc92389187b47e7444aa7d6ab6c70c3f3ba6bf2ced508027e60e82cb
+  md5: 9665531f18d2bcbc946e3ba0cf53ea91
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 885824
+  timestamp: 1781006802459
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+  sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
+  md5: 96b08867e21d4694fa5c2c226e6581b0
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.22,<1.0.23.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 311184
+  timestamp: 1779123989774
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601375
+  timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
+  md5: aaa2a381ccc56eac91d63b6c1240312f
+  depends:
+  - cpython
+  - python-gil
+  license: MIT
+  license_family: MIT
+  size: 8191
+  timestamp: 1744137672556
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+  md5: a9965dd99f683c5f444428f896635716
+  depends:
+  - __unix
+  license: ISC
+  size: 128866
+  timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+  sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
+  md5: 554304a07e581a85891b15e39ea9f268
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 104999
+  timestamp: 1779900548735
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
+  noarch: generic
+  sha256: 42995d97d7e83d2bedbe8173bc9aa022ea412bf33dd2ff0e3db2c01a5242cd0a
+  md5: 22ff6a23190a29024b0df04b4caa0c66
+  depends:
+  - python >=3.13,<3.14.0a0
+  - python_abi * *_cp313
+  license: Python-2.0
+  size: 48337
+  timestamp: 1781257766256
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+  md5: ffc17e785d64e12fc311af9184221839
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34766
+  timestamp: 1779714582554
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
+  sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
+  md5: 4ebae00eae9705b0c3d6d1018a81d047
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_core >=4.12,!=5.0.*
+  - python >=3.9
+  - python-dateutil >=2.8.2
+  - pyzmq >=23.0
+  - tornado >=6.2
+  - traitlets >=5.3
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 106342
+  timestamp: 1733441040958
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+  sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
+  md5: b38fe4e78ee75def7e599843ef4c1ab0
+  depends:
+  - __unix
+  - python
+  - platformdirs >=2.5
+  - python >=3.10
+  - traitlets >=5.3
+  - python
+  constrains:
+  - pywin32 >=300
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 65503
+  timestamp: 1760643864586
+- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+  sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
+  md5: e9c622e0d00fa24a6292279af3ab6d06
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11766
+  timestamp: 1745776666688
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+  md5: 4c06a92e74452cfa53623a81592e8934
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 91574
+  timestamp: 1777103621679
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+  sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
+  md5: 11adc78451c998c0fd162584abfa3559
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 56559
+  timestamp: 1777271601895
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+  sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
+  md5: 2c5ef45db85d34799771629bd5860fd7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 26308
+  timestamp: 1779972894916
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
+  depends:
+  - python >=3.9
+  - six >=1.5
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.14-h4df99d1_100.conda
+  sha256: c7a8f98ea1cda5a84377c236ccd4bf1b6e2212c5a258d60bba295fb9f0260235
+  md5: 200323d73f85b9c5c411db8c8c4942db
+  depends:
+  - cpython 3.13.14.*
+  - python_abi * *_cp313
+  license: Python-2.0
+  size: 48307
+  timestamp: 1781257788601
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+  build_number: 8
+  sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
+  md5: 94305520c52a4aa3f6c2b1ff6008d9f8
+  constrains:
+  - python 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7002
+  timestamp: 1752805902938
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+  sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+  md5: 3339e3b65d58accf4ca4fb8748ab16b3
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 18455
+  timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+  sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
+  md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115158
+  timestamp: 1780507822178
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+  sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+  md5: ba3dcdc8584155c97c648ae9c044b7a3
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 24190
+  timestamp: 1779159948016
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
+  md5: a44032f282e7d2acdeb1c240308052dd
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8325
+  timestamp: 1764092507920
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  sha256: 540fe54be35fac0c17feefbdc3e29725cce05d7367ffedfaaa1bdda234b019df
+  md5: 620b85a3f45526a8bc4d23fd78fc22f0
+  depends:
+  - __osx >=11.0
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 124834
+  timestamp: 1771350416561
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 12361647
+  timestamp: 1773822915649
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
+  sha256: c740e4a2e7247776a9883158fdab50ae0732c8f67f96d8f1db8ad9da5e0b5222
+  md5: 8780f41b013d19219faef9c82260744b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1159780
+  timestamp: 1781859501654
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
+  build_number: 8
+  sha256: 8f5ec18ead0619a9cf0f38b49796c22f6fc0f44850c0df2baea0f5277db16e75
+  md5: dbfe729181a32741ae63ecb41eefbac6
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  - libcblas   3.11.0   8*_openblas
+  - mkl <2027
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18949
+  timestamp: 1779859141315
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
+  build_number: 8
+  sha256: f93efcd44bc24f97c2478c7474d3baa6801a057974f330e1d06bedc33e4c778f
+  md5: 03a2ef3491da9e5b4d18c03e9f4b3109
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18911
+  timestamp: 1779859147634
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  sha256: a2e7abab5add9750fab064c024394de48e49f97631c605ad5db5c8ac3fc769ef
+  md5: 89f76a2a21a3ec3ec983b5eb237c4113
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 569349
+  timestamp: 1781670209146
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
+  sha256: 66aa216a403de0bb0c1340a88d1a06adaff66bae2cfd196731aa24db9859d631
+  md5: 44083d2d2c2025afca315c7a172eab2b
+  depends:
+  - ncurses
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 107691
+  timestamp: 1738479560845
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  md5: a915151d5d3c5bf039f5ccc8402a436f
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 69362
+  timestamp: 1781203631990
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  sha256: 6686a26466a527585e6a75cc2a242bf4a3d97d6d6c86424a441677917f28bec7
+  md5: 43c04d9cb46ef176bb2a4c77e324d599
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 40979
+  timestamp: 1769456747661
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
+  sha256: 06644fa4d34d57c9e48f4d84b1256f9e5f654fdb37f43acc8a58a396952d42b7
+  md5: 644058123986582db33aebd4ae2ca184
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 404080
+  timestamp: 1778273064154
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
+  sha256: d4837b3b9b30af3132d260225e91ab9dde83be04c59513f500cc81050fb37486
+  md5: 1ea03f87cdb1078fbc0e2b2deb63752c
+  depends:
+  - libgfortran5 15.2.0 hdae7583_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 139675
+  timestamp: 1778273280875
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
+  sha256: d0a68b7a121d115b80c169e24d1265dcc25a3fe58d107df1bbc430797e226d88
+  md5: ba36d8c606a6a53fe0b8c12d47267b3d
+  depends:
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 599691
+  timestamp: 1778273075448
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
+  build_number: 8
+  sha256: 8a076fe82142a00fe85f5a5a5351e286e8064f0100fe13608d19182cd0018c25
+  md5: 85adeb3d469d082dbd9c8c39e36dec57
+  depends:
+  - libblas 3.11.0 8_h51639a9_openblas
+  constrains:
+  - libcblas   3.11.0   8*_openblas
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18925
+  timestamp: 1779859153970
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  sha256: 34878d87275c298f1a732c6806349125cebbf340d24c6c23727268184bba051e
+  md5: b1fd823b5ae54fbec272cea0811bd8a9
+  depends:
+  - __osx >=11.0
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 92472
+  timestamp: 1775825802659
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  sha256: 1089c7f15d5b62c622625ec6700732ece83be8b705da8c6607f4dabb0c4bd6d2
+  md5: 57c4be259f5e0b99a5983799a228ae55
+  depends:
+  - __osx >=11.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 73690
+  timestamp: 1769482560514
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
+  sha256: 9dd455b2d172aeedfa2058d324b5b5822b0bc1b7c1f32cd183d7078540d2f6eb
+  md5: 909e41855c29f0d52ae630198cd57135
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4304965
+  timestamp: 1776995497368
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.22-h1a92334_1.conda
+  sha256: 202be45db5726757a8ea1f374f85aacc18c504f5ff15b2558496dff4c8779c48
+  md5: 9ed5ab909c449bdcae72322e44875a18
+  depends:
+  - __osx >=11.0
+  license: ISC
+  size: 247352
+  timestamp: 1779164136206
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  sha256: 862463917e8ef5ac3ebdaf8f19914634b457609cc27ba678b7197124cefeb1f7
+  md5: 1ebde5c677f00765233a17e278571177
+  depends:
+  - __osx >=11.0
+  - icu >=78.3,<79.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 927724
+  timestamp: 1780575223548
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
+  depends:
+  - __osx >=11.0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 47759
+  timestamp: 1774072956767
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.8-hc7d1edf_0.conda
+  sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
+  md5: a9c118f6343fb6301b6f3b4e94c4c562
+  depends:
+  - __osx >=11.0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.8|22.1.8.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 286313
+  timestamp: 1781736516782
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  sha256: 4ea6c620b87bd1d42bb2ccc2c87cd2483fa2d7f9e905b14c223f11ff3f4c455d
+  md5: 343d10ed5b44030a2f67193905aea159
+  depends:
+  - __osx >=11.0
+  license: X11 AND BSD-3-Clause
+  size: 805509
+  timestamp: 1777423252320
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.5.0-py313hce9b930_0.conda
+  sha256: 9192f87dfc1d57249ed8d7367353de6ab6caa8525d6fd6efa03d83758f46adad
+  md5: cb5c510ee24c7966001e122abe8d85b8
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=11.0
+  - python_abi 3.13.* *_cp313
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7055163
+  timestamp: 1782112549179
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
+  md5: 8187a86242741725bfa74785fe812979
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  size: 3102584
+  timestamp: 1781069820667
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
+  build_number: 100
+  sha256: c89eedab6b293fae654d75483d8f3e5eb3ff9ce2478134d902676c1dd20c7dfd
+  md5: e556c07deaa168043f8430bb046092e2
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.13.* *_cp313
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  license: Python-2.0
+  size: 17017633
+  timestamp: 1781257915644
+  python_site_packages_path: lib/python3.13/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_3.conda
+  noarch: python
+  sha256: 086cc67ec57afb7c9c09b5e09e7356b536b5b1af6c2e97117dc022cd22f0d472
+  md5: 73f22bde4991f30ae2bfac3811577c15
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=11.0
+  - zeromq >=4.3.5,<4.4.0a0
+  - _python_abi3_support 1.*
+  - cpython >=3.12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 191432
+  timestamp: 1779484184540
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  sha256: a77010528efb4b548ac2a4484eaf7e1c3907f2aec86123ed9c5212ae44502477
+  md5: f8381319127120ce51e081dce4865cf4
+  depends:
+  - __osx >=11.0
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 313930
+  timestamp: 1765813902568
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
+  sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
+  md5: 110ff05ffef908af95192bb17c4006a0
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=2.0.0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 14094513
+  timestamp: 1781912946907
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  sha256: 799cab4b6cde62f91f750149995d149bc9db525ec12595e8a1d91b9317f038b3
+  md5: a9d86bc62f39b94c4661716624eb21b0
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3127137
+  timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+  sha256: 02c7b05be4d74da0d7329f92445646e3489634f0c3e59b26efefd846662ac20a
+  md5: dbc95e65c936251c3d32111c867d84e1
+  depends:
+  - __osx >=11.0
+  - python >=3.13,<3.14.0a0
+  - python >=3.13,<3.14.0a0 *_cp313
+  - python_abi 3.13.* *_cp313
+  license: Apache-2.0
+  license_family: Apache
+  size: 889689
+  timestamp: 1781007967544
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
+  sha256: 01fd50d2801b23b59fafea6bf704a6c5faf0f5969104400eae0e6572cb2e5304
+  md5: d31c0e54c4f9c51100ec8c812ee925d1
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.22,<1.0.23.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 245404
+  timestamp: 1779124076307
+- conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
+  sha256: 5778f999b69cf77bd6f07ccaf32d0bafc258fe75206afc8e88919269cebb6e75
+  md5: afeb126acb57602a5f9b8153e75e1c3c
+  depends:
+  - python >=3.10
+  - mojo-compiler ==1.0.0
+  - mblack ==26.5.0
+  - jupyter_client >=8.6.2,<8.7
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 115641078
+  timestamp: 1786292404342
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
+  sha256: 4394c6146d47ec7794a9a3ed5775ae158f59f83f8e1aed59408b17c4909821b3
+  md5: 75d2e2ca9d87fdc76513d7939202e7dc
+  depends:
+  - mojo-python ==1.0.0
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 68511359
+  timestamp: 1786292410712
+- conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
+  noarch: python
+  sha256: 49102b55366eab56b04620533302b8693b4fa4a6c5972b3cc978b3f3bad83ebe
+  md5: 0cbfc119215c063cd279f0a6beb04285
+  depends:
+  - python >=3.10
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9.0
+  - platformdirs >=2
+  - tomli >=1.1.0
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 137187
+  timestamp: 1786151006088
+- conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
+  noarch: python
+  sha256: fc449a47c7707ed96a794768e29d5d2b0bf7afab373e2a9751f281ed7c4f822c
+  md5: 4a27e1596a5c2d27330a2377090b12c5
+  depends:
+  - python >=3.10
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 24040
+  timestamp: 1785891558838
+- conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
+  sha256: 200bd9ace6e06ad2a9b4f4cce9afa3e5f3c00b3d87a6d57206249df2a5568e38
+  md5: 954433eb905b424cc3d4325c9c2242de
+  depends:
+  - python >=3.10
+  - mojo-compiler ==1.0.0
+  - mblack ==26.5.0
+  - jupyter_client >=8.6.2,<8.7
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 101155040
+  timestamp: 1786294689438
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
+  sha256: c52054bc444d851e5c38cc33e790fb011a1080470244aaa59351ac5056d08c59
+  md5: b5103c9d9978173a1e97c5e5eed1aeba
+  depends:
+  - mojo-python ==1.0.0
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 61221085
+  timestamp: 1786294690001

--- a/pixi.lock
+++ b/pixi.lock
@@ -73,6 +73,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.modular.com/max/linux-64/max-core-26.5.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-compiler-1.0.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
@@ -130,6 +131,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.5.0-release.conda
       - conda: https://conda.modular.com/max/noarch/mojo-python-1.0.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/max-core-26.5.0-release.conda
       - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
       - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-1.0.0-release.conda
 packages:
@@ -1131,6 +1133,15 @@ packages:
   license_family: MOZILLA
   size: 245404
   timestamp: 1779124076307
+- conda: https://conda.modular.com/max/linux-64/max-core-26.5.0-release.conda
+  sha256: a2aca8a7dc43cdac10f286ba31a811468794631e514f0df2687464cba15deeb0
+  md5: 85c39f2cdbb36c2837c59150fad012d9
+  depends:
+  - mojo-compiler ==1.0.0
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 117588665
+  timestamp: 1786292557073
 - conda: https://conda.modular.com/max/linux-64/mojo-1.0.0-release.conda
   sha256: 5778f999b69cf77bd6f07ccaf32d0bafc258fe75206afc8e88919269cebb6e75
   md5: afeb126acb57602a5f9b8153e75e1c3c
@@ -1178,6 +1189,15 @@ packages:
   run_exports: {}
   size: 24040
   timestamp: 1785891558838
+- conda: https://conda.modular.com/max/osx-arm64/max-core-26.5.0-release.conda
+  sha256: 774f2b368d1473553debbfb61566e2d1091951990f003340eb836fd4baeb50ea
+  md5: 24bbf832b1dc7d486b3e8b051b7c001c
+  depends:
+  - mojo-compiler ==1.0.0
+  license: LicenseRef-Modular-Proprietary
+  run_exports: {}
+  size: 66719553
+  timestamp: 1786294908386
 - conda: https://conda.modular.com/max/osx-arm64/mojo-1.0.0-release.conda
   sha256: 200bd9ace6e06ad2a9b4f4cce9afa3e5f3c00b3d87a6d57206249df2a5568e38
   md5: 954433eb905b424cc3d4325c9c2242de

--- a/pixi.toml
+++ b/pixi.toml
@@ -35,13 +35,13 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-mojo = "==1.0.0b2"
+mojo = ">=1.0.0, <1.1.0"
 
 [package.build-dependencies]
-mojo = "==1.0.0b2"
+mojo = ">=1.0.0, <1.1.0"
 
 [package.run-dependencies]
-mojo = "==1.0.0b2"
+mojo = ">=1.0.0, <1.1.0"
 
 [tasks]
 # compile the package and copy it to the tests folder
@@ -73,7 +73,7 @@ doc_pages = "mojo doc numojo/ -o docs.json"
 release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
-mojo = "==1.0.0b2"
+mojo = ">=1.0.0, <1.1.0"
 numpy = ">=2.4.2,<3"
 python = ">=3.13,<3.14"
 scipy = ">=1.17.0,<2"

--- a/pixi.toml
+++ b/pixi.toml
@@ -74,6 +74,7 @@ release = "clear && pixi run final && pixi run doc_pages"
 
 [dependencies]
 mojo = ">=1.0.0, <1.1.0"
+max-core = ">=26.5.0,<27"
 numpy = ">=2.4.2,<3"
 python = ">=3.13,<3.14"
 scipy = ">=1.17.0,<2"

--- a/tests/core/test_diagonal.mojo
+++ b/tests/core/test_diagonal.mojo
@@ -67,7 +67,7 @@ def test_diagonal_not_2d_no_longer_errors_for_3d() raises:
 
 
 def test_diagonal_1d_raises() raises:
-    """diagonal on a 1-D array raises (fewer than 2 dims)."""
+    """Diagonal on a 1-D array raises (fewer than 2 dims)."""
     var a = nm.arange[nm.i32](0, 5)
     var raised = False
     try:
@@ -78,7 +78,7 @@ def test_diagonal_1d_raises() raises:
 
 
 def test_diagonal_same_axis_raises() raises:
-    """diagonal with axis1 == axis2 raises."""
+    """Diagonal with axis1 == axis2 raises."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var raised = False
     try:

--- a/tests/core/test_fancy_index.mojo
+++ b/tests/core/test_fancy_index.mojo
@@ -31,7 +31,7 @@ def test_fancy_index_2d_free_fn() raises:
 
 
 def test_fancy_index_getitem_list_syntax() raises:
-    """a[[rows, cols]] subscript syntax via List[NDArray[DType.int]]."""
+    """A[[rows, cols]] subscript syntax via List[NDArray[DType.int]]."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var rows = nm.array[nm.int]("[0, 1, 2]")
     var cols = nm.array[nm.int]("[2, 3, 0]")

--- a/tests/core/test_matrix.mojo
+++ b/tests/core/test_matrix.mojo
@@ -238,8 +238,8 @@ def test_qr_decomposition() raises:
     var np = Python.import_module("numpy")
 
     var Q_R = nm.linalg.qr(A)
-    Q = Q_R[0].copy()
-    R = Q_R[1].copy()
+    var Q = Q_R[0].copy()
+    var R = Q_R[1].copy()
 
     # Check if Q^T Q is close to the identity matrix, i.e Q is orthonormal
     var id = Q.transpose() @ Q
@@ -265,8 +265,8 @@ def test_qr_decomposition_asym_reduced() raises:
     var np = Python.import_module("numpy")
     var A = Matrix.rand[f64]((12, 5), order=order)
     var Q_R = nm.linalg.qr(A, mode="reduced")
-    Q = Q_R[0].copy()
-    R = Q_R[1].copy()
+    var Q = Q_R[0].copy()
+    var R = Q_R[1].copy()
 
     assert_true(
         Q.shape[0] == 12 and Q.shape[1] == 5,
@@ -383,9 +383,9 @@ def test_eigen_decomposition() raises:
     var Lambda = Q_Lambda[1].copy()
 
     # Use NumPy for comparison
-    namedtuple = np.linalg.eig(Anp)
+    var namedtuple = np.linalg.eig(Anp)
 
-    np_eigenvalues = namedtuple.eigenvalues
+    var np_eigenvalues = namedtuple.eigenvalues
 
     # Sort eigenvalues and eigenvectors for comparison (numpy doesn't guarantee order)
     var np_sorted_eigenvalues = np.sort(np_eigenvalues)

--- a/tests/core/test_nonzero.mojo
+++ b/tests/core/test_nonzero.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_nonzero_1d() raises:
-    """nonzero on a 1-D array returns flat positions of non-zero entries."""
+    """Nonzero on a 1-D array returns flat positions of non-zero entries."""
     var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
     var idx = a.nonzero()
     assert_equal(len(idx), 1)
@@ -17,7 +17,7 @@ def test_nonzero_1d() raises:
 
 
 def test_nonzero_2d() raises:
-    """nonzero on a 2-D array returns one coordinate array per dimension."""
+    """Nonzero on a 2-D array returns one coordinate array per dimension."""
     var b = nm.array[nm.i32]("[[1, 0], [0, 4]]")
     var idx2 = b.nonzero()
     assert_equal(len(idx2), 2)

--- a/tests/core/test_put.mojo
+++ b/tests/core/test_put.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_put_array_values_happy_path() raises:
-    """put with an array of values writes into flat positions."""
+    """Put with an array of values writes into flat positions."""
     var a = nm.arange[nm.i32](0, 6)
     a.put(nm.array[nm.int]("[0, 2]"), nm.array[nm.i32]("[10, 20]"))
     assert_equal(Int(a.item(0)), 10)
@@ -16,7 +16,7 @@ def test_put_array_values_happy_path() raises:
 
 
 def test_put_scalar_broadcast() raises:
-    """put with a scalar value broadcasts to all indices."""
+    """Put with a scalar value broadcasts to all indices."""
     var a = nm.arange[nm.i32](0, 6)
     a.put(nm.array[nm.int]("[0, 2]"), Scalar[nm.i32](99))
     assert_equal(Int(a.item(0)), 99)
@@ -26,7 +26,7 @@ def test_put_scalar_broadcast() raises:
 
 
 def test_put_negative_indices() raises:
-    """put accepts negative (from-the-end) flat indices."""
+    """Put accepts negative (from-the-end) flat indices."""
     var a = nm.arange[nm.i32](0, 6)
     a.put(nm.array[nm.int]("[-1, -2]"), nm.array[nm.i32]("[100, 200]"))
     assert_equal(Int(a.item(5)), 100)
@@ -44,7 +44,7 @@ def test_put_values_broadcast_cyclically() raises:
 
 
 def test_put_on_2d_array_flat_indexing() raises:
-    """put indexes into the flattened (ravel-order) positions of an N-D array.
+    """Put indexes into the flattened (ravel-order) positions of an N-D array.
     """
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     a.put(nm.array[nm.int]("[0, 5, 11]"), nm.array[nm.i32]("[-1, -2, -3]"))
@@ -54,7 +54,7 @@ def test_put_on_2d_array_flat_indexing() raises:
 
 
 def test_put_out_of_bounds_raises() raises:
-    """put raises when an index is out of bounds for the flattened array."""
+    """Put raises when an index is out of bounds for the flattened array."""
     var a = nm.arange[nm.i32](0, 6)
     var raised = False
     try:

--- a/tests/core/test_searchsorted.mojo
+++ b/tests/core/test_searchsorted.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_searchsorted_scalar_left() raises:
-    """searchsorted with a scalar value, default side='left'."""
+    """Searchsorted with a scalar value, default side='left'."""
     var a = nm.array[nm.i32]("[1, 3, 5, 7]")
     assert_equal(a.searchsorted(Scalar[nm.i32](4)), 2)
     assert_equal(a.searchsorted(Scalar[nm.i32](1)), 0)
@@ -15,14 +15,14 @@ def test_searchsorted_scalar_left() raises:
 
 
 def test_searchsorted_scalar_right() raises:
-    """searchsorted with side='right' returns the rightmost insertion point."""
+    """Searchsorted with side='right' returns the rightmost insertion point."""
     var a = nm.array[nm.i32]("[1, 3, 5, 7]")
     assert_equal(a.searchsorted(Scalar[nm.i32](3), side="right"), 2)
     assert_equal(a.searchsorted(Scalar[nm.i32](3), side="left"), 1)
 
 
 def test_searchsorted_array_values() raises:
-    """searchsorted with an array of values returns one index per value."""
+    """Searchsorted with an array of values returns one index per value."""
     var a = nm.array[nm.i32]("[1, 3, 5, 7]")
     var result = a.searchsorted(nm.array[nm.i32]("[2, 6]"))
     assert_equal(result.size, 2)
@@ -31,14 +31,14 @@ def test_searchsorted_array_values() raises:
 
 
 def test_searchsorted_duplicates_left_right() raises:
-    """searchsorted handles duplicate values correctly for both sides."""
+    """Searchsorted handles duplicate values correctly for both sides."""
     var a = nm.array[nm.i32]("[1, 2, 2, 2, 5]")
     assert_equal(a.searchsorted(Scalar[nm.i32](2), side="left"), 1)
     assert_equal(a.searchsorted(Scalar[nm.i32](2), side="right"), 4)
 
 
 def test_searchsorted_non_1d_raises() raises:
-    """searchsorted raises when `self` is not 1-D."""
+    """Searchsorted raises when `self` is not 1-D."""
     var a = nm.arange[nm.i32](0, 6).reshape(Shape(2, 3))
     var raised = False
     try:
@@ -49,7 +49,7 @@ def test_searchsorted_non_1d_raises() raises:
 
 
 def test_searchsorted_invalid_side_raises() raises:
-    """searchsorted raises for an invalid `side` argument."""
+    """Searchsorted raises for an invalid `side` argument."""
     var a = nm.array[nm.i32]("[1, 3, 5, 7]")
     var raised = False
     try:

--- a/tests/core/test_take.mojo
+++ b/tests/core/test_take.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_take_axis0() raises:
-    """take along axis 0 selects rows."""
+    """Take along axis 0 selects rows."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var result = a.take(nm.array[nm.int]("[2, 0, 1]"), axis=0)
     assert_equal(result.shape[0], 3)
@@ -17,7 +17,7 @@ def test_take_axis0() raises:
 
 
 def test_take_axis1() raises:
-    """take along axis 1 selects columns."""
+    """Take along axis 1 selects columns."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var result = a.take(nm.array[nm.int]("[1, 3]"), axis=1)
     assert_equal(result.shape[0], 3)
@@ -27,7 +27,7 @@ def test_take_axis1() raises:
 
 
 def test_take_flat_no_axis() raises:
-    """take without axis flattens first."""
+    """Take without axis flattens first."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var result = a.take(nm.array[nm.int]("[0, 5, 11]"))
     assert_equal(result.ndim, 1)
@@ -37,14 +37,14 @@ def test_take_flat_no_axis() raises:
 
 
 def test_take_negative_indices() raises:
-    """take normalises negative indices along the axis."""
+    """Take normalises negative indices along the axis."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var result = a.take(nm.array[nm.int]("[-1]"), axis=0)
     assert_equal(Int(result.item(0, 0)), 8)
 
 
 def test_take_out_of_bounds_raises() raises:
-    """take raises for an out-of-bounds index along the axis."""
+    """Take raises for an out-of-bounds index along the axis."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var raised = False
     try:

--- a/tests/core/test_take_along_axis.mojo
+++ b/tests/core/test_take_along_axis.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_take_along_axis_method_axis0() raises:
-    """a.take_along_axis(indices, axis) delegates to the routine correctly."""
+    """A.take_along_axis(indices, axis) delegates to the routine correctly."""
     var a = nm.arange[nm.i32](0, 12).reshape(Shape(3, 4))
     var ind = nm.array[nm.int]("[[0, 1, 2, 0], [1, 0, 2, 1]]").reshape(
         Shape(2, 4)

--- a/tests/core/test_where.mojo
+++ b/tests/core/test_where.mojo
@@ -6,7 +6,7 @@ from numojo.prelude import *
 
 
 def test_where_array_array() raises:
-    """where(cond, x, y) with two arrays picks x where True, y where False."""
+    """Where(cond, x, y) with two arrays picks x where True, y where False."""
     var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
     var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
     var mask = nm.array[boolean]("[1, 0, 1, 0]")
@@ -19,7 +19,7 @@ def test_where_array_array() raises:
 
 
 def test_where_array_scalar() raises:
-    """where(cond, x, scalar) fills scalar where False."""
+    """Where(cond, x, scalar) fills scalar where False."""
     var a = nm.array[nm.f32]("[1.0, 2.0, 3.0, 4.0]")
     var mask = nm.array[boolean]("[1, 0, 1, 0]")
     var result = nm.`where`(mask, a, Scalar[nm.f32](0.0))
@@ -30,7 +30,7 @@ def test_where_array_scalar() raises:
 
 
 def test_where_scalar_array() raises:
-    """where(cond, scalar, y) fills scalar where True."""
+    """Where(cond, scalar, y) fills scalar where True."""
     var b = nm.array[nm.f32]("[10.0, 20.0, 30.0, 40.0]")
     var mask = nm.array[boolean]("[1, 0, 1, 0]")
     var result = nm.`where`(mask, Scalar[nm.f32](-1.0), b)
@@ -63,7 +63,7 @@ def test_where_all_false() raises:
 
 
 def test_where_2d() raises:
-    """where works element-wise on 2-D arrays."""
+    """Where works element-wise on 2-D arrays."""
     var a = nm.arange[nm.i32](1, 5).reshape(Shape(2, 2))
     var b = nm.zeros[nm.i32](Shape(2, 2))
     # mask = [[True, False],[False, True]]

--- a/tests/routines/test_creation.mojo
+++ b/tests/routines/test_creation.mojo
@@ -156,24 +156,24 @@ def test_diag() raises:
     x_nm.resize(Shape(3, 3))
     var x_np = np.arange(0, 9, step=1).reshape(3, 3)
 
-    x_nm_k0 = nm.diag[f32](x_nm, k=0)
-    x_np_k0 = np.diag(x_np, k=0)
+    var x_nm_k0 = nm.diag[f32](x_nm, k=0)
+    var x_np_k0 = np.diag(x_np, k=0)
     check(x_nm_k0, x_np_k0, "Diag is broken (k=0)")
 
-    x_nm_k1 = nm.diag[f32](x_nm, k=1)
-    x_np_k1 = np.diag(x_np, k=1)
+    var x_nm_k1 = nm.diag[f32](x_nm, k=1)
+    var x_np_k1 = np.diag(x_np, k=1)
     check(x_nm_k1, x_np_k1, "Diag is broken (k=1)")
 
-    x_nm_km1 = nm.diag[f32](x_nm, k=-1)
-    x_np_km1 = np.diag(x_np, k=-1)
+    var x_nm_km1 = nm.diag[f32](x_nm, k=-1)
+    var x_np_km1 = np.diag(x_np, k=-1)
     check(x_nm_km1, x_np_km1, "Diag is broken (k=-1)")
 
-    x_nm_rev_k1 = nm.diag[f32](x_nm_k0, k=0)
-    x_np_rev_k1 = np.diag(x_np_k0, k=0)
+    var x_nm_rev_k1 = nm.diag[f32](x_nm_k0, k=0)
+    var x_np_rev_k1 = np.diag(x_np_k0, k=0)
     check(x_nm_rev_k1, x_np_rev_k1, "Diag reverse is broken (k=0)")
 
-    x_nm_rev_km1 = nm.diag[f32](x_nm_km1, k=-1)
-    x_np_rev_km1 = np.diag(x_np_km1, k=-1)
+    var x_nm_rev_km1 = nm.diag[f32](x_nm_km1, k=-1)
+    var x_np_rev_km1 = np.diag(x_np_km1, k=-1)
     check(x_nm_rev_km1, x_np_rev_km1, "Diag reverse is broken (k=-1)")
 
 

--- a/tests/routines/test_linalg.mojo
+++ b/tests/routines/test_linalg.mojo
@@ -79,7 +79,7 @@ def test_matmul_2dx1d() raises:
 # ! The `inv` is broken, it outputs -INF for some values
 def test_inv() raises:
     var np = Python.import_module("numpy")
-    var arr = nm.core.random.rand(100, 100)
+    var arr = nm.random.rand(100, 100)
     var np_arr = arr.to_numpy()
     check_is_close(
         nm.math.linalg.inv(arr), np.linalg.inv(np_arr), "Inverse is broken"
@@ -89,8 +89,8 @@ def test_inv() raises:
 # ! The `solve` is broken, it outputs -INF, nan, 0 etc for some values
 def test_solve() raises:
     var np = Python.import_module("numpy")
-    var A = nm.core.random.randn(100, 100)
-    var B = nm.core.random.randn(100, 50)
+    var A = nm.random.randn(100, 100)
+    var B = nm.random.randn(100, 50)
     var A_np = A.to_numpy()
     var B_np = B.to_numpy()
     check_is_close(
@@ -102,7 +102,7 @@ def test_solve() raises:
 
 def norms() raises:
     var np = Python.import_module("numpy")
-    var arr = nm.core.random.rand(20, 20)
+    var arr = nm.random.rand(20, 20)
     var np_arr = arr.to_numpy()
     check_values_close(
         nm.math.linalg.det(arr), np.linalg.det(np_arr), "`det` is broken"
@@ -111,7 +111,7 @@ def norms() raises:
 
 def test_misc() raises:
     var np = Python.import_module("numpy")
-    var arr = nm.core.random.rand(4, 8)
+    var arr = nm.random.rand(4, 8)
     var np_arr = arr.to_numpy()
     for i in range(-(arr.shape[0] - 1), arr.shape[1]):
         check_is_close(

--- a/tests/routines/test_random.mojo
+++ b/tests/routines/test_random.mojo
@@ -206,13 +206,13 @@ def test_rand_exponential() raises:
     # Test that all values are non-negative
     for i in range(arr_variadic.size):
         assert_true(
-            arr_variadic._buf.ptr[i] >= 0,
+            arr_variadic._buf.ptr[unsafe_offset=i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )
 
     for i in range(arr_list.size):
         assert_true(
-            arr_list._buf.ptr[i] >= 0,
+            arr_list._buf.ptr[unsafe_offset=i] >= 0,
             "Exponential distribution should only produce non-negative values",
         )
 
@@ -229,14 +229,15 @@ def test_randbool() raises:
     var all_true = nm.random.randbool(10, 10, p=1.0)
     for i in range(all_true.size):
         assert_true(
-            all_true._buf.ptr[i] == True, "All values should be True with p=1.0"
+            all_true._buf.ptr[unsafe_offset=i] == True,
+            "All values should be True with p=1.0",
         )
 
     # All values are False when p=0.0
     var all_false = nm.random.randbool(10, 10, p=0.0)
     for i in range(all_false.size):
         assert_true(
-            all_false._buf.ptr[i] == False,
+            all_false._buf.ptr[unsafe_offset=i] == False,
             "All values should be False with p=0.0",
         )
 
@@ -244,7 +245,7 @@ def test_randbool() raises:
     var big = nm.random.randbool(Shape(50, 50), p=0.5)
     var count_true: Int = 0
     for i in range(big.size):
-        if big._buf.ptr[i]:
+        if big._buf.ptr[unsafe_offset=i]:
             count_true += 1
     var frac = Float64(count_true) / Float64(big.size)
     assert_true(

--- a/tests/routines/test_sorting.mojo
+++ b/tests/routines/test_sorting.mojo
@@ -97,7 +97,7 @@ def test_inplace_sort() raises:
     var C = nm.random.randn(2, 3, 4)
     for i in range(3):
         C.sort(axis=i)
-        Cnp = C.to_numpy()
+        var Cnp = C.to_numpy()
         Cnp.sort(axis=i)
         check(
             C,


### PR DESCRIPTION
This PR updates the codebase to Mojo v1.0.0 (20260811).

The changes are as minimal as possible. So the purpose is to make the code running without errors.

The changes include but not limited to:
- Relative imports
- `take` -> `move`
- `Int` is now a `Scalar`. So some reloads are redundant
- Some stdlibs are relocated
- Explicit `unsafe` prefix for many functions
- Pointers

Some objects have use-after-free issues due to the ASAP destruction policy and the use of unsafe memory instructions. They are manually extended with `var _ = some^` to ensure they are not destroyed too early.