### PR TITLE
[Mojo][Max] Pin Mojo & Max in pixi-build-backend

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -35,16 +35,16 @@ backend = {name = "pixi-build-mojo", version = "0.*", channels = [
 name = "numojo"
 
 [package.host-dependencies]
-mojo = ">=1.0.0, <1.1.0"
-max-core = ">=26.5.0,<27"
+mojo = "==1.0.0"
+max-core = "==26.5.0"
 
 [package.build-dependencies]
-mojo = ">=1.0.0, <1.1.0"
-max-core = ">=26.5.0,<27"
+mojo = "==1.0.0"
+max-core = "==26.5.0"
 
 [package.run-dependencies]
-mojo = ">=1.0.0, <1.1.0"
-max-core = ">=26.5.0,<27"
+mojo = "==1.0.0"
+max-core = "==26.5.0"
 
 [tasks]
 # compile the package and copy it to the tests folder


### PR DESCRIPTION
This PR pins the Mojo and max version exactly for pixi-build-backend to work. 