### PR TITLE
[Math] Add scalar overload to contents checking

### DIFF
--- a/numojo/routines/logic/contents.mojo
+++ b/numojo/routines/logic/contents.mojo
@@ -22,7 +22,6 @@ Exports
 - `isposinf`: Check for positive infinity.
 """
 
-# TODO: Add scalar overloads of these functions.
 # TODO: Implement commented functions now that Mojo supports them in SIMD.
 # FIXME: Make all SIMD vectorized once bool bit-packing issue is resolved.
 
@@ -76,6 +75,33 @@ def isinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, is_inf_kernel](array)
 
 
+def isinf[dtype: DType](value: Scalar[dtype]) raises -> Scalar[DType.bool]:
+    """
+    Checks if the input scalar is infinite.
+
+    Parameters:
+        dtype: Data type of the input scalar.
+
+    Args:
+        value: Input scalar to check.
+
+    Returns:
+        True if `value` is positive or negative infinity, False otherwise.
+
+    Examples:
+        ```mojo
+        from numojo.prelude import *
+        from numojo.routines.logic.contents import isinf
+        from std.utils.numerics import inf
+
+        def main() raises:
+            print(isinf(inf[f64]()))  # Output: True
+            print(isinf(Scalar[f64](1.0)))  # Output: False
+        ```
+    """
+    return math.isinf(value)
+
+
 def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is finite.
@@ -107,6 +133,32 @@ def isfinite[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         return math.isfinite(x)
 
     return HostExecutor.apply_unary_predicate[dtype, is_finite_kernel](array)
+
+
+def isfinite[dtype: DType](value: Scalar[dtype]) raises -> Scalar[DType.bool]:
+    """
+    Checks if the input scalar is finite.
+
+    Parameters:
+        dtype: Data type of the input scalar.
+
+    Args:
+        value: Input scalar to check.
+
+    Returns:
+        True if `value` is neither infinite nor NaN, False otherwise.
+
+    Examples:
+        ```mojo
+        from numojo.prelude import *
+        from numojo.routines.logic.contents import isfinite
+
+        def main() raises:
+            print(isfinite(Scalar[f64](1.0)))  # Output: True
+            print(isfinite(Float64.MAX))  # Output: True
+        ```
+    """
+    return math.isfinite(value)
 
 
 def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
@@ -142,6 +194,33 @@ def isnan[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, is_nan_kernel](array)
 
 
+def isnan[dtype: DType](value: Scalar[dtype]) raises -> Scalar[DType.bool]:
+    """
+    Checks if the input scalar is NaN.
+
+    Parameters:
+        dtype: Data type of the input scalar.
+
+    Args:
+        value: Input scalar to check.
+
+    Returns:
+        True if `value` is NaN, False otherwise.
+
+    Examples:
+        ```mojo
+        from numojo.prelude import *
+        from numojo.routines.logic.contents import isnan
+        from std.utils.numerics import nan
+
+        def main() raises:
+            print(isnan(nan[f64]()))  # Output: True
+            print(isnan(Scalar[f64](1.0)))  # Output: False
+        ```
+    """
+    return math.isnan(value)
+
+
 def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is negative infinity.
@@ -175,6 +254,33 @@ def isneginf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     return HostExecutor.apply_unary_predicate[dtype, is_neginf](array)
 
 
+def isneginf[dtype: DType](value: Scalar[dtype]) raises -> Scalar[DType.bool]:
+    """
+    Checks if the input scalar is negative infinity.
+
+    Parameters:
+        dtype: Data type of the input scalar.
+
+    Args:
+        value: Input scalar to check.
+
+    Returns:
+        True if `value` is negative infinity, False otherwise.
+
+    Examples:
+        ```mojo
+        from numojo.prelude import *
+        from numojo.routines.logic.contents import isneginf
+        from std.utils.numerics import neg_inf
+
+        def main() raises:
+            print(isneginf(neg_inf[f64]()))  # Output: True
+            print(isneginf(Scalar[f64](-1.0)))  # Output: False
+        ```
+    """
+    return value.eq(neg_inf[dtype]())
+
+
 def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
     """
     Checks if each element of the input array is positive infinity.
@@ -206,3 +312,30 @@ def isposinf[dtype: DType](array: NDArray[dtype]) raises -> NDArray[DType.bool]:
         return x.eq(SIMD[dtype, simd_width](inf[dtype]()))
 
     return HostExecutor.apply_unary_predicate[dtype, is_posinf](array)
+
+
+def isposinf[dtype: DType](value: Scalar[dtype]) raises -> Scalar[DType.bool]:
+    """
+    Checks if the input scalar is positive infinity.
+
+    Parameters:
+        dtype: Data type of the input scalar.
+
+    Args:
+        value: Input scalar to check.
+
+    Returns:
+        True if `value` is positive infinity, False otherwise.
+
+    Examples:
+        ```mojo
+        from numojo.prelude import *
+        from numojo.routines.logic.contents import isposinf
+        from std.utils.numerics import inf
+
+        def main() raises:
+            print(isposinf(inf[f64]()))  # Output: True
+            print(isposinf(Scalar[f64](1.0)))  # Output: False
+        ```
+    """
+    return value.eq(inf[dtype]())

--- a/tests/routines/test_logic.mojo
+++ b/tests/routines/test_logic.mojo
@@ -122,6 +122,28 @@ def test_contents_isinf_isfinite_isnan() raises:
     check(isposinf(a), np.isposinf(p_arr), "isposinf")
     check(isneginf(a), np.isneginf(p_arr), "isneginf")
 
+    # The scalar overloads must agree with the array results checked above,
+    # element by element, and so with NumPy.
+    for i in range(a.size):
+        var x = a.item(i)
+        assert_equal(
+            Bool(nm.isinf(x)), Bool(np.isinf(p_arr[i])), "isinf(scalar)"
+        )
+        assert_equal(
+            Bool(nm.isfinite(x)),
+            Bool(np.isfinite(p_arr[i])),
+            "isfinite(scalar)",
+        )
+        assert_equal(
+            Bool(nm.isnan(x)), Bool(np.isnan(p_arr[i])), "isnan(scalar)"
+        )
+        assert_equal(
+            Bool(isposinf(x)), Bool(np.isposinf(p_arr[i])), "isposinf(scalar)"
+        )
+        assert_equal(
+            Bool(isneginf(x)), Bool(np.isneginf(p_arr[i])), "isneginf(scalar)"
+        )
+
 
 def test_truth_all_any() raises:
     var np = Python.import_module("numpy")


### PR DESCRIPTION
This PR implement scalar overloads of `isinf`, `isfinite`, `isnan`, `isposinf`, `isneginf` functions and their respective tests. 