### PR TITLE
[Indexing][NDArray] Add `count_nonzero` & `ptp`

### DIFF
--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -266,6 +266,7 @@ from numojo.routines.indexing import (
     unravel_index,
     ravel_multi_index,
     flatnonzero,
+    count_nonzero,
     fancy_index,
 )
 

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -267,7 +267,6 @@ from numojo.routines.indexing import (
     unravel_index,
     ravel_multi_index,
     flatnonzero,
-    count_nonzero,
     fancy_index,
 )
 
@@ -295,7 +294,7 @@ from numojo.routines import sorting
 from numojo.routines.sorting import sort, argsort
 
 from numojo.routines import searching
-from numojo.routines.searching import argmax, argmin
+from numojo.routines.searching import argmax, argmin, count_nonzero
 
 # ===----------------------------------------------------------------------=== #
 # Alias for users

--- a/numojo/__init__.mojo
+++ b/numojo/__init__.mojo
@@ -178,6 +178,7 @@ from numojo.routines.math import (
     min,
     minimum,
     maximum,
+    ptp,
 )
 from numojo.routines.math import copysign
 from numojo.routines.math import (

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4935,11 +4935,27 @@ struct NDArray[dtype: DType = DType.float64](
         return _flatnonzero(self)
 
     def count_nonzero(self) raises -> Int:
-        """Counts the number of non-zero elements in the array."""
+        """Counts the number of non-zero elements in the array.
+
+        Returns:
+            The number of elements in the array that are non-zero.
+        """
         return _count_nonzero(self)
 
     def count_nonzero(self, axis: Int) raises -> NDArray[DType.int]:
-        """Counts non-zero elements along a given axis."""
+        """Counts non-zero elements along a given axis.
+
+        Args:
+            axis: The axis along which to count non-zero elements.
+
+        Returns:
+            An integer `NDArray` with the array's shape minus the reduced
+            axis, containing the count of non-zero elements along that axis.
+
+        Raises:
+            NumojoError: If the axis is out of bound.
+            NumojoError: If the array is 1-D (use `count_nonzero()` instead).
+        """
         return _count_nonzero(self, axis)
 
     def contiguous(self) raises -> Self:

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -88,6 +88,7 @@ from numojo.routines.indexing import (
     take_along_axis as _take_along_axis,
     nonzero as _nonzero,
     flatnonzero as _flatnonzero,
+    count_nonzero as _count_nonzero,
     put as _put,
     searchsorted as _searchsorted,
     fancy_index as _fancy_index,
@@ -4932,6 +4933,14 @@ struct NDArray[dtype: DType = DType.float64](
     def flatnonzero(self) raises -> NDArray[DType.int]:
         """Returns flat indices of non-zero elements."""
         return _flatnonzero(self)
+
+    def count_nonzero(self) raises -> Int:
+        """Counts the number of non-zero elements in the array."""
+        return _count_nonzero(self)
+
+    def count_nonzero(self, axis: Int) raises -> NDArray[DType.int]:
+        """Counts non-zero elements along a given axis."""
+        return _count_nonzero(self, axis)
 
     def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -4939,6 +4939,14 @@ struct NDArray[dtype: DType = DType.float64](
 
         Returns:
             The number of elements in the array that are non-zero.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+            print(a.count_nonzero())  # 3
+            ```
         """
         return _count_nonzero(self)
 
@@ -4955,6 +4963,15 @@ struct NDArray[dtype: DType = DType.float64](
         Raises:
             NumojoError: If the axis is out of bound.
             NumojoError: If the array is 1-D (use `count_nonzero()` instead).
+
+        Examples:
+            ```mojo
+            import numojo as nm
+            from numojo.prelude import *
+
+            var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4]]")
+            print(a.count_nonzero(axis=0))  # [1, 0, 2]
+            ```
         """
         return _count_nonzero(self, axis)
 
@@ -5799,6 +5816,50 @@ struct NDArray[dtype: DType = DType.float64](
         """
 
         return numojo_math.min(self, axis=axis)
+
+    def ptp(self) raises -> Scalar[Self.dtype]:
+        """Finds the range (max - min) of an array.
+
+        When no axis is given, the array is flattened before computing.
+
+        Returns:
+            The difference between the max and min values.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+
+            var a = nm.array[nm.i32]("[3, 7, 1, 9, 4]")
+            print(a.ptp())  # 8
+            ```
+        """
+
+        return numojo_math.ptp(self)
+
+    def ptp(self, axis: Int) raises -> Self:
+        """Finds the range (max - min) of an array along the axis. The
+        number of dimensions will be reduced by 1.
+
+        Args:
+            axis: The axis along which the range is computed.
+
+        Returns:
+            An array with reduced number of dimensions.
+
+        Raises:
+            NumojoError: If the axis is out of bound.
+
+        Examples:
+            ```mojo
+            import numojo as nm
+            from numojo.prelude import *
+
+            var a = nm.array[nm.i32]("[[1, 5, 3], [4, 2, 9]]")
+            print(a.ptp(axis=0))  # [3, 3, 6]
+            ```
+        """
+
+        return numojo_math.ptp(self, axis=axis)
 
     def nditer(self) raises -> _NDIter[origin_of(self._buf.origin), Self.dtype]:
         """Returns an iterator yielding the array elements according to the

--- a/numojo/core/ndarray.mojo
+++ b/numojo/core/ndarray.mojo
@@ -88,7 +88,6 @@ from numojo.routines.indexing import (
     take_along_axis as _take_along_axis,
     nonzero as _nonzero,
     flatnonzero as _flatnonzero,
-    count_nonzero as _count_nonzero,
     put as _put,
     searchsorted as _searchsorted,
     fancy_index as _fancy_index,
@@ -4948,7 +4947,7 @@ struct NDArray[dtype: DType = DType.float64](
             print(a.count_nonzero())  # 3
             ```
         """
-        return _count_nonzero(self)
+        return searching.count_nonzero(self)
 
     def count_nonzero(self, axis: Int) raises -> NDArray[DType.int]:
         """Counts non-zero elements along a given axis.
@@ -4973,7 +4972,7 @@ struct NDArray[dtype: DType = DType.float64](
             print(a.count_nonzero(axis=0))  # [1, 0, 2]
             ```
         """
-        return _count_nonzero(self, axis)
+        return searching.count_nonzero(self, axis)
 
     def contiguous(self) raises -> Self:
         """Returns a new C-contiguous array owning a copy of the data.

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -78,7 +78,6 @@ from .functional import (
 )
 from .indexing import (
     compress,
-    count_nonzero,
     fancy_index,
     flatnonzero,
     nonzero,
@@ -189,6 +188,7 @@ from .operations import HostExecutor
 from .searching import (
     argmax,
     argmin,
+    count_nonzero,
 )
 from .sorting import (
     argsort,

--- a/numojo/routines/__init__.mojo
+++ b/numojo/routines/__init__.mojo
@@ -78,6 +78,7 @@ from .functional import (
 )
 from .indexing import (
     compress,
+    count_nonzero,
     fancy_index,
     flatnonzero,
     nonzero,

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -1416,6 +1416,14 @@ def count_nonzero[
     Raises:
         NumojoError: If the axis is out of bound.
         NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4]]")
+        print(nm.count_nonzero(a, axis=0))  # [1, 0, 2]
+        ```
     """
     var normalized_axis: Int = axis
     if normalized_axis < 0:

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -18,7 +18,7 @@ Exports
 - `where`: Conditional element selection.
 - `compress`: Extract elements based on condition.
 - `take`, `take_along_axis`: Advanced indexing.
-- `nonzero`, `flatnonzero`: Find non-zero elements.
+- `nonzero`, `flatnonzero`, `count_nonzero`: Find/count non-zero elements.
 - `fancy_index`: Apply fancy indexing.
 - `unravel_index`, `ravel_multi_index`: Index conversion.
 """
@@ -40,6 +40,7 @@ from numojo.core.indexing import IndexMethods
 from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.ndarray import NDArray
 from numojo.routines.creation import array as _array_creation_from_list
+from numojo.routines.creation import zeros
 from numojo.core.type_aliases import Shape
 from numojo.core.indexing.item import Item
 from numojo.routines.manipulation import ravel
@@ -1362,6 +1363,105 @@ def ravel_multi_index(
 ) raises -> NDArray[DType.int]:
     """Overload of `ravel_multi_index` accepting a shape list."""
     return ravel_multi_index(multi_index, NDArrayShape(shape), order)
+
+
+def count_nonzero[
+    dtype: DType,
+    //,
+](a: NDArray[dtype]) raises -> Int:
+    """Counts the number of non-zero elements in an array.
+
+    Args:
+        a: Input array.
+
+    Returns:
+        The number of elements in `a` that are non-zero.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+        print(nm.count_nonzero(a))  # 3
+        ```
+    """
+    var a_c = a.contiguous()
+    var count: Int = 0
+    for i in range(a_c.size):
+        if a_c.unsafe_get(i) != 0:
+            count += 1
+    return count
+
+
+def count_nonzero[
+    dtype: DType,
+    //,
+](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
+    """Counts non-zero elements along a given axis.
+
+    Args:
+        a: Input array.
+        axis: The axis along which to count non-zero elements.
+
+    Raises:
+        NumojoError: If the axis is out of bound.
+        NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
+
+    Returns:
+        An integer `NDArray` with `a`'s shape minus the reduced axis,
+        containing the count of non-zero elements along that axis.
+    """
+    var normalized_axis: Int = axis
+    if normalized_axis < 0:
+        normalized_axis += a.ndim
+
+    if (normalized_axis < 0) or (normalized_axis >= a.ndim):
+        raise Error(
+            NumojoError(
+                category="index",
+                message=(
+                    "Axis out of range: got {}, expected 0 <= axis < {}."
+                    .format(axis, a.ndim)
+                ),
+                location=String("routines.indexing.count_nonzero(a, axis)"),
+            )
+        )
+    if a.ndim == 1:
+        raise Error(
+            NumojoError(
+                category="shape",
+                message=String(
+                    "Cannot use axis with 1D array. Call `count_nonzero(a)`"
+                    " without axis, or reshape a to 2D or higher."
+                ),
+                location=String("routines.indexing.count_nonzero(a, axis)"),
+            )
+        )
+
+    var result_shape: List[Int] = List[Int]()
+    var size_of_axis: Int = a.shape[normalized_axis]
+    var slices: List[Slice] = List[Slice]()
+    for i in range(a.ndim):
+        if i != normalized_axis:
+            result_shape.append(a.shape[i])
+            slices.append(Slice(0, a.shape[i]))
+        else:
+            slices.append(Slice(0, 0))  # Temp value
+
+    var result: NDArray[DType.int] = zeros[DType.int](
+        NDArrayShape(result_shape)
+    )
+    for i in range(size_of_axis):
+        slices[normalized_axis] = Slice(i, i + 1)
+        var arr_slice: NDArray[dtype] = a._getitem_list_slices(slices.copy())
+        var mask = NDArray[DType.int](arr_slice.shape)
+        for j in range(arr_slice.size):
+            mask.unsafe_set(
+                j, Scalar[DType.int](1) if arr_slice.unsafe_get(j) != 0 else 0
+            )
+        result += mask
+
+    return result^
 
 
 def flatnonzero[

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -18,7 +18,7 @@ Exports
 - `where`: Conditional element selection.
 - `compress`: Extract elements based on condition.
 - `take`, `take_along_axis`: Advanced indexing.
-- `nonzero`, `flatnonzero`, `count_nonzero`: Find/count non-zero elements.
+- `nonzero`, `flatnonzero`: Find non-zero elements.
 - `fancy_index`: Apply fancy indexing.
 - `unravel_index`, `ravel_multi_index`: Index conversion.
 """
@@ -40,7 +40,6 @@ from numojo.core.indexing import IndexMethods
 from numojo.core.layout import NDArrayShape, NDArrayStrides
 from numojo.core.ndarray import NDArray
 from numojo.routines.creation import array as _array_creation_from_list
-from numojo.routines.creation import zeros
 from numojo.core.type_aliases import Shape
 from numojo.core.indexing.item import Item
 from numojo.routines.manipulation import ravel
@@ -1363,119 +1362,6 @@ def ravel_multi_index(
 ) raises -> NDArray[DType.int]:
     """Overload of `ravel_multi_index` accepting a shape list."""
     return ravel_multi_index(multi_index, NDArrayShape(shape), order)
-
-
-def count_nonzero[
-    dtype: DType,
-    //,
-](a: NDArray[dtype]) raises -> Int:
-    """Counts the number of non-zero elements in an array.
-
-    Parameters:
-        dtype: Data type of the source array.
-
-    Args:
-        a: Input array.
-
-    Returns:
-        The number of elements in `a` that are non-zero.
-
-    Examples:
-        ```mojo
-        import numojo as nm
-
-        var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
-        print(nm.count_nonzero(a))  # 3
-        ```
-    """
-    var a_c = a.contiguous()
-    var count: Int = 0
-    for i in range(a_c.size):
-        if a_c.unsafe_get(i) != 0:
-            count += 1
-    return count
-
-
-def count_nonzero[
-    dtype: DType,
-    //,
-](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
-    """Counts non-zero elements along a given axis.
-
-    Parameters:
-        dtype: Data type of the source array.
-
-    Args:
-        a: Input array.
-        axis: The axis along which to count non-zero elements.
-
-    Returns:
-        An integer `NDArray` with `a`'s shape minus the reduced axis,
-        containing the count of non-zero elements along that axis.
-
-    Raises:
-        NumojoError: If the axis is out of bound.
-        NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
-
-    Examples:
-        ```mojo
-        import numojo as nm
-
-        var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4]]")
-        print(nm.count_nonzero(a, axis=0))  # [1, 0, 2]
-        ```
-    """
-    var normalized_axis: Int = axis
-    if normalized_axis < 0:
-        normalized_axis += a.ndim
-
-    if (normalized_axis < 0) or (normalized_axis >= a.ndim):
-        raise Error(
-            NumojoError(
-                category="index",
-                message=(
-                    "Axis out of range: got {}, expected 0 <= axis < {}."
-                    .format(axis, a.ndim)
-                ),
-                location=String("routines.indexing.count_nonzero(a, axis)"),
-            )
-        )
-    if a.ndim == 1:
-        raise Error(
-            NumojoError(
-                category="shape",
-                message=String(
-                    "Cannot use axis with 1D array. Call `count_nonzero(a)`"
-                    " without axis, or reshape a to 2D or higher."
-                ),
-                location=String("routines.indexing.count_nonzero(a, axis)"),
-            )
-        )
-
-    var result_shape: List[Int] = List[Int]()
-    var size_of_axis: Int = a.shape[normalized_axis]
-    var slices: List[Slice] = List[Slice]()
-    for i in range(a.ndim):
-        if i != normalized_axis:
-            result_shape.append(a.shape[i])
-            slices.append(Slice(0, a.shape[i]))
-        else:
-            slices.append(Slice(0, 0))  # Temp value
-
-    var result: NDArray[DType.int] = zeros[DType.int](
-        NDArrayShape(result_shape)
-    )
-    for i in range(size_of_axis):
-        slices[normalized_axis] = Slice(i, i + 1)
-        var arr_slice: NDArray[dtype] = a._getitem_list_slices(slices.copy())
-        var mask = NDArray[DType.int](arr_slice.shape)
-        for j in range(arr_slice.size):
-            mask.unsafe_set(
-                j, Scalar[DType.int](1) if arr_slice.unsafe_get(j) != 0 else 0
-            )
-        result += mask
-
-    return result^
 
 
 def flatnonzero[

--- a/numojo/routines/indexing.mojo
+++ b/numojo/routines/indexing.mojo
@@ -1371,6 +1371,9 @@ def count_nonzero[
 ](a: NDArray[dtype]) raises -> Int:
     """Counts the number of non-zero elements in an array.
 
+    Parameters:
+        dtype: Data type of the source array.
+
     Args:
         a: Input array.
 
@@ -1399,17 +1402,20 @@ def count_nonzero[
 ](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
     """Counts non-zero elements along a given axis.
 
+    Parameters:
+        dtype: Data type of the source array.
+
     Args:
         a: Input array.
         axis: The axis along which to count non-zero elements.
 
-    Raises:
-        NumojoError: If the axis is out of bound.
-        NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
-
     Returns:
         An integer `NDArray` with `a`'s shape minus the reduced axis,
         containing the count of non-zero elements along that axis.
+
+    Raises:
+        NumojoError: If the axis is out of bound.
+        NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
     """
     var normalized_axis: Int = axis
     if normalized_axis < 0:

--- a/numojo/routines/math/__init__.mojo
+++ b/numojo/routines/math/__init__.mojo
@@ -62,6 +62,7 @@ from .extrema import (
     maximum,
     min,
     minimum,
+    ptp,
 )
 from .floating import copysign
 from .hyper import (

--- a/numojo/routines/math/extrema.mojo
+++ b/numojo/routines/math/extrema.mojo
@@ -17,6 +17,7 @@ Exports
 -------
 - `min`, `max`: Element-wise minimum and maximum.
 - `minimum`, `maximum`: Element-wise operations (aliases).
+- `ptp`: Range (max - min) of an array.
 """
 
 # ===----------------------------------------------------------------------=== #
@@ -244,6 +245,60 @@ def min[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
     return apply_along_axis_reduce[func1d=extrema_1d[is_max=False]](
         a=a, axis=normalized_axis
     )
+
+
+def ptp[dtype: DType](a: NDArray[dtype]) raises -> Scalar[dtype]:
+    """
+    Find the range (max - min) of an array.
+
+    Parameters:
+        dtype: The element type.
+
+    Args:
+        a: An array.
+
+    Returns:
+        The difference between the max and min values.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        from numojo.prelude import *
+
+        var a = nm.arange[f32](0, 6).reshape(Shape(2, 3))
+        var r = nm.ptp(a)
+        ```
+    """
+    return max(a) - min(a)
+
+
+def ptp[dtype: DType](a: NDArray[dtype], axis: Int) raises -> NDArray[dtype]:
+    """
+    Find the range (max - min) of an array along an axis.
+
+    Parameters:
+        dtype: The element type.
+
+    Args:
+        a: An array.
+        axis: The axis along which the range is computed.
+
+    Returns:
+        An array with reduced number of dimensions.
+
+    Raises:
+        NumojoError: If the axis is out of bound.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+        from numojo.prelude import *
+
+        var a = nm.arange[f32](0, 6).reshape(Shape(2, 3))
+        var r = nm.ptp(a, axis=0)
+        ```
+    """
+    return max(a, axis) - min(a, axis)
 
 
 # ===-----------------------------------------------------------------------===#

--- a/numojo/routines/searching.mojo
+++ b/numojo/routines/searching.mojo
@@ -16,13 +16,16 @@ Exports
 -------
 - `argmax`: Index of maximum value.
 - `argmin`: Index of minimum value.
+- `count_nonzero`: Count of non-zero elements.
 """
 
 # ===----------------------------------------------------------------------=== #
 # NuMojo
 # ===----------------------------------------------------------------------=== #
 from numojo.core.error import NumojoError
+from numojo.core.layout import NDArrayShape
 from numojo.core.ndarray import NDArray
+from numojo.routines.creation import zeros
 from numojo.routines.functional import apply_along_axis_reduce_to_int
 from numojo.routines.manipulation import ravel
 
@@ -248,3 +251,114 @@ def argmin[
     return apply_along_axis_reduce_to_int[dtype, func1d=argmin_1d](
         a=a, axis=normalized_axis
     )
+
+
+def count_nonzero[
+    dtype: DType,
+    //,
+](a: NDArray[dtype]) raises -> Int:
+    """Counts the number of non-zero elements in an array.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Input array.
+
+    Returns:
+        The number of elements in `a` that are non-zero.
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+        print(nm.count_nonzero(a))  # 3
+        ```
+    """
+    var a_c = a.contiguous()
+    var count: Int = 0
+    for i in range(a_c.size):
+        if a_c.unsafe_get(i) != 0:
+            count += 1
+    return count
+
+
+def count_nonzero[
+    dtype: DType,
+    //,
+](a: NDArray[dtype], axis: Int) raises -> NDArray[DType.int]:
+    """Counts non-zero elements along a given axis.
+
+    Parameters:
+        dtype: Data type of the source array.
+
+    Args:
+        a: Input array.
+        axis: The axis along which to count non-zero elements.
+
+    Returns:
+        An integer `NDArray` with `a`'s shape minus the reduced axis,
+        containing the count of non-zero elements along that axis.
+
+    Raises:
+        NumojoError: If the axis is out of bound.
+        NumojoError: If the array is 1-D (use `count_nonzero(a)` instead).
+
+    Examples:
+        ```mojo
+        import numojo as nm
+
+        var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4]]")
+        print(nm.count_nonzero(a, axis=0))  # [1, 0, 2]
+        ```
+    """
+    var normalized_axis = axis
+    if axis < 0:
+        normalized_axis += a.ndim
+    if (normalized_axis < 0) or (normalized_axis >= a.ndim):
+        raise Error(
+            NumojoError(
+                category="index",
+                message=String(
+                    "Error in `count_nonzero`: Axis {} not in bound [-{}, {})"
+                ).format(axis, a.ndim, a.ndim),
+                location="count_nonzero",
+            )
+        )
+    if a.ndim == 1:
+        raise Error(
+            NumojoError(
+                category="shape",
+                message=String(
+                    "Cannot use axis with 1D array. Call `count_nonzero(a)`"
+                    " without axis, or reshape a to 2D or higher."
+                ),
+                location="count_nonzero",
+            )
+        )
+
+    var result_shape: List[Int] = List[Int]()
+    var size_of_axis: Int = a.shape[normalized_axis]
+    var slices: List[Slice] = List[Slice]()
+    for i in range(a.ndim):
+        if i != normalized_axis:
+            result_shape.append(a.shape[i])
+            slices.append(Slice(0, a.shape[i]))
+        else:
+            slices.append(Slice(0, 0))  # Temp value
+
+    var result: NDArray[DType.int] = zeros[DType.int](
+        NDArrayShape(result_shape)
+    )
+    for i in range(size_of_axis):
+        slices[normalized_axis] = Slice(i, i + 1)
+        var arr_slice: NDArray[dtype] = a._getitem_list_slices(slices.copy())
+        var mask = NDArray[DType.int](arr_slice.shape)
+        for j in range(arr_slice.size):
+            mask.unsafe_set(
+                j, Scalar[DType.int](1) if arr_slice.unsafe_get(j) != 0 else 0
+            )
+        result += mask
+
+    return result^

--- a/scripts/check_mojo_standards.py
+++ b/scripts/check_mojo_standards.py
@@ -906,6 +906,14 @@ def check_signature_docstring(
             f"no 'Raises:' section (should name NumojoError).",
         )
 
+    if "Examples" not in present_canonical:
+        report.add(
+            start + 1,
+            "signatures",
+            f"'{sig.name}': docstring has no 'Examples:' section (required "
+            f"for all public functions/methods).",
+        )
+
 
 def extract_documented_names(body: list[str], section: str) -> set[str]:
     names = set()

--- a/tests/core/test_count_nonzero.mojo
+++ b/tests/core/test_count_nonzero.mojo
@@ -1,0 +1,91 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_count_nonzero_1d() raises:
+    """Count_nonzero counts non-zero entries in a 1-D array."""
+    var a = nm.array[nm.i32]("[3, 0, 5, 0, 2]")
+    assert_equal(nm.count_nonzero(a), 3)
+
+
+def test_count_nonzero_method() raises:
+    """NDArray.count_nonzero delegates to the indexing routine."""
+    var a = nm.array[nm.i32]("[0, 4, 0, 7]")
+    assert_equal(a.count_nonzero(), 2)
+
+
+def test_count_nonzero_2d_flat() raises:
+    """Count_nonzero without axis counts over the whole array."""
+    var a = nm.array[nm.i32]("[[0, 1, 0], [2, 0, 3]]")
+    assert_equal(nm.count_nonzero(a), 3)
+
+
+def test_count_nonzero_bool() raises:
+    """Count_nonzero treats True bool values as non-zero."""
+    var a = nm.array[boolean]("[[0, 1], [1, 0]]")
+    assert_equal(nm.count_nonzero(a), 2)
+
+
+def test_count_nonzero_all_zero_returns_zero() raises:
+    """Count_nonzero returns 0 when nothing is non-zero."""
+    var a = nm.zeros[nm.i32](Shape(2, 3))
+    assert_equal(nm.count_nonzero(a), 0)
+
+
+def test_count_nonzero_axis0() raises:
+    """Count_nonzero(axis=0) counts non-zero entries down each column."""
+    var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4], [1, 1, 0]]")
+    var result = nm.count_nonzero(a, axis=0)
+    assert_equal(result.ndim, 1)
+    assert_equal(Int(result.item(0)), 2)
+    assert_equal(Int(result.item(1)), 1)
+    assert_equal(Int(result.item(2)), 2)
+
+
+def test_count_nonzero_axis1() raises:
+    """Count_nonzero(axis=1) counts non-zero entries across each row."""
+    var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4], [1, 1, 0]]")
+    var result = nm.count_nonzero(a, axis=1)
+    assert_equal(result.ndim, 1)
+    assert_equal(Int(result.item(0)), 2)
+    assert_equal(Int(result.item(1)), 1)
+    assert_equal(Int(result.item(2)), 2)
+
+
+def test_count_nonzero_negative_axis() raises:
+    """Count_nonzero accepts negative axis indices."""
+    var a = nm.array[nm.i32]("[[1, 0, 3], [0, 0, 4], [1, 1, 0]]")
+    var result_pos = nm.count_nonzero(a, axis=1)
+    var result_neg = nm.count_nonzero(a, axis=-1)
+    assert_equal(Int(result_pos.item(0)), Int(result_neg.item(0)))
+    assert_equal(Int(result_pos.item(1)), Int(result_neg.item(1)))
+    assert_equal(Int(result_pos.item(2)), Int(result_neg.item(2)))
+
+
+def test_count_nonzero_axis_out_of_bound_raises() raises:
+    """Count_nonzero raises when axis is out of bounds."""
+    var a = nm.array[nm.i32]("[[1, 0], [0, 4]]")
+    var raised = False
+    try:
+        _ = nm.count_nonzero(a, axis=5)
+    except:
+        raised = True
+    assert_equal(raised, True)
+
+
+def test_count_nonzero_axis_on_1d_raises() raises:
+    """Count_nonzero raises when axis is passed for a 1-D array."""
+    var a = nm.array[nm.i32]("[1, 0, 2]")
+    var raised = False
+    try:
+        _ = nm.count_nonzero(a, axis=0)
+    except:
+        raised = True
+    assert_equal(raised, True)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/core/test_ptp.mojo
+++ b/tests/core/test_ptp.mojo
@@ -1,0 +1,78 @@
+from std.testing import TestSuite
+from std.testing.testing import assert_equal, assert_almost_equal
+
+import numojo as nm
+from numojo.prelude import *
+
+
+def test_ptp_1d() raises:
+    """Ptp returns max - min over a flattened 1-D array."""
+    var a = nm.array[nm.i32]("[3, 7, 1, 9, 4]")
+    assert_equal(Int(nm.ptp(a)), 8)
+
+
+def test_ptp_method() raises:
+    """NDArray.ptp delegates to the extrema routine."""
+    var a = nm.array[nm.i32]("[3, 7, 1, 9, 4]")
+    assert_equal(Int(a.ptp()), 8)
+
+
+def test_ptp_2d_flat() raises:
+    """Ptp without axis reduces over the whole array."""
+    var a = nm.array[nm.i32]("[[1, 5], [9, 2]]")
+    assert_equal(Int(nm.ptp(a)), 8)
+
+
+def test_ptp_constant_array_is_zero() raises:
+    """Ptp of a constant array is zero."""
+    var a = nm.full[nm.i32](Shape(3, 3), 5)
+    assert_equal(Int(nm.ptp(a)), 0)
+
+
+def test_ptp_axis0() raises:
+    """Ptp(axis=0) computes range down each column."""
+    var a = nm.array[nm.i32]("[[1, 5, 3], [4, 2, 9]]")
+    var result = nm.ptp(a, axis=0)
+    assert_equal(result.ndim, 1)
+    assert_equal(Int(result.item(0)), 3)
+    assert_equal(Int(result.item(1)), 3)
+    assert_equal(Int(result.item(2)), 6)
+
+
+def test_ptp_axis1() raises:
+    """Ptp(axis=1) computes range across each row."""
+    var a = nm.array[nm.i32]("[[1, 5, 3], [4, 2, 9]]")
+    var result = nm.ptp(a, axis=1)
+    assert_equal(result.ndim, 1)
+    assert_equal(Int(result.item(0)), 4)
+    assert_equal(Int(result.item(1)), 7)
+
+
+def test_ptp_method_axis() raises:
+    """NDArray.ptp(axis) delegates to the extrema routine."""
+    var a = nm.array[nm.i32]("[[1, 5, 3], [4, 2, 9]]")
+    var result = a.ptp(axis=0)
+    assert_equal(Int(result.item(0)), 3)
+    assert_equal(Int(result.item(1)), 3)
+    assert_equal(Int(result.item(2)), 6)
+
+
+def test_ptp_float() raises:
+    """Ptp works on floating-point arrays."""
+    var a = nm.array[nm.f32]("[1.5, 4.5, -2.0, 3.0]")
+    assert_almost_equal(Float64(nm.ptp(a)), 6.5)
+
+
+def test_ptp_axis_out_of_bound_raises() raises:
+    """Ptp raises when axis is out of bounds."""
+    var a = nm.array[nm.i32]("[[1, 5], [9, 2]]")
+    var raised = False
+    try:
+        _ = nm.ptp(a, axis=5)
+    except:
+        raised = True
+    assert_equal(raised, True)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR implements `count_nonzero` function that counts non-zero elements in an NDArray and `ptp` function that computes the max-min of an NDArray, both flat or along an axis.

## Summary:
- Add `count_nonzero(a) → Int`, and `count_nonzero(a, axis) → NDArray[DType.int]` with their corresponding NDArray.count_nonzero() / .count_nonzero(axis) methods
- Add `ptp(a) → Scalar[dtype]` and `ptp(a, axis) → NDArray[dtype]` with their corresponding NDArray.ptp() / .ptp(axis) methods.
- Added tests for count_nonzero and ptp
- Update mojo standards script to require `Examples` section in docstring. 

#398 
#396 