### PR TITLE
[NuMojo] Add the python scripts for numojo standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@
 *.css
 *.py
 *.pyc
+# ...but the developer tooling under scripts/ is tracked (see #392).
+!scripts/*.py
 
 # Miscellaneous files
 mojo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,13 @@ repos:
         stages: [pre-commit]
         # pass_filenames: false  # Don't pass filenames to the formatter
         # always_run: true  # Always run the formatter
+
+  # `mojo format` only understands Mojo, so the Python tooling under scripts/
+  # gets its own formatter. pre-commit installs ruff itself; it is not a pixi
+  # dependency.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.5
+    hooks:
+      - id: ruff-format
+        files: '^scripts/.*\.py$'
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         name: mojo-format
         entry: pixi run mojo format
         language: system
-        files: '\.(mojo|py)$'
+        files: '\.mojo$'
         stages: [pre-commit]
         # pass_filenames: false  # Don't pass filenames to the formatter
         # always_run: true  # Always run the formatter

--- a/pixi.toml
+++ b/pixi.toml
@@ -69,6 +69,10 @@ test_routines = "pixi run package && bash tests/test_routines.sh"
 # (reporting only, never rewrites files; see scripts/check_mojo_standards.py)
 check_standards = "python3 scripts/check_mojo_standards.py numojo"
 
+# group and sort imports under their Stdlib/External/NuMojo separators.
+# (rewrites files; add --diff or --check for a dry run)
+organize_imports = "python3 scripts/organize_mojo_imports.py numojo"
+
 # run all final checks before a commit
 f = "clear && pixi run final"
 final = "pixi run format && pixi run test"

--- a/scripts/check_mojo_standards.py
+++ b/scripts/check_mojo_standards.py
@@ -81,9 +81,7 @@ SECTION_CANONICAL = {
     "Example": "Examples",
     "Examples": "Examples",
 }
-SECTION_HEADER_RE = re.compile(
-    r"^(?P<indent>\s*)(?P<name>[A-Za-z]+):\s*$"
-)
+SECTION_HEADER_RE = re.compile(r"^(?P<indent>\s*)(?P<name>[A-Za-z]+):\s*$")
 
 VALID_ERROR_LABEL = "NumojoError"
 BAD_ERROR_LABELS = {
@@ -99,8 +97,12 @@ BAD_ERROR_LABELS = {
 TODO_RE = re.compile(r"#\s*(TODO|FIXME)\b")
 TODO_OK_RE = re.compile(r"#\s*(TODO|FIXME):\s+[A-Z0-9`@]")
 
-DEF_RE = re.compile(r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
-STRUCT_RE = re.compile(r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?:struct|trait)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+DEF_RE = re.compile(
+    r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+)
+STRUCT_RE = re.compile(
+    r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?:struct|trait)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -246,9 +248,7 @@ def check_module_docstring(
     while idx < len(lines) and lines[idx].strip() == "":
         idx += 1
     if idx >= len(lines) or '"""' not in lines[idx]:
-        report.add(
-            header_end + 1, "docstring", "Missing module-level docstring."
-        )
+        report.add(header_end + 1, "docstring", "Missing module-level docstring.")
         return None
 
     doc_start = idx
@@ -256,7 +256,7 @@ def check_module_docstring(
         report.add(
             idx + 1,
             "docstring",
-            "Module docstring should open with a bare '\"\"\"' line "
+            'Module docstring should open with a bare \'"""\' line '
             "(title goes on the next line).",
         )
 
@@ -278,9 +278,7 @@ def check_module_docstring(
 
     title_line = lines[idx + 1].rstrip("\n")
     if close < idx + 3:
-        report.add(
-            idx + 2, "docstring", "Module docstring missing title/underline."
-        )
+        report.add(idx + 2, "docstring", "Module docstring missing title/underline.")
         return close
 
     underline_line = lines[idx + 2].rstrip("\n")
@@ -324,17 +322,15 @@ def check_module_docstring(
 
     body = lines[idx : close + 1]
     body_text = "".join(body)
-    if re.search(r"^\s*(TODO|FIXME):", body_text, re.M):
+    if re.search(r"^\s*(TODO|FIXME):", body_text, re.MULTILINE):
         report.add(
             idx + 1,
             "docstring",
             "TODO:/FIXME: item found inside module docstring — move it to a "
-            "standalone comment after the closing '\"\"\"'.",
+            'standalone comment after the closing \'"""\'.',
         )
 
-    has_exports_header = any(
-        line.strip() == "Exports" for line in body
-    )
+    has_exports_header = any(line.strip() == "Exports" for line in body)
     if not has_exports_header:
         # Only worth flagging if the module defines public top-level symbols.
         pass  # checked by caller against actual declarations
@@ -393,9 +389,7 @@ def find_public_top_level_symbols(lines: list[str], after: int) -> set[str]:
     for i in range(after + 1, len(lines)):
         line = lines[i]
         if re.match(r"^[A-Za-z_]", line):
-            m = re.match(
-                r"^(?:struct|trait)\s+([A-Za-z_][A-Za-z0-9_]*)", line
-            )
+            m = re.match(r"^(?:struct|trait)\s+([A-Za-z_][A-Za-z0-9_]*)", line)
             if m and not m.group(1).startswith("_"):
                 names.add(m.group(1))
                 continue
@@ -414,9 +408,7 @@ def find_public_top_level_symbols(lines: list[str], after: int) -> set[str]:
 # ===----------------------------------------------------------------------=== #
 
 
-def check_body(
-    lines: list[str], body_start: int, report: FileReport
-) -> None:
+def check_body(lines: list[str], body_start: int, report: FileReport) -> None:
     doc_spans = set()
     for s, e in docstring_spans(lines[body_start:]):
         for i in range(s, e + 1):
@@ -477,8 +469,10 @@ def check_imports(lines: list[str], body_start: int, report: FileReport) -> None
         if s.startswith("from ") or s.startswith("import "):
             first_import = idx
             break
-        if s.startswith("struct ") or s.startswith("trait ") or re.match(
-            r"^(def|fn)\s", s
+        if (
+            s.startswith("struct ")
+            or s.startswith("trait ")
+            or re.match(r"^(def|fn)\s", s)
         ):
             break
         idx += 1
@@ -499,8 +493,7 @@ def check_imports(lines: list[str], body_start: int, report: FileReport) -> None
         report.add(
             first_import + 1,
             "imports",
-            "Imports are not preceded by a '# ===' / <Group> / '# ===' "
-            "section header.",
+            "Imports are not preceded by a '# ===' / <Group> / '# ===' section header.",
         )
 
 
@@ -521,8 +514,7 @@ def check_error_handling(lines: list[str], report: FileReport) -> None:
         report.add(
             i + 1,
             "error-handling",
-            f"Raw 'raise Error(...)' not wrapped in NumojoError: "
-            f"{line.strip()!r}",
+            f"Raw 'raise Error(...)' not wrapped in NumojoError: {line.strip()!r}",
         )
 
 
@@ -571,7 +563,9 @@ def parse_signature(lines: list[str], start: int) -> Signature | None:
     def/fn keyword, possibly after decorator lines already consumed by the
     caller). Returns None if this doesn't look like a real signature."""
     line0 = lines[start]
-    m = re.match(r"^(?P<indent>\s*)(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)", line0)
+    m = re.match(
+        r"^(?P<indent>\s*)(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)", line0
+    )
     if not m:
         return None
     indent = len(m.group("indent"))
@@ -883,8 +877,7 @@ def check_signature_docstring(
         report.add(
             start + 1,
             "docstring",
-            f"'{sig.name}': has a return type but docstring has no "
-            f"'Returns:' section.",
+            f"'{sig.name}': has a return type but docstring has no 'Returns:' section.",
         )
 
     if sig.self_raises and "Raises" not in present_canonical:
@@ -973,10 +966,7 @@ def find_top_level_defs(lines: list[str]) -> list[int]:
             # indent on the closing ')...:' line — don't get misread as a
             # sibling/dedent that pops this def off the stack early.
             depth = (
-                line.count("[")
-                + line.count("(")
-                - line.count("]")
-                - line.count(")")
+                line.count("[") + line.count("(") - line.count("]") - line.count(")")
             )
             j = i
             while depth > 0 and j + 1 < n:

--- a/scripts/check_mojo_standards.py
+++ b/scripts/check_mojo_standards.py
@@ -7,6 +7,9 @@ format, section-separator format, import grouping, TODO/FIXME formatting,
 and — for every `def`/`fn` — whether its docstring documents the parameters,
 args, raises, and return value that its signature actually has.
 
+The standard being checked is `docs/developer-guide/style-guide.md`; that
+document is the authority, this script is only an approximation of it.
+
 This is a *reporting* tool. It never rewrites files (use
 `organize_mojo_imports.py` for the import-reorg autofix). Exit code is 0 if
 clean, 1 if any file has findings, 2 on a usage/parse error.
@@ -32,7 +35,7 @@ from pathlib import Path
 # Constants
 # ===----------------------------------------------------------------------=== #
 
-SEPARATOR_WIDTH = 80  # "# ===" + 70 "-" + "=== #"
+# 80 characters: "# ===" + 70 "-" + "=== #".
 EXPECTED_SEPARATOR = "# ===" + "-" * 70 + "=== #"
 LICENSE_LINES = [
     "# Distributed under the Apache 2.0 License with LLVM Exceptions.",
@@ -41,14 +44,15 @@ LICENSE_LINES = [
     "# https://llvm.org/LICENSE.txt",
 ]
 
-# Canonical docstring section order (§1.5). Sections not in this list are
-# left alone (e.g. `Attributes:`, `Constants:` on struct docstrings).
-# NOTE: extras/cleanup.md §1.5 states Raises before Returns, but a survey of
-# the actual codebase (2026-08-22) found Returns-before-Raises outnumbers
-# Raises-before-Returns roughly 143 to a handful — i.e. that's the real de
-# facto convention here, not the documented one. This list follows what the
-# codebase actually does; if the team wants to enforce the documented order
-# instead, swap Raises/Returns below and update extras/cleanup.md to match.
+# Canonical docstring section order for functions, per the "Functions"
+# section of docs/developer-guide/style-guide.md: parameters and arguments
+# first, then `Returns:`, with constraints and raised errors "after
+# `Returns:`". Sections not in this list are left alone (e.g. `Attributes:`,
+# `Constants:` on struct docstrings).
+#
+# NOTE: the struct example in the style guide puts `Constraints:` *before*
+# `Parameters:`. Only functions are checked here, so the two don't collide in
+# practice, but the guide is inconsistent with itself on that point.
 SECTION_ORDER = [
     "Parameters",
     "Args",
@@ -94,16 +98,13 @@ BAD_ERROR_LABELS = {
     "ArithmeticError",
 }
 
+# Dunder methods have a contract fixed by the language, so their arguments and
+# return values are self-evident and don't need restating. `__init__` is the
+# exception: a constructor's arguments are real API surface.
+DOCUMENTED_DUNDERS = {"__init__"}
+
 TODO_RE = re.compile(r"#\s*(TODO|FIXME)\b")
 TODO_OK_RE = re.compile(r"#\s*(TODO|FIXME):\s+[A-Z0-9`@]")
-
-DEF_RE = re.compile(
-    r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
-)
-STRUCT_RE = re.compile(
-    r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?:struct|trait)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
-)
-
 
 # ===----------------------------------------------------------------------=== #
 # Data model
@@ -129,10 +130,6 @@ class FileReport:
 # ===----------------------------------------------------------------------=== #
 # Low-level helpers
 # ===----------------------------------------------------------------------=== #
-
-
-def strip_backticks(s: str) -> str:
-    return s.replace("`", "")
 
 
 def is_separator_line(line: str) -> bool:
@@ -174,23 +171,23 @@ def docstring_spans(lines: list[str]) -> list[tuple[int, int]]:
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: file header (§1.1)
+# Check: file header
 # ===----------------------------------------------------------------------=== #
 
 
 def check_header(lines: list[str], report: FileReport) -> int:
     """Returns the 0-indexed line number right after the header block."""
     if not lines:
-        report.add(1, "header", "File is empty.")
+        report.add(1, "headers", "File is empty.")
         return 0
 
     if not is_separator_line(lines[0]):
-        report.add(1, "header", "File must start with the header separator line.")
+        report.add(1, "headers", "File must start with the header separator line.")
         return 0
     if lines[0].rstrip("\n") != EXPECTED_SEPARATOR:
         report.add(
             1,
-            "header",
+            "headers",
             f"Header separator malformed (expected exactly 80 chars, "
             f"'# ===' + 70 dashes + '=== #'): {lines[0].rstrip()!r}",
         )
@@ -198,7 +195,7 @@ def check_header(lines: list[str], report: FileReport) -> int:
     if len(lines) < 2 or not lines[1].lstrip().startswith("# NuMojo:"):
         report.add(
             2,
-            "header",
+            "headers",
             "Second header line should read '# NuMojo: <short description>'.",
         )
 
@@ -207,18 +204,18 @@ def check_header(lines: list[str], report: FileReport) -> int:
         if idx >= len(lines) or lines[idx].rstrip("\n") != expected:
             report.add(
                 idx + 1,
-                "header",
+                "headers",
                 f"Header line does not match expected license text: {expected!r}",
             )
         idx += 1
 
     if idx >= len(lines) or not is_separator_line(lines[idx]):
-        report.add(idx + 1, "header", "Header must close with a separator line.")
+        report.add(idx + 1, "headers", "Header must close with a separator line.")
     else:
         if lines[idx].rstrip("\n") != EXPECTED_SEPARATOR:
             report.add(
                 idx + 1,
-                "header",
+                "headers",
                 f"Closing header separator malformed: {lines[idx].rstrip()!r}",
             )
         idx += 1
@@ -227,7 +224,7 @@ def check_header(lines: list[str], report: FileReport) -> int:
     if idx < len(lines) and lines[idx].strip() == "":
         report.add(
             idx + 1,
-            "header",
+            "headers",
             "Blank line between header and module docstring (should be none).",
         )
 
@@ -235,7 +232,7 @@ def check_header(lines: list[str], report: FileReport) -> int:
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: module docstring (§1.2)
+# Check: module docstring
 # ===----------------------------------------------------------------------=== #
 
 
@@ -251,7 +248,6 @@ def check_module_docstring(
         report.add(header_end + 1, "docstring", "Missing module-level docstring.")
         return None
 
-    doc_start = idx
     if lines[idx].strip() != '"""':
         report.add(
             idx + 1,
@@ -330,10 +326,9 @@ def check_module_docstring(
             'standalone comment after the closing \'"""\'.',
         )
 
-    has_exports_header = any(line.strip() == "Exports" for line in body)
-    if not has_exports_header:
-        # Only worth flagging if the module defines public top-level symbols.
-        pass  # checked by caller against actual declarations
+    # A missing `Exports` section is only worth flagging when the module
+    # actually declares public top-level symbols; `check_exports_accuracy`
+    # does that against the real declarations.
 
     for label in ("Example:", "Note:", "Return:", "Parameter:"):
         if any(line.strip() == label for line in body):
@@ -404,11 +399,22 @@ def find_public_top_level_symbols(lines: list[str], after: int) -> set[str]:
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: section separators (§1.4) + TODO/FIXME (§1.7)
+# Check: section separators + TODO/FIXME
 # ===----------------------------------------------------------------------=== #
 
 
-def check_body(lines: list[str], body_start: int, report: FileReport) -> None:
+def check_body(
+    lines: list[str],
+    body_start: int,
+    report: FileReport,
+    *,
+    separators: bool = True,
+    todos: bool = True,
+) -> None:
+    """Walk the body once, reporting only the categories asked for.
+
+    Both checks share this pass, so each is gated individually — otherwise
+    `--only todo` would also emit every separator finding."""
     doc_spans = set()
     for s, e in docstring_spans(lines[body_start:]):
         for i in range(s, e + 1):
@@ -420,13 +426,13 @@ def check_body(lines: list[str], body_start: int, report: FileReport) -> None:
         line = lines[i]
         stripped = line.rstrip("\n")
 
-        if re.match(r"^\s*#\s*=", stripped) and "=" in stripped:
+        if separators and re.match(r"^\s*#\s*=", stripped) and "=" in stripped:
             if is_separator_line(line):
                 indent = separator_indent(stripped)
                 if stripped != indent + EXPECTED_SEPARATOR:
                     report.add(
                         i + 1,
-                        "separator",
+                        "separators",
                         f"Section separator malformed (expected 80-char "
                         f"'# ===' + 70 dashes + '=== #', same indent as "
                         f"surrounding code): {stripped.strip()!r}",
@@ -435,15 +441,17 @@ def check_body(lines: list[str], body_start: int, report: FileReport) -> None:
                 # A "banner" comment that uses ===/--- decoration but isn't
                 # a bare separator line (e.g. has a title embedded in the
                 # same line) — not the standard 3-line
-                # separator/title/separator block from §1.4.
+                # separator/title/separator block from the style guide.
                 report.add(
                     i + 1,
-                    "separator",
+                    "separators",
                     f"Non-standard banner comment (should be a 3-line "
                     f"'# ===...=== #' / '# Title' / '# ===...=== #' block, "
                     f"not decoration on one line): {stripped!r}",
                 )
 
+        if not todos:
+            continue
         m = TODO_RE.search(stripped)
         if m and not stripped.lstrip().startswith(("# ===", "#===")):
             if not TODO_OK_RE.search(stripped):
@@ -456,7 +464,7 @@ def check_body(lines: list[str], body_start: int, report: FileReport) -> None:
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: imports (§1.3) — delegates structural check to organize script
+# Check: imports — delegates the structural rewrite to organize script
 # ===----------------------------------------------------------------------=== #
 
 
@@ -498,7 +506,7 @@ def check_imports(lines: list[str], body_start: int, report: FileReport) -> None
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: raw `raise Error(...)` (§1.6)
+# Check: raw `raise Error(...)`
 # ===----------------------------------------------------------------------=== #
 
 
@@ -538,7 +546,7 @@ def check_raises_docstring_labels(lines: list[str], report: FileReport) -> None:
 
 
 # ===----------------------------------------------------------------------=== #
-# Check: function/method signature vs. docstring (§1.5)
+# Check: function/method signature vs. docstring
 # ===----------------------------------------------------------------------=== #
 
 
@@ -788,19 +796,25 @@ def check_signature_docstring(
     if is_stub_body(lines, sig.sig_end):
         return  # trait method declaration, not a real implementation
 
+    # Private helpers and most dunders only need a one-line summary, if that:
+    # their signature is either an implementation detail or fixed by the
+    # language. They're still checked for section spelling and ordering below.
+    brief_is_enough = sig.is_private or (
+        sig.is_dunder and sig.name not in DOCUMENTED_DUNDERS
+    )
+
     doc_span = extract_docstring_for(lines, sig.sig_end)
     if doc_span is None:
-        if not sig.is_private:
+        if not brief_is_enough:
             report.add(
                 sig.sig_start + 1,
-                "docstring",
+                "signatures",
                 f"'{sig.kind} {sig.name}' has no docstring.",
             )
         return
 
     start, end = doc_span
     body = lines[start : end + 1]
-    body_text = "".join(body)
 
     # Which canonical sections are present, and are they labeled with a
     # non-canonical (singular/alternate) spelling?
@@ -819,7 +833,7 @@ def check_signature_docstring(
         if raw != canon:
             report.add(
                 start + 1,
-                "docstring",
+                "signatures",
                 f"'{sig.name}': docstring section '{raw}:' should be "
                 f"'{canon}:' (canonical plural form).",
             )
@@ -829,14 +843,14 @@ def check_signature_docstring(
     if seen_order != sorted(seen_order):
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': docstring sections out of order "
             f"({' -> '.join(present_order)}); expected order is "
             f"{' -> '.join(SECTION_ORDER)}.",
         )
 
-    if sig.is_private:
-        return  # one-line docstring is sufficient for private helpers
+    if brief_is_enough:
+        return
 
     # Documented parameter/arg names.
     documented_params = extract_documented_names(body, "Parameters")
@@ -846,14 +860,14 @@ def check_signature_docstring(
     if missing_params and "Parameters" not in present_canonical and sig.params:
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': has type parameter(s) {sig.params} but "
             f"docstring has no 'Parameters:' section.",
         )
     elif missing_params:
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': type parameter(s) not documented in "
             f"Parameters: {missing_params}",
         )
@@ -862,32 +876,32 @@ def check_signature_docstring(
     if missing_args and "Args" not in present_canonical and sig.args:
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': has argument(s) {sig.args} but docstring has "
             f"no 'Args:' section.",
         )
     elif missing_args:
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': argument(s) not documented in Args: {missing_args}",
         )
 
     if sig.returns and "Returns" not in present_canonical:
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': has a return type but docstring has no 'Returns:' section.",
         )
 
     if sig.self_raises and "Raises" not in present_canonical:
         # Only flagged when the function's own body has an explicit `raise`
         # statement (not merely `raises`-annotated because it calls other
-        # raising functions) — matches the plan's "don't add speculatively"
-        # rule.
+        # raising functions), so the docstring isn't asked to speculate about
+        # errors that originate elsewhere.
         report.add(
             start + 1,
-            "docstring",
+            "signatures",
             f"'{sig.name}': body has an explicit 'raise' but docstring has "
             f"no 'Raises:' section (should name NumojoError).",
         )
@@ -1025,7 +1039,13 @@ def check_file(path: Path, only: set[str] | None) -> FileReport:
     body_start = doc_end + 1 if doc_end is not None else header_end
 
     if enabled("separators") or enabled("todo"):
-        check_body(lines, body_start, report)
+        check_body(
+            lines,
+            body_start,
+            report,
+            separators=enabled("separators"),
+            todos=enabled("todo"),
+        )
     if enabled("imports"):
         check_imports(lines, body_start, report)
     if enabled("error-handling"):

--- a/scripts/check_mojo_standards.py
+++ b/scripts/check_mojo_standards.py
@@ -1,0 +1,1144 @@
+#!/usr/bin/env python3
+"""Check `.mojo` files against the NuMojo standards.
+
+Run this before opening a PR to get a clean, file-by-file list of every
+place a file deviates from the standard: header format, module docstring
+format, section-separator format, import grouping, TODO/FIXME formatting,
+and — for every `def`/`fn` — whether its docstring documents the parameters,
+args, raises, and return value that its signature actually has.
+
+This is a *reporting* tool. It never rewrites files (use
+`organize_mojo_imports.py` for the import-reorg autofix). Exit code is 0 if
+clean, 1 if any file has findings, 2 on a usage/parse error.
+
+Usage:
+    python3 scripts/check_mojo_standards.py numojo
+    python3 scripts/check_mojo_standards.py numojo/core/ndarray.mojo
+    python3 scripts/check_mojo_standards.py numojo --only headers,imports
+    python3 scripts/check_mojo_standards.py numojo --quiet   # summary only
+    python3 scripts/check_mojo_standards.py numojo --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ===----------------------------------------------------------------------=== #
+# Constants
+# ===----------------------------------------------------------------------=== #
+
+SEPARATOR_WIDTH = 80  # "# ===" + 70 "-" + "=== #"
+EXPECTED_SEPARATOR = "# ===" + "-" * 70 + "=== #"
+LICENSE_LINES = [
+    "# Distributed under the Apache 2.0 License with LLVM Exceptions.",
+    "# See LICENSE and the LLVM License for more information.",
+    "# https://github.com/Mojo-Numerics-and-Algorithms-group/NuMojo/blob/main/LICENSE",
+    "# https://llvm.org/LICENSE.txt",
+]
+
+# Canonical docstring section order (§1.5). Sections not in this list are
+# left alone (e.g. `Attributes:`, `Constants:` on struct docstrings).
+# NOTE: extras/cleanup.md §1.5 states Raises before Returns, but a survey of
+# the actual codebase (2026-08-22) found Returns-before-Raises outnumbers
+# Raises-before-Returns roughly 143 to a handful — i.e. that's the real de
+# facto convention here, not the documented one. This list follows what the
+# codebase actually does; if the team wants to enforce the documented order
+# instead, swap Raises/Returns below and update extras/cleanup.md to match.
+SECTION_ORDER = [
+    "Parameters",
+    "Args",
+    "Returns",
+    "Raises",
+    "Constraints",
+    "Notes",
+    "References",
+    "Examples",
+]
+# Singular/alternate spellings seen in the wild that should be the plural
+# canonical form.
+SECTION_CANONICAL = {
+    "Parameter": "Parameters",
+    "Parameters": "Parameters",
+    "Arg": "Args",
+    "Args": "Args",
+    "Argument": "Args",
+    "Arguments": "Args",
+    "Raise": "Raises",
+    "Raises": "Raises",
+    "Return": "Returns",
+    "Returns": "Returns",
+    "Constraint": "Constraints",
+    "Constraints": "Constraints",
+    "Note": "Notes",
+    "Notes": "Notes",
+    "Reference": "References",
+    "References": "References",
+    "Example": "Examples",
+    "Examples": "Examples",
+}
+SECTION_HEADER_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<name>[A-Za-z]+):\s*$"
+)
+
+VALID_ERROR_LABEL = "NumojoError"
+BAD_ERROR_LABELS = {
+    "Error",
+    "IndexError",
+    "ShapeError",
+    "ValueError",
+    "BroadcastError",
+    "MemoryError",
+    "ArithmeticError",
+}
+
+TODO_RE = re.compile(r"#\s*(TODO|FIXME)\b")
+TODO_OK_RE = re.compile(r"#\s*(TODO|FIXME):\s+[A-Z0-9`@]")
+
+DEF_RE = re.compile(r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+STRUCT_RE = re.compile(r"^(?P<indent>\s*)(?:@\w+(\(.*\))?\s*\n\s*)*(?:struct|trait)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)")
+
+
+# ===----------------------------------------------------------------------=== #
+# Data model
+# ===----------------------------------------------------------------------=== #
+
+
+@dataclass
+class Finding:
+    line: int
+    category: str
+    message: str
+
+
+@dataclass
+class FileReport:
+    path: Path
+    findings: list[Finding] = field(default_factory=list)
+
+    def add(self, line: int, category: str, message: str) -> None:
+        self.findings.append(Finding(line, category, message))
+
+
+# ===----------------------------------------------------------------------=== #
+# Low-level helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def strip_backticks(s: str) -> str:
+    return s.replace("`", "")
+
+
+def is_separator_line(line: str) -> bool:
+    stripped = line.rstrip("\n").lstrip()
+    return bool(re.match(r"^#\s*=+[-=]*=+\s*#?\s*$", stripped)) and "=" in stripped
+
+
+def separator_indent(line: str) -> str:
+    """Leading whitespace before the '#' of a separator line (separators
+    inside a struct/trait body are indented to match; module-level ones are
+    not)."""
+    return line[: len(line) - len(line.lstrip())]
+
+
+def docstring_spans(lines: list[str]) -> list[tuple[int, int]]:
+    """Return (start, end) 0-indexed line ranges of every triple-quoted
+    docstring/string block, inclusive of the quote lines."""
+    spans = []
+    i = 0
+    n = len(lines)
+    in_str = False
+    start = None
+    while i < n:
+        line = lines[i]
+        count = line.count('"""')
+        if not in_str:
+            if count >= 1:
+                start = i
+                if count >= 2:
+                    spans.append((i, i))
+                else:
+                    in_str = True
+        else:
+            if count >= 1:
+                spans.append((start, i))
+                in_str = False
+        i += 1
+    return spans
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: file header (§1.1)
+# ===----------------------------------------------------------------------=== #
+
+
+def check_header(lines: list[str], report: FileReport) -> int:
+    """Returns the 0-indexed line number right after the header block."""
+    if not lines:
+        report.add(1, "header", "File is empty.")
+        return 0
+
+    if not is_separator_line(lines[0]):
+        report.add(1, "header", "File must start with the header separator line.")
+        return 0
+    if lines[0].rstrip("\n") != EXPECTED_SEPARATOR:
+        report.add(
+            1,
+            "header",
+            f"Header separator malformed (expected exactly 80 chars, "
+            f"'# ===' + 70 dashes + '=== #'): {lines[0].rstrip()!r}",
+        )
+
+    if len(lines) < 2 or not lines[1].lstrip().startswith("# NuMojo:"):
+        report.add(
+            2,
+            "header",
+            "Second header line should read '# NuMojo: <short description>'.",
+        )
+
+    idx = 2
+    for expected in LICENSE_LINES:
+        if idx >= len(lines) or lines[idx].rstrip("\n") != expected:
+            report.add(
+                idx + 1,
+                "header",
+                f"Header line does not match expected license text: {expected!r}",
+            )
+        idx += 1
+
+    if idx >= len(lines) or not is_separator_line(lines[idx]):
+        report.add(idx + 1, "header", "Header must close with a separator line.")
+    else:
+        if lines[idx].rstrip("\n") != EXPECTED_SEPARATOR:
+            report.add(
+                idx + 1,
+                "header",
+                f"Closing header separator malformed: {lines[idx].rstrip()!r}",
+            )
+        idx += 1
+
+    # No blank line between header and docstring.
+    if idx < len(lines) and lines[idx].strip() == "":
+        report.add(
+            idx + 1,
+            "header",
+            "Blank line between header and module docstring (should be none).",
+        )
+
+    return idx
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: module docstring (§1.2)
+# ===----------------------------------------------------------------------=== #
+
+
+def check_module_docstring(
+    lines: list[str], header_end: int, report: FileReport
+) -> int | None:
+    """Returns the 0-indexed line number of the closing `\"\"\"`, or None if
+    no module docstring was found at all (flagged separately)."""
+    idx = header_end
+    while idx < len(lines) and lines[idx].strip() == "":
+        idx += 1
+    if idx >= len(lines) or '"""' not in lines[idx]:
+        report.add(
+            header_end + 1, "docstring", "Missing module-level docstring."
+        )
+        return None
+
+    doc_start = idx
+    if lines[idx].strip() != '"""':
+        report.add(
+            idx + 1,
+            "docstring",
+            "Module docstring should open with a bare '\"\"\"' line "
+            "(title goes on the next line).",
+        )
+
+    # Find closing line.
+    close = None
+    j = idx + 1
+    while j < len(lines):
+        if '"""' in lines[j]:
+            close = j
+            break
+        j += 1
+    if close is None:
+        report.add(idx + 1, "docstring", "Module docstring is never closed.")
+        return None
+
+    if close == idx + 1:
+        report.add(idx + 1, "docstring", "Module docstring is empty.")
+        return close
+
+    title_line = lines[idx + 1].rstrip("\n")
+    if close < idx + 3:
+        report.add(
+            idx + 2, "docstring", "Module docstring missing title/underline."
+        )
+        return close
+
+    underline_line = lines[idx + 2].rstrip("\n")
+    if not re.match(r"^=+$", underline_line):
+        report.add(
+            idx + 3,
+            "docstring",
+            "Second line of module docstring should be a bare '===' underline.",
+        )
+    elif len(underline_line) != len(title_line):
+        report.add(
+            idx + 3,
+            "docstring",
+            f"Underline length ({len(underline_line)}) does not match title "
+            f"length ({len(title_line)}): title={title_line!r}",
+        )
+
+    if not re.match(r"^[A-Za-z_].*\)\.$", title_line):
+        report.add(
+            idx + 2,
+            "docstring",
+            f"Title line should look like 'Name (numojo.dotted.path).': {title_line!r}",
+        )
+
+    if close >= idx + 4:
+        desc_line = lines[idx + 3].rstrip("\n")
+        if desc_line.strip() == "":
+            report.add(
+                idx + 4,
+                "docstring",
+                "Blank line between underline and description paragraph "
+                "(should be none).",
+            )
+        elif not re.search(r"[.!?`]\s*$", desc_line):
+            report.add(
+                idx + 4,
+                "docstring",
+                f"Description paragraph should end in '.', '!', '?', or a "
+                f"backtick: {desc_line!r}",
+            )
+
+    body = lines[idx : close + 1]
+    body_text = "".join(body)
+    if re.search(r"^\s*(TODO|FIXME):", body_text, re.M):
+        report.add(
+            idx + 1,
+            "docstring",
+            "TODO:/FIXME: item found inside module docstring — move it to a "
+            "standalone comment after the closing '\"\"\"'.",
+        )
+
+    has_exports_header = any(
+        line.strip() == "Exports" for line in body
+    )
+    if not has_exports_header:
+        # Only worth flagging if the module defines public top-level symbols.
+        pass  # checked by caller against actual declarations
+
+    for label in ("Example:", "Note:", "Return:", "Parameter:"):
+        if any(line.strip() == label for line in body):
+            canon = SECTION_CANONICAL[label.rstrip(":")]
+            report.add(
+                idx + 1,
+                "docstring",
+                f"Module docstring uses '{label}' — canonical form is "
+                f"'{canon}' (with '{'-' * len(canon)}' underline).",
+            )
+
+    return close
+
+
+def check_exports_accuracy(
+    lines: list[str], doc_start: int, doc_end: int, report: FileReport
+) -> None:
+    """Cross-check the Exports section (if present) against actual
+    top-level public struct/trait/def/fn/comptime declarations."""
+    body = lines[doc_start : doc_end + 1]
+    if not any(line.strip() == "Exports" for line in body):
+        # Does the file define public top-level symbols? If so, flag missing.
+        top_level_public = find_public_top_level_symbols(lines, doc_end)
+        if top_level_public:
+            names = ", ".join(sorted(top_level_public)[:6])
+            report.add(
+                doc_start + 1,
+                "docstring",
+                f"Module defines public top-level symbols ({names}, ...) but "
+                f"docstring has no 'Exports' section.",
+            )
+        return
+
+    exported_names = set()
+    for line in body:
+        m = re.match(r"^-\s*`([A-Za-z_][A-Za-z0-9_]*)`", line.strip())
+        if m:
+            exported_names.add(m.group(1))
+
+    top_level_public = find_public_top_level_symbols(lines, doc_end)
+    missing = top_level_public - exported_names
+    if missing:
+        names = ", ".join(sorted(missing)[:8])
+        report.add(
+            doc_start + 1,
+            "docstring",
+            f"Public top-level symbol(s) not mentioned in Exports: {names}",
+        )
+
+
+def find_public_top_level_symbols(lines: list[str], after: int) -> set[str]:
+    names = set()
+    for i in range(after + 1, len(lines)):
+        line = lines[i]
+        if re.match(r"^[A-Za-z_]", line):
+            m = re.match(
+                r"^(?:struct|trait)\s+([A-Za-z_][A-Za-z0-9_]*)", line
+            )
+            if m and not m.group(1).startswith("_"):
+                names.add(m.group(1))
+                continue
+            m = re.match(r"^(?:def|fn)\s+([A-Za-z_][A-Za-z0-9_]*)", line)
+            if m and not m.group(1).startswith("_"):
+                names.add(m.group(1))
+                continue
+            m = re.match(r"^comptime\s+([A-Za-z_][A-Za-z0-9_]*)", line)
+            if m and not m.group(1).startswith("_"):
+                names.add(m.group(1))
+    return names
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: section separators (§1.4) + TODO/FIXME (§1.7)
+# ===----------------------------------------------------------------------=== #
+
+
+def check_body(
+    lines: list[str], body_start: int, report: FileReport
+) -> None:
+    doc_spans = set()
+    for s, e in docstring_spans(lines[body_start:]):
+        for i in range(s, e + 1):
+            doc_spans.add(body_start + i)
+
+    for i in range(body_start, len(lines)):
+        if i in doc_spans:
+            continue
+        line = lines[i]
+        stripped = line.rstrip("\n")
+
+        if re.match(r"^\s*#\s*=", stripped) and "=" in stripped:
+            if is_separator_line(line):
+                indent = separator_indent(stripped)
+                if stripped != indent + EXPECTED_SEPARATOR:
+                    report.add(
+                        i + 1,
+                        "separator",
+                        f"Section separator malformed (expected 80-char "
+                        f"'# ===' + 70 dashes + '=== #', same indent as "
+                        f"surrounding code): {stripped.strip()!r}",
+                    )
+            elif re.search(r"[-=]{4,}", stripped):
+                # A "banner" comment that uses ===/--- decoration but isn't
+                # a bare separator line (e.g. has a title embedded in the
+                # same line) — not the standard 3-line
+                # separator/title/separator block from §1.4.
+                report.add(
+                    i + 1,
+                    "separator",
+                    f"Non-standard banner comment (should be a 3-line "
+                    f"'# ===...=== #' / '# Title' / '# ===...=== #' block, "
+                    f"not decoration on one line): {stripped!r}",
+                )
+
+        m = TODO_RE.search(stripped)
+        if m and not stripped.lstrip().startswith(("# ===", "#===")):
+            if not TODO_OK_RE.search(stripped):
+                report.add(
+                    i + 1,
+                    "todo",
+                    f"TODO/FIXME not formatted as '# TODO: Capitalized "
+                    f"sentence.' : {stripped.strip()!r}",
+                )
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: imports (§1.3) — delegates structural check to organize script
+# ===----------------------------------------------------------------------=== #
+
+
+def check_imports(lines: list[str], body_start: int, report: FileReport) -> None:
+    # Find first import line after body_start.
+    idx = body_start
+    first_import = None
+    while idx < len(lines):
+        s = lines[idx].strip()
+        if s.startswith("from ") or s.startswith("import "):
+            first_import = idx
+            break
+        if s.startswith("struct ") or s.startswith("trait ") or re.match(
+            r"^(def|fn)\s", s
+        ):
+            break
+        idx += 1
+    if first_import is None:
+        return
+
+    # Look a few lines back for a section header; imports must be preceded
+    # by a `# ===` / title / `# ===` block (allowing blank lines between the
+    # docstring and the header).
+    j = first_import - 1
+    while j >= body_start and lines[j].strip() == "":
+        j -= 1
+    if j < body_start + 2 or not (
+        is_separator_line(lines[j - 2])
+        and lines[j - 1].strip().startswith("#")
+        and is_separator_line(lines[j])
+    ):
+        report.add(
+            first_import + 1,
+            "imports",
+            "Imports are not preceded by a '# ===' / <Group> / '# ===' "
+            "section header.",
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: raw `raise Error(...)` (§1.6)
+# ===----------------------------------------------------------------------=== #
+
+
+def check_error_handling(lines: list[str], report: FileReport) -> None:
+    for i, line in enumerate(lines):
+        if "raise Error(" not in line:
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        nxt = lines[i + 1] if i + 1 < len(lines) else ""
+        if "NumojoError(" in line or "NumojoError(" in nxt:
+            continue
+        report.add(
+            i + 1,
+            "error-handling",
+            f"Raw 'raise Error(...)' not wrapped in NumojoError: "
+            f"{line.strip()!r}",
+        )
+
+
+def check_raises_docstring_labels(lines: list[str], report: FileReport) -> None:
+    for i, line in enumerate(lines):
+        if line.strip() != "Raises:":
+            continue
+        for j in range(i + 1, min(i + 8, len(lines))):
+            b = lines[j]
+            if b.strip() == "" or b.strip().startswith('"""'):
+                break
+            m = re.match(r"\s+([A-Za-z]+):", b)
+            if m and m.group(1) in BAD_ERROR_LABELS:
+                report.add(
+                    j + 1,
+                    "error-handling",
+                    f"Raises: label '{m.group(1)}' should be "
+                    f"'{VALID_ERROR_LABEL}' (this codebase raises only "
+                    f"NumojoError): {b.strip()!r}",
+                )
+
+
+# ===----------------------------------------------------------------------=== #
+# Check: function/method signature vs. docstring (§1.5)
+# ===----------------------------------------------------------------------=== #
+
+
+@dataclass
+class Signature:
+    name: str
+    kind: str  # "def" or "fn"
+    indent: int
+    sig_start: int
+    sig_end: int  # last line of the signature (the one ending in ':')
+    params: list[str]
+    args: list[str]
+    raises: bool
+    returns: bool
+    is_private: bool
+    is_dunder: bool
+    self_raises: bool = False  # has an explicit `raise` statement in its own body
+
+
+def parse_signature(lines: list[str], start: int) -> Signature | None:
+    """Parse a def/fn signature starting at `start` (the line with the
+    def/fn keyword, possibly after decorator lines already consumed by the
+    caller). Returns None if this doesn't look like a real signature."""
+    line0 = lines[start]
+    m = re.match(r"^(?P<indent>\s*)(?P<kind>def|fn)\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)", line0)
+    if not m:
+        return None
+    indent = len(m.group("indent"))
+    kind = m.group("kind")
+    name = m.group("name")
+
+    # Collect the full signature text until the line ending in ':' at
+    # bracket-depth 0 (accounting for [] and ()).
+    text_parts = [line0]
+    depth = line0.count("[") + line0.count("(") - line0.count("]") - line0.count(")")
+    end = start
+    while True:
+        stripped_end = text_parts[-1].rstrip("\n").rstrip()
+        if depth <= 0 and stripped_end.endswith(":"):
+            break
+        end += 1
+        if end >= len(lines):
+            return None
+        text_parts.append(lines[end])
+        depth += (
+            lines[end].count("[")
+            + lines[end].count("(")
+            - lines[end].count("]")
+            - lines[end].count(")")
+        )
+        if end - start > 200:
+            return None
+
+    full = "".join(text_parts)
+
+    # Extract the parameter list [...]  (generic/comptime params) — the
+    # FIRST bracket group after the name.
+    params: list[str] = []
+    pm = re.search(r"\[", full)
+    args_search_from = 0
+    if pm and full[: pm.start()].rstrip().endswith(name):
+        depth2 = 0
+        j = pm.start()
+        buf = []
+        while j < len(full):
+            c = full[j]
+            if c == "[":
+                depth2 += 1
+                if depth2 == 1:
+                    j += 1
+                    continue
+            if c == "]":
+                depth2 -= 1
+                if depth2 == 0:
+                    j += 1
+                    break
+            buf.append(c)
+            j += 1
+        param_block = "".join(buf)
+        params = split_top_level(param_block)
+        args_search_from = j
+
+    # Extract the argument list (...) — the paren group after params (or
+    # after the name if no param brackets).
+    args: list[str] = []
+    am = re.search(r"\(", full[args_search_from:])
+    if am:
+        start_paren = args_search_from + am.start()
+        depth3 = 0
+        j = start_paren
+        buf = []
+        while j < len(full):
+            c = full[j]
+            if c == "(":
+                depth3 += 1
+                if depth3 == 1:
+                    j += 1
+                    continue
+            if c == ")":
+                depth3 -= 1
+                if depth3 == 0:
+                    j += 1
+                    break
+            buf.append(c)
+            j += 1
+        arg_block = "".join(buf)
+        args = split_top_level(arg_block)
+
+    tail = full[args_search_from:]
+    # Everything after the closing paren of args, up to the final ':'.
+    close_paren_idx = None
+    depth4 = 0
+    started = False
+    for idx, c in enumerate(tail):
+        if c == "(":
+            depth4 += 1
+            started = True
+        elif c == ")":
+            depth4 -= 1
+            if started and depth4 == 0:
+                close_paren_idx = idx
+                break
+    rest = tail[close_paren_idx + 1 :] if close_paren_idx is not None else ""
+
+    raises = bool(re.search(r"\braises\b", rest))
+    # Returns something other than None: a `->` present.
+    returns = "->" in rest and not re.search(r"->\s*None\b", rest)
+
+    is_dunder = name.startswith("__") and name.endswith("__")
+    is_private = name.startswith("_") and not is_dunder
+
+    return Signature(
+        name=name,
+        kind=kind,
+        indent=indent,
+        sig_start=start,
+        sig_end=end,
+        params=[p for p in params if p and not p.startswith("*")],
+        args=[a for a in args if a],
+        raises=raises,
+        returns=returns,
+        is_private=is_private,
+        is_dunder=is_dunder,
+        self_raises=body_has_explicit_raise(lines, end, indent),
+    )
+
+
+def body_has_explicit_raise(lines: list[str], sig_end: int, sig_indent: int) -> bool:
+    """True if this function's own body (before the next sibling def/fn/
+    struct at the same or shallower indent) contains an explicit `raise`
+    statement — as opposed to merely being `raises`-annotated because it
+    calls something else that can raise."""
+    i = sig_end + 1
+    while i < len(lines):
+        line = lines[i]
+        if line.strip() == "":
+            i += 1
+            continue
+        this_indent = len(line) - len(line.lstrip())
+        if this_indent <= sig_indent and re.match(
+            r"^\s*(def|fn|struct|trait|@)\s*", line
+        ):
+            break
+        if re.search(r"(?<![\w.])raise\b", line) and not line.lstrip().startswith("#"):
+            return True
+        i += 1
+    return False
+
+
+def split_top_level(block: str) -> list[str]:
+    """Split a `[a, b: T, c: U = v]` or `(a, b: T)` block on top-level
+    commas, stripping the outer brackets, and return just the bound names
+    (before ':' or '=')."""
+    if len(block) >= 2 and block[0] in "[(":
+        block = block[1:-1]
+    parts = []
+    depth = 0
+    cur = []
+    for c in block:
+        if c in "[(":
+            depth += 1
+        elif c in "])":
+            depth -= 1
+        elif c == "," and depth == 0:
+            parts.append("".join(cur))
+            cur = []
+            continue
+        cur.append(c)
+    if cur:
+        parts.append("".join(cur))
+
+    names = []
+    for p in parts:
+        p = p.strip()
+        if not p:
+            continue
+        # Strip leading modifiers.
+        p = re.sub(r"^(var|mut|ref|out|owned|read|\*\*|\*)\s*", "", p).strip()
+        if not p or p in ("self", "*"):
+            continue
+        if p in ("self",):
+            continue
+        # name is up to the first ':' or '=' or whitespace.
+        m = re.match(r"^([A-Za-z_][A-Za-z0-9_]*)", p)
+        if m:
+            nm = m.group(1)
+            if nm == "self":
+                continue
+            names.append(nm)
+    return names
+
+
+def extract_docstring_for(lines: list[str], sig_end: int) -> tuple[int, int] | None:
+    """Given the line index of the ':' closing a signature, find the
+    function's docstring span (start, end) if the next non-blank line opens
+    one. Returns None if there's no docstring immediately following."""
+    i = sig_end + 1
+    if i >= len(lines):
+        return None
+    if '"""' not in lines[i]:
+        return None
+    start = i
+    if lines[i].count('"""') >= 2:
+        return (start, i)
+    j = i + 1
+    while j < len(lines):
+        if '"""' in lines[j]:
+            return (start, j)
+        j += 1
+    return None
+
+
+def is_stub_body(lines: list[str], sig_end: int) -> bool:
+    """True if the line right after the signature is a bare '...' stub
+    (trait method declaration with no implementation)."""
+    i = sig_end + 1
+    while i < len(lines) and lines[i].strip() == "":
+        i += 1
+    return i < len(lines) and lines[i].strip() == "..."
+
+
+def check_signature_docstring(
+    sig: Signature, lines: list[str], report: FileReport
+) -> None:
+    if is_stub_body(lines, sig.sig_end):
+        return  # trait method declaration, not a real implementation
+
+    doc_span = extract_docstring_for(lines, sig.sig_end)
+    if doc_span is None:
+        if not sig.is_private:
+            report.add(
+                sig.sig_start + 1,
+                "docstring",
+                f"'{sig.kind} {sig.name}' has no docstring.",
+            )
+        return
+
+    start, end = doc_span
+    body = lines[start : end + 1]
+    body_text = "".join(body)
+
+    # Which canonical sections are present, and are they labeled with a
+    # non-canonical (singular/alternate) spelling?
+    present_canonical: set[str] = set()
+    present_order: list[str] = []
+    for line in body:
+        m = SECTION_HEADER_RE.match(line.rstrip("\n"))
+        if not m:
+            continue
+        raw = m.group("name")
+        if raw not in SECTION_CANONICAL:
+            continue
+        canon = SECTION_CANONICAL[raw]
+        present_canonical.add(canon)
+        present_order.append(canon)
+        if raw != canon:
+            report.add(
+                start + 1,
+                "docstring",
+                f"'{sig.name}': docstring section '{raw}:' should be "
+                f"'{canon}:' (canonical plural form).",
+            )
+
+    # Order check.
+    seen_order = [SECTION_ORDER.index(c) for c in present_order if c in SECTION_ORDER]
+    if seen_order != sorted(seen_order):
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': docstring sections out of order "
+            f"({' -> '.join(present_order)}); expected order is "
+            f"{' -> '.join(SECTION_ORDER)}.",
+        )
+
+    if sig.is_private:
+        return  # one-line docstring is sufficient for private helpers
+
+    # Documented parameter/arg names.
+    documented_params = extract_documented_names(body, "Parameters")
+    documented_args = extract_documented_names(body, "Args")
+
+    missing_params = [p for p in sig.params if p not in documented_params]
+    if missing_params and "Parameters" not in present_canonical and sig.params:
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': has type parameter(s) {sig.params} but "
+            f"docstring has no 'Parameters:' section.",
+        )
+    elif missing_params:
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': type parameter(s) not documented in "
+            f"Parameters: {missing_params}",
+        )
+
+    missing_args = [a for a in sig.args if a not in documented_args]
+    if missing_args and "Args" not in present_canonical and sig.args:
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': has argument(s) {sig.args} but docstring has "
+            f"no 'Args:' section.",
+        )
+    elif missing_args:
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': argument(s) not documented in Args: {missing_args}",
+        )
+
+    if sig.returns and "Returns" not in present_canonical:
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': has a return type but docstring has no "
+            f"'Returns:' section.",
+        )
+
+    if sig.self_raises and "Raises" not in present_canonical:
+        # Only flagged when the function's own body has an explicit `raise`
+        # statement (not merely `raises`-annotated because it calls other
+        # raising functions) — matches the plan's "don't add speculatively"
+        # rule.
+        report.add(
+            start + 1,
+            "docstring",
+            f"'{sig.name}': body has an explicit 'raise' but docstring has "
+            f"no 'Raises:' section (should name NumojoError).",
+        )
+
+
+def extract_documented_names(body: list[str], section: str) -> set[str]:
+    names = set()
+    in_section = False
+    section_indent = None
+    for line in body:
+        stripped = line.rstrip("\n")
+        m = SECTION_HEADER_RE.match(stripped)
+        if m and SECTION_CANONICAL.get(m.group("name")) == section:
+            in_section = True
+            section_indent = len(m.group("indent"))
+            continue
+        if in_section:
+            if stripped.strip() == "":
+                continue
+            this_indent = len(stripped) - len(stripped.lstrip())
+            if section_indent is not None and this_indent <= section_indent:
+                if SECTION_HEADER_RE.match(stripped):
+                    in_section = False
+                    continue
+                if this_indent < section_indent:
+                    in_section = False
+                    continue
+            nm = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
+            if nm:
+                names.add(nm.group(1))
+    return names
+
+
+# ===----------------------------------------------------------------------=== #
+# Driver: walk a file, find every def/fn, run the checks
+# ===----------------------------------------------------------------------=== #
+
+
+def find_top_level_defs(lines: list[str]) -> list[int]:
+    """Line indices where a module-level or struct/trait-member def/fn
+    signature begins. Excludes def/fn nested inside another function's body
+    (local helper closures like a `@parameter def kernel[...]` defined
+    inside a method) — those are implementation-detail plumbing, not public
+    API, and don't need standalone docstrings."""
+    starts = []
+    i = 0
+    n = len(lines)
+    doc_spans = set()
+    for s, e in docstring_spans(lines):
+        for k in range(s, e + 1):
+            doc_spans.add(k)
+
+    # Track a stack of (indent, kind) for enclosing def/fn/struct/trait
+    # blocks, based on indentation, to detect nesting inside a function body.
+    block_stack: list[tuple[int, str]] = []
+    while i < n:
+        if i in doc_spans:
+            i += 1
+            continue
+        line = lines[i]
+        if line.strip() == "":
+            i += 1
+            continue
+        indent = len(line) - len(line.lstrip())
+        while block_stack and indent <= block_stack[-1][0]:
+            block_stack.pop()
+
+        m = re.match(r"^\s*(def|fn)\s+[A-Za-z_]", line)
+        if m:
+            nested_in_def = any(kind in ("def", "fn") for _, kind in block_stack)
+            if not nested_in_def:
+                starts.append(i)
+            block_stack.append((indent, m.group(1)))
+            # Skip over the rest of a (possibly multi-line) signature so its
+            # continuation lines — which can dedent back to the def's own
+            # indent on the closing ')...:' line — don't get misread as a
+            # sibling/dedent that pops this def off the stack early.
+            depth = (
+                line.count("[")
+                + line.count("(")
+                - line.count("]")
+                - line.count(")")
+            )
+            j = i
+            while depth > 0 and j + 1 < n:
+                j += 1
+                depth += (
+                    lines[j].count("[")
+                    + lines[j].count("(")
+                    - lines[j].count("]")
+                    - lines[j].count(")")
+                )
+            i = j
+        elif re.match(r"^\s*(struct|trait)\s+[A-Za-z_]", line):
+            block_stack.append((indent, "struct"))
+        i += 1
+    return starts
+
+
+def check_file(path: Path, only: set[str] | None) -> FileReport:
+    report = FileReport(path=path)
+    text = path.read_text()
+    lines = text.splitlines(keepends=True)
+
+    def enabled(cat: str) -> bool:
+        return only is None or cat in only
+
+    if enabled("headers"):
+        header_end = check_header(lines, report)
+    else:
+        # Best-effort: find end of header block without reporting.
+        header_end = 0
+        while header_end < len(lines) and not (
+            header_end > 0 and is_separator_line(lines[header_end])
+        ):
+            header_end += 1
+        header_end += 1
+
+    doc_end = None
+    if enabled("docstring"):
+        doc_end = check_module_docstring(lines, header_end, report)
+        if doc_end is not None:
+            check_exports_accuracy(lines, header_end, doc_end, report)
+    if doc_end is None:
+        # locate it anyway for downstream checks
+        idx = header_end
+        while idx < len(lines) and lines[idx].strip() == "":
+            idx += 1
+        if idx < len(lines) and '"""' in lines[idx]:
+            j = idx + 1
+            if lines[idx].count('"""') < 2:
+                while j < len(lines) and '"""' not in lines[j]:
+                    j += 1
+            doc_end = j
+        else:
+            doc_end = header_end
+
+    body_start = doc_end + 1 if doc_end is not None else header_end
+
+    if enabled("separators") or enabled("todo"):
+        check_body(lines, body_start, report)
+    if enabled("imports"):
+        check_imports(lines, body_start, report)
+    if enabled("error-handling"):
+        check_error_handling(lines, report)
+        check_raises_docstring_labels(lines, report)
+
+    if enabled("signatures"):
+        for start in find_top_level_defs(lines):
+            sig = parse_signature(lines, start)
+            if sig is None:
+                continue
+            check_signature_docstring(sig, lines, report)
+
+    return report
+
+
+# ===----------------------------------------------------------------------=== #
+# CLI
+# ===----------------------------------------------------------------------=== #
+
+ALL_CATEGORIES = [
+    "headers",
+    "docstring",
+    "separators",
+    "imports",
+    "todo",
+    "error-handling",
+    "signatures",
+]
+
+
+def iter_mojo_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.mojo")))
+        elif p.suffix == ".mojo":
+            files.append(p)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument(
+        "--only",
+        type=str,
+        default=None,
+        help=f"Comma-separated subset of checks to run: {', '.join(ALL_CATEGORIES)}",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Print only the summary line."
+    )
+    parser.add_argument(
+        "--json", type=Path, default=None, help="Write full results as JSON."
+    )
+    args = parser.parse_args()
+
+    only = set(args.only.split(",")) if args.only else None
+    if only:
+        unknown = only - set(ALL_CATEGORIES)
+        if unknown:
+            print(f"Unknown --only categories: {unknown}", file=sys.stderr)
+            return 2
+
+    files = iter_mojo_files(args.paths)
+    reports: list[FileReport] = []
+    total_findings = 0
+    for f in files:
+        try:
+            report = check_file(f, only)
+        except Exception as exc:  # keep going across a bad file
+            report = FileReport(path=f)
+            report.add(1, "internal", f"Checker error on this file: {exc!r}")
+        if report.findings:
+            reports.append(report)
+            total_findings += len(report.findings)
+
+    if args.json:
+        payload = [
+            {
+                "file": str(r.path),
+                "findings": [
+                    {"line": f.line, "category": f.category, "message": f.message}
+                    for f in r.findings
+                ],
+            }
+            for r in reports
+        ]
+        args.json.write_text(json.dumps(payload, indent=2))
+
+    if not args.quiet:
+        for r in reports:
+            print(f"\n{r.path}  ({len(r.findings)} finding(s))")
+            for f in r.findings:
+                print(f"  {r.path}:{f.line}: [{f.category}] {f.message}")
+
+    print(
+        f"\n{len(files)} file(s) checked, {len(reports)} file(s) with "
+        f"findings, {total_findings} total finding(s)."
+    )
+    return 1 if total_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/organize_mojo_imports.py
+++ b/scripts/organize_mojo_imports.py
@@ -1,0 +1,550 @@
+#!/usr/bin/env python3
+"""Organize Mojo imports and remove unused imported names.
+
+Usage:
+    python3 scripts/organize_mojo_imports.py numojo
+
+The script rewrites `.mojo` files under the given path by default. Use
+`--check` or `--diff` for dry runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+IMPORT_RE = re.compile(r"^(?P<indent>\s*)(?P<kind>from|import)\s+(?P<body>.+)$")
+FROM_RE = re.compile(r"^from\s+(?P<module>\S+)\s+import\s+(?P<names>.+)$", re.DOTALL)
+IMPORT_AS_RE = re.compile(r"^(?P<module>[^\s,]+)(?:\s+as\s+(?P<alias>\w+))?$")
+IDENT_RE = re.compile(r"`[^`]+`|[A-Za-z_][A-Za-z0-9_]*")
+BANNER_RE = re.compile(r"^# ===-+===\s*#?\s*$")
+
+GROUP_TITLES = {
+    0: "Stdlib",
+    1: "External",
+    2: "NuMojo",
+    4: "NuMojo",
+}
+
+
+@dataclass(frozen=True)
+class ImportedName:
+    raw: str
+    bound: str
+
+
+@dataclass(frozen=True)
+class ImportStatement:
+    text: str
+    kind: str
+    module: str
+    imported: tuple[ImportedName, ...]
+    sortable: bool = True
+    force_parenthesized: bool = False
+
+    @property
+    def has_wildcard(self) -> bool:
+        return any(name.raw == "*" for name in self.imported)
+
+
+def normalize_identifier(value: str) -> str:
+    value = value.strip()
+    if value.startswith("`") and value.endswith("`"):
+        return value[1:-1]
+    return value
+
+
+def split_top_level_commas(value: str) -> list[str]:
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for ch in value:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            item = "".join(current).strip()
+            if item:
+                parts.append(item)
+            current = []
+            continue
+        current.append(ch)
+    item = "".join(current).strip()
+    if item:
+        parts.append(item)
+    return parts
+
+
+def strip_outer_parens(value: str) -> str:
+    value = value.strip()
+    if value.startswith("(") and value.endswith(")"):
+        return value[1:-1]
+    return value
+
+
+def imported_bound_name(raw_name: str) -> str:
+    name = raw_name.strip().rstrip(",")
+    if " as " in name:
+        return normalize_identifier(name.rsplit(" as ", 1)[1])
+    return normalize_identifier(name)
+
+
+def parse_from_import(text: str) -> ImportStatement | None:
+    flattened = " ".join(line.strip() for line in text.splitlines())
+    match = FROM_RE.match(flattened)
+    if not match:
+        return None
+    module = match.group("module")
+    raw_names = strip_outer_parens(match.group("names"))
+    names = []
+    for item in split_top_level_commas(raw_names):
+        item = item.strip().rstrip(",")
+        if not item:
+            continue
+        names.append(ImportedName(item, imported_bound_name(item)))
+    return ImportStatement(
+        text=text,
+        kind="from",
+        module=module,
+        imported=tuple(names),
+        force_parenthesized="\n" in text,
+    )
+
+
+def parse_plain_import(text: str) -> ImportStatement | None:
+    flattened = " ".join(line.strip() for line in text.splitlines())
+    if not flattened.startswith("import "):
+        return None
+    names = []
+    modules = []
+    for item in split_top_level_commas(flattened[len("import ") :]):
+        match = IMPORT_AS_RE.match(item.strip())
+        if not match:
+            return ImportStatement(
+                text=text, kind="import", module=flattened, imported=(), sortable=False
+            )
+        module = match.group("module")
+        alias = match.group("alias")
+        modules.append(module)
+        bound = alias if alias else module.split(".")[0]
+        names.append(ImportedName(item.strip(), bound))
+    return ImportStatement(
+        text=text, kind="import", module=",".join(modules), imported=tuple(names)
+    )
+
+
+def parse_import_statement(text: str) -> ImportStatement | None:
+    stripped = text.lstrip()
+    if stripped.startswith("from "):
+        return parse_from_import(text)
+    if stripped.startswith("import "):
+        return parse_plain_import(text)
+    return None
+
+
+def paren_delta(line: str) -> int:
+    return line.count("(") - line.count(")")
+
+
+def collect_import_statement(lines: list[str], start: int) -> tuple[str, int]:
+    collected = [lines[start]]
+    depth = paren_delta(lines[start])
+    idx = start + 1
+    while depth > 0 and idx < len(lines):
+        collected.append(lines[idx])
+        depth += paren_delta(lines[idx])
+        idx += 1
+    return "".join(collected), idx
+
+
+def is_banner_comment(line: str) -> bool:
+    return BANNER_RE.match(line.strip()) is not None
+
+
+def is_generated_group_title(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped.startswith("# "):
+        return False
+    return stripped[2:] in set(GROUP_TITLES.values())
+
+
+def is_import_section_comment(lines: list[str], idx: int) -> bool:
+    if idx + 2 >= len(lines):
+        return False
+    return (
+        is_banner_comment(lines[idx])
+        and is_generated_group_title(lines[idx + 1])
+        and is_banner_comment(lines[idx + 2])
+    )
+
+
+def previous_import_section_start(lines: list[str], first_import: int) -> int:
+    start = first_import
+    idx = first_import - 1
+    while idx >= 0 and lines[idx].strip() == "":
+        idx -= 1
+    if idx >= 2 and is_import_section_comment(lines, idx - 2):
+        start = idx - 2
+        idx = start - 1
+        while idx >= 0 and lines[idx].strip() == "":
+            start = idx
+            idx -= 1
+    return start
+
+
+def lines_inside_triple_quoted_strings(lines: list[str]) -> set[int]:
+    """Return indices of lines that fall (even partially) inside a
+    triple-quoted string literal, so import-like text inside docstrings
+    (e.g. example code in ```mojo fences) isn't mistaken for real imports.
+    """
+    inside: set[int] = set()
+    in_string = False
+    quote = ""
+    for idx, line in enumerate(lines):
+        pos = 0
+        while pos < len(line):
+            if not in_string:
+                marker = None
+                for candidate in ('"""', "'''"):
+                    found = line.find(candidate, pos)
+                    if found != -1 and (marker is None or found < marker[0]):
+                        marker = (found, candidate)
+                if marker is None:
+                    break
+                found, candidate = marker
+                in_string = True
+                quote = candidate
+                pos = found + 3
+            else:
+                inside.add(idx)
+                found = line.find(quote, pos)
+                if found == -1:
+                    pos = len(line)
+                else:
+                    in_string = False
+                    pos = found + 3
+        if in_string:
+            inside.add(idx)
+    return inside
+
+
+def find_import_block(lines: list[str]) -> tuple[int, int, list[str]] | None:
+    in_string = lines_inside_triple_quoted_strings(lines)
+    start = None
+    idx = 0
+    while idx < len(lines):
+        if idx in in_string:
+            idx += 1
+            continue
+        stripped = lines[idx].strip()
+        if lines[idx].startswith("from ") or lines[idx].startswith("import "):
+            start = idx
+            break
+        idx += 1
+    if start is None:
+        return None
+
+    statements: list[str] = []
+    first_import = start
+    start = previous_import_section_start(lines, first_import)
+    idx = start
+    saw_comment = False
+    while idx < len(lines):
+        stripped = lines[idx].strip()
+        if stripped == "":
+            idx += 1
+            continue
+        if is_import_section_comment(lines, idx):
+            idx += 3
+            continue
+        if stripped.startswith("#"):
+            saw_comment = True
+            idx += 1
+            continue
+        if lines[idx].startswith("from ") or lines[idx].startswith("import "):
+            text, idx = collect_import_statement(lines, idx)
+            statements.append(text)
+            continue
+        break
+
+    if saw_comment:
+        return None
+    return start, idx, statements
+
+
+def import_group(module: str) -> int:
+    if module.startswith("."):
+        return 4
+    root = module.split(".", 1)[0].split(",", 1)[0]
+    if root == "std":
+        return 0
+    if root == "max":
+        return 1
+    if root == "numojo":
+        return 2
+    if root == "utils_for_test":
+        return 4
+    return 1
+
+
+def sort_imported_names(names: tuple[ImportedName, ...]) -> tuple[ImportedName, ...]:
+    return tuple(sorted(names, key=lambda item: item.raw.replace("`", "").lower()))
+
+
+def render_from_import(module: str, names: tuple[ImportedName, ...]) -> str:
+    names = sort_imported_names(names)
+    if len(names) == 1:
+        return f"from {module} import {names[0].raw}\n"
+    if len(names) <= 4 and sum(len(name.raw) for name in names) + len(module) < 88:
+        return f"from {module} import {', '.join(name.raw for name in names)}\n"
+
+    body = "".join(f"    {name.raw},\n" for name in names)
+    return f"from {module} import (\n{body})\n"
+
+
+def render_import_statement(statement: ImportStatement) -> str:
+    if statement.kind == "from":
+        if statement.force_parenthesized and len(statement.imported) > 1:
+            names = sort_imported_names(statement.imported)
+            body = "".join(f"    {name.raw},\n" for name in names)
+            return f"from {statement.module} import (\n{body})\n"
+        return render_from_import(statement.module, statement.imported)
+    return f"import {', '.join(name.raw for name in sort_imported_names(statement.imported))}\n"
+
+
+def strip_strings_and_comments(text: str) -> str:
+    result: list[str] = []
+    idx = 0
+    quote: str | None = None
+    triple = False
+    while idx < len(text):
+        ch = text[idx]
+        if quote:
+            if triple and text.startswith(quote * 3, idx):
+                quote = None
+                triple = False
+                idx += 3
+                result.append(" ")
+                continue
+            if not triple and ch == quote:
+                quote = None
+            result.append(" ")
+            idx += 1
+            continue
+        if ch == "#":
+            while idx < len(text) and text[idx] != "\n":
+                result.append(" ")
+                idx += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            triple = text.startswith(ch * 3, idx)
+            idx += 3 if triple else 1
+            result.append(" ")
+            continue
+        result.append(ch)
+        idx += 1
+    return "".join(result)
+
+
+def used_identifiers(text: str) -> set[str]:
+    stripped = strip_strings_and_comments(text)
+    return {
+        normalize_identifier(match.group(0)) for match in IDENT_RE.finditer(stripped)
+    }
+
+
+def remove_unused_imports(
+    statements: list[ImportStatement], body: str, *, skip_unused: bool
+) -> list[ImportStatement]:
+    if skip_unused:
+        return statements
+    used = used_identifiers(body)
+    kept: list[ImportStatement] = []
+    for statement in statements:
+        if statement.has_wildcard or not statement.imported:
+            kept.append(statement)
+            continue
+        names = tuple(name for name in statement.imported if name.bound in used)
+        if not names:
+            continue
+        if names == statement.imported:
+            kept.append(statement)
+        else:
+            kept.append(
+                ImportStatement(
+                    text=statement.text,
+                    kind=statement.kind,
+                    module=statement.module,
+                    imported=names,
+                    sortable=statement.sortable,
+                    force_parenthesized=statement.force_parenthesized,
+                )
+            )
+    return kept
+
+
+def merge_from_imports(statements: list[ImportStatement]) -> list[ImportStatement]:
+    merged: dict[str, ImportStatement] = {}
+    output: list[ImportStatement] = []
+
+    for statement in statements:
+        if statement.kind != "from" or statement.has_wildcard:
+            output.append(statement)
+            continue
+
+        existing = merged.get(statement.module)
+        if existing is None:
+            merged[statement.module] = statement
+            output.append(statement)
+            continue
+
+        seen = {name.raw for name in existing.imported}
+        names = list(existing.imported)
+        for name in statement.imported:
+            if name.raw in seen:
+                continue
+            names.append(name)
+            seen.add(name.raw)
+
+        combined = ImportStatement(
+            text=existing.text,
+            kind="from",
+            module=existing.module,
+            imported=tuple(names),
+            sortable=existing.sortable and statement.sortable,
+            force_parenthesized=(
+                existing.force_parenthesized
+                or statement.force_parenthesized
+                or len(names) > 1
+            ),
+        )
+        merged[statement.module] = combined
+        output[output.index(existing)] = combined
+
+    return output
+
+
+def organized_import_block(statements: list[ImportStatement]) -> str:
+    statements = merge_from_imports(statements)
+    grouped: dict[int, list[ImportStatement]] = {}
+    for statement in statements:
+        grouped.setdefault(import_group(statement.module), []).append(statement)
+
+    rendered_groups: list[str] = []
+    for group in sorted(grouped):
+        ordered = sorted(
+            grouped[group],
+            key=lambda stmt: (
+                stmt.module.replace("`", "").lower(),
+                render_import_statement(stmt).lower(),
+            ),
+        )
+        title = GROUP_TITLES.get(group, "Imports")
+        header = (
+            "# ===----------------------------------------------------------------------=== #\n"
+            f"# {title}\n"
+            "# ===----------------------------------------------------------------------=== #\n"
+        )
+        rendered_groups.append(
+            header + "".join(render_import_statement(stmt) for stmt in ordered)
+        )
+    return "\n".join(rendered_groups)
+
+
+def organize_file(path: Path, *, keep_unused: bool) -> str | None:
+    original = path.read_text()
+    lines = original.splitlines(keepends=True)
+    block = find_import_block(lines)
+    if block is None:
+        return None
+    start, end, raw_statements = block
+    statements = []
+    for text in raw_statements:
+        statement = parse_import_statement(text)
+        if statement is None or not statement.sortable:
+            return None
+        statements.append(statement)
+
+    body = "".join(lines[end:])
+    skip_unused = (
+        path.name == "__init__.mojo" or keep_unused or not body.strip()
+    )
+    statements = remove_unused_imports(statements, body, skip_unused=skip_unused)
+    new_block = organized_import_block(statements)
+    tail = "".join(lines[end:]).lstrip("\n")
+    if new_block and tail.strip():
+        new_block += "\n\n"
+    head = "".join(lines[:start])
+    if new_block and head.strip() and not head.endswith("\n\n"):
+        head = head.rstrip("\n") + "\n\n"
+    updated = head + new_block + tail
+    if updated == original:
+        return None
+    return updated
+
+
+def iter_mojo_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.mojo")))
+        elif path.suffix == ".mojo":
+            files.append(path)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Top-level package/file path(s) to organize recursively.",
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Exit non-zero if changes are needed."
+    )
+    parser.add_argument("--diff", action="store_true", help="Print unified diffs.")
+    parser.add_argument(
+        "--keep-unused",
+        action="store_true",
+        help="Sort imports without removing unused imported names.",
+    )
+    args = parser.parse_args()
+
+    changed = []
+    for path in iter_mojo_files(args.paths):
+        updated = organize_file(path, keep_unused=args.keep_unused)
+        if updated is None:
+            continue
+        changed.append(path)
+        original = path.read_text()
+        if args.diff:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    updated.splitlines(keepends=True),
+                    fromfile=str(path),
+                    tofile=str(path),
+                )
+            )
+        if not args.check and not args.diff:
+            path.write_text(updated)
+
+    if args.check and changed:
+        for path in changed:
+            print(f"imports need organizing: {path}", file=sys.stderr)
+        return 1
+    if not args.diff and not args.check:
+        print(f"organized imports in {len(changed)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/organize_mojo_imports.py
+++ b/scripts/organize_mojo_imports.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
-"""Organize Mojo imports and remove unused imported names.
+"""Organize Mojo imports into the groups described in the style guide.
+
+See `docs/developer-guide/style-guide.md` for the grouping this produces
+(`Stdlib`, `External`, `NuMojo`, each under its own 80-character separator).
 
 Usage:
     python3 scripts/organize_mojo_imports.py numojo
 
 The script rewrites `.mojo` files under the given path by default. Use
 `--check` or `--diff` for dry runs.
+
+Sorting and grouping are safe and always applied. Dropping imported names
+that appear unused is *opt-in* (`--remove-unused`), because "unused" is
+decided by a text scan of the remaining source rather than by the compiler.
+
+Output is line-width compatible with `pixi run mojo format`: a `from ... import`
+that fits in 80 columns is emitted on one line, anything longer is
+parenthesized with a trailing comma (which `mojo format` then leaves alone).
 """
 
 from __future__ import annotations
@@ -17,18 +28,26 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-IMPORT_RE = re.compile(r"^(?P<indent>\s*)(?P<kind>from|import)\s+(?P<body>.+)$")
 FROM_RE = re.compile(r"^from\s+(?P<module>\S+)\s+import\s+(?P<names>.+)$", re.DOTALL)
 IMPORT_AS_RE = re.compile(r"^(?P<module>[^\s,]+)(?:\s+as\s+(?P<alias>\w+))?$")
 IDENT_RE = re.compile(r"`[^`]+`|[A-Za-z_][A-Za-z0-9_]*")
 BANNER_RE = re.compile(r"^# ===-+===\s*#?\s*$")
 
+# The three groups from the style guide, in emission order.
+GROUP_STDLIB = 0
+GROUP_EXTERNAL = 1
+GROUP_NUMOJO = 2
 GROUP_TITLES = {
-    0: "Stdlib",
-    1: "External",
-    2: "NuMojo",
-    4: "NuMojo",
+    GROUP_STDLIB: "Stdlib",
+    GROUP_EXTERNAL: "External",
+    GROUP_NUMOJO: "NuMojo",
 }
+
+# `mojo format` wraps at 80 columns; match it so the two tools agree.
+MAX_LINE_LENGTH = 80
+
+# The 80-character section separator from the style guide.
+SEPARATOR = "# ===" + "-" * 70 + "=== #"
 
 
 @dataclass(frozen=True)
@@ -112,7 +131,9 @@ def parse_from_import(text: str) -> ImportStatement | None:
         kind="from",
         module=module,
         imported=tuple(names),
-        force_parenthesized="\n" in text,
+        # True only when the statement really spanned several lines — `text`
+        # always ends in a newline, so test the stripped form.
+        force_parenthesized="\n" in text.strip(),
     )
 
 
@@ -241,7 +262,6 @@ def find_import_block(lines: list[str]) -> tuple[int, int, list[str]] | None:
         if idx in in_string:
             idx += 1
             continue
-        stripped = lines[idx].strip()
         if lines[idx].startswith("from ") or lines[idx].startswith("import "):
             start = idx
             break
@@ -278,43 +298,54 @@ def find_import_block(lines: list[str]) -> tuple[int, int, list[str]] | None:
 
 
 def import_group(module: str) -> int:
+    # Relative imports and the test helpers are in-tree, so they belong in
+    # the same `NuMojo` block as absolute `numojo.*` imports rather than in a
+    # second block under a duplicate title.
     if module.startswith("."):
-        return 4
+        return GROUP_NUMOJO
     root = module.split(".", 1)[0].split(",", 1)[0]
     if root == "std":
-        return 0
-    if root == "max":
-        return 1
+        return GROUP_STDLIB
     if root == "numojo":
-        return 2
+        return GROUP_NUMOJO
     if root == "utils_for_test":
-        return 4
-    return 1
+        return GROUP_NUMOJO
+    return GROUP_EXTERNAL
 
 
 def sort_imported_names(names: tuple[ImportedName, ...]) -> tuple[ImportedName, ...]:
     return tuple(sorted(names, key=lambda item: item.raw.replace("`", "").lower()))
 
 
-def render_from_import(module: str, names: tuple[ImportedName, ...]) -> str:
-    names = sort_imported_names(names)
-    if len(names) == 1:
-        return f"from {module} import {names[0].raw}\n"
-    if len(names) <= 4 and sum(len(name.raw) for name in names) + len(module) < 88:
-        return f"from {module} import {', '.join(name.raw for name in names)}\n"
-
+def render_parenthesized(module: str, names: tuple[ImportedName, ...]) -> str:
     body = "".join(f"    {name.raw},\n" for name in names)
     return f"from {module} import (\n{body})\n"
 
 
+def render_from_import(module: str, names: tuple[ImportedName, ...]) -> str:
+    names = sort_imported_names(names)
+    # Measure the rendered line, not an approximation of it: the `from `,
+    # ` import ` and `, ` separators all count against the 80-column budget
+    # `mojo format` enforces. Getting this wrong makes the two tools undo
+    # each other's work on every run.
+    one_line = f"from {module} import {', '.join(name.raw for name in names)}\n"
+    if len(one_line.rstrip("\n")) <= MAX_LINE_LENGTH:
+        return one_line
+    return render_parenthesized(module, names)
+
+
 def render_import_statement(statement: ImportStatement) -> str:
     if statement.kind == "from":
-        if statement.force_parenthesized and len(statement.imported) > 1:
-            names = sort_imported_names(statement.imported)
-            body = "".join(f"    {name.raw},\n" for name in names)
-            return f"from {statement.module} import (\n{body})\n"
+        # A statement the author already wrote parenthesized keeps that shape:
+        # the trailing comma is a "magic trailing comma" that `mojo format`
+        # honours, so collapsing it here would just be re-expanded.
+        if statement.force_parenthesized:
+            return render_parenthesized(
+                statement.module, sort_imported_names(statement.imported)
+            )
         return render_from_import(statement.module, statement.imported)
-    return f"import {', '.join(name.raw for name in sort_imported_names(statement.imported))}\n"
+    modules = ", ".join(name.raw for name in sort_imported_names(statement.imported))
+    return f"import {modules}\n"
 
 
 def strip_strings_and_comments(text: str) -> str:
@@ -330,6 +361,13 @@ def strip_strings_and_comments(text: str) -> str:
                 triple = False
                 idx += 3
                 result.append(" ")
+                continue
+            # A backslash escapes the next character, so `"a\"b"` is one
+            # string, not two. Without this the scanner ends the string early
+            # and starts reading code as string content (or vice versa).
+            if ch == "\\":
+                result.append("  ")
+                idx += 2
                 continue
             if not triple and ch == quote:
                 quote = None
@@ -360,10 +398,8 @@ def used_identifiers(text: str) -> set[str]:
 
 
 def remove_unused_imports(
-    statements: list[ImportStatement], body: str, *, skip_unused: bool
+    statements: list[ImportStatement], body: str
 ) -> list[ImportStatement]:
-    if skip_unused:
-        return statements
     used = used_identifiers(body)
     kept: list[ImportStatement] = []
     for statement in statements:
@@ -419,9 +455,7 @@ def merge_from_imports(statements: list[ImportStatement]) -> list[ImportStatemen
             imported=tuple(names),
             sortable=existing.sortable and statement.sortable,
             force_parenthesized=(
-                existing.force_parenthesized
-                or statement.force_parenthesized
-                or len(names) > 1
+                existing.force_parenthesized or statement.force_parenthesized
             ),
         )
         merged[statement.module] = combined
@@ -446,18 +480,14 @@ def organized_import_block(statements: list[ImportStatement]) -> str:
             ),
         )
         title = GROUP_TITLES.get(group, "Imports")
-        header = (
-            "# ===----------------------------------------------------------------------=== #\n"
-            f"# {title}\n"
-            "# ===----------------------------------------------------------------------=== #\n"
-        )
+        header = f"{SEPARATOR}\n# {title}\n{SEPARATOR}\n"
         rendered_groups.append(
             header + "".join(render_import_statement(stmt) for stmt in ordered)
         )
     return "\n".join(rendered_groups)
 
 
-def organize_file(path: Path, *, keep_unused: bool) -> str | None:
+def organize_file(path: Path, *, remove_unused: bool) -> str | None:
     original = path.read_text()
     lines = original.splitlines(keepends=True)
     block = find_import_block(lines)
@@ -472,10 +502,10 @@ def organize_file(path: Path, *, keep_unused: bool) -> str | None:
         statements.append(statement)
 
     body = "".join(lines[end:])
-    skip_unused = (
-        path.name == "__init__.mojo" or keep_unused or not body.strip()
-    )
-    statements = remove_unused_imports(statements, body, skip_unused=skip_unused)
+    # `__init__.mojo` re-exports on purpose, so nothing there is ever "unused".
+    prune = remove_unused and path.name != "__init__.mojo" and bool(body.strip())
+    if prune:
+        statements = remove_unused_imports(statements, body)
     new_block = organized_import_block(statements)
     tail = "".join(lines[end:]).lstrip("\n")
     if new_block and tail.strip():
@@ -512,15 +542,19 @@ def main() -> int:
     )
     parser.add_argument("--diff", action="store_true", help="Print unified diffs.")
     parser.add_argument(
-        "--keep-unused",
+        "--remove-unused",
         action="store_true",
-        help="Sort imports without removing unused imported names.",
+        help=(
+            "Also drop imported names that no longer appear in the file. This "
+            "is decided by a text scan, not by the compiler, so review the "
+            "result (pair it with --diff first)."
+        ),
     )
     args = parser.parse_args()
 
     changed = []
     for path in iter_mojo_files(args.paths):
-        updated = organize_file(path, keep_unused=args.keep_unused)
+        updated = organize_file(path, remove_unused=args.remove_unused)
         if updated is None:
             continue
         changed.append(path)


### PR DESCRIPTION
This fixes #392 by git tracking the two python files. 

`docs/developer-guide/pre-pr-checks.md` and `docs/developer-guide/style-guide.md`
both tell contributors to run the standards scripts, and `pixi.toml` has a
`check_standards` task pointing at one of them — but neither file was ever in
git, because `.gitignore` ignores `*.py` wholesale. `pixi run check_standards`
failed with `No such file or directory` on a fresh clone.

## What this adds

- **`scripts/check_mojo_standards.py`** — reporting-only checker (never rewrites
  files). Covers file headers and license block, module docstring shape,
  `Exports` accuracy against real top-level declarations, section separators,
  import section headers, TODO/FIXME formatting, raw `raise Error(...)` and
  `Raises:` labels, and per-function signature-vs-docstring agreement.
  Supports `--only`, `--quiet` and `--json`; exits 0 clean, 1 with findings,
  2 on a usage error.
- **`scripts/organize_mojo_imports.py`** — groups and sorts imports under their
  `Stdlib` / `External` / `NuMojo` separators and merges duplicate `from`
  imports. `--check` and `--diff` for dry runs.
- **`.gitignore`** — `!scripts/*.py`, so the next script added here doesn't get
  silently dropped the same way.
- **`.pre-commit-config.yaml`** — the `mojo-format` hook no longer matches `.py`
  (`mojo format` only understands Mojo); a `ruff-format` hook scoped to
  `scripts/` takes over. pre-commit installs ruff itself, so this is not a new
  pixi dependency.
- **`pixi.toml`** — adds an `organize_imports` task alongside `check_standards`.

## Fixes applied to the scripts before landing

- The import organizer measured line width with an approximation
  (`sum(len(name)) + len(module) < 88`) that ignored the `from ` / ` import `
  overhead, so it emitted 82-column lines that `mojo format` immediately
  re-wrapped — the two tools undid each other on every run. It now measures the
  real rendered line against 80 columns. Verified: organizer → `mojo format` →
  organizer over all 82 files is now a fixed point.
- Unused-import removal was on by default and decided by a text scan rather than
  the compiler. It's now opt-in via `--remove-unused`.
- Relative and `utils_for_test` imports were emitted as a second group under a
  duplicate `NuMojo` title; they now fold into the single `NuMojo` group.
- `--only` didn't filter: separator and TODO checks shared one pass, so
  `--only todo` also emitted 112 separator findings. Per-category counts now sum
  to the reported total.
- Finding categories are aligned with the `--only` names (`headers`,
  `separators`, `signatures`), so `--json` output is filterable.
- `is_dunder` was computed but never used, producing ~300 low-value findings
  (`__eq__` "has argument(s) ['other']", etc.). Dunders other than `__init__`
  are now exempt from the completeness checks; `__init__` stays fully checked.
- Comments referenced `extras/cleanup.md` and `§1.1`–`§1.7`, neither of which
  exists in the repo. They now point at `docs/developer-guide/style-guide.md`.